### PR TITLE
Flexible formatting of DecimalType

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.library.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.library.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
@@ -33,27 +33,38 @@ public class DecimalTypeTest {
 	}
 
 	@Test
-	public void testFormat() {
+	public void testIntFormat() {
+		DecimalType dt;
+
 		// Basic test with an integer value.
-		DecimalType dt1 = new DecimalType("87");
-		assertEquals("87", dt1.format("%d"));
+		dt = new DecimalType("87");
+		assertEquals("87", dt.format("%d"));
 
 		// Again an integer value, but this time an "advanced" pattern.
-		DecimalType dt2 = new DecimalType("87");
-		assertEquals(" 87", dt2.format("%3d"));
+		dt = new DecimalType("87");
+		assertEquals(" 87", dt.format("%3d"));
 
 		// Again an integer value, but this time an "advanced" pattern.
-		DecimalType dt3 = new DecimalType("87");
-		assertEquals("0x57", dt3.format("%#x"));
+		dt = new DecimalType("87");
+		assertEquals("0x57", dt.format("%#x"));
 
 		// A float value cannot be converted into hex.
-		DecimalType dt4 = new DecimalType("87.5");
+		dt = new DecimalType("87.5");
 		try {
-			dt4.format("%x");
+			dt.format("%x");
 			fail();
 		} catch (Exception e) {
 			// That's what we expect.
 		}
+
+		// An integer (with different representation) with int conversion.
+		dt = new DecimalType("11.0");
+		assertEquals("11", dt.format("%d"));
+	}
+
+	@Test
+	public void testFloatFormat() {
+		DecimalType dt;
 
 		// We know that DecimalType calls "String.format()" without a locale. So
 		// we have to do the same thing here in order to get the right decimal
@@ -61,11 +72,15 @@ public class DecimalTypeTest {
 		final char sep = (new DecimalFormatSymbols().getDecimalSeparator());
 
 		// A float value with float conversion.
-		DecimalType dt5 = new DecimalType("11.123");
-		assertEquals("11" + sep + "1", dt5.format("%.1f")); // "11.1"
+		dt = new DecimalType("11.123");
+		assertEquals("11" + sep + "1", dt.format("%.1f")); // "11.1"
 
 		// An integer value with float conversion. This has to work.
-		DecimalType dt6 = new DecimalType("11");
-		assertEquals("11" + sep + "0", dt6.format("%.1f")); // "11.0"
+		dt = new DecimalType("11");
+		assertEquals("11" + sep + "0", dt.format("%.1f")); // "11.0"
+
+		// An integer value with float conversion. This has to work.
+		dt = new DecimalType("11.0");
+		assertEquals("11" + sep + "0", dt.format("%.1f")); // "11.0"
 	}
 }

--- a/bundles/core/org.eclipse.smarthome.core.library/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core.library/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -59,19 +59,17 @@ public class DecimalType extends Number implements PrimitiveType, State,
 	}
 
 	public String format(String pattern) {
-		if (value.scale() == 0) {
-			// The value is an integer value. Convert to BigInteger in order to
-			// have access to more conversion formats.
-			try {
-				return String.format(pattern, value.toBigIntegerExact());
-			} catch (ArithmeticException ae) {
-				// Could not convert to integer value without loss of
-				// information. Fall through to default behavior.
-			} catch (IllegalFormatConversionException ifce) {
-				// The conversion is not valid for the type BigInteger. This
-				// happens, if the format is like "%.1f" but the value is an
-				// integer. Fall through to default behavior.
-			}
+		// The value could be an integer value. Try to convert to BigInteger in
+		// order to have access to more conversion formats.
+		try {
+			return String.format(pattern, value.toBigIntegerExact());
+		} catch (ArithmeticException ae) {
+			// Could not convert to integer value without loss of
+			// information. Fall through to default behavior.
+		} catch (IllegalFormatConversionException ifce) {
+			// The conversion is not valid for the type BigInteger. This
+			// happens, if the format is like "%.1f" but the value is an
+			// integer. Fall through to default behavior.
 		}
 
 		return String.format(pattern, value);

--- a/bundles/ui/org.eclipse.smarthome.ui.test/src/test/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/src/test/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
@@ -12,6 +12,9 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.text.DecimalFormatSymbols;
+
 import junit.framework.Assert;
 
 import org.eclipse.smarthome.core.items.Item;
@@ -22,18 +25,19 @@ import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.UnDefType;
-import org.eclipse.smarthome.ui.internal.items.ItemUIRegistryImpl;
-import org.eclipse.smarthome.ui.items.ItemUIProvider;
-import org.junit.Before;
-import org.junit.Test;
 import org.eclipse.smarthome.model.sitemap.Sitemap;
 import org.eclipse.smarthome.model.sitemap.SitemapFactory;
 import org.eclipse.smarthome.model.sitemap.Widget;
+import org.eclipse.smarthome.ui.items.ItemUIProvider;
+import org.junit.Before;
+import org.junit.Test;
 
 public class ItemUIRegistryImplTest {
 
 	static private ItemRegistry registry;
 	static private ItemUIRegistryImpl uiRegistry = new ItemUIRegistryImpl();
+	// we need to get the decimal separator of the default locale for our tests
+	static private final char sep = (new DecimalFormatSymbols().getDecimalSeparator());
 
 	@Before
 	public void prepareRegistry() {
@@ -87,6 +91,34 @@ public class ItemUIRegistryImplTest {
 	}
 
 	@Test
+	public void getLabel_labelWithIntegerValueAndWidth() throws ItemNotFoundException {
+		String testLabel = "Label [%3d]";
+		Widget w = mock(Widget.class);
+		Item item = mock(Item.class);
+		when(w.getLabel()).thenReturn(testLabel);
+		when(w.getItem()).thenReturn("Item");
+		when(registry.getItem("Item")).thenReturn(item);
+		when(item.getState()).thenReturn(new DecimalType(20));
+		when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(20));
+		String label = uiRegistry.getLabel(w);
+		assertEquals("Label [ 20]", label);
+	}
+
+	@Test
+	public void getLabel_labelWithHexValueAndWidth() throws ItemNotFoundException {
+		String testLabel = "Label [%3x]";
+		Widget w = mock(Widget.class);
+		Item item = mock(Item.class);
+		when(w.getLabel()).thenReturn(testLabel);
+		when(w.getItem()).thenReturn("Item");
+		when(registry.getItem("Item")).thenReturn(item);
+		when(item.getState()).thenReturn(new DecimalType(20));
+		when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(20));
+		String label = uiRegistry.getLabel(w);
+		assertEquals("Label [ 14]", label);
+	}
+
+	@Test
 	public void getLabel_labelWithDecimalValue() throws ItemNotFoundException {
 		String testLabel = "Label [%.3f]";
 		Widget w = mock(Widget.class);
@@ -97,7 +129,7 @@ public class ItemUIRegistryImplTest {
 		when(item.getState()).thenReturn(new DecimalType(10f/3f));
 		when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(10f/3f));
 		String label = uiRegistry.getLabel(w);
-		assertEquals("Label [3.333]", label);
+		assertEquals("Label [3" + sep + ".333]", label);
 	}
 
 	@Test
@@ -111,7 +143,7 @@ public class ItemUIRegistryImplTest {
 		when(item.getState()).thenReturn(new DecimalType(10f/3f));
 		when(item.getStateAs(DecimalType.class)).thenReturn(new DecimalType(10f/3f));
 		String label = uiRegistry.getLabel(w);
-		assertEquals("Label [3.3 %]", label);
+		assertEquals("Label [3" + sep + "3 %]", label);
 	}
 
 	@Test

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -79,8 +79,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 	/* RegEx to extract and parse a function String <code>'\[(.*?)\((.*)\):(.*)\]'</code> */
 	protected static final Pattern EXTRACT_TRANSFORMFUNCTION_PATTERN = Pattern.compile("\\[(.*?)\\((.*)\\):(.*)\\]");
 	
-	/* RegEx to identify format patterns */
-	protected static final String IDENTIFY_FORMAT_PATTERN_PATTERN = "%(\\d\\$)?(<)?(\\.\\d)?[a-zA-Z]{1,2}";
+	/* RegEx to identify format patterns. See java.util.Formatter#formatSpecifier (without the '%' at the very end). */
+	protected static final String IDENTIFY_FORMAT_PATTERN_PATTERN = "%(\\d+\\$)?([-#+ 0,(\\<]*)?(\\d+)?(\\.\\d+)?([tT])?([a-zA-Z])";
 
 	protected Set<ItemUIProvider> itemUIProviders = new HashSet<ItemUIProvider>();
 
@@ -247,10 +247,14 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 				// The following exception handling has been added to work around a Java bug with formatting
 				// numbers. See http://bugs.sun.com/view_bug.do?bug_id=6476425
 				// Without this catch, the whole sitemap, or page can not be displayed!
+				// This also handles IllegalFormatConversionException, which is a subclass of IllegalArgument.
 				try {
-				formatPattern = ((Type) state).format(formatPattern);
-			}
+					formatPattern = ((Type) state).format(formatPattern);
+				}
 				catch(IllegalArgumentException e) {
+					logger.warn(
+							"Exception while formatting value '{}' of item {} with format '{}': {}",
+							state, itemName, formatPattern, e);
 					formatPattern = new String("Err"); 
 				}
 			}
@@ -291,9 +295,15 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 	 */
 	protected String formatUndefined(String formatPattern) {
 		String undefinedFormatPattern = 
-			formatPattern.replaceAll(IDENTIFY_FORMAT_PATTERN_PATTERN, "%1\\$s");
-		String formattedValue = String.format(undefinedFormatPattern, "-");
-		return formattedValue;
+				formatPattern.replaceAll(IDENTIFY_FORMAT_PATTERN_PATTERN, "%1\\$s");
+		try {
+			return String.format(undefinedFormatPattern, "-");
+		} catch (Exception e) {
+			logger.warn(
+					"Exception while formatting undefined value [sourcePattern={}, targetPattern={}, {}]",
+					formatPattern, undefinedFormatPattern, e);
+			return "Err";
+		}
 	}
 	
 	/*


### PR DESCRIPTION
My initial pull request #18 threw an exception, if a DecimalType like "11.0" was formatted with an integer pattern like "%d". This pull request contains a fix for this issue.

Details can be found on the original issue of openHab: https://github.com/openhab/openhab/issues/1013

Note: I've also added a fix for the test suite org.eclipse.smarthome.ui.test, which is disabled at the moment (I think because of localization issues with the decimal separator). I fixed this localization issue but I get an error (Surefire cannot find the bundle) when I try to activate the test suite. In openHab I could activate this test suite without problems.

To point it out: The test suite should work with my fixes, but the whole test suite does not execute because of an Surefire error, as soon as I active the tests in pom.xml:

```
!ENTRY org.eclipse.osgi 4 0 2014-06-02 11:34:12.637
!MESSAGE Application error
!STACK 1
java.lang.RuntimeException: Bundle org.eclipse.smarthome.ui.test is not found
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.getBundleClassLoader(OsgiSurefireBooter.java:149)
    at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:67)
    at org.eclipse.tycho.surefire.osgibooter.HeadlessTestApplication.run(HeadlessTestApplication.java:21)
```

Any hints about what is going wrong here? And how I could fix this bundle problem?
