### PR TITLE
Made logger of Configuration transient because it will be persisted. 

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -29,7 +29,7 @@ public class Configuration {
 
     final private Map<String, Object> properties;
 
-    private final Logger logger = LoggerFactory.getLogger(Configuration.class);
+    private transient final Logger logger = LoggerFactory.getLogger(Configuration.class);
 
     public Configuration() {
     	this(new HashMap<String, Object>());


### PR DESCRIPTION
Otherwise a StackOverflowExeption would occur because GSON tries to serialize the logger.

Signed-off-by: Andre Fuechsel a.fuechsel@telekom.de
