### PR TITLE
allow negative numbers as commands in mappings

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
@@ -128,7 +128,7 @@ ColorArray:
 	((item=ID)? (condition=("==" | ">" | "<" | ">=" | "<=" | "!="))? (sign=('-'|'+'))? (state=XState) '=')? (arg=STRING);
 
 Command returns ecore::EString:
-	INT | ID | STRING;
+	Number | ID | STRING;
 
 Number returns ecore::EBigDecimal:
 	'-'? (INT | FLOAT);


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer kai@openhab.org
