### PR TITLE
mqtt transport: fix reconnect and improve producer handling

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttConnectionObserver.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttConnectionObserver.java
@@ -1,0 +1,29 @@
+/**
+w * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.transport.mqtt;
+
+/**
+ * All MQTT connection observers which want to register as a connection observer to a MqttBrokerConnection should
+ * implement this interface.
+ *
+ * @author Markus Rathgeb - Initial contribution and API
+ */
+
+public interface MqttConnectionObserver {
+
+    /**
+     * Inform the observer if the connection is active or disconnected.
+     *
+     * This callback is called after a observer is registered to a MqttBrokerConnection or if the connection state
+     * changed.
+     *
+     * @param connected true if the connection is established, false if disconnected.
+     */
+    public void setConnected(boolean connected);
+
+}

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageConsumer.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageConsumer.java
@@ -10,8 +10,8 @@ package org.eclipse.smarthome.io.transport.mqtt;
 import org.eclipse.smarthome.core.events.EventPublisher;
 
 /**
- * All message consumers which want to register as a message consumer to a
- * MqttBrokerConnection should implement this interface.
+ * All message consumers which want to register as a message consumer to a MqttBrokerConnection should implement this
+ * interface.
  *
  * @author Davy Vanherbergen
  */
@@ -20,10 +20,8 @@ public interface MqttMessageConsumer {
     /**
      * Process a received MQTT message.
      *
-     * @param topic
-     *            The mqtt topic on which the message was received.
-     * @param payload
-     *            content of the message.
+     * @param topic The mqtt topic on which the message was received.
+     * @param payload content of the message.
      */
     public void processMessage(String topic, byte[] payload);
 
@@ -35,14 +33,12 @@ public interface MqttMessageConsumer {
     /**
      * Set Topic to subscribe to. May contain + or # wildcards
      *
-     * @param topic
-     *            to subscribe to.
+     * @param topic to subscribe to.
      */
     public void setTopic(String topic);
 
     /**
-     * Set the event publisher to use when broadcasting received messages onto
-     * the smarthome event bus.
+     * Set the event publisher to use when broadcasting received messages onto the smarthome event bus.
      *
      * @param eventPublisher
      */

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageConsumer.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageConsumer.java
@@ -19,7 +19,7 @@ public interface MqttMessageConsumer {
 
     /**
      * Process a received MQTT message.
-     * 
+     *
      * @param topic
      *            The mqtt topic on which the message was received.
      * @param payload
@@ -34,7 +34,7 @@ public interface MqttMessageConsumer {
 
     /**
      * Set Topic to subscribe to. May contain + or # wildcards
-     * 
+     *
      * @param topic
      *            to subscribe to.
      */
@@ -43,7 +43,7 @@ public interface MqttMessageConsumer {
     /**
      * Set the event publisher to use when broadcasting received messages onto
      * the smarthome event bus.
-     * 
+     *
      * @param eventPublisher
      */
     public void setEventPublisher(EventPublisher eventPublisher);

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageProducer.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageProducer.java
@@ -21,4 +21,5 @@ public interface MqttMessageProducer {
      * @param channel Sender Channel which will be set by the MqttBrokerConnection.
      */
     public void setSenderChannel(MqttSenderChannel channel);
+
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageProducer.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageProducer.java
@@ -8,19 +8,17 @@
 package org.eclipse.smarthome.io.transport.mqtt;
 
 /**
- * All message producers which want to register as a message producer to a
- * MqttBrokerConnection should implement this interface.
+ * All message producers which want to register as a message producer to a MqttBrokerConnection should implement this
+ * interface.
  *
  * @author Davy Vanherbergen
  */
 public interface MqttMessageProducer {
 
     /**
-     * Set the sender channel which the message producer should use to publish
-     * any message.
+     * Set the sender channel which the message producer should use to publish any message.
      *
-     * @param channel
-     *            Sender Channel which will be set by the MqttBrokerConnection.
+     * @param channel Sender Channel which will be set by the MqttBrokerConnection.
      */
     public void setSenderChannel(MqttSenderChannel channel);
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageProducer.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttMessageProducer.java
@@ -18,7 +18,7 @@ public interface MqttMessageProducer {
     /**
      * Set the sender channel which the message producer should use to publish
      * any message.
-     * 
+     *
      * @param channel
      *            Sender Channel which will be set by the MqttBrokerConnection.
      */

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttSenderChannel.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttSenderChannel.java
@@ -16,7 +16,7 @@ public interface MqttSenderChannel {
 
     /**
      * Send a message to the MQTT broker.
-     * 
+     *
      * @param topic
      *            Topic to publish the message to.
      * @param message

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttSenderChannel.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttSenderChannel.java
@@ -17,12 +17,9 @@ public interface MqttSenderChannel {
     /**
      * Send a message to the MQTT broker.
      *
-     * @param topic
-     *            Topic to publish the message to.
-     * @param message
-     *            message payload.
-     * @throws Exception
-     *             if an error occurs during sending.
+     * @param topic Topic to publish the message to.
+     * @param message message payload.
+     * @throws Exception if an error occurs during sending.
      */
     public void publish(String topic, byte[] message) throws Exception;
 

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
@@ -136,7 +136,7 @@ public class MqttService implements ManagedService {
 
     /**
      * Lookup an broker connection by name.
-     * 
+     *
      * @param brokerName
      *            to look for.
      * @return existing connection or new one if it didn't exist yet.
@@ -153,7 +153,7 @@ public class MqttService implements ManagedService {
 
     /**
      * Register a new message consumer which can process messages received on
-     * 
+     *
      * @param brokerName
      *            Name of the broker on which to listen for messages.
      * @param mqttMessageConsumer
@@ -167,7 +167,7 @@ public class MqttService implements ManagedService {
 
     /**
      * Unregisters an existing message.
-     * 
+     *
      * @param mqttMessageConsumer
      *            Consumer which needs to be unregistered.
      */
@@ -184,7 +184,7 @@ public class MqttService implements ManagedService {
     /**
      * Register a new message producer which can send messages to the given
      * broker.
-     * 
+     *
      * @param brokerName
      *            Name of the broker to which messages can be sent.
      * @param mqttMessageProducer
@@ -197,7 +197,7 @@ public class MqttService implements ManagedService {
 
     /**
      * Set the publisher to use for publishing SmartHome updates.
-     * 
+     *
      * @param eventPublisher
      *            EventPublisher
      */
@@ -207,7 +207,7 @@ public class MqttService implements ManagedService {
 
     /**
      * Remove the publisher to use for publishing SmartHome updates.
-     * 
+     *
      * @param eventPublisher
      *            EventPublisher
      */

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
@@ -105,6 +105,7 @@ public class MqttService implements ManagedService {
             try {
                 con.start();
             } catch (Exception e) {
+                con.connectionLost(e);
                 logger.error("Error starting broker connection", e);
             }
         }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
@@ -150,6 +150,26 @@ public class MqttService implements ManagedService {
     }
 
     /**
+     * Register a new connection observer that could act on MQTT connection changes.
+     *
+     * @param brokerName Name of the broker that connection should be observed.
+     * @param connectionObserver The connection observer that should be informed about connection changes.
+     */
+    public void registerConnectionObserver(String brokerName, MqttConnectionObserver connectionObserver) {
+        getConnection(brokerName).addConnectionObserver(connectionObserver);
+    }
+
+    /**
+     * Unregister an existing connection observer.
+     *
+     * @param brokerName Name of the broker that connection has been observed.
+     * @param connectionObserver The connection observer that should not be informed anymore.
+     */
+    public void unregisterConnectionObserver(String brokerName, MqttConnectionObserver connectionObserver) {
+        getConnection(brokerName).removeConnectionObserver(connectionObserver);
+    }
+
+    /**
      * Register a new message consumer which can process messages received on
      *
      * @param brokerName Name of the broker on which to listen for messages.

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
@@ -20,9 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * MQTT Service for creating new connections to MQTT brokers from the Smart Home
- * configuration file and registering message publishers and subscribers. This
- * service is the main entry point for all bundles wanting to use the MQTT
+ * MQTT Service for creating new connections to MQTT brokers from the Smart Home configuration file and registering
+ * message publishers and subscribers. This service is the main entry point for all bundles wanting to use the MQTT
  * transport.
  *
  * @author Davy Vanherbergen
@@ -137,8 +136,7 @@ public class MqttService implements ManagedService {
     /**
      * Lookup an broker connection by name.
      *
-     * @param brokerName
-     *            to look for.
+     * @param brokerName to look for.
      * @return existing connection or new one if it didn't exist yet.
      */
     private synchronized MqttBrokerConnection getConnection(String brokerName) {
@@ -154,10 +152,8 @@ public class MqttService implements ManagedService {
     /**
      * Register a new message consumer which can process messages received on
      *
-     * @param brokerName
-     *            Name of the broker on which to listen for messages.
-     * @param mqttMessageConsumer
-     *            Consumer which will process any received message.
+     * @param brokerName Name of the broker on which to listen for messages.
+     * @param mqttMessageConsumer Consumer which will process any received message.
      */
     public void registerMessageConsumer(String brokerName, MqttMessageConsumer mqttMessageConsumer) {
 
@@ -168,8 +164,7 @@ public class MqttService implements ManagedService {
     /**
      * Unregisters an existing message.
      *
-     * @param mqttMessageConsumer
-     *            Consumer which needs to be unregistered.
+     * @param mqttMessageConsumer Consumer which needs to be unregistered.
      */
     public void unregisterMessageConsumer(String brokerName, MqttMessageConsumer mqttMessageConsumer) {
 
@@ -185,10 +180,8 @@ public class MqttService implements ManagedService {
      * Register a new message producer which can send messages to the given
      * broker.
      *
-     * @param brokerName
-     *            Name of the broker to which messages can be sent.
-     * @param mqttMessageProducer
-     *            Producer which generates the messages.
+     * @param brokerName Name of the broker to which messages can be sent.
+     * @param mqttMessageProducer Producer which generates the messages.
      */
     public void unregisterMessageProducer(String brokerName, MqttMessageProducer commandPublisher) {
 
@@ -198,8 +191,7 @@ public class MqttService implements ManagedService {
     /**
      * Set the publisher to use for publishing SmartHome updates.
      *
-     * @param eventPublisher
-     *            EventPublisher
+     * @param eventPublisher EventPublisher
      */
     public void setEventPublisher(EventPublisher eventPublisher) {
         this.eventPublisher = eventPublisher;
@@ -208,8 +200,7 @@ public class MqttService implements ManagedService {
     /**
      * Remove the publisher to use for publishing SmartHome updates.
      *
-     * @param eventPublisher
-     *            EventPublisher
+     * @param eventPublisher EventPublisher
      */
     public void unsetEventPublisher(EventPublisher eventPublisher) {
         this.eventPublisher = null;

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttWillAndTestament.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttWillAndTestament.java
@@ -10,8 +10,7 @@ package org.eclipse.smarthome.io.transport.mqtt;
 import org.apache.commons.lang.StringUtils;
 
 /**
- * Class encapsulating the last will and testament that is published after the
- * client has gone offline.
+ * Class encapsulating the last will and testament that is published after the client has gone offline.
  *
  * @author Markus Mann
  *
@@ -23,8 +22,7 @@ public class MqttWillAndTestament {
     private boolean retain = false;
 
     /**
-     * Create an instance of the last will using a string with the following
-     * format:<br/>
+     * Create an instance of the last will using a string with the following format:<br/>
      * topic:message:qos:retained <br/>
      * Where
      * <ul>
@@ -34,8 +32,7 @@ public class MqttWillAndTestament {
      * <li>retain true if messages shall be retained</li>
      * </ul>
      *
-     * @param string
-     *            the string to parse. If null, null is returned
+     * @param string the string to parse. If null, null is returned
      * @return the will instance, will be null only if parameter is null
      */
     public static MqttWillAndTestament fromString(String string) {
@@ -77,8 +74,7 @@ public class MqttWillAndTestament {
     /**
      * Set the topic for the last will.
      *
-     * @param topic
-     *            the topic
+     * @param topic the topic
      */
     public void setTopic(String topic) {
         this.topic = topic;
@@ -94,8 +90,7 @@ public class MqttWillAndTestament {
     /**
      * Set the payload of the last will.
      *
-     * @param payload
-     *            the payload
+     * @param payload the payload
      */
     public void setPayload(byte[] payload) {
         this.payload = payload;
@@ -111,8 +106,7 @@ public class MqttWillAndTestament {
     /**
      * Set quality of service. Valid values are 0,1,2
      *
-     * @param qos
-     *            level.
+     * @param qos level.
      */
     public void setQos(int qos) {
         if (qos >= 0 && qos <= 2) {
@@ -130,8 +124,7 @@ public class MqttWillAndTestament {
     /**
      * Set whether the last will should be retained by the broker.
      *
-     * @param retain
-     *            true to retain.
+     * @param retain true to retain.
      */
     public void setRetain(boolean retain) {
         this.retain = retain;

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttWillAndTestament.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttWillAndTestament.java
@@ -33,7 +33,7 @@ public class MqttWillAndTestament {
      * <li>qos Valid values are 0 (Deliver at most once),1 (Deliver at least once) or 2</li>
      * <li>retain true if messages shall be retained</li>
      * </ul>
-     * 
+     *
      * @param string
      *            the string to parse. If null, null is returned
      * @return the will instance, will be null only if parameter is null
@@ -76,7 +76,7 @@ public class MqttWillAndTestament {
 
     /**
      * Set the topic for the last will.
-     * 
+     *
      * @param topic
      *            the topic
      */
@@ -93,7 +93,7 @@ public class MqttWillAndTestament {
 
     /**
      * Set the payload of the last will.
-     * 
+     *
      * @param payload
      *            the payload
      */
@@ -110,7 +110,7 @@ public class MqttWillAndTestament {
 
     /**
      * Set quality of service. Valid values are 0,1,2
-     * 
+     *
      * @param qos
      *            level.
      */
@@ -129,7 +129,7 @@ public class MqttWillAndTestament {
 
     /**
      * Set whether the last will should be retained by the broker.
-     * 
+     *
      * @param retain
      *            true to retain.
      */

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnection.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnection.java
@@ -83,7 +83,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Create a new connection with the given name.
-     * 
+     *
      * @param name
      *            for the connection.
      */
@@ -95,7 +95,7 @@ public class MqttBrokerConnection implements MqttCallback {
      * Start the connection. This will try to open an MQTT client connection to
      * the MQTT broker and notify all publishers and subscribers on this
      * connection that the connection has become active.
-     * 
+     *
      * @throws Exception
      *             If connection could not be created.
      */
@@ -137,7 +137,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Get the url for the MQTT broker. Valid URL's are in the format:
      * tcp://localhost:1883 or ssl://localhost:8883
-     * 
+     *
      * @return url for the MQTT broker.
      */
     public String getUrl() {
@@ -147,7 +147,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Set the url for the MQTT broker. Valid URL's are in the format:
      * tcp://localhost:1883 or ssl://localhost:8883
-     * 
+     *
      * @param url
      *            url string for the MQTT broker.
      */
@@ -164,7 +164,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Set the optional user name to use when connecting to the MQTT broker.
-     * 
+     *
      * @param user
      *            name to use for connection.
      */
@@ -181,7 +181,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Set the optional password to use when connecting to the MQTT broker.
-     * 
+     *
      * @param password
      */
     public void setPassword(String password) {
@@ -197,7 +197,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Set quality of service. Valid values are 0,1,2
-     * 
+     *
      * @param qos
      *            level.
      */
@@ -217,7 +217,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Set whether any published messages should be retained by the broker.
-     * 
+     *
      * @param retain
      *            true to retain.
      */
@@ -246,7 +246,7 @@ public class MqttBrokerConnection implements MqttCallback {
      * asynchronously (the message is sent and the sendign thread does not wait
      * for delivery completion). In the case of async, the sending thread
      * currently does not receive any feedback when delivery is completed.
-     * 
+     *
      * @param async
      */
     public void setAsync(boolean async) {
@@ -256,7 +256,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Set client id to use when connecting to the broker. If none is specified,
      * a default is generated.
-     * 
+     *
      * @param value
      *            clientId to use.
      */
@@ -266,7 +266,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Open an MQTT client connection.
-     * 
+     *
      * @throws Exception
      */
     private void openConnection() throws Exception {
@@ -346,7 +346,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Create a trust manager which is not too concerned about validating
      * certificates.
-     * 
+     *
      * @return a trusting trust manager
      */
     private TrustManager getVeryTrustingTrustManager() {
@@ -379,7 +379,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Add a new message producer to this connection.
-     * 
+     *
      * @param publisher
      *            to add.
      */
@@ -392,7 +392,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Start a registered producer, so that it can start sending messages.
-     * 
+     *
      * @param publisher
      *            to start.
      */
@@ -437,7 +437,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Add a new message consumer to this connection.
-     * 
+     *
      * @param consumer
      *            to add.
      */
@@ -450,7 +450,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Start a registered consumer, so that it can start receiving messages.
-     * 
+     *
      * @param subscriber
      *            to start.
      */
@@ -468,7 +468,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Remove a previously registered producer from this connection.
-     * 
+     *
      * @param publisher
      *            to remove.
      */
@@ -480,7 +480,7 @@ public class MqttBrokerConnection implements MqttCallback {
 
     /**
      * Remove a previously registered consumer from this connection.
-     * 
+     *
      * @param subscriber
      *            to remove.
      */
@@ -555,7 +555,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Check if the topic on which a message was received matches provided
      * target topic. The matching will take into account the + and # wildcards.
-     * 
+     *
      * @param source
      *            topic from received message
      * @param target
@@ -590,7 +590,7 @@ public class MqttBrokerConnection implements MqttCallback {
      * If no heartbeat is received within this timeframe, the connection
      * will be considered dead. Set this to a higher value on systems which may
      * not always be able to process the heartbeat in time.
-     * 
+     *
      * @param keepAliveInterval interval in seconds
      */
     public void setKeepAliveInterval(int keepAliveInterval) {

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnection.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnection.java
@@ -36,12 +36,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An MQTTBrokerConnection represents a single client connection to a MQTT
- * broker. The connection is configured by the MQTTService with properties from
- * the smarthome.cfg file.
+ * An MQTTBrokerConnection represents a single client connection to a MQTT broker. The connection is configured by the
+ * MQTTService with properties from the smarthome.cfg file.
  *
- * When a connection to an MQTT broker is lost, it will try to reconnect every
- * 60 seconds.
+ * When a connection to an MQTT broker is lost, it will try to reconnect every 60 seconds.
  *
  * @author Davy Vanherbergen
  */
@@ -84,20 +82,17 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Create a new connection with the given name.
      *
-     * @param name
-     *            for the connection.
+     * @param name for the connection.
      */
     public MqttBrokerConnection(String name) {
         this.name = name;
     }
 
     /**
-     * Start the connection. This will try to open an MQTT client connection to
-     * the MQTT broker and notify all publishers and subscribers on this
-     * connection that the connection has become active.
+     * Start the connection. This will try to open an MQTT client connection to the MQTT broker and notify all
+     * publishers and subscribers on this connection that the connection has become active.
      *
-     * @throws Exception
-     *             If connection could not be created.
+     * @throws Exception If connection could not be created.
      */
     public synchronized void start() throws Exception {
 
@@ -148,8 +143,7 @@ public class MqttBrokerConnection implements MqttCallback {
      * Set the url for the MQTT broker. Valid URL's are in the format:
      * tcp://localhost:1883 or ssl://localhost:8883
      *
-     * @param url
-     *            url string for the MQTT broker.
+     * @param url url string for the MQTT broker.
      */
     public void setUrl(String url) {
         this.url = url;
@@ -165,8 +159,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Set the optional user name to use when connecting to the MQTT broker.
      *
-     * @param user
-     *            name to use for connection.
+     * @param user name to use for connection.
      */
     public void setUser(String user) {
         this.user = user;
@@ -198,8 +191,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Set quality of service. Valid values are 0,1,2
      *
-     * @param qos
-     *            level.
+     * @param qos level.
      */
     public void setQos(int qos) {
         if (qos >= 0 && qos <= 2) {
@@ -208,8 +200,7 @@ public class MqttBrokerConnection implements MqttCallback {
     }
 
     /**
-     * @return true if messages sent to the broker should be retained by the
-     *         broker.
+     * @return true if messages sent to the broker should be retained by the broker.
      */
     public boolean isRetain() {
         return retain;
@@ -218,8 +209,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Set whether any published messages should be retained by the broker.
      *
-     * @param retain
-     *            true to retain.
+     * @param retain true to retain.
      */
     public void setRetain(boolean retain) {
         this.retain = retain;
@@ -241,11 +231,10 @@ public class MqttBrokerConnection implements MqttCallback {
     }
 
     /**
-     * Set whether messages should be sent synchronously (the message is sent
-     * and the thread waits until delivery to the broker has completed) or
-     * asynchronously (the message is sent and the sendign thread does not wait
-     * for delivery completion). In the case of async, the sending thread
-     * currently does not receive any feedback when delivery is completed.
+     * Set whether messages should be sent synchronously (the message is sent and the thread waits until delivery to the
+     * broker has completed) or asynchronously (the message is sent and the sendign thread does not wait for delivery
+     * completion). In the case of async, the sending thread currently does not receive any feedback when delivery is
+     * completed.
      *
      * @param async
      */
@@ -254,11 +243,9 @@ public class MqttBrokerConnection implements MqttCallback {
     }
 
     /**
-     * Set client id to use when connecting to the broker. If none is specified,
-     * a default is generated.
+     * Set client id to use when connecting to the broker. If none is specified, a default is generated.
      *
-     * @param value
-     *            clientId to use.
+     * @param value clientId to use.
      */
     public void setClientId(String value) {
         this.clientId = value;
@@ -344,8 +331,7 @@ public class MqttBrokerConnection implements MqttCallback {
     }
 
     /**
-     * Create a trust manager which is not too concerned about validating
-     * certificates.
+     * Create a trust manager which is not too concerned about validating certificates.
      *
      * @return a trusting trust manager
      */
@@ -380,8 +366,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Add a new message producer to this connection.
      *
-     * @param publisher
-     *            to add.
+     * @param publisher to add.
      */
     public synchronized void addProducer(MqttMessageProducer publisher) {
         producers.add(publisher);
@@ -393,8 +378,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Start a registered producer, so that it can start sending messages.
      *
-     * @param publisher
-     *            to start.
+     * @param publisher to start.
      */
     private void startProducer(MqttMessageProducer publisher) {
 
@@ -438,8 +422,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Add a new message consumer to this connection.
      *
-     * @param consumer
-     *            to add.
+     * @param consumer to add.
      */
     public synchronized void addConsumer(MqttMessageConsumer subscriber) {
         consumers.add(subscriber);
@@ -451,8 +434,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Start a registered consumer, so that it can start receiving messages.
      *
-     * @param subscriber
-     *            to start.
+     * @param subscriber to start.
      */
     private void startConsumer(MqttMessageConsumer subscriber) {
 
@@ -469,8 +451,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Remove a previously registered producer from this connection.
      *
-     * @param publisher
-     *            to remove.
+     * @param publisher to remove.
      */
     public synchronized void removeProducer(MqttMessageProducer publisher) {
         logger.debug("Removing message producer for broker '{}'", name);
@@ -481,8 +462,7 @@ public class MqttBrokerConnection implements MqttCallback {
     /**
      * Remove a previously registered consumer from this connection.
      *
-     * @param subscriber
-     *            to remove.
+     * @param subscriber to remove.
      */
     public synchronized void removeConsumer(MqttMessageConsumer subscriber) {
         logger.debug("Unsubscribing message consumer for topic '{}' from broker '{}'", subscriber.getTopic(), name);
@@ -553,13 +533,11 @@ public class MqttBrokerConnection implements MqttCallback {
     }
 
     /**
-     * Check if the topic on which a message was received matches provided
-     * target topic. The matching will take into account the + and # wildcards.
+     * Check if the topic on which a message was received matches provided target topic. The matching will take into
+     * account the + and # wildcards.
      *
-     * @param source
-     *            topic from received message
-     * @param target
-     *            topic as defined with possible wildcards.
+     * @param source topic from received message
+     * @param target topic as defined with possible wildcards.
      * @return true if both topics match.
      */
     private boolean isTopicMatch(String source, String target) {
@@ -586,10 +564,9 @@ public class MqttBrokerConnection implements MqttCallback {
     }
 
     /**
-     * Set the keep alive interval. The default interval is 60 seconds.
-     * If no heartbeat is received within this timeframe, the connection
-     * will be considered dead. Set this to a higher value on systems which may
-     * not always be able to process the heartbeat in time.
+     * Set the keep alive interval. The default interval is 60 seconds. If no heartbeat is received within this
+     * timeframe, the connection will be considered dead. Set this to a higher value on systems which may not always be
+     * able to process the heartbeat in time.
      *
      * @param keepAliveInterval interval in seconds
      */

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnectionHelper.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnectionHelper.java
@@ -21,7 +21,7 @@ public class MqttBrokerConnectionHelper extends TimerTask {
 
     /**
      * Create new connection helper to help reconnect the given connection.
-     * 
+     *
      * @param connection
      *            to reconnect.
      */

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnectionHelper.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnectionHelper.java
@@ -10,8 +10,8 @@ package org.eclipse.smarthome.io.transport.mqtt.internal;
 import java.util.TimerTask;
 
 /**
- * Connection helper which can be executed periodically to try to reconnect to a
- * broker if the connection was previously lost.
+ * Connection helper which can be executed periodically to try to reconnect to a broker if the connection was previously
+ * lost.
  *
  * @author Davy Vanherbergen
  */
@@ -22,8 +22,7 @@ public class MqttBrokerConnectionHelper extends TimerTask {
     /**
      * Create new connection helper to help reconnect the given connection.
      *
-     * @param connection
-     *            to reconnect.
+     * @param connection to reconnect.
      */
     public MqttBrokerConnectionHelper(MqttBrokerConnection connection) {
         this.connection = connection;


### PR DESCRIPTION
I started playing around with the mqtt transport.
I kept the commits separate, so you could check them separately.

style only:
* The first one applies the ESH clean up (remove trailing whitespaces).
* The second cleans up manual line breaks in the javadoc. The formatter does not remove manual line breaks, but I cleaned it manually and started the clean up again - so all fine.

feature:
* The third commit adds a method to the interfaces (consumer / producer) that informs the implemented clcass about the current state of the connection.
After a broker connection is established it is a common case to transmit the current state of all items, to inform subscribers about the current state (and guarantees that not a state change keeps not transmitted). 

bugfix:
* The fourth commit fix a connection problem. If a connection is established and lost later, a reconnect will be done automatically. If the connection could not be established in the handling of the update method of the MqttService, the connection will never established again. So let's call the normal retry mechanism so it will be retried later.