### PR TITLE
improved lifecycle behaviour in a few points

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManager.java
@@ -163,8 +163,10 @@ public class ThingLinkManager {
 
         @Override
         public void updated(ItemChannelLink oldElement, ItemChannelLink element) {
-            this.removed(oldElement);
-            this.added(element);
+            if(!oldElement.equals(element)) {
+                this.removed(oldElement);
+                this.added(element);
+            }
         }
 
     };

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -242,32 +242,58 @@ abstract public class GenericItem implements ActiveItem {
         }
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        return result;
-    }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        GenericItem other = (GenericItem) obj;
-        if (name == null) {
-            if (other.name != null)
-                return false;
-        } else if (!name.equals(other.name))
-            return false;
-        return true;
-    }
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result
+				+ ((category == null) ? 0 : category.hashCode());
+		result = prime * result + ((label == null) ? 0 : label.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + ((tags == null) ? 0 : tags.hashCode());
+		result = prime * result + ((type == null) ? 0 : type.hashCode());
+		return result;
+	}
 
-    @Override
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		GenericItem other = (GenericItem) obj;
+		if (category == null) {
+			if (other.category != null)
+				return false;
+		} else if (!category.equals(other.category))
+			return false;
+		if (label == null) {
+			if (other.label != null)
+				return false;
+		} else if (!label.equals(other.label))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (tags == null) {
+			if (other.tags != null)
+				return false;
+		} else if (!tags.equals(other.tags))
+			return false;
+		if (type == null) {
+			if (other.type != null)
+				return false;
+		} else if (!type.equals(other.type))
+			return false;
+		return true;
+	}
+
+	@Override
     public Set<String> getTags() {
         return ImmutableSet.copyOf(tags);
     }

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
@@ -109,7 +109,7 @@ public class AutoUpdateGenericBindingConfigProvider implements AutoUpdateBinding
      * {@inheritDoc}
      */
     @Override
-    public void removeConfigurations(String context) {
+    public void startConfigurationUpdate(String context) {
         Set<String> itemNames = contextMap.get(context);
         if (itemNames != null) {
             for (String itemName : itemNames) {
@@ -118,6 +118,10 @@ public class AutoUpdateGenericBindingConfigProvider implements AutoUpdateBinding
             }
             contextMap.remove(context);
         }
+    }
+
+    @Override
+    public void stopConfigurationUpdate(String context) {
     }
 
     protected void addBindingConfig(String itemType, String itemName, AutoUpdateBindingConfig config) {

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/BindingConfigReader.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/BindingConfigReader.java
@@ -52,10 +52,18 @@ public interface BindingConfigReader {
             throws BindingConfigParseException;
 
     /**
-     * Removes all configuration information for a given context. This is usually called if a config file is reloaded,
-     * so that the old values are removed, before the new ones are processed.
+     * Informs the reader that configurations will be processed for a given context. This is usually called if a config
+     * file is reloaded, so that the old values are removed, before the new ones are processed.
      * 
-     * @param context the context of the configurations that should be removed
+     * @param context the context of the configurations that will be processed
      */
-    public void removeConfigurations(String context);
+    public void startConfigurationUpdate(String context);
+
+    /**
+     * Informs the reader that configuration update is completed for a given context. This is usually called after a config
+     * file is reloaded, so that the reader can clean up afterwards.
+     * 
+     * @param context the context of the configurations that were processed
+     */
+    public void stopConfigurationUpdate(String context);
 }

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -147,9 +147,9 @@ public class GenericItemProvider extends AbstractProvider<Item> implements Model
                 return;
             }
 
-            // clear the old binding configuration
+            // start binding configuration processing
             for (BindingConfigReader reader : bindingConfigReaders.values()) {
-                reader.removeConfigurations(modelName);
+                reader.startConfigurationUpdate(modelName);
             }
 
             // create items and read new binding configuration
@@ -159,7 +159,12 @@ public class GenericItemProvider extends AbstractProvider<Item> implements Model
                     internalDispatchBindings(modelName, item, modelItem.getBindings());
                 }
             }
-        }
+
+            // end binding configuration processing
+            for (BindingConfigReader reader : bindingConfigReaders.values()) {
+                reader.stopConfigurationUpdate(modelName);
+            }
+}
     }
 
     private Item createItemFromModelItem(ModelItem modelItem) {
@@ -347,7 +352,7 @@ public class GenericItemProvider extends AbstractProvider<Item> implements Model
                 }
             } else {
                 logger.trace("Couldn't find config reader for binding type '{}' > "
-                        + "parsing binding configuration of Iten '{}' aborted!", bindingType, item);
+                        + "parsing binding configuration of Item '{}' aborted!", bindingType, item);
             }
         }
     }


### PR DESCRIPTION
- when links are added, REFRESH commands are sent by the registry
- ItemRegistryImpl.allItemsChanged now informs downstream listeners about diffs only
- GenericItem.equals and .hashCode now also considers label, category and tags
- BindingConfigReaders get start/stop information on parsing configs for a context

As a result, on a "touch" of an items file, no unnecessary reprocessing is triggered anymore.

Sorry for not implementing additional tests, I was really struggling with that and gave up...

Signed-off-by: Kai Kreuzer <kai@openhab.org>