### PR TITLE
lifx binding: fix maven warning

### DIFF
--- a/binding/org.eclipse.smarthome.binding.lifx/pom.xml
+++ b/binding/org.eclipse.smarthome.binding.lifx/pom.xml
@@ -4,8 +4,8 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.eclipse.smarthome</groupId>
-    <artifactId>binding</artifactId>
+    <groupId>org.eclipse.smarthome.binding</groupId>
+    <artifactId>pom</artifactId>
     <version>0.8.0-SNAPSHOT</version>
   </parent>
 
@@ -17,7 +17,7 @@
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.lifx</artifactId>
   <version>0.8.0-SNAPSHOT</version>
-  
+
   <name>Eclipse SmartHome LIFX Binding</name>
   <packaging>eclipse-plugin</packaging>
 


### PR DESCRIPTION
The change will remove a warning of maven.
[WARNING]
[WARNING] Some problems were encountered while building the effective
model for
org.eclipse.smarthome.binding:org.eclipse.smarthome.binding.lifx:eclipse-plugin:0.8.0-SNAPSHOT
[WARNING] 'parent.relativePath' points at
org.eclipse.smarthome.binding:pom instead of
org.eclipse.smarthome:binding, please verify your project structure @
line 6, column 11
[WARNING]
[WARNING] It is highly recommended to fix these problems because they
threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support
building such malformed projects.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>