### PR TITLE
Added update method when thing is updated

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
@@ -156,6 +156,7 @@ public class ThingSetupManager {
         thingRegistry.add(thing);
         itemRegistry.add(groupItem);
         itemThingLinkRegistry.add(new ItemThingLink(itemName, thing.getUID()));
+        thingRegistry.update(thing);
 
         ThingType thingType = thingTypeRegistry.getThingType(thingTypeUID);
         if (thingType != null) {


### PR DESCRIPTION
This updates the thing after the item link has been added. After the link gets added, the thing has been changed and it seems useful to update the registry so everyone knows it's been updated.
https://bugs.eclipse.org/bugs/show_bug.cgi?id=464953
Signed-off-by: Chris Jackson <chris@cd-jackson.com>