### PR TITLE
rest: do not bind configuration to bundle

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/RootResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/RootResource.java
@@ -85,7 +85,7 @@ public class RootResource {
     public void activate() {
         Configuration configuration;
         try {
-            configuration = configurationAdmin.getConfiguration(Constants.JAXRS_CONNECTOR_CONFIG);
+            configuration = configurationAdmin.getConfiguration(Constants.JAXRS_CONNECTOR_CONFIG, null);
 
             if (configuration != null) {
                 Dictionary properties = configuration.getProperties();


### PR DESCRIPTION
This PR will unbind the configuration to the rest bundle, so it could used by other ones.
This is done to "fix" the following error message using Felix OSGi framework:
Cannot use configuration com.eclipsesource.jaxrs.connector for [org.osgi.service.cm.ManagedService, id=99, bundle=51/file:base/repo/oh2/com.eclipsesource.jaxrs.publisher_4.1.0.201407131319.jar]: No visibility to configuration bound to file:base/repo/esh/plugins/org.eclipse.smarthome.io.rest_0.8.0.201501261711.jar

Is this okay, or should the error ignored.