### PR TITLE
Hue pairing

### DIFF
--- a/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
+++ b/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * @author Dennis Nobel - Initial contribution of hue binding
  * @author Oliver Libutzki
  * @author Kai Kreuzer - improved state handling
- * @author Andre Fuechsel - implemented getFullLights
+ * @author Andre Fuechsel - implemented getFullLights(), startSearch()
  * 
  */
 public class HueBridgeHandler extends BaseBridgeHandler {
@@ -61,7 +61,7 @@ public class HueBridgeHandler extends BaseBridgeHandler {
 
     private static final int POLLING_FREQUENCY = 10; // in seconds
 
-	private static final String DEFAULT_USERNAME = "EclipseSmartHome";
+    private static final String DEFAULT_USERNAME = "EclipseSmartHome";
 
 	private Logger logger = LoggerFactory.getLogger(HueBridgeHandler.class);
 
@@ -158,8 +158,8 @@ public class HueBridgeHandler extends BaseBridgeHandler {
         	}
         }
 
-		private boolean isReachable(String ipAddress) {
-			try {
+        private boolean isReachable(String ipAddress) {
+            try {
 				// note that InetAddress.isReachable is unreliable, see
 				// http://stackoverflow.com/questions/9922543/why-does-inetaddress-isreachable-return-false-when-i-can-ping-the-ip-address
 				// That's why we do an HTTP access instead
@@ -212,9 +212,9 @@ public class HueBridgeHandler extends BaseBridgeHandler {
     @Override
     public void dispose() {
         logger.debug("Handler disposed.");
-        if(pollingJob!=null && !pollingJob.isCancelled()) {
-        	pollingJob.cancel(true);
-        	pollingJob = null;
+        if (pollingJob != null && !pollingJob.isCancelled()) {
+            pollingJob.cancel(true);
+            pollingJob = null;
         }
         if (bridge != null) {
             bridge = null;
@@ -342,6 +342,16 @@ public class HueBridgeHandler extends BaseBridgeHandler {
             }
         }
         return lights;
+    }
+
+    public void startSearch() {
+        if (bridge != null) {
+            try {
+                bridge.startSearch();
+            } catch (IOException | ApiException e) {
+                logger.error("Bridge cannot start search mode", e);
+            }
+        }
     }
 
     private boolean isEqual(State state1, State state2) {

--- a/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -31,17 +31,22 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link HueBridgeServiceTracker} tracks for hue lights which are connected
- * to a paired hue bridge.
+ * to a paired hue bridge. The default search time for hue is 60 seconds. 
+ * 
+ * @author Kai Kreuzer - Initial contribution
+ * @author Andre Fuechsel - changed search timeout
  * 
  */
 public class HueLightDiscoveryService extends AbstractDiscoveryService implements LightStatusListener {
 
     private final static Logger logger = LoggerFactory.getLogger(HueLightDiscoveryService.class);
 
+    private final static int SEARCH_TIME = 60; 
+    
 	private HueBridgeHandler hueBridgeHandler;
 
     public HueLightDiscoveryService(HueBridgeHandler hueBridgeHandler) {
-        super(5);
+        super(SEARCH_TIME);
     	this.hueBridgeHandler = hueBridgeHandler;
     }
 
@@ -59,16 +64,15 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService implement
 	}
 
 	@Override
-	public int getScanTimeout() {
-		return 1;
-	}
-
-	@Override
 	public void startScan() {
 	    List<FullLight> lights = hueBridgeHandler.getFullLights(); 
-        for (FullLight l : lights) {
-            onLightAddedInternal(l);
-        }
+	    if (lights != null) {
+            for (FullLight l : lights) {
+                onLightAddedInternal(l);
+            }
+	    }
+        // search for unpaired lights
+        hueBridgeHandler.startSearch();
 	}
 
 	@Override


### PR DESCRIPTION
HueLightDiscoveryService#startScan calls HueBridge#startSearch to trigger a search for new lights. Tineout of HueLightDiscoveryService set to 60s. 
