### PR TITLE
#455434: Bugfix for "Deserialization of entities with GSON does not work in all JVMs"

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
@@ -15,8 +15,17 @@ import java.util.List;
  * {@link ChannelUID} represents a unique identifier for channels.
  * 
  * @author Oliver Libutzki - Initital contribution
+ * @author Jochen Hiller - Bugfix 455434: added default constructor
  */
 public class ChannelUID extends UID {
+
+    /**
+     * Default constructor in package scope only. Will allow to instantiate this
+     * class by reflection. Not intended to be used for normal instantiation.
+     */
+    ChannelUID() {
+        super();
+    }
 
     public ChannelUID(String channelUid) {
         super(channelUid);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingTypeUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingTypeUID.java
@@ -13,8 +13,17 @@ package org.eclipse.smarthome.core.thing;
  * {@link ThingTypeUID} represents a unique identifier for thing types.
  * 
  * @author Dennis Nobel - Initial contribution
+ * @author Jochen Hiller - Bugfix 455434: added default constructor
  */
 public class ThingTypeUID extends UID {
+
+    /**
+     * Default constructor in package scope only. Will allow to instantiate this
+     * class by reflection. Not intended to be used for normal instantiation.
+     */
+    ThingTypeUID() {
+        super();
+    }
 
     public ThingTypeUID(String uid) {
         super(uid);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingUID.java
@@ -16,8 +16,17 @@ import java.util.List;
  * {@link ThingUID} represents a unique identifier for things.
  *  
  * @author Dennis Nobel - Initial contribution
+ * @author Jochen Hiller - Bugfix 455434: added default constructor
  */
 public class ThingUID extends UID {
+
+    /**
+     * Default constructor in package scope only. Will allow to instantiate this
+     * class by reflection. Not intended to be used for normal instantiation.
+     */
+    ThingUID() {
+        super();
+    }
 
     /**
      * Instantiates a new thing UID.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/UID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/UID.java
@@ -16,12 +16,21 @@ import com.google.common.base.Joiner;
  * framework. A UID must always start with a binding ID.
  * 
  * @author Dennis Nobel - Initial contribution
- * @authoer Oliver Libutzki - Added possibility to define UIDs with variable amount of segments
+ * @author Oliver Libutzki - Added possibility to define UIDs with variable amount of segments
+ * @author Jochen Hiller - Bugfix 455434: added default constructor, object is now mutable
  */
 public abstract class UID {
 
     private static final String SEPARATOR = ":";
-    private final String[] segments;
+    private String[] segments;
+
+    /**
+     * Default constructor in package scope only. Will allow to instantiate this
+     * class by reflection. Not intended to be used for normal instantiation. 
+     */
+    UID() {
+        this.segments = null;
+    }
 
     /**
      * Parses a UID for a given string. The UID must be in the format

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLink.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLink.java
@@ -15,12 +15,22 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
  * {@link Channel}.
  * 
  * @author Dennis Nobel - Initial contribution, Added getIDFor method
+ * @author Jochen Hiller - Bugfix 455434: added default constructor, object is now mutable
  */
 public class ItemChannelLink {
 
-    private final String itemName;
+    private String itemName;
 
-    private final ChannelUID channelUID;
+    private ChannelUID channelUID;
+
+    /**
+     * Default constructor in package scope only. Will allow to instantiate this
+     * class by reflection. Not intended to be used for normal instantiation.
+     */
+    ItemChannelLink() {
+        this.itemName = null;
+        this.channelUID = null;
+    }
 
     public ItemChannelLink(String itemName, ChannelUID channelUID) {
         this.itemName = itemName;

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeUID.java
@@ -13,8 +13,17 @@ import org.eclipse.smarthome.core.thing.UID;
  * {@link ChannelTypeUID} represents a unique identifier for channel types.
  * 
  * @author Dennis Nobel - Initial contribution
+ * @author Jochen Hiller - Bugfix 455434: added default constructor
  */
 public class ChannelTypeUID extends UID {
+
+    /**
+     * Default constructor in package scope only. Will allow to instantiate this
+     * class by reflection. Not intended to be used for normal instantiation.
+     */
+    ChannelTypeUID() {
+        super();
+    }
 
     public ChannelTypeUID(String channelUid) {
         super(channelUid);


### PR DESCRIPTION
- added default constructors in package scope
- make final field non-final where necessary

Signed-off-by: Jochen Hiller j.hiller@telekom.de
