### PR TITLE
Change ActiveItem setters to return a changed flag. Improved item.equals()

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ActiveItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ActiveItem.java
@@ -24,16 +24,20 @@ public interface ActiveItem extends Item {
      *
      * @param label
      *            label (can be null)
+     * @return boolean
+     *            true if the label changed
      */
-    void setLabel(String label);
+    boolean setLabel(String label);
 
     /**
      * Sets the category of the item (can be null)
      *
      * @param category
      *            category
+     * @return boolean
+     *            true if the category changed
      */
-    void setCategory(String category);
+    boolean setCategory(String category);
 
     /**
      * Adds a tag to the item.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -37,6 +38,7 @@ import com.google.common.collect.ImmutableSet;
  * 
  * @author Kai Kreuzer - Initial contribution and API
  * @author Andre Fuechsel - Added tags
+ * @author Chris Jackson - updated setters to return change flag
  *
  */
 abstract public class GenericItem implements ActiveItem {
@@ -265,30 +267,15 @@ abstract public class GenericItem implements ActiveItem {
 		if (getClass() != obj.getClass())
 			return false;
 		GenericItem other = (GenericItem) obj;
-		if (category == null) {
-			if (other.category != null)
-				return false;
-		} else if (!category.equals(other.category))
+		if (Objects.equals(category, other.category) == false)
 			return false;
-		if (label == null) {
-			if (other.label != null)
-				return false;
-		} else if (!label.equals(other.label))
+		if (Objects.equals(label, other.label) == false)
 			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
+		if (Objects.equals(name, other.name) == false)
 			return false;
-		if (tags == null) {
-			if (other.tags != null)
-				return false;
-		} else if (!tags.equals(other.tags))
+		if (Objects.equals(tags, other.tags) == false)
 			return false;
-		if (type == null) {
-			if (other.type != null)
-				return false;
-		} else if (!type.equals(other.type))
+		if (Objects.equals(type, other.type) == false)
 			return false;
 		return true;
 	}
@@ -334,8 +321,10 @@ abstract public class GenericItem implements ActiveItem {
     }
 
     @Override
-    public void setLabel(String label) {
+    public boolean setLabel(String label) {
+    	boolean changed = Objects.equals(this.label, label);
         this.label = label;
+        return changed;
     }
 
     @Override
@@ -344,8 +333,10 @@ abstract public class GenericItem implements ActiveItem {
     }
 
     @Override
-    public void setCategory(String category) {
+    public boolean setCategory(String category) {
+    	boolean changed = Objects.equals(this.category, category);
         this.category = category;
+        return changed;
     }
 
     @Override


### PR DESCRIPTION
I think this is more convenient for the setters to return a change flag - this can allow the tidying up of some other code which does change detection. I'm looking in the REST interfaces, and if this merge is ok I'll use these returns in some of the REST interfaces to remove some of the duplication.
I know this changes a core interface, but I doubt it is being used elsewhere, and if it is, it's a simple thing to change. I think it's a useful addition, but I leave it to you to evaluate.
The other thing I've done is to tidy the item.equals() method (we are using Java 7 as the minimum requirement right?)

One further comment - I've not fully tested this - I tested the comparisons in the REST core and it works fine, but it's more difficult to import this into my OH2 environment as a whole as I end up with an inconsistent environment if I just import the core bundle...

Signed-off-by: Chris Jackson <chris@cd-jackson.com>
