### PR TITLE
Fixed bug in ThingRegistryImpl

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -77,7 +77,7 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing> implements ThingR
 
     @Override
     protected void notifyListenersAboutRemovedElement(Thing element) {
-        super.notifyListenersAboutAddedElement(element);
+        super.notifyListenersAboutRemovedElement(element);
         notifyTrackers(element, ThingTrackerEvent.THING_REMOVED);
     }
 


### PR DESCRIPTION
Fixed bug in ThingRegistryImpl (wrong listener was notified when thing was removed).

Signed-off-by: Dennis Nobel d.nobel@external.telekom.de
