### PR TITLE
channel link item not established on startup

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -70,8 +70,9 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String> implements 
         elementMap.put(provider, items);
         for (Item item : provider.getAll()) {
             try {
-            	onAddElement(item);
-            	items.add(item);
+                onAddElement(item);
+                items.add(item);
+                notifyListenersAboutAddedElement(item);
             } catch(IllegalArgumentException ex) {
             	 logger.warn("Could not add item: " + ex.getMessage(), ex);
             }


### PR DESCRIPTION
Add missing listener notification about added items on all items changed
handler.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=457808
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>