### PR TITLE
Improved GenericItemProvider

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -349,6 +349,10 @@ public class GenericItemProvider extends AbstractProvider<Item> implements Model
                 } catch (BindingConfigParseException e) {
                     logger.error("Binding configuration of type '" + bindingType + "' of item ‘" + item.getName()
                             + "‘ could not be parsed correctly.", e);
+                } catch (Exception e) {
+                    // Catch badly behaving binding exceptions and continue processing
+                    logger.error("Binding configuration of type '" + bindingType + "' of item ‘" + item.getName()
+                            + "‘ could not be parsed correctly.", e);
                 }
             } else {
                 logger.trace("Couldn't find config reader for binding type '{}' > "


### PR DESCRIPTION
Changed GenericItemProvider to catch all exceptions caused by badly behaving bindings.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com> (github: paulianttila)