### PR TITLE
add imports used by bundled libs

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
@@ -11,7 +11,12 @@ Import-Package: org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.i18n,
  org.osgi.framework,
  org.osgi.util.tracker,
- org.slf4j
+ org.slf4j,
+ javax.xml.stream,
+ javax.xml.transform,
+ javax.xml.transform.stream,
+ javax.xml.namespace,
+ javax.security.auth
 Bundle-Activator: org.eclipse.smarthome.config.xml.internal.Activator
 Export-Package: com.thoughtworks.xstream,com.thoughtworks.xstream.conv
  erters,com.thoughtworks.xstream.io,org.eclipse.smarthome.config.xml,o


### PR DESCRIPTION
The bundled xstream library is added to the classpath of the config xml
bundle. So the MANIFEST of xstream is not evaluated by OSGi.
So we have to add the imported packages necessary for the used xstream classes
to the import package section of the config xml bundle.
I added some imports, that are currently used on a ESH instance with the
Yahoo Weather binding running.
I do not know, why this is currently working with Equinox, perhaps
caused by this one:
https://wiki.eclipse.org/index.php/Equinox_Boot_Delegation
But this is something that should be fixed.
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>