### PR TITLE
Added discovery result representation

### DIFF
--- a/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueBridgeDiscoveryParticipantOSGITest.groovy
+++ b/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueBridgeDiscoveryParticipantOSGITest.groovy
@@ -7,75 +7,66 @@
  */
 package org.eclipse.smarthome.binding.hue.test
 
-import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_BRIDGE;
+import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
-import java.util.Collections;
-
-import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
 import org.eclipse.smarthome.binding.hue.internal.discovery.HueBridgeDiscoveryParticipant
-import org.eclipse.smarthome.config.discovery.DiscoveryListener
-import org.eclipse.smarthome.config.discovery.DiscoveryResult
 import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag
-import org.eclipse.smarthome.config.discovery.DiscoveryService
-import org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant;
+import org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant
 import org.eclipse.smarthome.core.thing.ThingUID
-import org.eclipse.smarthome.test.AsyncResultWrapper
 import org.eclipse.smarthome.test.OSGiTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.jupnp.model.types.DeviceType
-import org.jupnp.model.types.UDN
 import org.jupnp.model.meta.DeviceDetails
 import org.jupnp.model.meta.ManufacturerDetails
 import org.jupnp.model.meta.ModelDetails
 import org.jupnp.model.meta.RemoteDevice
 import org.jupnp.model.meta.RemoteDeviceIdentity
-import org.osgi.service.device.Constants
-import org.osgi.service.upnp.UPnPDevice
+import org.jupnp.model.types.DeviceType
+import org.jupnp.model.types.UDN
 
 /**
  * Tests for {@link HueBridgeDiscoveryParticipant}.
  *
  * @author Kai Kreuzer - Initial contribution
+ * @author Thomas Höfer - Added representation
  */
 class HueBridgeDiscoveryParticipantOSGITest extends OSGiTest {
 
     UpnpDiscoveryParticipant discoveryParticipant
 
-	RemoteDevice hueDevice
-	RemoteDevice otherDevice
-	
+    RemoteDevice hueDevice
+    RemoteDevice otherDevice
+
     @Before
     void setUp() {
         discoveryParticipant = getService(UpnpDiscoveryParticipant, HueBridgeDiscoveryParticipant)
         assertThat discoveryParticipant, is(notNullValue())
-		
-		hueDevice = new RemoteDevice(
-			new RemoteDeviceIdentity(new UDN("123"), 60, new URL("http://hue"), null, null), 
-			new DeviceType("namespace", "type"),
-			new DeviceDetails(
-				new URL("http://1.2.3.4/"),
-				"Hue Bridge", 
-				new ManufacturerDetails("Philips"), 
-				new ModelDetails("Philips hue bridge"),
-				"serial123",
-				"upc",
-				null))
-		
-		otherDevice = new RemoteDevice(
-			new RemoteDeviceIdentity(new UDN("567"), 60, new URL("http://acme"), null, null),
-			new DeviceType("namespace", "type"),
-			new DeviceDetails(
-				"Some Device",
-				new ManufacturerDetails("Taiwan"),
-				new ModelDetails("��\$%&/"),
-				"serial567",
-				"upc"))
 
+        hueDevice = new RemoteDevice(
+                new RemoteDeviceIdentity(new UDN("123"), 60, new URL("http://hue"), null, null),
+                new DeviceType("namespace", "type"),
+                new DeviceDetails(
+                new URL("http://1.2.3.4/"),
+                "Hue Bridge",
+                new ManufacturerDetails("Philips"),
+                new ModelDetails("Philips hue bridge"),
+                "serial123",
+                "upc",
+                null))
+
+        otherDevice = new RemoteDevice(
+                new RemoteDeviceIdentity(new UDN("567"), 60, new URL("http://acme"), null, null),
+                new DeviceType("namespace", "type"),
+                new DeviceDetails(
+                "Some Device",
+                new ManufacturerDetails("Taiwan"),
+                new ModelDetails("��\$%&/"),
+                "serial567",
+                "upc"))
     }
 
     @After
@@ -84,35 +75,35 @@ class HueBridgeDiscoveryParticipantOSGITest extends OSGiTest {
 
     @Test
     void 'assert correct supported types'() {
-		assertThat discoveryParticipant.supportedThingTypeUIDs.size(), is(1)
-		assertThat discoveryParticipant.supportedThingTypeUIDs.first(), is(THING_TYPE_BRIDGE)
+        assertThat discoveryParticipant.supportedThingTypeUIDs.size(), is(1)
+        assertThat discoveryParticipant.supportedThingTypeUIDs.first(), is(THING_TYPE_BRIDGE)
     }
 
     @Test
     void 'assert correct thing UID'() {
-		assertThat discoveryParticipant.getThingUID(hueDevice), is(new ThingUID("hue:bridge:serial123"))
-	}
+        assertThat discoveryParticipant.getThingUID(hueDevice), is(new ThingUID("hue:bridge:serial123"))
+    }
 
-	@Test
-	void 'assert valid DiscoveryResult'() {
-		discoveryParticipant.createResult(hueDevice).with {
-			assertThat flag, is (DiscoveryResultFlag.NEW)
-			assertThat thingUID, is(new ThingUID("hue:bridge:serial123"))
-			assertThat thingTypeUID, is (THING_TYPE_BRIDGE)
-			assertThat bridgeUID, is(nullValue())
+    @Test
+    void 'assert valid DiscoveryResult'() {
+        discoveryParticipant.createResult(hueDevice).with {
+            assertThat flag, is (DiscoveryResultFlag.NEW)
+            assertThat thingUID, is(new ThingUID("hue:bridge:serial123"))
+            assertThat thingTypeUID, is (THING_TYPE_BRIDGE)
+            assertThat bridgeUID, is(nullValue())
             assertThat properties.get(HOST), is("1.2.3.4")
             assertThat properties.get(SERIAL_NUMBER), is("serial123")
-		}
+            assertThat representationProperty, is(SERIAL_NUMBER)
+        }
+    }
 
-	}
-	
-	@Test
-	void 'assert no thing UID for unknown device'() {
-		assertThat discoveryParticipant.getThingUID(otherDevice), is(nullValue())
-	}
+    @Test
+    void 'assert no thing UID for unknown device'() {
+        assertThat discoveryParticipant.getThingUID(otherDevice), is(nullValue())
+    }
 
-	@Test
-	void 'assert no discovery result for unknown device'() {
-		assertThat discoveryParticipant.createResult(otherDevice), is(nullValue())
-	}
+    @Test
+    void 'assert no discovery result for unknown device'() {
+        assertThat discoveryParticipant.createResult(otherDevice), is(nullValue())
+    }
 }

--- a/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -30,7 +30,7 @@ import org.jupnp.model.meta.RemoteDevice;
  * removed hue bridges. It uses the central {@link UpnpDiscoveryService}.
  *
  * @author Kai Kreuzer - Initial contribution
- *
+ * @author Thomas Höfer - Added representation
  */
 public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
@@ -48,9 +48,8 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
             properties.put(SERIAL_NUMBER, device.getDetails().getSerialNumber());
 
             DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                    .withLabel(device.getDetails().getFriendlyName())
-                    .withTTL(Math.max(MIN_MAX_AGE_SECS, device.getIdentity().getMaxAgeSeconds()))
-                    .build();
+                    .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(SERIAL_NUMBER)
+                    .withTTL(Math.max(MIN_MAX_AGE_SECS, device.getIdentity().getMaxAgeSeconds())).build();
             return result;
         } else {
             return null;

--- a/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  * @author Andre Fuechsel - changed search timeout
- *
+ * @author Thomas Höfer - Added representation
  */
 public class HueLightDiscoveryService extends AbstractDiscoveryService implements LightStatusListener {
 
@@ -95,6 +95,12 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService implement
             ThingUID bridgeUID = hueBridgeHandler.getThing().getUID();
             Map<String, Object> properties = new HashMap<>(1);
             properties.put(LIGHT_ID, light.getId());
+
+            /*
+             * TODO retrieve the light´s unique id (available since Hue bridge versions > 1.3) and set the mac address
+             * as discovery result representationÏ. For this purpose the jue library has to be modified.
+             */
+
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
                     .withBridge(bridgeUID).withLabel(light.getName()).build();
 

--- a/binding/org.eclipse.smarthome.binding.yahooweather/src/main/java/org/eclipse/smarthome/binding/yahooweather/discovery/YahooWeatherDiscoveryService.java
+++ b/binding/org.eclipse.smarthome.binding.yahooweather/src/main/java/org/eclipse/smarthome/binding/yahooweather/discovery/YahooWeatherDiscoveryService.java
@@ -36,6 +36,7 @@ import com.google.gson.JsonParser;
  * @author Marcel Verpaalen - Initial contribution
  * @author Jochen Hiller - Removed dependency to Apache HttpClient 3.x
  * @author Andre Fuechsel - Added call of removeOlderResults
+ * @author Thomas Höfer - Added representation
  */
 
 public class YahooWeatherDiscoveryService extends AbstractDiscoveryService {
@@ -157,7 +158,7 @@ public class YahooWeatherDiscoveryService extends AbstractDiscoveryService {
             Map<String, Object> properties = new HashMap<>(1);
             properties.put("location", locationWoeid);
             DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                    .withLabel("Yahoo weather " + locationName).build();
+                    .withRepresentationProperty("location").withLabel("Yahoo weather " + locationName).build();
             thingDiscovered(result);
         }
     }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryResultImplTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryResultImplTest.groovy
@@ -21,31 +21,32 @@ import org.junit.Test
  * and the synchronization of {@link DiscoveryResult}s work in a correct way.
  * 
  * @author Michael Grammling - Initial Contribution
+ * @author Thomas Höfer - Added representation
  */
 class DiscoveryResultImplTest {
-    
+
     def DEFAULT_TTL = 60
 
     @Test
     public void testInvalidConstructorForThingType() {
         try {
-            new DiscoveryResultImpl(new ThingUID("aa"), null, null, null, DEFAULT_TTL)
+            new DiscoveryResultImpl(new ThingUID("aa"), null, null, null, null, DEFAULT_TTL)
             fail "The constructor must throw an IllegalArgumentException if null is used"
             + " as Thing type!"
-        } catch (IllegalArgumentException iae) {
+        } catch (IllegalArgumentException expected) {
         }
     }
 
     @Test
     public void testInvalidConstructorForTTL() {
         try {
-       def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
+            def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
 
-        DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, null, null, -2)
+            DiscoveryResultImpl discoveryResult =
+                    new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, null, null, null, -2)
             fail "The constructor must throw an IllegalArgumentException if negative value is used"
             + " as ttl!"
-        } catch (IllegalArgumentException iae) {
+        } catch (IllegalArgumentException expected) {
         }
     }
 
@@ -54,15 +55,16 @@ class DiscoveryResultImplTest {
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
 
         DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, null, null, DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, null, null, null, DEFAULT_TTL)
 
         assertEquals("bindingId:thingType", discoveryResult.getThingTypeUID().toString())
         assertEquals("bindingId:thingType:thingId", discoveryResult.getThingUID().toString())
         assertEquals("bindingId", discoveryResult.getBindingId())
         assertEquals("", discoveryResult.getLabel())
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag())
-        
+
         assertNotNull("The properties must never be null!", discoveryResult.getProperties())
+        assertNull(discoveryResult.getRepresentationProperty())
     }
 
     @Test
@@ -71,58 +73,62 @@ class DiscoveryResultImplTest {
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
         def discoveryResultSourceMap = [ "ipAddress" : "127.0.0.1" ]
         DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "TARGET", DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL)
 
         discoveryResult.setFlag(DiscoveryResultFlag.IGNORED)
 
         discoveryResult.synchronize(null)
 
         assertEquals("127.0.0.1", discoveryResult.getProperties().get("ipAddress"))
+        assertEquals("ipAddress", discoveryResult.getRepresentationProperty())
         assertEquals("TARGET", discoveryResult.getLabel())
         assertEquals(DiscoveryResultFlag.IGNORED, discoveryResult.getFlag())
     }
 
     @Test
     public void testIrrelevantSynchronize() {
-        
+
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
         def discoveryResultSourceMap = [ "ipAddress" : "127.0.0.1" ]
         DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "TARGET", DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL)
 
         discoveryResult.setFlag(DiscoveryResultFlag.IGNORED)
 
         DiscoveryResultImpl discoveryResultSource =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "anotherThingId"), null, null, null, DEFAULT_TTL)
-        
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "anotherThingId"), null, null, null, null, DEFAULT_TTL)
+
 
         discoveryResult.synchronize(discoveryResultSource)
 
         assertEquals("127.0.0.1", discoveryResult.getProperties().get("ipAddress"))
+        assertEquals("ipAddress", discoveryResult.getRepresentationProperty())
         assertEquals("TARGET", discoveryResult.getLabel())
         assertEquals(DiscoveryResultFlag.IGNORED, discoveryResult.getFlag())
     }
 
     @Test
     public void testSynchronize() {
-        
+
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
         def discoveryResultSourceMap = [ "ipAddress" : "127.0.0.1" ]
         DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "TARGET", DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL)
 
         discoveryResult.setFlag(DiscoveryResultFlag.IGNORED)
-        
-        def discoveryResultMap = [ "ipAddress" : "192.168.178.1" ]
-        DiscoveryResultImpl discoveryResultSource =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultMap, "SOURCE", DEFAULT_TTL)
 
-  
+        def discoveryResultMap = [ "ipAddress" : "192.168.178.1", "macAddress" : "AA:BB:CC:DD:EE:FF" ]
+        DiscoveryResultImpl discoveryResultSource =
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultMap, "macAddress", "SOURCE", DEFAULT_TTL)
+
+
         discoveryResultSource.setFlag(DiscoveryResultFlag.NEW)
 
         discoveryResult.synchronize(discoveryResultSource);
 
         assertEquals("192.168.178.1", discoveryResult.getProperties().get("ipAddress"))
+        assertEquals("AA:BB:CC:DD:EE:FF", discoveryResult.getProperties().get("macAddress"))
+        assertEquals("macAddress", discoveryResult.getRepresentationProperty())
         assertEquals("SOURCE", discoveryResult.getLabel())
         assertEquals(DiscoveryResultFlag.IGNORED, discoveryResult.getFlag())
     }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceMock.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceMock.groovy
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingUID
  * discovery is enforced or aborted. 
  * 
  * @author Michael Grammling - Initial Contribution
+ * @author Thomas Höfer - Added representation
  */
 class DiscoveryServiceMock extends AbstractDiscoveryService {
 
@@ -46,6 +47,6 @@ class DiscoveryServiceMock extends AbstractDiscoveryService {
         if (faulty) {
             throw new Exception()
         }
-        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, generator((('A'..'Z')+('0'..'9')).join(), 9)), null, null, null, DEFAULT_TTL))
+        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, generator((('A'..'Z')+('0'..'9')).join(), 9)), null, null, null, null, DEFAULT_TTL))
     }
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/DynamicThingUpdateOSGITest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/DynamicThingUpdateOSGITest.groovy
@@ -44,13 +44,14 @@ import org.junit.Test
  * A dummy {@link ThingHandler} and {@link ThingHandlerFactory} is used to detect an updated event.
  * 
  * @author Michael Grammling - Initial Contribution
+ * @author Thomas Höfer - Added representation
  */
 class DynamicThingUpdateOSGITest extends OSGiTest {
 
     def DEFAULT_TTL = 60
 
-        final BINDING_ID = 'dnamicUpdateBindingId'
-    final THING_TYPE_ID = 'dnamicUpdateThingType'
+    final BINDING_ID = 'dynamicUpdateBindingId'
+    final THING_TYPE_ID = 'dynamicUpdateThingType'
     final THING_ID = 'dynamicUpdateThingId'
 
     final ThingTypeUID THING_TYPE_UID = new ThingTypeUID(BINDING_ID, THING_TYPE_ID)
@@ -80,7 +81,9 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
 
     @After
     void cleanUp() {
-        managedThingProvider.all.each { managedThingProvider.remove(it.getUID()) }
+        managedThingProvider.all.each {
+            managedThingProvider.remove(it.getUID())
+        }
     }
 
     ThingHandler createThingHandler(Thing thing) {
@@ -88,13 +91,16 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
             'initialize' : { },
             'dispose' : { },
             'getThing' : { return thing },
-            'handleCommand' : { ChannelUID channelUID, Command command -> },
-            'handleUpdate' : { ChannelUID channelUID, State newState -> },
+            'handleCommand' : { ChannelUID channelUID, Command command ->
+            },
+            'handleUpdate' : { ChannelUID channelUID, State newState ->
+            },
             'thingUpdated' : { Thing updatedThing ->
                 this.thingUpdated = true
                 this.updatedThing = updatedThing
             },
-            'setCallback': {}
+            'setCallback': {
+            }
         ] as ThingHandler )
 
         return thingHandler
@@ -103,7 +109,7 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
     ThingHandlerFactory createThingHandlerFactory() {
         ThingHandlerFactory thingHandlerFactory = ( [
             'supportsThingType' : { ThingTypeUID thingTypeUID ->
-                return THING_TYPE_UID.equals(thingTypeUID) 
+                return THING_TYPE_UID.equals(thingTypeUID)
             },
             'registerHandler' : { Thing thing, ThingHandlerCallback callback ->
                 thingHandler = createThingHandler(thing)
@@ -116,11 +122,11 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
             'unregisterHandler' : { Thing thing ->
                 unregisterService(thingHandler)
             },
-            'createThing' : { ThingTypeUID thingTypeUID, Configuration configuration,
-                    ThingUID thingUID, ThingUID bridgeUID ->
+            'createThing' : { ThingTypeUID thingTypeUID, Configuration configuration, ThingUID thingUID, ThingUID bridgeUID ->
                 return null
             },
-            'removeThing' : { ThingUID thingUID -> }
+            'removeThing' : { ThingUID thingUID ->
+            }
         ] as ThingHandlerFactory )
 
         return thingHandlerFactory;
@@ -134,9 +140,9 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
         registerService(thingHandlerFactory, ThingHandlerFactory.class.name)
 
         managedThingProvider.add ThingBuilder.create(THING_TYPE_UID, THING_ID).build()
-        
+
         Hashtable discoveryResultProps = [ "ipAddress" : "127.0.0.1" ]
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_UID, null, discoveryResultProps, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_UID, null, discoveryResultProps, "ipAddress", "DummyLabel1", DEFAULT_TTL)
 
         inbox.add discoveryResult
 
@@ -157,8 +163,8 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
 
         managedThingProvider.add ThingBuilder.create(THING_TYPE_UID, THING_ID).build()
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_UID, null, [:], "DummyLabel", DEFAULT_TTL)
-         
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_UID, null, [:], null, "DummyLabel", DEFAULT_TTL)
+
         inbox.add discoveryResult
 
         assertThat inbox.getAll().size(), is(0)
@@ -166,5 +172,4 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
 
         unregisterService(thingHandlerFactory)
     }
-
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/InboxOSGITest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/InboxOSGITest.groovy
@@ -18,7 +18,6 @@ import org.eclipse.smarthome.config.discovery.inbox.Inbox
 import org.eclipse.smarthome.config.discovery.inbox.InboxFilterCriteria
 import org.eclipse.smarthome.config.discovery.inbox.InboxListener
 import org.eclipse.smarthome.config.discovery.internal.DiscoveryResultImpl
-import org.eclipse.smarthome.config.discovery.internal.PersistentInbox
 import org.eclipse.smarthome.core.thing.ManagedThingProvider
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
@@ -44,7 +43,7 @@ class InboxOSGITest extends OSGiTest {
 
     @Before
     void setUp() {
-		registerVolatileStorageService()
+        registerVolatileStorageService()
 
         discoveryResults.clear()
         inboxListeners.clear()
@@ -56,11 +55,15 @@ class InboxOSGITest extends OSGiTest {
 
     @After
     void cleanUp() {
-        discoveryResults.each { inbox.remove(it.key) }
+        discoveryResults.each {
+            inbox.remove(it.key)
+        }
         inboxListeners.each { inbox.removeInboxListener(it) }
         discoveryResults.clear()
         inboxListeners.clear()
-        managedThingProvider.all.each { managedThingProvider.remove(it.getUID())}
+        managedThingProvider.all.each {
+            managedThingProvider.remove(it.getUID())
+        }
     }
 
     private boolean addDiscoveryResult(DiscoveryResult discoveryResult) {
@@ -81,14 +84,14 @@ class InboxOSGITest extends OSGiTest {
 
     private void addInboxListener(InboxListener inboxListener) {
         inbox.addInboxListener(inboxListener)
-// TODO: the test fails if this line is used
-//        inboxListeners.add(inboxListener)
+        // TODO: the test fails if this line is used
+        //        inboxListeners.add(inboxListener)
     }
 
     private void removeInboxListener(InboxListener inboxListener) {
         inbox.removeInboxListener(inboxListener)
-// TODO: the test fails if this line is used
-//        inboxListeners.remove(inboxListener)
+        // TODO: the test fails if this line is used
+        //        inboxListeners.remove(inboxListener)
     }
 
     @Test
@@ -99,12 +102,12 @@ class InboxOSGITest extends OSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
 
-		Map<String, Object> props = new HashMap<>()
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>()
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props,"DummyLabel1", DEFAULT_TTL)
-		
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property1", "DummyLabel1", DEFAULT_TTL)
+
         assertTrue addDiscoveryResult(discoveryResult)
 
         allDiscoveryResults = inbox.all
@@ -119,6 +122,7 @@ class InboxOSGITest extends OSGiTest {
             assertThat properties.size(), is(2)
             assertThat properties.get("property1"), is("property1value1")
             assertThat properties.get("property2"), is("property2value1")
+            assertThat representationProperty, is("property1")
         }
     }
 
@@ -130,19 +134,19 @@ class InboxOSGITest extends OSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
 
-		Map<String, Object> props = new HashMap<>()
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>()
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property1", "DummyLabel1", DEFAULT_TTL)
         assertTrue addDiscoveryResult(discoveryResult)
 
-		props.clear()
-		props.put("property2", "property2value2")
-		props.put("property3", "property3value1")
+        props.clear()
+        props.put("property2", "property2value2")
+        props.put("property3", "property3value1")
 
-        discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel2", DEFAULT_TTL)
-         
+        discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property3", "DummyLabel2", DEFAULT_TTL)
+
         assertTrue addDiscoveryResult(discoveryResult)
 
         allDiscoveryResults = inbox.all
@@ -157,6 +161,7 @@ class InboxOSGITest extends OSGiTest {
             assertThat properties.size(), is(2)
             assertThat properties.get("property2"), is("property2value2")
             assertThat properties.get("property3"), is("property3value1")
+            assertThat representationProperty, is("property3")
         }
     }
 
@@ -168,13 +173,13 @@ class InboxOSGITest extends OSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, null, "DummyLabel1", DEFAULT_TTL)
-       
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, null, null, "DummyLabel1", DEFAULT_TTL)
+
         assertTrue addDiscoveryResult(discoveryResult)
 
         ThingUID thingUID2 = new ThingUID(thingTypeUID, "dummyThingId2")
-        discoveryResult = new DiscoveryResultImpl(thingUID2, null, null, "DummyLabel2", DEFAULT_TTL)
-        
+        discoveryResult = new DiscoveryResultImpl(thingUID2, null, null, null, "DummyLabel2", DEFAULT_TTL)
+
         addDiscoveryResult(discoveryResult)
 
         allDiscoveryResults = inbox.all
@@ -189,11 +194,11 @@ class InboxOSGITest extends OSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
 
-		Map<String, Object> props = new HashMap<>()
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>()
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property1", "DummyLabel1", DEFAULT_TTL)
         assertTrue addDiscoveryResult(discoveryResult)
 
         allDiscoveryResults = inbox.all
@@ -213,22 +218,22 @@ class InboxOSGITest extends OSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
 
-		Map<String, Object> props = new HashMap<>()
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>()
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property1", "DummyLabel1", DEFAULT_TTL)
         assertTrue addDiscoveryResult(discoveryResult)
 
         allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(1)
 
-		props.clear()
-		props.put("property2", "property2value2")
-		props.put("property3", "property3value1")
-		
-        DiscoveryResult discoveryResultUpdate = new DiscoveryResultImpl(thingUID, null ,props, "DummyLabel2", DEFAULT_TTL)
-         
+        props.clear()
+        props.put("property2", "property2value2")
+        props.put("property3", "property3value1")
+
+        DiscoveryResult discoveryResultUpdate = new DiscoveryResultImpl(thingUID, null, props, "property3", "DummyLabel2", DEFAULT_TTL)
+
         assertTrue addDiscoveryResult(discoveryResultUpdate)
 
         allDiscoveryResults = inbox.all
@@ -239,7 +244,7 @@ class InboxOSGITest extends OSGiTest {
         allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
     }
-    
+
     @Test
     void 'assert that get with InboxFilterCriteria returns correct results'() {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
@@ -248,21 +253,21 @@ class InboxOSGITest extends OSGiTest {
         ThingTypeUID thingTypeUID = new ThingTypeUID("dummyBindingId", "dummyThingType")
         ThingUID thingUID = new ThingUID(thingTypeUID, "dummyThingId")
 
-        DiscoveryResult discoveryResult1 = new DiscoveryResultImpl(thingUID, null, null, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult1 = new DiscoveryResultImpl(thingUID, null, null, null, "DummyLabel1", DEFAULT_TTL)
         assertTrue addDiscoveryResult(discoveryResult1)
 
         def thingUID2 = new ThingUID(thingTypeUID, "dummyThingId2")
-        DiscoveryResult discoveryResult2 = new DiscoveryResultImpl(thingUID2, null, null, "DummyLabel2", DEFAULT_TTL)
+        DiscoveryResult discoveryResult2 = new DiscoveryResultImpl(thingUID2, null, null, null, "DummyLabel2", DEFAULT_TTL)
         assertTrue addDiscoveryResult(discoveryResult2)
 
         inbox.setFlag(thingUID2, DiscoveryResultFlag.IGNORED)
-        
+
         def thingTypeUID3 = new ThingTypeUID("dummyBindingId", "dummyThingType3")
-        DiscoveryResult discoveryResult3 = new DiscoveryResultImpl(new ThingUID(thingTypeUID3, "dummyThingId3"), null, null, "DummyLabel3", DEFAULT_TTL)
+        DiscoveryResult discoveryResult3 = new DiscoveryResultImpl(new ThingUID(thingTypeUID3, "dummyThingId3"), null, null, null, "DummyLabel3", DEFAULT_TTL)
         assertTrue addDiscoveryResult(discoveryResult3)
 
-        DiscoveryResult discoveryResult4 = new DiscoveryResultImpl(new ThingUID(thingTypeUID, "dummyThingId4"), null, null, "DummyLabel4", DEFAULT_TTL)
-         
+        DiscoveryResult discoveryResult4 = new DiscoveryResultImpl(new ThingUID(thingTypeUID, "dummyThingId4"), null, null, null, "DummyLabel4", DEFAULT_TTL)
+
         assertTrue addDiscoveryResult(discoveryResult4)
 
 
@@ -340,11 +345,11 @@ class InboxOSGITest extends OSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
 
-		Map<String, Object> props = new HashMap<>()
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>()
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property1", "DummyLabel1", DEFAULT_TTL)
 
         AsyncResultWrapper<DiscoveryResult> addedDiscoveryResultWrapper = new AsyncResultWrapper<DiscoveryResult>()
         AsyncResultWrapper<DiscoveryResult> updatedDiscoveryResultWrapper = new AsyncResultWrapper<DiscoveryResult>()
@@ -386,6 +391,7 @@ class InboxOSGITest extends OSGiTest {
             assertThat properties.size(), is(2)
             assertThat properties.get("property1"), is("property1value1")
             assertThat properties.get("property2"), is("property2value1")
+            assertThat representationProperty, is("property1")
         }
     }
 
@@ -397,18 +403,18 @@ class InboxOSGITest extends OSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
 
-		Map<String, Object> props = new HashMap<>();
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>();
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property1", "DummyLabel1", DEFAULT_TTL)
         assertTrue addDiscoveryResult(discoveryResult)
 
-		props.clear()
-		props.put("property2", "property2value2")
-		props.put("property3", "property3value1")
+        props.clear()
+        props.put("property2", "property2value2")
+        props.put("property3", "property3value1")
 
-        discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel2", DEFAULT_TTL)
+        discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property3", "DummyLabel2", DEFAULT_TTL)
 
         AsyncResultWrapper<DiscoveryResult> addedDiscoveryResultWrapper = new AsyncResultWrapper<DiscoveryResult>()
         AsyncResultWrapper<DiscoveryResult> updatedDiscoveryResultWrapper = new AsyncResultWrapper<DiscoveryResult>()
@@ -449,6 +455,7 @@ class InboxOSGITest extends OSGiTest {
             assertThat properties.size(), is(2)
             assertThat properties.get("property2"), is("property2value2")
             assertThat properties.get("property3"), is("property3value1")
+            assertThat representationProperty, is("property3")
         }
     }
 
@@ -461,11 +468,11 @@ class InboxOSGITest extends OSGiTest {
         List<DiscoveryResult> allDiscoveryResults = inbox.all
         assertThat allDiscoveryResults.size(), is(0)
 
-		Map<String, Object> props = new HashMap<>()
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>()
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel1", DEFAULT_TTL)    
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property1", "DummyLabel1", DEFAULT_TTL)
         assertTrue addDiscoveryResult(discoveryResult)
 
         AsyncResultWrapper<DiscoveryResult> addedDiscoveryResultWrapper = new AsyncResultWrapper<DiscoveryResult>()
@@ -508,6 +515,7 @@ class InboxOSGITest extends OSGiTest {
             assertThat properties.size(), is(2)
             assertThat properties.get("property1"), is("property1value1")
             assertThat properties.get("property2"), is("property2value1")
+            assertThat representationProperty, is("property1")
         }
     }
 
@@ -518,11 +526,11 @@ class InboxOSGITest extends OSGiTest {
         ThingTypeUID thingTypeUID = new ThingTypeUID("dummyBindingId", "dummyThingType")
         ThingUID thingUID = new ThingUID(thingTypeUID, "dummyThingId")
 
-		Map<String, Object> props = new HashMap<>()
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>()
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, props, "property1", "DummyLabel1", DEFAULT_TTL)
 
         inbox.add discoveryResult
 
@@ -542,11 +550,11 @@ class InboxOSGITest extends OSGiTest {
 
         managedThingProvider.add ThingBuilder.create(thingTypeUID, "dummyThingId").build()
 
-		Map<String, Object> props = new HashMap<>()
-		props.put("property1", "property1value1")
-		props.put("property2", "property2value1")
+        Map<String, Object> props = new HashMap<>()
+        props.put("property1", "property1value1")
+        props.put("property2", "property2value1")
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, null, "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(thingUID, null, null, null, "DummyLabel1", DEFAULT_TTL)
 
         inbox.add discoveryResult
 

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryResult.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryResult.java
@@ -20,16 +20,17 @@ import org.eclipse.smarthome.core.thing.ThingUID;
  *
  * @author Kai Kreuzer - Initial API
  * @author Andre Fuechsel - added support for time to live
+ * @author Thomas Höfer - Added representation
  *
  * @see DiscoveryService
  * @see DiscoveryListener
  */
 public interface DiscoveryResult {
-    
-    /** 
-     * Specifies that the {@link DiscoveryResult} has no given time to live. 
+
+    /**
+     * Specifies that the {@link DiscoveryResult} has no given time to live.
      */
-    long TTL_UNLIMITED = -1; 
+    long TTL_UNLIMITED = -1;
 
     /**
      * Returns the unique {@code Thing} ID of this result object.
@@ -73,6 +74,18 @@ public interface DiscoveryResult {
     public Map<String, Object> getProperties();
 
     /**
+     * Returns the representation property of this result object.
+     * <p>
+     * The representation property represents an unique human and/or machine readable identifier of the thing that was
+     * discovered. Its actual value can be retrieved from the {@link DiscoveryResult#getProperties()} map. Such unique
+     * identifiers are typically the <code>ipAddress</code>, the <code>macAddress</code> or the
+     * <code>serialNumber</code> of the discovered thing.
+     * 
+     * @return the representation property of this result object (could be null)
+     */
+    public String getRepresentationProperty();
+
+    /**
      * Returns the flag of this result object.<br>
      * The flag signals e.g. if the result is {@link DiscoveryResultFlag#NEW} or has been marked as
      * {@link DiscoveryResultFlag#IGNORED}. In the latter
@@ -96,7 +109,7 @@ public interface DiscoveryResult {
      * @return the unique bridge ID (could be null)
      */
     public ThingUID getBridgeUID();
-    
+
     /**
      * Get the timestamp of this {@link DiscoveryResult}.
      * 

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryResultBuilder.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryResultBuilder.java
@@ -18,6 +18,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
  *
  * @author Kai Kreuzer - Initial API
  * @author Andre Fuechsel - added support for time to live
+ * @author Thomas Höfer - Added representation
  *
  * @see DiscoveryResult
  */
@@ -27,8 +28,9 @@ public class DiscoveryResultBuilder {
 
     private ThingUID bridgeUID;
     private Map<String, Object> properties = new HashMap<>();
+    private String representationProperty;
     private String label;
-    private long ttl = DiscoveryResult.TTL_UNLIMITED; 
+    private long ttl = DiscoveryResult.TTL_UNLIMITED;
 
     private DiscoveryResultBuilder(ThingUID thingUID) {
         this.thingUID = thingUID;
@@ -68,6 +70,17 @@ public class DiscoveryResultBuilder {
     }
 
     /**
+     * Sets the representation Property of the desired result
+     * 
+     * @param representationProperty the representation property of the desired result
+     * @return the updated builder
+     */
+    public DiscoveryResultBuilder withRepresentationProperty(String representationProperty) {
+        this.representationProperty = representationProperty;
+        return this;
+    }
+
+    /**
      * Sets the bridgeUID of the desired result
      * 
      * @param bridgeUID of the desired result
@@ -89,15 +102,15 @@ public class DiscoveryResultBuilder {
         return this;
     }
 
-    /** 
+    /**
      * Sets the time to live for the result in seconds
      * 
      * @param ttl time to live in seconds
      * @return the updated builder
      */
     public DiscoveryResultBuilder withTTL(long ttl) {
-        this.ttl = ttl; 
-        return this; 
+        this.ttl = ttl;
+        return this;
     }
 
     /**
@@ -106,7 +119,7 @@ public class DiscoveryResultBuilder {
      * @return the desired result
      */
     public DiscoveryResult build() {
-        return new DiscoveryResultImpl(thingUID, bridgeUID, properties, label, ttl);
+        return new DiscoveryResultImpl(thingUID, bridgeUID, properties, representationProperty, label, ttl);
     }
 
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryResultImpl.java
@@ -24,10 +24,11 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     private ThingUID thingUID;
 
     private Map<String, Object> properties;
+    private String representationProperty;
     private DiscoveryResultFlag flag;
     private String label;
-    private long timestamp; 
-    private long timeToLive = TTL_UNLIMITED; 
+    private long timestamp;
+    private long timeToLive = TTL_UNLIMITED;
 
     /**
      * Package protected default constructor to allow reflective instantiation.
@@ -44,6 +45,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      *            must be created. A typical {@code Thing} ID could be the
      *            serial number. It's usually <i>not</i> a product name.
      * @param properties the properties to be set (could be null or empty)
+     * @param representationProperty the representationProperty to be set (could be null or empty)
      * @param label the human readable label to set (could be null or empty)
      * @param bridgeUID the unique bridge ID to be set
      * @param timeToLive time to live in seconds
@@ -51,8 +53,8 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      * @throws IllegalArgumentException
      *             if the Thing type UID or the Thing UID is null
      */
-    public DiscoveryResultImpl(ThingUID thingUID, ThingUID bridgeUID, Map<String, Object> properties, String label, long timeToLive)
-            throws IllegalArgumentException {
+    public DiscoveryResultImpl(ThingUID thingUID, ThingUID bridgeUID, Map<String, Object> properties,
+            String representationProperty, String label, long timeToLive) throws IllegalArgumentException {
 
         if (thingUID == null) {
             throw new IllegalArgumentException("The thing UID must not be null!");
@@ -60,16 +62,17 @@ public class DiscoveryResultImpl implements DiscoveryResult {
         if (timeToLive < 1 && timeToLive != TTL_UNLIMITED) {
             throw new IllegalArgumentException("The ttl must not be 0 or negative!");
         }
-        
+
         this.thingUID = thingUID;
 
         this.bridgeUID = bridgeUID;
         this.properties = Collections.unmodifiableMap((properties != null) ? new HashMap<>(properties)
                 : new HashMap<String, Object>());
+        this.representationProperty = representationProperty;
         this.label = label == null ? "" : label;
-        
-        this.timestamp = new Date().getTime(); 
-        this.timeToLive = timeToLive; 
+
+        this.timestamp = new Date().getTime();
+        this.timeToLive = timeToLive;
 
         this.flag = DiscoveryResultFlag.NEW;
     }
@@ -132,6 +135,21 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     }
 
     /**
+     * Returns the representation property of this result object.
+     * <p>
+     * The representation property represents an unique human and/or machine readable identifier of the thing that was
+     * discovered. Its actual value can be retrieved from the {@link DiscoveryResult#getProperties()} map. Such unique
+     * identifiers are among others the <code>ipAddress</code>, the <code>macAddress</code> or the
+     * <code>serialNumber</code> of the discovered thing.
+     * 
+     * @return the representation property of this result object (could be null)
+     */
+    @Override
+    public String getRepresentationProperty() {
+        return this.representationProperty;
+    }
+
+    /**
      * Returns the flag of this result object.<br>
      * The flag signals e.g. if the result is {@link DiscoveryResultFlag#NEW} or has been marked as
      * {@link DiscoveryResultFlag#IGNORED}. In the latter
@@ -179,8 +197,9 @@ public class DiscoveryResultImpl implements DiscoveryResult {
         if ((sourceResult != null) && (sourceResult.getThingUID().equals(this.thingUID))) {
 
             this.properties = sourceResult.getProperties();
+            this.representationProperty = sourceResult.getRepresentationProperty();
             this.label = sourceResult.getLabel();
-            this.timestamp = new Date().getTime(); 
+            this.timestamp = new Date().getTime();
             this.timeToLive = sourceResult.getTimeToLive();
         }
     }
@@ -230,7 +249,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
         return "DiscoveryResult [thingUID=" + thingUID + ", properties=" + properties + ", flag=" + flag + ", label="
                 + label + ", bridgeUID=" + bridgeUID + ", ttl=" + timeToLive + ", timestamp=" + timestamp + "]";
     }
-    
+
     @Override
     public long getTimestamp() {
         return timestamp;

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/discovery/beans/DiscoveryResultBean.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/discovery/beans/DiscoveryResultBean.java
@@ -15,7 +15,7 @@ import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag;
  * This is a java bean that is used to serialize discovery results to JSON.
  *
  * @author Dennis Nobel - Initial contribution
- *
+ * @author Thomas Höfer - Added representation
  */
 public class DiscoveryResultBean {
 
@@ -23,18 +23,20 @@ public class DiscoveryResultBean {
     public DiscoveryResultFlag flag;
     public String label;
     public Map<String, Object> properties;
+    public String representationProperty;
     public String thingUID;
 
     public DiscoveryResultBean() {
     }
 
     public DiscoveryResultBean(String thingUID, String bridgeUID, String label, DiscoveryResultFlag flag,
-            Map<String, Object> properties) {
+            Map<String, Object> properties, String representationProperty) {
         this.thingUID = thingUID;
         this.bridgeUID = bridgeUID;
         this.label = label;
         this.flag = flag;
         this.properties = properties;
+        this.representationProperty = representationProperty;
     }
 
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/util/BeanMapper.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/util/BeanMapper.java
@@ -53,7 +53,7 @@ public class BeanMapper {
         GroupItemBean groupItemBean = groupItem != null ? (GroupItemBean) mapItemToBean(groupItem, true, uriPath)
                 : null;
 
-        return new ThingBean(thingUID, bridgeUID, thing.getStatus(), channelBeans, thing.getConfiguration(), 
+        return new ThingBean(thingUID, bridgeUID, thing.getStatus(), channelBeans, thing.getConfiguration(),
                 thing.getProperties(), groupItemBean);
     }
 
@@ -70,7 +70,8 @@ public class BeanMapper {
         ThingUID bridgeUID = discoveryResult.getBridgeUID();
 
         return new DiscoveryResultBean(thingUID.toString(), bridgeUID != null ? bridgeUID.toString() : null,
-                discoveryResult.getLabel(), discoveryResult.getFlag(), discoveryResult.getProperties());
+                discoveryResult.getLabel(), discoveryResult.getFlag(), discoveryResult.getProperties(),
+                discoveryResult.getRepresentationProperty());
     }
 
     private static void fillProperties(ItemBean bean, Item item, boolean drillDown, String uriPath) {


### PR DESCRIPTION
Currently discovery results contain only labels as human readable information to inform about new  things that were discovered. However solutions based on ESH might require an id property to give the solution´s UI a hint how to represent the unique id of the discovered thing. For this reason the discovery result was extended by a representation object containing the unique id and its type like IP address, MAC address, serial number, ...

Signed-off-by: Thomas Höfer <t.hoefer@telekom.de>