### PR TITLE
fix thing model and core handling

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
@@ -82,11 +82,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
 				]
 			}
 		}
-		if (things.empty) {
-			thingsMap.remove(modelName)
-		} else {
-			thingsMap.put(modelName, things)
-		}
+		thingsMap.put(modelName, things)
 	}
 
 	def private void createThing(ModelThing modelThing, Bridge parentBridge, Collection<Thing> thingList) {
@@ -327,7 +323,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
 	
 	def updateThings(){
 		thingsMap.keySet.forEach[
-			createThingsFromModel
+			modelChanged(it, org.eclipse.smarthome.model.core.EventType.MODIFIED)
 		]
 	}
 	


### PR DESCRIPTION
If a model for things is added and no thing could be created (e.g. the
factory is missing) the model is not added to the map containing all
thing models.
If a thing handler factory is added the list of things for all models is
processed.
So if a model handles things for a factory, that is not present ATM,
only, the things are not processed later, if the factory has been
registered.

If a factory is added all "known" things are updated. All modified
(added / removed) things must be notfied.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=459648
Signed-off-by: Markus Rathgeb maggu2810@gmail.com
