### PR TITLE
The script create_binding_skeleton.cmd changed to expect just one arumen...

### DIFF
--- a/binding/create_binding_skeleton.cmd
+++ b/binding/create_binding_skeleton.cmd
@@ -1,4 +1,4 @@
-@echo off
+@ECHO off
 
 
 SETLOCAL
@@ -6,11 +6,28 @@ SET ARGC=0
 
 FOR %%x IN (%*) DO SET /A ARGC+=1
 
-IF %ARGC% NEQ 2 (
-	echo Usage: %0 BindingIdInCamelCase BindingIdInLowerCase
-	exit /B 1
+IF %ARGC% NEQ 1 (
+	ECHO Usage: %0 BindingIdInCamelCase
+	EXIT /B 1
 )
 
-mvn archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding -DarchetypeVersion=0.8.0-SNAPSHOT -DgroupId=org.eclipse.smarthome.binding -DartifactId=org.eclipse.smarthome.binding.%2 -Dpackage=org.eclipse.smarthome.binding.%2 -DarchetypeCatalog='file://../archetype-catalog.xml' -Dversion=0.8.0-SNAPSHOT -DbindingId=%2 -DbindingIdCamelCase=%1
+SET BindingIdInCamelCase=%1
+SET BindingIdInLowerCase=%BindingIdInCamelCase%
+
+CALL :LoCase BindingIdInLowerCase
+
+mvn archetype:generate -N -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding -DarchetypeVersion=0.8.0-SNAPSHOT -DgroupId=org.eclipse.smarthome.binding -DartifactId=org.eclipse.smarthome.binding.%BindingIdInLowerCase% -Dpackage=org.eclipse.smarthome.binding.%BindingIdInLowerCase% -DarchetypeCatalog='file://../archetype-catalog.xml' -Dversion=0.8.0-SNAPSHOT -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase%
+
+SET BindingIdInLowerCase=
+SET BindingIdInCamelCase=
+
+GOTO:EOF
+
+
+:LoCase
+:: Subroutine to convert a variable VALUE to all lower case.
+:: The argument for this subroutine is the variable NAME.
+FOR %%i IN ("A=a" "B=b" "C=c" "D=d" "E=e" "F=f" "G=g" "H=h" "I=i" "J=j" "K=k" "L=l" "M=m" "N=n" "O=o" "P=p" "Q=q" "R=r" "S=s" "T=t" "U=u" "V=v" "W=w" "X=x" "Y=y" "Z=z") DO CALL SET "%1=%%%1:%%~i%%"
+GOTO:EOF
 
 ENDLOCAL


### PR DESCRIPTION
...t: BindingIdInCamelCase.

The argument will be use internaly for creation of BindingIdInLowerCase.

Signed-off-by: YordanDZhelev <zhelev.yordan@gmail.com>