### PR TITLE
Introduced support for System wide Channel Types that can be used in any

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
@@ -42,6 +42,11 @@
 							<level>4</level>
 							<autoStart>true</autoStart>
 						</bundle>
+						<bundle>
+							<id>org.eclipse.smarthome.core.thing</id>
+							<level>4</level>
+							<autoStart>true</autoStart>
+						</bundle>
 					</bundleStartLevel>
 				</configuration>
 			</plugin>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/groovy/org/eclipse/smarthome/core/thing/xml/test/SystemWideChannelTypesTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/groovy/org/eclipse/smarthome/core/thing/xml/test/SystemWideChannelTypesTest.groovy
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.xml.test
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+import static org.junit.matchers.JUnitMatchers.*
+
+import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider
+import org.eclipse.smarthome.core.thing.type.ChannelType
+import org.eclipse.smarthome.core.thing.type.SystemChannelTypeProvider
+import org.eclipse.smarthome.core.thing.type.ThingType
+import org.eclipse.smarthome.test.OSGiTest
+import org.eclipse.smarthome.test.SyntheticBundleInstaller
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.osgi.framework.Bundle
+import org.osgi.framework.ServiceReference
+
+/**
+ * @author Ivan Iliev - Initial contribution
+ *
+ */
+class SystemWideChannelTypesTest extends OSGiTest {
+
+    static final String SYSTEM_CHANNELS_BUNDLE_NAME = "SystemChannels.bundle"
+
+    static final String SYSTEM_CHANNELS_USER_BUNDLE_NAME = "SystemChannelsUser.bundle"
+
+    static final String SYSTEM_CHANNELS_WITHOUT_THING_TYPES_BUNDLE_NAME = "SystemChannelsNoThingTypes.bundle"
+
+    ThingTypeProvider thingTypeProvider
+
+    @Before
+    void setUp() {
+        thingTypeProvider = getService(ThingTypeProvider)
+        assertThat thingTypeProvider, is(notNullValue())
+    }
+
+    @After
+    void tearDown() {
+        SyntheticBundleInstaller.uninstall(getBundleContext(), SYSTEM_CHANNELS_BUNDLE_NAME)
+        SyntheticBundleInstaller.uninstall(getBundleContext(), SYSTEM_CHANNELS_USER_BUNDLE_NAME)
+        SyntheticBundleInstaller.uninstall(getBundleContext(), SYSTEM_CHANNELS_WITHOUT_THING_TYPES_BUNDLE_NAME)
+    }
+
+    @Test
+    void 'assert that System Channels are loaded and unloaded'() {
+        def bundleContext = getBundleContext()
+        def initialNumberOfThingTypes = thingTypeProvider.getThingTypes(null).size()
+
+        def initialNumberOfChannelTypes = getAllSystemChannelTypes().size()
+
+        // install test bundle
+        Bundle bundle = SyntheticBundleInstaller.install(bundleContext, SYSTEM_CHANNELS_BUNDLE_NAME)
+        assertThat bundle, is(notNullValue())
+
+        def thingTypes = thingTypeProvider.getThingTypes(null)
+        assertThat thingTypes.size(), is(initialNumberOfThingTypes + 1)
+
+        assertThat getAllSystemChannelTypes().size(), is(initialNumberOfChannelTypes + 1)
+
+        // uninstall test bundle
+        bundle.uninstall();
+        assertThat bundle.state, is(Bundle.UNINSTALLED)
+
+        thingTypes = thingTypeProvider.getThingTypes(null)
+        assertThat thingTypes.size(), is(initialNumberOfThingTypes)
+
+        assertThat getAllSystemChannelTypes().size(), is(initialNumberOfChannelTypes)
+
+    }
+
+    @Test
+    void 'assert that System Channels are used by other binding'() {
+        def bundleContext = getBundleContext()
+        def initialNumberOfThingTypes = thingTypeProvider.getThingTypes(null).size()
+        def initialNumberOfChannelTypes = getAllSystemChannelTypes().size()
+
+
+        // install test bundle
+        Bundle sysBundle = SyntheticBundleInstaller.install(bundleContext, SYSTEM_CHANNELS_BUNDLE_NAME)
+        assertThat sysBundle, is(notNullValue())
+
+        Bundle sysUserBundle = SyntheticBundleInstaller.install(bundleContext, SYSTEM_CHANNELS_USER_BUNDLE_NAME)
+        assertThat sysUserBundle, is(notNullValue())
+
+        def thingTypes = thingTypeProvider.getThingTypes(null)
+        assertThat thingTypes.size(), is(initialNumberOfThingTypes + 2)
+
+        assertThat getAllSystemChannelTypes().size(), is(initialNumberOfChannelTypes + 1)
+
+    }
+
+    @Test
+    void 'assert that Thing Types have proper channel definitions'() {
+        def bundleContext = getBundleContext()
+        def initialNumberOfThingTypes = thingTypeProvider.getThingTypes(null).size()
+        def initialNumberOfChannelTypes = getAllSystemChannelTypes().size()
+
+
+        // install test bundle
+        Bundle sysBundle = SyntheticBundleInstaller.install(bundleContext, SYSTEM_CHANNELS_BUNDLE_NAME)
+        assertThat sysBundle, is(notNullValue())
+
+        def thingTypes = thingTypeProvider.getThingTypes(null).findAll{it.getUID().getId().equals("wireless-router") }
+
+        assertThat thingTypes.size(), is(1)
+
+        def channelDefs = thingTypes[0].getChannelDefinitions();
+
+        assertThat channelDefs.size(),is(3)
+
+        def myChannel = channelDefs.findAll {
+            it.id.equals("test") &&
+                    it.getType().UID.getAsString().equals("system:my-channel") }
+
+        def sigStr = channelDefs.findAll {
+            it.id.equals("sigstr") &&
+                    it.getType().UID.getAsString().equals("system:signal-strength") }
+
+        def lowBat = channelDefs.findAll {
+            it.id.equals("lowbat") &&
+                    it.getType().UID.getAsString().equals("system:low-battery") }
+
+
+        assertThat myChannel.size(), is(1)
+        assertThat sigStr.size(), is(1)
+        assertThat lowBat.size(), is(1)
+    }
+
+
+    @Test
+    void 'assert that System Channels are added without thing types'() {
+        def bundleContext = getBundleContext()
+        def initialNumberOfThingTypes = thingTypeProvider.getThingTypes(null).size()
+        def initialNumberOfChannelTypes = getAllSystemChannelTypes().size()
+
+
+        // install test bundle
+        Bundle sysBundle = SyntheticBundleInstaller.install(bundleContext, SYSTEM_CHANNELS_WITHOUT_THING_TYPES_BUNDLE_NAME)
+        assertThat sysBundle, is(notNullValue())
+
+        def thingTypes = thingTypeProvider.getThingTypes(null)
+        assertThat thingTypes.size(), is(initialNumberOfThingTypes)
+
+        assertThat getAllSystemChannelTypes().size(), is(initialNumberOfChannelTypes + 1)
+
+        // uninstall test bundle
+        sysBundle.uninstall();
+        assertThat sysBundle.state, is(Bundle.UNINSTALLED)
+
+        assertThat getAllSystemChannelTypes().size(), is(initialNumberOfChannelTypes)
+
+    }
+
+    @Test
+    void 'assert that i18n is working for system channels'() {
+        def bundleContext = getBundleContext()
+        def initialNumberOfThingTypes = thingTypeProvider.getThingTypes(null).size()
+        def initialNumberOfChannelTypes = getAllSystemChannelTypes().size()
+
+
+        // install test bundle
+        Bundle sysBundle = SyntheticBundleInstaller.install(bundleContext, SYSTEM_CHANNELS_BUNDLE_NAME)
+        assertThat sysBundle, is(notNullValue())
+
+
+        def thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
+        assertThat thingTypes.size(), is(initialNumberOfThingTypes + 1)
+
+        def thingsFiltered = thingTypes.findAll { it.UID.getAsString().equals("SystemChannels:wireless-router") }
+
+        assertThat thingsFiltered.size(), is(1)
+
+        def channelDefs = thingsFiltered[0].getChannelDefinitions();
+
+        def myChannel = channelDefs.findAll {
+            it.id.equals("test") &&
+                    it.getType().UID.getAsString().equals("system:my-channel") }
+
+        def sigStr = channelDefs.findAll {
+            it.id.equals("sigstr") &&
+                    it.getType().UID.getAsString().equals("system:signal-strength") }
+
+
+        assertThat myChannel.size(), is(1)
+        assertThat sigStr.size(), is(1)
+
+        assertThat myChannel[0].getType().getLabel(), is("Mein String My Channel")
+        assertThat myChannel[0].getType().getDescription(), is("Wetterinformation mit My Channel Type Beschreibung")
+
+        assertThat sigStr[0].getType().getLabel(), is("Mein String Signal Strength")
+        assertThat sigStr[0].getType().getDescription(), is("Wetterinformation mit Signal Strength Channel Type Beschreibung")
+    }
+
+    List<ChannelType> getAllSystemChannelTypes() {
+        def bundleContext = getBundleContext()
+
+        List<ChannelType> list = new ArrayList<ChannelType>();
+
+        def allServices = bundleContext.getAllServiceReferences(SystemChannelTypeProvider.class.getName(), null);
+
+        for(ServiceReference ref : allServices) {
+            list.addAll(((SystemChannelTypeProvider)bundleContext.getService(ref)).getSystemChannelTypes());
+        }
+
+
+        return list;
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/binding/binding.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/binding/binding.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 org.eclipse.smarthome.binding.xsd"
+	id="SystemChannels">
+
+	<name>SystemChannels Test Binding</name>
+	<description>Used to test System Wide Channels. Provides definitions of system channels.</description>
+	<author>Deutsche Telekom AG</author>
+	
+</binding:binding>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/i18n/SystemChannels_de.properties
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/i18n/SystemChannels_de.properties
@@ -1,0 +1,7 @@
+channel-type.system.my-channel.label = Mein String My Channel
+channel-type.system.my-channel.description = Wetterinformation mit My Channel Type Beschreibung
+
+channel-type.system.signal-strength.label = Mein String Signal Strength
+channel-type.system.signal-strength.description = Wetterinformation mit Signal Strength Channel Type Beschreibung
+
+

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="SystemChannels"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <!-- YahooWeather Binding -->
+    <thing-type id="wireless-router">
+        <label>Simple wireless router</label>
+        <description>Simple wireless router</description>
+
+		<channels>
+			<channel id="sigstr" typeId="system.signal-strength" />
+			<channel id="test" typeId="system.my-channel" />
+			<channel id="lowbat" typeId="system.low-battery" />
+		</channels>
+
+    </thing-type> 
+    
+    <!-- System Channel Type -->
+	<channel-type id="my-channel" system="true">
+		<item-type>Number</item-type>
+		<label>My Channel</label>
+		<category>Other</category>
+		<tags>
+			<tag>
+				Test
+			</tag>
+		</tags>
+		<config-description>
+			<parameter name="range" type="integer" readOnly="true" min="0"
+				max="4" step="1" />
+		</config-description>
+	</channel-type>
+    
+</thing:thing-descriptions>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
-Bundle-SymbolicName: ThingTypesTest.bundle;singleton:=true
+Bundle-SymbolicName: SystemChannels.bundle;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/ESH-INF/binding/binding.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/ESH-INF/binding/binding.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 org.eclipse.smarthome.binding.xsd"
+	id="SystemChannelsNoThingTypes">
+
+	<name>SystemChannelsNoThingTypes Test Binding</name>
+	<description>Used to test System Wide Channels. Defines system channels
+		without thing types.</description>
+	<author>Deutsche Telekom AG</author>
+
+</binding:binding>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="SystemChannelsNoThingTypes"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+        
+    <!-- System Channel Type -->
+	<channel-type id="my-syschannel" system="true">
+		<item-type>Number</item-type>
+		<label>My System Channel</label>
+		<category>Other</category>
+		<tags>
+			<tag>
+				Test
+			</tag>
+		</tags>
+		<config-description>
+			<parameter name="range" type="integer" readOnly="true" min="0"
+				max="4" step="1" />
+		</config-description>
+	</channel-type>
+</thing:thing-descriptions>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
-Bundle-SymbolicName: ThingTypesTest.bundle;singleton:=true
+Bundle-SymbolicName: SystemChannelsNoThingTypes.bundle;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/ESH-INF/binding/binding.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/ESH-INF/binding/binding.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 org.eclipse.smarthome.binding.xsd"
+	id="SystemChannelsUser">
+
+	<name>SystemChannelsUser Test Binding</name>
+	<description>Used to test System Wide Channels. Consumes System Wide
+		Channels defined by another bundle.</description>
+	<author>Deutsche Telekom AG</author>
+
+</binding:binding>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="SystemChannelsUser"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="wireless-router-v2">
+        <label>Simple wireless router</label>
+        <description>Simple wireless router</description>
+
+		<channels>
+			<channel id="sigstrv2" typeId="system.signal-strength" />
+			<channel id="test" typeId="system.my-channel" />
+			<channel id="lowbat" typeId="system.low-battery" />
+		</channels>
+
+    </thing-type> 
+</thing:thing-descriptions>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
-Bundle-SymbolicName: ThingTypesTest.bundle;singleton:=true
+Bundle-SymbolicName: SystemChannelsUser.bundle;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
 Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.7.0.qualifier
+Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
@@ -20,5 +20,6 @@ Import-Package: com.thoughtworks.xstream,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
+ org.osgi.util.tracker,
  org.slf4j
 Bundle-Activator: org.eclipse.smarthome.core.thing.xml.internal.Activator

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/AbstractDescriptionTypeConverter.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/AbstractDescriptionTypeConverter.java
@@ -29,20 +29,20 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
  * definition information within an XML document into a concrete type object.
  * <p>
  * This class should be used for each type definition which inherits from the {@link AbstractDescriptionType} class.
- *
+ * 
  * @param <T> the result type of the conversion
- *
+ * 
  * @author Michael Grammling - Initial Contribution
  */
 public abstract class AbstractDescriptionTypeConverter<T> extends GenericUnmarshaller<T> {
 
     protected ConverterAttributeMapValidator attributeMapValidator;
 
-    private String type;
+    private final String type;
 
     /**
      * Creates a new instance of this class with the specified parameter.
-     *
+     * 
      * @param clazz the class of the result type (must not be null)
      * @param type the name of the type (e.g. "thing-type", "channel-type")
      */
@@ -56,7 +56,7 @@ public abstract class AbstractDescriptionTypeConverter<T> extends GenericUnmarsh
 
     /**
      * Returns the {@code id} attribute of the specific XML type definition.
-     *
+     * 
      * @param attributes the attributes where to extract the ID information (must not be null)
      * @return the ID of the type definition (neither null, nor empty)
      */
@@ -66,10 +66,10 @@ public abstract class AbstractDescriptionTypeConverter<T> extends GenericUnmarsh
 
     /**
      * Returns the full extracted UID of the specific XML type definition.
-     *
+     * 
      * @param attributes the attributes where to extract the ID information (must not be null)
      * @param context the context where to extract the binding ID information (must not be null)
-     *
+     * 
      * @return the UID of the type definition (neither null, nor empty)
      */
     protected String getUID(Map<String, String> attributes, UnmarshallingContext context) {
@@ -83,7 +83,7 @@ public abstract class AbstractDescriptionTypeConverter<T> extends GenericUnmarsh
 
     /**
      * Returns the value of the {@code label} tag from the specific XML type definition.
-     *
+     * 
      * @param nodeIterator the iterator to be used to extract the information (must not be null)
      * @return the value of the label (neither null, nor empty)
      * @throws ConversionException if the label could not be read
@@ -94,7 +94,7 @@ public abstract class AbstractDescriptionTypeConverter<T> extends GenericUnmarsh
 
     /**
      * Returns the value of the {@code description} tag from the specific XML type definition.
-     *
+     * 
      * @param nodeIterator the iterator to be used to extract the information (must not be null)
      * @return the value of the description (could be null or empty)
      */
@@ -155,19 +155,19 @@ public abstract class AbstractDescriptionTypeConverter<T> extends GenericUnmarsh
 
     /**
      * The abstract unmarshal method which must be implemented by the according type converter.
-     *
+     * 
      * @param reader the reader to be used to read XML information from a stream (not null)
-     *
+     * 
      * @param context the context to be used for the XML document conversion (not null)
-     *
+     * 
      * @param attributes the attributes map containing attributes of the type - only UID -
      *            (not null, could be empty)
-     *
+     * 
      * @param nodeIterator the iterator to be used to simply extract information in the right
      *            order and appearance from the XML stream
-     *
+     * 
      * @return the concrete type definition object (could be null)
-     *
+     * 
      * @throws ConversionException if any conversion error occurs
      */
     protected abstract T unmarshalType(HierarchicalStreamReader reader, UnmarshallingContext context,

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelTypeConverter.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelTypeConverter.java
@@ -33,8 +33,9 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
  * <p>
  * This converter converts {@code channel-type} XML tags. It uses the {@link AbstractDescriptionTypeConverter} which
  * offers base functionality for each type definition.
- *
+ * 
  * @author Michael Grammling - Initial Contribution
+ * @author Ivan Iliev - Added support for system wide channel types
  */
 public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<ChannelTypeXmlResult> {
 
@@ -42,11 +43,11 @@ public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<Chann
         super(ChannelTypeXmlResult.class, "channel-type");
 
         super.attributeMapValidator = new ConverterAttributeMapValidator(new String[][] { { "id", "true" },
-                { "advanced", "false" } });
+                { "advanced", "false" }, { "system", "false" } });
     }
 
-    private boolean isAdvanced(Map<String, String> attributes, boolean defaultValue) {
-        String advancedFlag = attributes.get("advanced");
+    private boolean readBoolean(Map<String, String> attributes, String attributeName, boolean defaultValue) {
+        String advancedFlag = attributes.get(attributeName);
 
         if (advancedFlag != null) {
             return Boolean.parseBoolean(advancedFlag);
@@ -107,8 +108,11 @@ public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<Chann
     protected ChannelTypeXmlResult unmarshalType(HierarchicalStreamReader reader, UnmarshallingContext context,
             Map<String, String> attributes, NodeIterator nodeIterator) throws ConversionException {
 
-        ChannelTypeUID channelTypeUID = new ChannelTypeUID(super.getUID(attributes, context));
-        boolean advanced = isAdvanced(attributes, false);
+        boolean advanced = readBoolean(attributes, "advanced", false);
+        boolean system = readBoolean(attributes, "system", false);
+
+        String uid = system ? XmlHelper.getSystemUID(super.getID(attributes)) : super.getUID(attributes, context);
+        ChannelTypeUID channelTypeUID = new ChannelTypeUID(uid);
 
         String itemType = readItemType(nodeIterator);
         String label = super.readLabel(nodeIterator);
@@ -124,7 +128,7 @@ public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<Chann
                 tags, stateDescription, (URI) configDescriptionObjects[0]);
 
         ChannelTypeXmlResult channelTypeXmlResult = new ChannelTypeXmlResult(channelType,
-                (ConfigDescription) configDescriptionObjects[1]);
+                (ConfigDescription) configDescriptionObjects[1], system);
 
         return channelTypeXmlResult;
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelTypeXmlResult.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelTypeXmlResult.java
@@ -16,17 +16,24 @@ import org.eclipse.smarthome.core.thing.type.ChannelType;
  * contains a {@link ChannelType} object.
  * <p>
  * If a {@link ConfigDescription} object exists, it must be added to the according {@link ConfigDescriptionProvider}.
- *
+ * 
  * @author Michael Grammling - Initial Contribution
+ * @author Ivan Iliev - Added support for system wide channel types
  */
 public class ChannelTypeXmlResult {
 
     private ChannelType channelType;
     private ConfigDescription configDescription;
+    private boolean system;
 
     public ChannelTypeXmlResult(ChannelType channelType, ConfigDescription configDescription) {
+        this(channelType, configDescription, false);
+    }
+
+    public ChannelTypeXmlResult(ChannelType channelType, ConfigDescription configDescription, boolean system) {
         this.channelType = channelType;
         this.configDescription = configDescription;
+        this.system = system;
     }
 
     public ChannelType getChannelType() {
@@ -35,6 +42,10 @@ public class ChannelTypeXmlResult {
 
     public ConfigDescription getConfigDescription() {
         return this.configDescription;
+    }
+
+    public boolean isSystem() {
+        return system;
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlResult.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlResult.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.SystemChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 
 import com.thoughtworks.xstream.converters.ConversionException;
@@ -29,8 +30,9 @@ import com.thoughtworks.xstream.converters.ConversionException;
  * contains all fields needed to create a concrete {@link ThingType} object.
  * <p>
  * If a {@link ConfigDescription} object exists, it must be added to the according {@link ConfigDescriptionProvider}.
- *
+ * 
  * @author Michael Grammling - Initial Contribution
+ * @author Ivan Iliev - Added support for system wide channel types
  */
 public class ThingTypeXmlResult {
 
@@ -74,6 +76,11 @@ public class ThingTypeXmlResult {
                     String typeId = channelTypeReference.getAttribute("typeId");
 
                     String typeUID = String.format("%s:%s", this.thingTypeUID.getBindingId(), typeId);
+
+                    int systemPrefixIdx = typeId.indexOf(SystemChannelTypeProvider.NAMESPACE_PREFIX);
+                    if (systemPrefixIdx != -1) {
+                        typeUID = XmlHelper.getSystemUID(typeId);
+                    }
 
                     ChannelType channelType = channelTypes.get(typeUID);
                     if (channelType != null) {

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlHelper.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.xml.internal;
+
+import org.eclipse.smarthome.core.thing.type.SystemChannelTypeProvider;
+
+/**
+ * Utility class containing helper methods to be used in XML generation.
+ * 
+ * @author Ivan Iliev - Initial contribution
+ * 
+ */
+public class XmlHelper {
+
+    /**
+     * Returns a UID in the format of {1}:{2}, where {1} is {@link SystemChannelTypeProvider #NAMESPACE} and {2} is the
+     * given typeId stripped of the prefix {@link SystemChannelTypeProvider #NAMESPACE_PREFIX} if it exists.
+     * 
+     * @param typeId
+     * @return system uid (e.g. "system:test")
+     */
+    public static String getSystemUID(String typeId) {
+        int prefixIdx = typeId.indexOf(SystemChannelTypeProvider.NAMESPACE_PREFIX);
+
+        if (prefixIdx != -1) {
+            typeId = typeId.substring(prefixIdx + SystemChannelTypeProvider.NAMESPACE_PREFIX.length());
+        }
+
+        return String.format("%s:%s", SystemChannelTypeProvider.NAMESPACE, typeId);
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlSystemChannelTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlSystemChannelTypeProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.xml.internal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.SystemChannelTypeProvider;
+
+/**
+ * Contributes all {@link SystemChannelTypeProvider}s that are found while
+ * parsing bundle XMLs.
+ * 
+ * @author Ivan Iliev - Initial contribution
+ * 
+ */
+public class XmlSystemChannelTypeProvider implements SystemChannelTypeProvider {
+
+    private List<ChannelType> channelTypes = new CopyOnWriteArrayList<>();
+
+    @Override
+    public Collection<ChannelType> getSystemChannelTypes() {
+        return Collections.unmodifiableCollection(channelTypes);
+    }
+
+    public void addChannelType(ChannelType type) {
+        channelTypes.add(type);
+    }
+
+    public boolean removeChannelType(ChannelType type) {
+        return channelTypes.remove(type);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlThingTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlThingTypeProvider.java
@@ -28,19 +28,22 @@ import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.thing.type.SystemChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
 import org.osgi.framework.Bundle;
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * The {@link XmlThingTypeProvider} is a concrete implementation of the {@link ThingTypeProvider} service interface.
  * <p>
  * This implementation manages any {@link ThingType} objects associated to specific modules. If a specific module
  * disappears, any registered {@link ThingType} objects associated with that module are released.
- *
+ * 
  * @author Michael Grammling - Initial Contribution
  * @author Dennis Nobel - Added locale support
+ * @author Ivan Iliev - Added support for system wide channel types
  */
 public class XmlThingTypeProvider implements ThingTypeProvider {
 
@@ -48,8 +51,15 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
 
     private ThingTypeI18nUtil thingTypeI18nUtil;
 
-    public XmlThingTypeProvider() {
+    private ServiceTracker<SystemChannelTypeProvider, SystemChannelTypeProvider> serviceTracker;
+
+    private XmlSystemChannelTypeProvider xmlSystemChannelTypeProvider;
+
+    public XmlThingTypeProvider(ServiceTracker<SystemChannelTypeProvider, SystemChannelTypeProvider> serviceTracker,
+            XmlSystemChannelTypeProvider xmlSystemChannelTypeProvider) {
         this.bundleThingTypesMap = new HashMap<>(10);
+        this.serviceTracker = serviceTracker;
+        this.xmlSystemChannelTypeProvider = xmlSystemChannelTypeProvider;
     }
 
     private List<ThingType> acquireThingTypes(Bundle bundle) {
@@ -73,9 +83,11 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
      * specified module.
      * <p>
      * This method returns silently, if any of the parameters is {@code null}.
-     *
-     * @param bundle the module to which the Thing type to be added
-     * @param thingType the Thing type to be added
+     * 
+     * @param bundle
+     *            the module to which the Thing type to be added
+     * @param thingType
+     *            the Thing type to be added
      */
     public synchronized void addThingType(Bundle bundle, ThingType thingType) {
         if (thingType != null) {
@@ -241,7 +253,7 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
      * with the specified module.
      * <p>
      * This method returns silently if the module is {@code null}.
-     *
+     * 
      * @param bundle
      *            the module for which all associated Thing types to be removed
      */
@@ -255,6 +267,27 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
         }
     }
 
+    public void addXmlSystemChannelType(ChannelType type) {
+        xmlSystemChannelTypeProvider.addChannelType(type);
+    }
+
+    public boolean removeXmlSystemChannelType(ChannelType type) {
+        return xmlSystemChannelTypeProvider.removeChannelType(type);
+    }
+
+    public List<ChannelType> getAllSystemChannelTypes() {
+
+        List<ChannelType> channelTypes = new ArrayList<ChannelType>();
+
+        Object[] providers = serviceTracker.getServices();
+
+        for (Object provider : providers) {
+            channelTypes.addAll(((SystemChannelTypeProvider) provider).getSystemChannelTypes());
+        }
+
+        return channelTypes;
+    }
+
     @Bind
     public void setI18nProvider(I18nProvider i18nProvider) {
         this.thingTypeI18nUtil = new ThingTypeI18nUtil(i18nProvider);
@@ -264,5 +297,4 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
     public void unsetI18nProvider(I18nProvider i18nProvider) {
         this.thingTypeI18nUtil = null;
     }
-
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/thing-description-1.0.0.xsd
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/thing-description-1.0.0.xsd
@@ -57,6 +57,7 @@
         </xs:sequence>
         <xs:attribute name="id" type="config-description:idRestrictionPattern" use="required"/>
         <xs:attribute name="advanced" type="xs:boolean" default="false" use="optional"/>
+        <xs:attribute name="system" type="xs:boolean" default="false" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="channelGroupType">
@@ -85,9 +86,15 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:simpleType name="namespaceIdRestrictionPattern">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Za-z0-9\-_.]+" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:complexType name="channel">
         <xs:attribute name="id" type="config-description:idRestrictionPattern" use="required"/>
-        <xs:attribute name="typeId" type="config-description:idRestrictionPattern" use="required"/>
+        <xs:attribute name="typeId" type="thing-description:namespaceIdRestrictionPattern" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="channelGroups">

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/DefaultSystemChannelTypeProvider.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/DefaultSystemChannelTypeProvider.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.core.thing.internal.SystemChannelTypeProviderImpl">
+   <implementation class="org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.core.thing.type.SystemChannelTypeProvider"/>
+   </service>
+</scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+import org.eclipse.smarthome.core.thing.type.SystemChannelTypeProvider;
+
+/**
+ * Implementation providing default system wide channel types
+ * 
+ * @author Ivan Iliev - Initial Contribution
+ * 
+ */
+public class DefaultSystemChannelTypeProvider implements SystemChannelTypeProvider {
+
+    /**
+     * Signal strength default system wide {@link ChannelType}. Represents signal strength of a device as a number
+     * with values 0, 1, 2, 3 or 4, 0 being worst strength and 4 being best strength.
+     */
+    public static final ChannelType SYSTEM_CHANNEL_SIGNAL_STRENGTH = new ChannelType(new ChannelTypeUID(
+            "system:signal-strength"), false, "Number", "Signal Strength", null, "QualityOfService", null, null, null);
+
+    /**
+     * Low battery default system wide {@link ChannelType}. Represents a low battery warning with possible values
+     * on/off.
+     */
+    public static final ChannelType SYSTEM_CHANNEL_LOW_BATTERY = new ChannelType(new ChannelTypeUID(
+            "system:low-battery"), false, "Switch", "Low Battery", null, "Battery", null, null, null);
+
+    private final Collection<ChannelType> channelTypes;
+
+    public DefaultSystemChannelTypeProvider() {
+        this.channelTypes = Collections.unmodifiableCollection(Arrays.asList(new ChannelType[] {
+                SYSTEM_CHANNEL_SIGNAL_STRENGTH, SYSTEM_CHANNEL_LOW_BATTERY }));
+
+    }
+
+    @Override
+    public Collection<ChannelType> getSystemChannelTypes() {
+        return this.channelTypes;
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/SystemChannelTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/SystemChannelTypeProvider.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.type;
+
+import java.util.Collection;
+
+/**
+ * A service responsible for providing systemwide {@link ChannelType}s.
+ * 
+ * @author Ivan Iliev - Initial contribution
+ * 
+ */
+public interface SystemChannelTypeProvider {
+
+    public static final String NAMESPACE_PREFIX = "system.";
+
+    public static final String NAMESPACE = "system";
+
+    /**
+     * Returns all System wide channel types.
+     * 
+     * @return
+     */
+    public Collection<ChannelType> getSystemChannelTypes();
+
+}

--- a/docs/sources/architecture/thing-definition.md
+++ b/docs/sources/architecture/thing-definition.md
@@ -44,6 +44,33 @@ The following XML snippet shows a thing type definition with 2 channels and one 
 </channel-type>
 ```
 
+In order to reuse identical channels in different bindings a channeltype can be systemwide. A channel-type can be declared as systemwide by setting its `system` property to true and can then be referenced using a `system.` prefix in a `channel` `typeId` attribute in any binding.  
+
+The following XML snippet shows a system channel-type definition and thing-type definition that references it:
+
+```xml 
+<thing-type id="thingTypeID">
+    <label>Sample Thing</label>
+    <description>Some sample description</description>
+    <channels>
+      <channel id="s" typeId="system.system-channel" />
+    </channels>
+</thing-type>
+<channel-type id="system-channel" system="true">
+    <item-type>Number</item-type>
+    <label>System Channel</label>
+    <category>QualityOfService</category>
+</channel-type>
+```
+
+There exist systemwide channels that are available by default:
+
+| Channel Type ID | Reference typeId       | Item Type    | Category         | Description  |
+|-----------------|------------------------|--------------|----------------- |------------- |
+| signal-strength | system.signal-strength | Number       | QualityOfService | Represents signal strength of a device as a Number with values 0, 1, 2, 3 or 4; 0 being worst strength and 4 being best strength.  |
+| low-battery     | system.low-battery     | Switch       | Battery          | Represents a low battery warning with possible values on/off |
+
+
 The `advanced` property indicates whether this channel is a basic or a more specific functionality of the thing. If `advanced` is set to `true` a user interface may hide this channel by default. The default value is `false` and thus will be taken if the `advanced` attribute is not specified. Especially for complex devices with a lot of channels, only a small set of channels - the most important ones - should be shown to the user to reduce complexity. Whether a channel should be declared as `advanced` depends on the device and can be decided by the binding developer. If a functionality is rarely used it should be better marked as `advanced`.
 
 In the following sections the declaration and semantics of tags, state descriptions and channel categories will be explained in more detail. For a complete sample of the thing types XML file and a full list of possible configuration options please see the [XML Configuration Guide](configuration.md).
@@ -109,6 +136,7 @@ The channel type definition allows to specify a category. Together with the defi
 | Player        | RW              | Player                 |
 | PowerOutlet   | RW              | Switch                 |
 | Pressure      | R               | Number                 |
+| QualityOfService      | R       | Number                 |
 | Rain          | R               | Switch, Number         |
 | Recorder      | RW              | String                 |
 | Smoke         | R               | Switch                 |


### PR DESCRIPTION
binding. There are default system channel types and every binding can
define its own through XML.

Signed-off-by: IVAN GEORGIEV ILIEV <ivan.iliev@musala.com>