### PR TITLE
Fixed execution time of hue tests

### DIFF
--- a/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
+++ b/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
@@ -234,7 +234,6 @@ public class HueBridgeHandler extends BaseBridgeHandler {
         		bridge = new HueBridge((String) getConfig().get(HOST));
         		bridge.setTimeout(5000);
         	}
-        	pollingRunnable.run();
         	onUpdate();        	
         } else {
             logger.warn("Cannot connect to hue bridge. IP address or user name not set.");
@@ -244,7 +243,7 @@ public class HueBridgeHandler extends BaseBridgeHandler {
     private synchronized void onUpdate() {
     	if (bridge != null) {
 			if (pollingJob == null || pollingJob.isCancelled()) {
-				pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, POLLING_FREQUENCY, POLLING_FREQUENCY, TimeUnit.SECONDS);
+				pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, 1, POLLING_FREQUENCY, TimeUnit.SECONDS);
 			}
     	}
     }
@@ -312,7 +311,6 @@ public class HueBridgeHandler extends BaseBridgeHandler {
         }
         boolean result = lightStatusListeners.add(lightStatusListener);
         if (result) {
-            pollingRunnable.run();
         	onUpdate();
             // inform the listener initially about all lights and their states
             for (FullLight light : lastLightStates.values()) {

--- a/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
+++ b/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
@@ -273,6 +273,9 @@ public class HueLightHandler extends BaseThingHandler implements
             updateState(new ChannelUID(getThing().getUID(),  CHANNEL_COLORTEMPERATURE), percentType);
             
             percentType = LightStateConverter.toBrightnessPercentType(fullLight.getState()); 
+            if (!fullLight.getState().isOn()) {
+            	percentType = new PercentType(0);
+            }
             updateState(new ChannelUID(getThing().getUID(),  CHANNEL_BRIGHTNESS), percentType);
         }
 


### PR DESCRIPTION
Set the brightness to 0 when device is switched off. Fixed the HueBridgeHandler and the associated test to run faster.

Signed-off-by: Andre Fuechsel a.fuechsel@telekom.de
