### PR TITLE
Changed config description URI of bridge type definitions to "thing-type://" instead of "bridge-type://".

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/groovy/org/eclipse/smarthome/core/thing/xml/test/ConfigDescriptionsTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/groovy/org/eclipse/smarthome/core/thing/xml/test/ConfigDescriptionsTest.groovy
@@ -11,18 +11,15 @@ import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
-import org.eclipse.smarthome.config.core.ConfigDescription;
-import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
-import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
-import org.eclipse.smarthome.config.core.ConfigDescriptionProvider;
-import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
+import org.eclipse.smarthome.config.core.ConfigDescription
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
+import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type
 import org.eclipse.smarthome.test.OSGiTest
-import org.eclipse.smarthome.test.SyntheticBundleInstaller;
-import org.junit.After;
+import org.eclipse.smarthome.test.SyntheticBundleInstaller
+import org.junit.After
 import org.junit.Before
-import org.junit.Rule;
 import org.junit.Test
-import org.junit.rules.TemporaryFolder
 import org.osgi.framework.Bundle
 
 class ConfigDescriptionsTest extends OSGiTest {
@@ -67,7 +64,7 @@ class ConfigDescriptionsTest extends OSGiTest {
         def configDescriptions = configDescriptionRegistry.getConfigDescriptions()
         assertThat configDescriptions.size(), is(initialNumberOfConfigDescriptions + 2)
         
-        ConfigDescription bridgeConfigDescription = configDescriptions.find { it.uri.equals(new URI("bridge-type://hue:bridge")) }
+        ConfigDescription bridgeConfigDescription = configDescriptions.find { it.uri.equals(new URI("thing-type://hue:bridge")) }
         assertThat bridgeConfigDescription, is(notNullValue())
         
         def parameters = bridgeConfigDescription.parameters

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/AbstractDescriptionTypeConverter.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/AbstractDescriptionTypeConverter.java
@@ -47,7 +47,7 @@ public abstract class AbstractDescriptionTypeConverter<T> extends GenericUnmarsh
      * Creates a new instance of this class with the specified parameter.
      * 
      * @param clazz the class of the result type (must not be null)
-     * @param type the name of the type (e.g. "thing-type", "bridge-type", "channel-type")
+     * @param type the name of the type (e.g. "thing-type", "channel-type")
      */
     public AbstractDescriptionTypeConverter(Class<T> clazz, String type) {
         super(clazz);

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/BridgeTypeConverter.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/BridgeTypeConverter.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 public class BridgeTypeConverter extends ThingTypeConverter {
 
     public BridgeTypeConverter() {
-        super(BridgeTypeXmlResult.class, "bridge-type");
+        super(BridgeTypeXmlResult.class, "thing-type");
     }
 
     @Override


### PR DESCRIPTION
Changed config description URI of bridge type definitions to "thing-type://" instead of "bridge-type://".

Signed-off-by: Dennis Nobel d.nobel@external.telekom.de
