### PR TITLE
fix execution of rules with command trigger

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTriggerManager.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTriggerManager.java
@@ -229,14 +229,18 @@ public class RuleTriggerManager {
 			break;
 		case COMMAND:  
 			if(newType instanceof Command) {
-				Command command = (Command) newType;
-				for(Rule rule : rules) {
-					for(EventTrigger t : rule.getEventtrigger()) {
+				final Command command = (Command) newType;
+				for (Rule rule : rules) {
+					for (final EventTrigger t : rule.getEventtrigger()) {
 						if (t instanceof CommandEventTrigger) {
-							CommandEventTrigger ct = (CommandEventTrigger) t;
-							Command triggerCommand = TypeParser.parseCommand(item.getAcceptedCommandTypes(), ct.getCommand());
-							if(ct.getItem().equals(item.getName()) &&
-									(triggerCommand==null || command.equals(triggerCommand))) {
+							final CommandEventTrigger ct = (CommandEventTrigger) t;
+							if (ct.getItem().equals(item.getName())) {
+								if (ct.getCommand() != null) {
+									final Command triggerCommand = TypeParser.parseCommand(item.getAcceptedCommandTypes(), ct.getCommand());
+									if (!command.equals(triggerCommand)) {
+										continue;
+									}
+								}
 								result.add(rule);
 							}
 						}


### PR DESCRIPTION
If a rule is triggered by a received command without specified command
(e.g. "Item &lt;item> received command", so missing optional argument
[&lt;command>]) the rule is not executed.
If a optional command is given "ct.getCommand()" should differ from "null", if
the optional is missing "ct.getCommand()" should be null.
So fix the logic to find a rule (so it is similar to the logic used for
a state update).

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>