### PR TITLE
Added OSRAM LED support to Hue binding

### DIFF
--- a/binding/org.eclipse.smarthome.binding.hue/.classpath
+++ b/binding/org.eclipse.smarthome.binding.hue/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry exported="true" kind="lib" path="lib/jue.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Classic_A60_RGBW.xml
+++ b/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Classic_A60_RGBW.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- OSRAM Lightify Classic A60 RGB TunableWhite LED with E27 socket -->
+    <!-- OSRAM Lightify bulb will return as modelid: "Classic A60 RGBW", which will be converted from blanks to "-" -->
+    <thing-type id="Classic_A60_RGBW">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify Classic A60 RGBW LED</label>
+        <description>This is a standard OSRAM Lightify LED bulb with E27 socket as RGB / TunableWhite lamp</description>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="color_temperature" typeId="color_temperature" />
+        </channels>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Surface_Light_TW.xml
+++ b/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/Surface_Light_TW.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- OSRAM Lightify Surface Light Tunable White  -->
+    <!-- OSRAM Lightify bulb will return as modelid: "Surface Light TW", which will be converted from blanks to "-" -->
+    <thing-type id="Surface_Light_TW">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="bridge" />
+        </supported-bridge-type-refs>
+
+        <label>OSRAM Lightify Surface Light Tunable White</label>
+        <description>This is a OSRAM Lightify Surface Light as Tunable White lamp</description>
+
+        <channels>
+            <channel id="color_temperature" typeId="color_temperature" />
+        </channels>
+
+        <config-description>
+            <parameter name="lightId" type="text">
+                <label>Light ID</label>
+                <description>The light identifier identifies one certain hue light.</description>
+                <required>true</required>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/HueBindingConstants.java
+++ b/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/HueBindingConstants.java
@@ -14,6 +14,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author Kai Kreuzer - Initial contribution
+ * @author Jochen Hiller - Added OSRAM Classic A60 RGBW
  */
 public class HueBindingConstants {
 
@@ -34,6 +35,8 @@ public class HueBindingConstants {
     public final static ThingTypeUID THING_TYPE_LST001 = new ThingTypeUID(BINDING_ID, "LST001");
     public final static ThingTypeUID THING_TYPE_LWB004 = new ThingTypeUID(BINDING_ID, "LWB004");
     public final static ThingTypeUID THING_TYPE_LWL001 = new ThingTypeUID(BINDING_ID, "LWL001");
+    public final static ThingTypeUID THING_TYPE_CLASSIC_A60_RGBW = new ThingTypeUID(BINDING_ID, "Classic_A60_RGBW");
+    public final static ThingTypeUID THING_TYPE_SURFACE_LIGHT_TW = new ThingTypeUID(BINDING_ID, "Surface_Light_TW");
     public final static ThingTypeUID THING_TYPE_ZLL_LIGHT = new ThingTypeUID(BINDING_ID, "ZLL_Light");
 
     // List all channels

--- a/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
+++ b/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
@@ -24,6 +24,8 @@ import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_L
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_LST001;
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_LWB004;
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_LWL001;
+import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_CLASSIC_A60_RGBW;
+import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_SURFACE_LIGHT_TW;
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_ZLL_LIGHT;
 
 import java.util.Set;
@@ -62,10 +64,14 @@ import com.google.common.collect.Sets;
  */
 public class HueLightHandler extends BaseThingHandler implements LightStatusListener {
 
-    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Sets.newHashSet(THING_TYPE_LCT001, THING_TYPE_LCT002,
-            THING_TYPE_LCT003, THING_TYPE_LLC001, THING_TYPE_LLC006, THING_TYPE_LLC007, THING_TYPE_LLC010,
-            THING_TYPE_LLC011, THING_TYPE_LLC012, THING_TYPE_LLC013, THING_TYPE_LWL001, THING_TYPE_LST001,
-            THING_TYPE_LCT003, THING_TYPE_LWB004, THING_TYPE_ZLL_LIGHT);
+	public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Sets
+			.newHashSet(THING_TYPE_LCT001, THING_TYPE_LCT002,
+					THING_TYPE_LCT003, THING_TYPE_LLC001, THING_TYPE_LLC006,
+					THING_TYPE_LLC007, THING_TYPE_LLC010, THING_TYPE_LLC011,
+					THING_TYPE_LLC012, THING_TYPE_LLC013, THING_TYPE_LWL001,
+					THING_TYPE_LST001, THING_TYPE_LCT003, THING_TYPE_LWB004,
+					THING_TYPE_CLASSIC_A60_RGBW, THING_TYPE_SURFACE_LIGHT_TW,
+					THING_TYPE_ZLL_LIGHT);
 
     private static final int DIM_STEPSIZE = 30;
 


### PR DESCRIPTION
Added support for 2 OSRAM Lightify LEDs to Philips Hue binding.
* Classic A60 RGBW: supports color, color temperature
* Surface Light TW: supports color temperature only
* also moved src folder to be first classpath entry

Signed-off-by: Jochen Hiller <j.hiller@telekom.de>