### PR TITLE
fix managed thing provider test for unordered storages

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/factory/ManagedThingProviderOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/factory/ManagedThingProviderOSGiTest.groovy
@@ -98,10 +98,11 @@ class ManagedThingProviderOSGiTest extends OSGiTest {
 		def thing2 = ThingBuilder.create(THING_TYPE_UID, THING2_ID).build()
 		managedThingProvider.add(thing2)
 		things = managedThingProvider.getAll()
+		// Check for exact size and if the collection contains every element.
+		// So, the order of the elements is ignored.
 		assertThat things.size(), is(2)
-		assertThat things.getAt(0), is(thing1)
-		assertThat things.getAt(1), is(thing2)
-		
+		assertTrue things.contains(thing1)
+		assertTrue things.contains(thing2)
 	}
 	
 	@Test(expected=IllegalArgumentException.class)


### PR DESCRIPTION
The documentation of the Storage interface used by a StorageService does
not contain any requirements of the order. So change test to ignore
order of the returned things.
See linked bug entry.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=457918
Signed-off-by: Markus Rathgeb maggu2810@gmail.com
