### PR TITLE
fix all items changed handler

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManager.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
  * The {@link ThingLinkManager} is used by the {@link ThingManager}.
  * 
  * @author Dennis Nobel - Initial contribution
+ * @author Markus Rathgeb - Handle item registry's all items changed notification
  */
 public class ThingLinkManager {
 
@@ -130,7 +131,6 @@ public class ThingLinkManager {
              */
             final Collection<Item> allCurrentItems = itemRegistry.getAll();
             for (final Item item : allCurrentItems) {
-                logger.debug("add item {}", item.getName());
                 added(item);
             }
         }


### PR DESCRIPTION
Implement the all items changed handler of the item registry listener
used in the thing link manager.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=457808
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>