### PR TITLE
update google guava to 15.0.0

### DIFF
--- a/targetplatform/smarthome.target
+++ b/targetplatform/smarthome.target
@@ -4,8 +4,8 @@
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.inject" version="3.0.0.v201312141243"/>
 <unit id="com.google.inject.source" version="3.0.0.v201312141243"/>
-<unit id="com.google.guava" version="10.0.1.v201203051515"/>
-<unit id="com.google.guava.source" version="10.0.1.v201203051515"/>
+<unit id="com.google.guava" version="15.0.0.v201403281430"/>
+<unit id="com.google.guava.source" version="15.0.0.v201403281430"/>
 <unit id="com.google.gson" version="2.2.4.v201311231704"/>
 <unit id="com.google.gson.source" version="2.2.4.v201311231704"/>
 <unit id="com.ibm.icu.base" version="52.1.0.v201404171520"/>


### PR DESCRIPTION
In order to make use of the RateLimiter (see http://docs.guava-libraries.googlecode.com/git/javadoc/com/google/common/util/concurrent/RateLimiter.html - introduces in guava 13) we'd like to update the current version the latest available in this Orbit-Drop.

Signed-off-by: Thomas Eichstädt-Engelen <thomas@openhab.org>