### PR TITLE
Fix Bug 465239: Make changing of state asynchronous

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/main.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/main.html
@@ -56,7 +56,7 @@
 			});
 			
 	        function ChangeState(request) {
-	            WA.Request(request, null, null);
+	            WA.Request(request, null, null, true);
 	        }
 
 			// Functions for image refresh


### PR DESCRIPTION
Caused by a bug in (at least) Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=664720) the onmouseup is not triggered if a synchronous Ajax request made in the onmousedown does not complete soon enough.
Anyway the use of synchronous HTTP Requests seems to be deprecated.
Same PR as https://github.com/openhab/openhab/pull/2473

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=465239
Signed-off-by: Dominic Lerbs <promguard-github@yahoo.de>