### PR TITLE
Move update of thing to after update of item to ensure information is correctly presented

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/setup/ThingSetupManagerResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/setup/ThingSetupManagerResource.java
@@ -86,13 +86,6 @@ public class ThingSetupManagerResource implements RESTResource {
         Configuration configuration = getConfiguration(thingBean);
 
         Thing thing = thingSetupManager.getThing(thingUID);
-        if (thing != null) {
-            if (bridgeUID != null) {
-                thing.setBridgeUID(bridgeUID);
-            }
-            updateConfiguration(thing, configuration);
-            thingSetupManager.updateThing(thing);
-        }
 
         String label = thingBean.item.label;
         List<String> groupNames = thingBean.item.groupNames;
@@ -110,6 +103,14 @@ public class ThingSetupManagerResource implements RESTResource {
                     thingSetupManager.updateItem(thingGroupItem);
                 }
             }
+        }
+        
+        if (thing != null) {
+            if (bridgeUID != null) {
+                thing.setBridgeUID(bridgeUID);
+            }
+            updateConfiguration(thing, configuration);
+            thingSetupManager.updateThing(thing);
         }
 
         return Response.ok().build();


### PR DESCRIPTION
Currently, when you update the label in the linked thing, the 'thing updated' event responds with the updated information being the same as the old information. This is because the thing is updated before the item, so we send incorrect information.
This PR reverses the order - the thing information is updated after the item, so the item changes are now correctly presented in the SSE event.
https://bugs.eclipse.org/bugs/show_bug.cgi?id=465079
Signed-off-by: Chris Jackson <chris@cd-jackson.com>