### PR TITLE
change line wrapping policy for enum constants

### DIFF
--- a/targetplatform/esh-formatter.xml
+++ b/targetplatform/esh-formatter.xml
@@ -26,7 +26,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
 <setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>


### PR DESCRIPTION
The previous line wrapping policy for enum constants was set to "Do not
wrap" and the force split was unset, too.
This could result in a non-readable code.
With the new setting "Wrap all elements, every element on a new line"
and the activated "force split" every enum value gets its own line.

Here a short example with the old and new setting:

old
```java
public enum DeviceParameter {

    BUTTON_DIM_A("BUTTON_DIM_A", RockerSwitchAction.class), BUTTON_DIM_B("BUTTON_DIM_B", RockerSwitchAction.class), ENERGY_WS(
            "ENERGY_WS", Long.class), HUMIDITY_PERCENT("HUMIDITY_PERCENT", Double.class), ILLUMINATION_LUX(
            "ILLUMINATION_LUX", Double.class), MOTION("MOTION", Boolean.class), OCCUPANCY_BUTTON("OCCUPANCY_BUTTON",
            Boolean.class), POSITION_PERCENT(Integer.class), POWER_W(Long.class), SETPOINT_POSITION_PERCENT(
            Integer.class), SETPOINT_TEMPERATURE_CELSIUS(Double.class), SUPPLY_VOLTAGE_V("SUPPLY_VOLTAGE_V",
            Double.class), SWITCH("SWITCH", Boolean.class), TEMPERATURE_CELSIUS("TEMPERATURE_CELSIUS", Double.class), TEMPERATURE_CONTROL_ENABLE(
            Boolean.class), TEMPERATURE_CONTROL_CUR_TEMP(Double.class), WINDOW_HANDLE_POSITION(
            "WINDOW_HANDLE_POSITION", WindowHandlePosition.class),

    /* temporary workaround to force sending configuration to device */
    TMP_SEND_CONFIGURATION(Boolean.class),
```

new
```java
public enum DeviceParameter {

    BUTTON_DIM_A("BUTTON_DIM_A", RockerSwitchAction.class),
    BUTTON_DIM_B("BUTTON_DIM_B", RockerSwitchAction.class),
    ENERGY_WS("ENERGY_WS", Long.class),
    HUMIDITY_PERCENT("HUMIDITY_PERCENT", Double.class),
    ILLUMINATION_LUX("ILLUMINATION_LUX", Double.class),
    MOTION("MOTION", Boolean.class),
    OCCUPANCY_BUTTON("OCCUPANCY_BUTTON", Boolean.class),
    POSITION_PERCENT(Integer.class),
    POWER_W(Long.class),
    SETPOINT_POSITION_PERCENT(Integer.class),
    SETPOINT_TEMPERATURE_CELSIUS(Double.class),
    SUPPLY_VOLTAGE_V("SUPPLY_VOLTAGE_V", Double.class),
    SWITCH("SWITCH", Boolean.class),
    TEMPERATURE_CELSIUS("TEMPERATURE_CELSIUS", Double.class),
    TEMPERATURE_CONTROL_ENABLE(Boolean.class),
    TEMPERATURE_CONTROL_CUR_TEMP(Double.class),
    WINDOW_HANDLE_POSITION("WINDOW_HANDLE_POSITION", WindowHandlePosition.class),

    /* temporary workaround to force sending configuration to device */
    TMP_SEND_CONFIGURATION(Boolean.class),
```