### PR TITLE
fixed the inbox entry expiration checks 

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryResultImpl.java
@@ -27,7 +27,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     private DiscoveryResultFlag flag;
     private String label;
     private long timestamp; 
-    private long timeToLive; 
+    private long timeToLive = TTL_UNLIMITED; 
 
     /**
      * Package protected default constructor to allow reflective instantiation.

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
@@ -87,6 +87,9 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
         }
         
         private boolean isResultExpired(DiscoveryResult result, long now) {
+            if (result.getTimeToLive() == DiscoveryResult.TTL_UNLIMITED) {
+                return false; 
+            }
             return (result.getTimestamp() + result.getTimeToLive() * 1000 < now); 
         }
     }

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/console/InboxConsoleCommandExtension.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/console/InboxConsoleCommandExtension.java
@@ -8,6 +8,7 @@
 package org.eclipse.smarthome.config.discovery.internal.console;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -126,8 +127,10 @@ public class InboxConsoleCommandExtension implements ConsoleCommandExtension {
             DiscoveryResultFlag flag = discoveryResult.getFlag();
             ThingUID bridgeId = discoveryResult.getBridgeUID();
             Map<String, Object> properties = discoveryResult.getProperties();
-            console.println(String.format("%s [%s]: %s [thingId=%s, bridgeId=%s, properties=%s]", flag.name(),
-                    thingTypeUID, label, thingUID, bridgeId, properties));
+            String timestamp = new Date(discoveryResult.getTimestamp()).toString(); 
+            String timeToLive = discoveryResult.getTimeToLive() == DiscoveryResult.TTL_UNLIMITED ? "UNLIMITED" : "" + discoveryResult.getTimeToLive(); 
+            console.println(String.format("%s [%s]: %s [thingId=%s, bridgeId=%s, properties=%s, timestamp=%s, timeToLive=%s]", 
+                    flag.name(), thingTypeUID, label, thingUID, bridgeId, properties, timestamp, timeToLive));
 
         }
     }


### PR DESCRIPTION
Inbox expiration checkes fixed o make it backwards compatible and added output of timestamp and timeToLive to the inbox' console output (e.g. "timestamp=Mon Mar 30 07:55:33 CEST 2015, timeToLive=1800")

Signed-off-by: Andre Fuechsel a.fuechsel@telekom.de
