### PR TITLE
Fixed all entries of OSGI-INF/* to be OSGI-INF/*.xml

### DIFF
--- a/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
+++ b/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
@@ -28,7 +28,7 @@ Import-Package: com.google.common.collect,
  org.osgi.service.upnp,
  org.osgi.util.tracker,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.binding.hue,
  org.eclipse.smarthome.binding.hue.handler
 Require-Bundle: com.google.gson

--- a/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
+++ b/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
@@ -17,6 +17,6 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.types,
  org.osgi.service.component,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.binding.lifx,
  org.eclipse.smarthome.binding.lifx.handler

--- a/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
+++ b/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
@@ -20,7 +20,7 @@ Import-Package: com.google.common.collect,
  org.jupnp.model.meta,
  org.jupnp.model.types,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.binding.wemo,
  org.eclipse.smarthome.binding.wemo.handler
 

--- a/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
+++ b/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
@@ -18,6 +18,6 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.binding.yahooweather,org.eclipse
  .smarthome.binding.yahooweather.handler

--- a/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
@@ -18,4 +18,4 @@ Import-Package: com.google.common.collect,
 Export-Package: org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.core.i18n
 Bundle-ActivationPolicy: lazy
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml

--- a/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
@@ -22,6 +22,6 @@ Import-Package: com.google.common.collect,
  org.osgi.service.component,
  org.osgi.util.tracker,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.config.discovery,org.eclipse.sma
  rthome.config.discovery.inbox

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
@@ -11,4 +11,4 @@ Import-Package: org.apache.commons.io;version="2.2.0",
  org.eclipse.smarthome.core.service,
  org.osgi.service.cm;version="1.5.0",
  org.slf4j;version="1.7.2"
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml

--- a/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
@@ -18,6 +18,6 @@ Import-Package: org.apache.commons.lang,
  org.slf4j
 Bundle-SymbolicName: org.eclipse.smarthome.core.autoupdate
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Bundle-ClassPath: .
 Export-Package: org.eclipse.smarthome.core.autoupdate

--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -32,5 +32,5 @@ Export-Package: org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.setup,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.thing.util
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Bundle-Activator: org.eclipse.smarthome.core.thing.internal.Activator

--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Export-Package: org.eclipse.smarthome.core.binding,
  org.eclipse.smarthome.core.service,
  org.eclipse.smarthome.core.storage,
  org.eclipse.smarthome.core.types
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Private-Package: org.eclipse.smarthome.core.internal,org.eclipse.smarthome.core.internal.e
  vents,org.eclipse.smarthome.core.internal.items,org.eclipse.smarthome.core.internal.loggi
  ng

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -35,5 +35,5 @@ Export-Package: org.eclipse.smarthome.io.rest.core.discovery.beans,
  org.eclipse.smarthome.io.rest.core.thing,
  org.eclipse.smarthome.io.rest.core.thing.beans,
  org.eclipse.smarthome.io.rest.core.util
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Import-Package: com.google.common.collect,
  org.osgi.util.tracker,
  org.slf4j
 Bundle-ClassPath: .
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.io.rest
 Bundle-Activator: org.eclipse.smarthome.io.rest.internal.RESTActivator
 

--- a/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
@@ -39,4 +39,4 @@ Import-Package: org.apache.commons.lang,
  org.eclipse.xtext.xbase.lib,
  org.osgi.framework,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml

--- a/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
@@ -49,7 +49,7 @@ Import-Package: com.google.common.collect,
  org.quartz.utils,
  org.slf4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.model.rule,org.eclipse.smarthome
  .model.rule.services,org.eclipse.smarthome.model.rule.rules,org.eclip
  se.smarthome.model.rule.rules.impl,org.eclipse.smarthome.model.rule.r

--- a/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
@@ -46,7 +46,7 @@ Import-Package: com.google.common.base,
  org.quartz.utils,
  org.slf4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.model.script,org.eclipse.smartho
  me.model.script.actions,org.eclipse.smarthome.model.script.engine,org
  .eclipse.smarthome.model.script.formatting,org.eclipse.smarthome.mode

--- a/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
@@ -32,7 +32,7 @@ Import-Package: org.apache.log4j,
  org.eclipse.smarthome.model.item,
  org.eclipse.xtext.xbase.lib,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.smarthome.model.thing,org.eclipse.smarthom
  e.model.thing.services,org.eclipse.smarthome.model.thing.thing,org.ec

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
@@ -15,5 +15,5 @@ Bundle-DocURL: http://www.openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,
  lib/mapdb-1.0.2.jar
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Require-Bundle: com.google.gson;bundle-version="2.2.4"

--- a/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -13,6 +13,6 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.types,
  org.slf4j
-Service-Component: OSGI-INF/*
+Service-Component: OSGI-INF/*.xml
 Export-Package: ${package},
  ${package}.handler


### PR DESCRIPTION
Fixed bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=459608
MANIFEST entry "Service-Component: OSGI-INF/*" will raise warnings in some OSGi frameworks

Signed-off-by: Jochen Hiller <j.hiller@telekom.de>