### PR TITLE
Config parameter and interface enhancements

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescription.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescription.java
@@ -19,6 +19,11 @@ import java.util.List;
  * data itself and is usually used for data validation of the concrete
  * configuration or for supporting user interfaces.
  * <p>
+ * The {@link ConfigDescriptionParameterGroup} provides a method to group parameters to allow the UI to better display
+ * the parameter information. This can be left blank for small devices where there are only a few parameters, however
+ * devices with larger numbers of parameters can set the group member in the {@link ConfigDescriptionParameter} and then
+ * provide group information as part of the {@link ConfigDescription} class.
+ * <p>
  * The description is stored within the {@link ConfigDescriptionRegistry} under the given URI. The URI has to follow the
  * syntax {@code '<scheme>:<token>[:<token>]'} (e.g. {@code "binding:hue:bridge"}).
  * <p>
@@ -26,11 +31,13 @@ import java.util.List;
  *
  * @author Michael Grammling - Initial Contribution
  * @author Dennis Nobel - Initial Contribution
+ * @author Chris Jackson - Added parameter groups
  */
 public class ConfigDescription {
 
     private URI uri;
     private List<ConfigDescriptionParameter> parameters;
+    private List<ConfigDescriptionParameterGroup> parameterGroups;
 
     /**
      * Creates a new instance of this class with the specified parameter.
@@ -39,7 +46,7 @@ public class ConfigDescription {
      * @throws IllegalArgumentException if the URI is null or invalid
      */
     public ConfigDescription(URI uri) throws IllegalArgumentException {
-        this(uri, null);
+        this(uri, null, null);
     }
 
     /**
@@ -54,6 +61,24 @@ public class ConfigDescription {
      * @throws IllegalArgumentException if the URI is null or invalid
      */
     public ConfigDescription(URI uri, List<ConfigDescriptionParameter> parameters) {
+        this(uri, parameters, null);
+    }
+
+    /**
+     * Creates a new instance of this class with the specified parameters.
+     *
+     * @param uri the URI of this description within the {@link ConfigDescriptionRegistry} (must neither be null nor
+     *            empty)
+     *
+     * @param parameters the description of a concrete configuration parameter
+     *            (could be null or empty)
+     *            
+     * @param groups the list of groups associated with the parameters
+     *
+     * @throws IllegalArgumentException if the URI is null or invalid
+     */
+    public ConfigDescription(URI uri, List<ConfigDescriptionParameter> parameters,
+            List<ConfigDescriptionParameterGroup> groups) {
         if (uri == null) {
             throw new IllegalArgumentException("The URI must not be null!");
         }
@@ -70,6 +95,12 @@ public class ConfigDescription {
             this.parameters = Collections.unmodifiableList(parameters);
         } else {
             this.parameters = Collections.unmodifiableList(new ArrayList<ConfigDescriptionParameter>(0));
+        }
+
+        if (groups != null) {
+            this.parameterGroups = Collections.unmodifiableList(groups);
+        } else {
+            this.parameterGroups = Collections.unmodifiableList(new ArrayList<ConfigDescriptionParameterGroup>(0));
         }
     }
 
@@ -94,9 +125,20 @@ public class ConfigDescription {
         return this.parameters;
     }
 
+    /**
+     * Returns the list of configuration parameter groups associated with the parameters.
+     * <p>
+     * The returned list is immutable.
+     *
+     * @return the list of parameter groups parameter (not null, could be empty)
+     */
+    public List<ConfigDescriptionParameterGroup> getParameterGroups() {
+        return this.parameterGroups;
+    }
+
     @Override
     public String toString() {
-        return "ConfigDescription [uri=" + uri + ", parameters=" + parameters + "]";
+        return "ConfigDescription [uri=" + uri + ", parameters=" + parameters + ", groups=" + parameterGroups + "]";
     }
 
 }

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterBuilder.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterBuilder.java
@@ -23,6 +23,9 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
 public class ConfigDescriptionParameterBuilder {
     private String name;
     private Type type;
+
+    private String groupName;
+
     private BigDecimal min;
     private BigDecimal max;
     private BigDecimal step;
@@ -30,11 +33,15 @@ public class ConfigDescriptionParameterBuilder {
     private boolean required;
     private boolean readOnly;
     private boolean multiple;
+    private Integer multipleLimit;
 
     private String context;
     private String defaultValue;
     private String label;
     private String description;
+
+    private boolean limitToOptions;
+    private boolean advanced;
 
     private List<ParameterOption> options = new ArrayList<ParameterOption>();
     private List<FilterCriteria> filterCriteria = new ArrayList<FilterCriteria>();
@@ -116,6 +123,16 @@ public class ConfigDescriptionParameterBuilder {
     }
 
     /**
+     * Set the configuration parameter to allow multiple selection
+     *
+     * @param multiple
+     */
+    public ConfigDescriptionParameterBuilder withMultipleLimit(Integer multipleLimit) {
+        this.multipleLimit = multipleLimit;
+        return this;
+    }
+
+    /**
      * Set the context of the configuration parameter
      *
      * @param context
@@ -176,6 +193,36 @@ public class ConfigDescriptionParameterBuilder {
     }
 
     /**
+     * Set the configuration parameter as an advanced parameter
+     *
+     * @param options
+     */
+    public ConfigDescriptionParameterBuilder withAdvanced(Boolean advanced) {
+        this.advanced = advanced;
+        return this;
+    }
+
+    /**
+     * Set the configuration parameter to be limited to the values in the options list
+     *
+     * @param options
+     */
+    public ConfigDescriptionParameterBuilder withLimitToOptions(Boolean limitToOptions) {
+        this.limitToOptions = limitToOptions;
+        return this;
+    }
+
+    /**
+     * Set the configuration parameter to be limited to the values in the options list
+     *
+     * @param options
+     */
+    public ConfigDescriptionParameterBuilder withGroupName(String groupName) {
+        this.groupName = groupName;
+        return this;
+    }
+
+    /**
      * Set the filter criteria of the configuration parameter
      *
      * @param filterCriteria
@@ -192,7 +239,8 @@ public class ConfigDescriptionParameterBuilder {
      */
     public ConfigDescriptionParameter build() throws IllegalArgumentException {
         return new ConfigDescriptionParameter(name, type, min, max, step, pattern, required, readOnly, multiple,
-                context, defaultValue, label, description, options, filterCriteria);
+                context, defaultValue, label, description, options, filterCriteria, groupName, advanced,
+                limitToOptions, multipleLimit);
     }
 
 }

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterGroup.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterGroup.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.core;
+
+/**
+ * The {@link ConfigDescriptionParameterGroup} specifies information about parameter groups.
+ * A parameter group is used to group a number of parameters together so they can
+ * be displayed together in the UI (eg in a single tab).
+ * <p>
+ * A {@link ConfigDescriptionParameter} instance must also contain the groupName. It should be permissible to use the
+ * groupId in the {@link ConfigDesctiptionParameter} without supplying a corresponding
+ * {@link ConfigDescriptionParameterGroup} - in this way the UI can group the parameters together, but doesn't have the
+ * group information.
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
+public class ConfigDescriptionParameterGroup {
+
+    private String name;
+    private String context;
+    private boolean advanced;
+    private String label;
+    private String description;
+
+    /**
+     * Create a Parameter Group. A group is used by the user interface to display groups
+     * of parameters together.
+     *
+     * @param name
+     *            the name, used to link the group, to the parameter
+     * @param context
+     *            a context string. Can be used to provide some context to the group
+     * @param advanced
+     *            a flag that is set to true if this group contains advanced settings
+     * @param label
+     *            the human readable group label
+     * @param description
+     *            a description that can be provided to the user
+     */
+    public ConfigDescriptionParameterGroup(String name, String context, Boolean advanced, String label,
+            String description) {
+        this.name = name;
+        this.context = context;
+        this.advanced = advanced;
+        this.label = label;
+        this.description = description;
+    }
+
+    /**
+     * Get the name of the group.
+     *
+     * @return groupName as string
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Get the context of the group.
+     *
+     * @return group context as a string
+     */
+    public String getContext() {
+        return context;
+    }
+
+    /**
+     * Gets the advanced flag for this group.
+     *
+     * @return advanced flag - true if the group contains advanced properties
+     */
+    public boolean isAdvanced() {
+        return advanced;
+    }
+
+    /**
+     * Get the human readable label of the group
+     *
+     * @return group label as a string
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Get the human readable description of the parameter group
+     *
+     * @return group description as a string
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + " [groupId=\"" + name + "\", context=\"" + context + "\", advanced=\""
+                + advanced + "\", label=\"" + label + "\", description=\"" + description + "\"]";
+    }
+}

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -65,7 +65,8 @@ public class Configuration {
                 Object value = properties.get(fieldName);
 
                 if (value == null && field.getType().isPrimitive()) {
-                    logger.debug("Skipping field '{}', because it's primitive data type and value is not set", fieldName);
+                    logger.debug("Skipping field '{}', because it's primitive data type and value is not set",
+                            fieldName);
                     continue;
                 }
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigDescriptionGroupI18nUtil.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigDescriptionGroupI18nUtil.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.core.i18n;
+
+import java.net.URI;
+import java.util.Locale;
+
+import org.eclipse.smarthome.core.i18n.I18nProvider;
+import org.eclipse.smarthome.core.i18n.I18nUtil;
+import org.osgi.framework.Bundle;
+
+/**
+ * The {@link ConfigDescriptionGroupI18nUtil} uses the {@link I18nProvider} to
+ * resolve the localized texts in the configuration parameter groups. It automatically infers the key if the default
+ * text is not a constant.
+ *
+ * @author Chris Jackson - Initial contribution
+ */
+public class ConfigDescriptionGroupI18nUtil {
+
+    private I18nProvider i18nProvider;
+
+    public ConfigDescriptionGroupI18nUtil(I18nProvider i18nProvider) {
+        this.i18nProvider = i18nProvider;
+    }
+
+    public String getGroupDescription(Bundle bundle, URI configDescriptionURI, String groupName,
+            String defaultDescription, Locale locale) {
+        String key = I18nUtil.isConstant(defaultDescription) ? I18nUtil.stripConstant(defaultDescription) : inferKey(
+                configDescriptionURI, groupName, "description");
+        return i18nProvider.getText(bundle, key, defaultDescription, locale);
+    }
+
+    public String getGroupLabel(Bundle bundle, URI configDescriptionURI, String groupName, String defaultLabel,
+            Locale locale) {
+        String key = I18nUtil.isConstant(defaultLabel) ? I18nUtil.stripConstant(defaultLabel) : inferKey(
+                configDescriptionURI, groupName, "label");
+        return i18nProvider.getText(bundle, key, defaultLabel, locale);
+    }
+
+    private String inferKey(URI configDescriptionURI, String groupName, String lastSegment) {
+        String uri = configDescriptionURI.getSchemeSpecificPart().replace(":", ".");
+        return configDescriptionURI.getScheme() + ".config." + uri + ".group." + groupName + "." + lastSegment;
+    }
+}

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/groovy/org/eclipse/smarthome/config/xml/test/ConfigDescriptionI18nTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/groovy/org/eclipse/smarthome/config/xml/test/ConfigDescriptionI18nTest.groovy
@@ -13,6 +13,7 @@ import static org.junit.matchers.JUnitMatchers.*
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
 import org.eclipse.smarthome.test.OSGiTest
 import org.eclipse.smarthome.test.SyntheticBundleInstaller
@@ -59,8 +60,7 @@ class ConfigDescriptionI18nTest extends OSGiTest {
         assertThat configDescriptions.size(), is(initialNumberOfConfigDescriptions + 1)
 
         def config = configDescriptions.first() as ConfigDescription
-
-
+        
         assertThat config, is(notNullValue())
         assertEquals("""
         location.label = Ort
@@ -71,9 +71,11 @@ class ConfigDescriptionI18nTest extends OSGiTest {
         refresh.description = Spezifiziert das Aktualisierungsintervall in Sekunden
         question.pattern = Wie ist das Wetter in [\\w]*?
         question.options = München, Köln
+        group.label = Group 1 German Label
+        group.description = Group 1 German Description
         """, asString(config))
 
-
+        
     }
 
     String asString(final ConfigDescription self) {
@@ -93,6 +95,10 @@ class ConfigDescriptionI18nTest extends OSGiTest {
         def pattern = question.getPattern()
         def options = question.getOptions().collect { it.getLabel() }.join(", ")
         
+        ConfigDescriptionParameterGroup group = self.getParameterGroups().find { it.getName().equals("group1") }
+        def group_label = group.getLabel()
+        def group_description = group.getDescription()
+
         return """
         location.label = ${location_label}
         location.description = ${location_description}
@@ -102,6 +108,8 @@ class ConfigDescriptionI18nTest extends OSGiTest {
         refresh.description = ${refresh_description}
         question.pattern = ${pattern}
         question.options = ${options}
+        group.label = ${group_label}
+        group.description = ${group_description}
         """
     }
 }

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/groovy/org/eclipse/smarthome/config/xml/test/ConfigDescriptionsTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/groovy/org/eclipse/smarthome/config/xml/test/ConfigDescriptionsTest.groovy
@@ -13,6 +13,7 @@ import static org.junit.matchers.JUnitMatchers.*
 
 import org.eclipse.smarthome.config.core.ConfigDescription
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type
 import org.eclipse.smarthome.config.core.ParameterOption;
@@ -61,14 +62,15 @@ class ConfigDescriptionsTest extends OSGiTest {
         ConfigDescription dummyConfigDescription = configDescriptions.find {
                 it.uri.equals(new URI("config:dummyConfig")) }
         assertThat dummyConfigDescription, is(notNullValue())
-        
+
         def parameters = dummyConfigDescription.parameters
-        assertThat parameters.size(), is(5)
+        assertThat parameters.size(), is(6)
         
         ConfigDescriptionParameter ipParameter = parameters.find { it.name.equals("ip") }
         assertThat ipParameter, is(notNullValue())
         assertThat ipParameter.type, is(Type.TEXT)
         ipParameter.with {
+	        assertThat groupName, is(null)
             assertThat context, is("network-address")
             assertThat label, is("Network Address")
             assertThat description, is("Network address of the hue bridge.")
@@ -82,6 +84,7 @@ class ConfigDescriptionsTest extends OSGiTest {
         assertThat usernameParameter, is(notNullValue())
         assertThat usernameParameter.type, is(Type.TEXT)
         usernameParameter.with {
+	        assertThat groupName, is("user")
             assertThat context, is("password")
             assertThat label, is("Username")
             assertThat required, is(false)
@@ -102,32 +105,68 @@ class ConfigDescriptionsTest extends OSGiTest {
             assertThat context, is("password")
             assertThat label, is("Password")
         }
-        
-        ConfigDescriptionParameter listParameter = parameters.find { it.name.equals("list") }
-        assertThat listParameter, is(notNullValue())
-        assertThat listParameter.type, is(Type.TEXT)
-        listParameter.with {
+
+        ConfigDescriptionParameter colorItemParameter = parameters.find { it.name.equals("color-alarming-light") }
+        assertThat colorItemParameter, is(notNullValue())
+        assertThat colorItemParameter.type, is(Type.TEXT)
+        colorItemParameter.with {
+            assertThat required, is(false)
+            assertThat readOnly, is(false)
+            assertThat context, is("item")
+            assertThat filterCriteria, is(notNullValue())
+            assertThat filterCriteria.join(", "), is("FilterCriteria [name=\"tags\", value=\"alarm, light\"], FilterCriteria [name=\"type\", value=\"color\"], FilterCriteria [name=\"binding-id\", value=\"hue\"]")
+        }
+
+        ConfigDescriptionParameter listParameter1 = parameters.find { it.name.equals("list1") }
+        assertThat listParameter1, is(notNullValue())
+        assertThat listParameter1.type, is(Type.TEXT)
+        listParameter1.with {
             assertThat required, is(false)
             assertThat multiple, is(true)
             assertThat readOnly, is(false)
             assertThat min, is(2 as BigDecimal)
             assertThat max, is(3 as BigDecimal)
             assertThat options, is(notNullValue())
+            assertThat advanced, is(false)
+            assertThat limitToOptions, is(true)
+            assertThat multipleLimit, is(null)
             assertThat options.join(", "), is("ParameterOption [value=\"key1\", label=\"label1\"], ParameterOption [value=\"key2\", label=\"label2\"]")
         }
         
-        ConfigDescriptionParameter colorItemParameter = parameters.find { it.name.equals("color-alarming-light") }
-        assertThat colorItemParameter, is(notNullValue())
-        assertThat colorItemParameter.type, is(Type.TEXT)
-        colorItemParameter.with {
+        ConfigDescriptionParameter listParameter2 = parameters.find { it.name.equals("list2") }
+        assertThat listParameter2, is(notNullValue())
+        assertThat listParameter2.type, is(Type.TEXT)
+        listParameter2.with {
             assertThat required, is(false)
             assertThat multiple, is(true)
             assertThat readOnly, is(false)
-            assertThat context, is("item")
-            assertThat filterCriteria, is(notNullValue())
-            assertThat filterCriteria.join(", "), is("FilterCriteria [name=\"tags\", value=\"alarm, light\"], FilterCriteria [name=\"type\", value=\"color\"], FilterCriteria [name=\"binding-id\", value=\"hue\"]")
+            assertThat options, is(notNullValue())
+            assertThat advanced, is(true)
+            assertThat limitToOptions, is(false)
+            assertThat multipleLimit, is(4)
         }
         
+        def groups = dummyConfigDescription.parameterGroups
+        assertThat groups.size(), is(2)
+
+        ConfigDescriptionParameterGroup group1 = groups.find { it.name.equals("group1") }
+        assertThat group1, is(notNullValue())
+        group1.with {
+            assertThat label, is("Group 1")
+            assertThat description, is("Description Group 1")
+            assertThat advanced, is(false)
+            assertThat context, is("Context-Group1")
+        }
+
+        ConfigDescriptionParameterGroup group2 = groups.find { it.name.equals("group2") }
+        assertThat group1, is(notNullValue())
+        group2.with {
+            assertThat label, is("Group 2")
+            assertThat description, is("Description Group 2")
+            assertThat advanced, is(true)
+            assertThat context, is("Context-Group2")
+        }
+
         // uninstall test bundle
         bundle.uninstall();
         assertThat bundle.state, is(Bundle.UNINSTALLED)

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/ESH-INF/config/config.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/ESH-INF/config/config.xml
@@ -2,40 +2,65 @@
 <config-description:config-descriptions
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
-	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 ../../../../../../../../org.eclipse.smarthome.config.xml/org.eclipse.smarthome.config-description.xsd ">
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description/v1.0.0">
 
 	<!-- test dummy -->
 	<config-description uri="config:dummyConfig">
+		<parameter-group name="group1">
+			<context>Context-Group1</context>
+			<label>Group 1</label>
+			<description>Description Group 1</description>
+			<advanced>false</advanced>
+		</parameter-group>
 
+		<parameter-group name="group2">
+			<context>Context-Group2</context>
+			<label>Group 2</label>
+			<description>Description Group 2</description>
+			<advanced>true</advanced>
+		</parameter-group>
+			
 		<parameter name="ip" type="text" pattern="[0-9]{3}.[0-9]{3}.[0-9]{3}.[0-9]{3}" required="true" readOnly="true">
+	        <multipleLimit>4</multipleLimit>
 			<context>network-address</context>
 			<label>Network Address</label>
 			<description>Network address of the hue bridge.</description>
 			<required>true</required><!-- deprecated -->
+			<limitToOptions>true</limitToOptions>
 		</parameter>
 
-		<parameter name="username" type="text">
+		<parameter name="username" type="text" groupName="user">
 			<context>password</context>
 			<label>Username</label>
 			<description>Name of a registered hue bridge user, that allows to access the API.
 			</description>
 		</parameter>
-		    
+
 		<!-- password with min 8, max 16 characters -->
-		<parameter name="user-pass" type="text" min="8" max="16" required="true">
+		<parameter name="user-pass" type="text" groupName="user" min="8" max="16" required="true">
 			<context>password</context>
 			<label>Password</label>
 			<required>true</required><!-- deprecated -->
 		</parameter>
 		
 		<!-- a static selection list allowing multiple selections with min 2 max 3 items -->
-	    <parameter name="list" type="text" multiple="true" min="2" max="3">
+	    <parameter name="list1" type="text" multiple="true" min="2" max="3">
 	        <options>
 	            <option value="key1">label1</option>
 	            <option value="key2">label2</option>
 	        </options>
 	    </parameter>
-	     
+
+	    <parameter name="list2" type="text" multiple="true" min="2" max="3">
+	        <options>
+	            <option value="key1">label1</option>
+	            <option value="key2">label2</option>
+	        </options>
+	        <advanced>true</advanced>
+	        <multipleLimit>4</multipleLimit>
+	        <limitToOptions>false</limitToOptions>
+	    </parameter>
+
 	    <!-- a selection list of color items that have the tags "alarm" and "light" -->
 	    <parameter name="color-alarming-light" type="text" multiple="true">
 	        <context>item</context>
@@ -45,7 +70,7 @@
 	            <criteria name="binding-id">hue</criteria>
 	        </filter>
 		</parameter>
-		
+
 	</config-description>
 
 </config-description:config-descriptions>

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/ESH-INF/config/config.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/ESH-INF/config/config.xml
@@ -6,6 +6,13 @@
 
 	<!-- test dummy -->
 	<config-description uri="config:Dummy">
+		<parameter-group name="group1">
+			<context>Context-Group1</context>
+			<label>Group 1</label>
+			<description>Description Group 1</description>
+			<advanced>false</advanced>
+		</parameter-group>
+
 		<parameter name="location" type="text" required="true">
 			<label>Location</label>
 			<description>Location for the weather information. Syntax is WOEID, see https://en.wikipedia.org/wiki/WOEID.</description>

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src�test/resources/test-bundle-pool/yahooweather.bundle/ESH-INF/i18n/yahooweather_de.properties
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src�test/resources/test-bundle-pool/yahooweather.bundle/ESH-INF/i18n/yahooweather_de.properties
@@ -8,5 +8,6 @@ config.config.Dummy.unit.description = Spezifiziert die Einheit der Daten. Valid
 config.config.Dummy.refresh.label = Aktualisierungsintervall
 config.config.Dummy.refresh.description = Spezifiziert das Aktualisierungsintervall in Sekunden
 
-config.config.Dummy.group.group1.label = Group 1 German Label
-config.config.Dummy.group.group1.description = Group 1 German Description
+config.configGroup.Dummy.group1.label = Group 1 German Label
+config.configGroup.Dummy.group1.description = Group 1 German Description
+

--- a/bundles/config/org.eclipse.smarthome.config.xml/config-description-1.0.0.xsd
+++ b/bundles/config/org.eclipse.smarthome.config.xml/config-description-1.0.0.xsd
@@ -1,57 +1,81 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-        xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
-        targetNamespace="http://eclipse.org/smarthome/schemas/config-description/v1.0.0">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	targetNamespace="http://eclipse.org/smarthome/schemas/config-description/v1.0.0">
 
 	<xs:element name="config-descriptions">
 		<xs:complexType>
 			<xs:sequence>
-				<xs:element name="config-description" type="config-description:configDescription" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="config-description" type="config-description:configDescription"
+					minOccurs="1" maxOccurs="unbounded" />
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
 
-	<xs:element name="config-description" type="config-description:configDescription"/>
+	<xs:element name="config-description" type="config-description:configDescription" />
 
-    <xs:simpleType name="idRestrictionPattern">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z0-9\-_]+"/>
-        </xs:restriction>
-    </xs:simpleType>
+	<xs:simpleType name="idRestrictionPattern">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Za-z0-9\-_]+" />
+		</xs:restriction>
+	</xs:simpleType>
 
-    <xs:simpleType name="uriRestrictionPattern">
-        <xs:restriction base="xs:string">
-            <xs:pattern value="[A-Za-z0-9\-_]+(:[A-Za-z0-9\-_]+){1,2}"/>
-        </xs:restriction>
-    </xs:simpleType>
+	<xs:simpleType name="uriRestrictionPattern">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[A-Za-z0-9\-_]+(:[A-Za-z0-9\-_]+){1,2}" />
+		</xs:restriction>
+	</xs:simpleType>
 
 	<xs:complexType name="configDescription">
 		<xs:sequence>
-			<xs:element name="parameter" type="config-description:parameter" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="parameter-group" type="config-description:parameterGroup"
+				minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="parameter" type="config-description:parameter"
+				minOccurs="0" maxOccurs="unbounded" />
 		</xs:sequence>
-		<xs:attribute name="uri" type="config-description:uriRestrictionPattern" use="optional"/>
+		<xs:attribute name="uri"
+			type="config-description:uriRestrictionPattern" use="optional" />
 	</xs:complexType>
 
 	<xs:complexType name="parameter">
 		<xs:all>
-			<xs:element name="context" type="xs:string" minOccurs="0"/>
-			 <!-- deprecated element "required" -->
-			<xs:element name="required" type="xs:boolean" default="false" minOccurs="0"/>
-			<xs:element name="default" type="xs:string" minOccurs="0"/>
-			<xs:element name="label" type="xs:string" minOccurs="0"/>
-			<xs:element name="description" type="xs:string" minOccurs="0"/>
-			<xs:element name="options" type="config-description:optionsType" minOccurs="0"/>
-			<xs:element name="filter" type="config-description:filterType" minOccurs="0"/>
+			<xs:element name="context" type="xs:string" minOccurs="0" />
+			<!-- deprecated element "required" -->
+			<xs:element name="required" type="xs:boolean" default="false"
+				minOccurs="0" />
+			<xs:element name="default" type="xs:string" minOccurs="0" />
+			<xs:element name="label" type="xs:string" minOccurs="0" />
+			<xs:element name="description" type="xs:string" minOccurs="0" />
+			<xs:element name="options" type="config-description:optionsType"
+				minOccurs="0" />
+			<xs:element name="limitToOptions" type="xs:boolean"
+				minOccurs="0" />
+			<xs:element name="filter" type="config-description:filterType"
+				minOccurs="0" />
+			<xs:element name="advanced" type="xs:boolean" minOccurs="0" />
+			<xs:element name="multipleLimit" type="xs:integer" minOccurs="0" />
 		</xs:all>
-		<xs:attribute name="name" type="xs:string" use="required"/>
-		<xs:attribute name="type" type="config-description:parameterType" use="required"/>
-		<xs:attribute name="min" type="xs:decimal"/>
-		<xs:attribute name="max" type="xs:decimal"/>
-		<xs:attribute name="step" type="xs:decimal"/>
-		<xs:attribute name="pattern" type="xs:string"/>
-		<xs:attribute name="required" type="xs:boolean"/>
-		<xs:attribute name="readOnly" type="xs:boolean"/>
-		<xs:attribute name="multiple" type="xs:boolean"/>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="type" type="config-description:parameterType"
+			use="required" />
+		<xs:attribute name="groupName" type="xs:string" />
+		<xs:attribute name="min" type="xs:decimal" />
+		<xs:attribute name="max" type="xs:decimal" />
+		<xs:attribute name="step" type="xs:decimal" />
+		<xs:attribute name="pattern" type="xs:string" />
+		<xs:attribute name="required" type="xs:boolean" />
+		<xs:attribute name="readOnly" type="xs:boolean" />
+		<xs:attribute name="multiple" type="xs:boolean" />
+	</xs:complexType>
+
+	<xs:complexType name="parameterGroup">
+		<xs:all>
+			<xs:element name="label" type="xs:string" minOccurs="0" />
+			<xs:element name="description" type="xs:string" minOccurs="0" />
+			<xs:element name="context" type="xs:string" minOccurs="0" />
+			<xs:element name="advanced" type="xs:boolean" minOccurs="0" />
+		</xs:all>
+		<xs:attribute name="name" type="xs:string" use="required" />
 	</xs:complexType>
 
 	<xs:complexType name="optionsType">
@@ -80,19 +104,20 @@
 				</xs:complexType>
 			</xs:element>
 		</xs:sequence>
-	</xs:complexType>	
+	</xs:complexType>
 
 	<xs:simpleType name="parameterType">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="text"/>
-			<xs:enumeration value="integer"/>
-			<xs:enumeration value="decimal"/>
-			<xs:enumeration value="boolean"/>
+			<xs:enumeration value="text" />
+			<xs:enumeration value="integer" />
+			<xs:enumeration value="decimal" />
+			<xs:enumeration value="boolean" />
 		</xs:restriction>
 	</xs:simpleType>
 
-    <xs:complexType name="configDescriptionRef">
-        <xs:attribute name="uri" type="config-description:uriRestrictionPattern" use="required"/>
-    </xs:complexType>
+	<xs:complexType name="configDescriptionRef">
+		<xs:attribute name="uri"
+			type="config-description:uriRestrictionPattern" use="required" />
+	</xs:complexType>
 
 </xs:schema>

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionConverter.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionConverter.java
@@ -9,14 +9,17 @@ package org.eclipse.smarthome.config.xml;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.xml.util.ConverterAssertion;
 import org.eclipse.smarthome.config.xml.util.ConverterAttributeMapValidator;
 import org.eclipse.smarthome.config.xml.util.GenericUnmarshaller;
+import org.eclipse.smarthome.config.xml.util.NodeIterator;
 
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.Converter;
@@ -25,12 +28,13 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 
 /**
  * The {@link ConfigDescriptionConverter} is a concrete implementation of the {@code XStream} {@link Converter}
- * interface used to convert config description information within an XML
- * document into a {@link ConfigDescription} object.
+ * interface used to convert config
+ * description information within an XML document into a {@link ConfigDescription} object.
  * <p>
  * This converter converts {@code config-description} XML tags.
  *
  * @author Michael Grammling - Initial Contribution
+ * @author Chris Jackson - Added configuration groups
  */
 public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescription> {
 
@@ -51,7 +55,8 @@ public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescri
         Map<String, String> attributes = this.attributeMapValidator.readValidatedAttributes(reader);
         String uriText = attributes.get("uri");
         if (uriText == null) {
-            // the URI could be overridden by a context field if it could be automatically extracted
+            // the URI could be overridden by a context field if it could be
+            // automatically extracted
             uriText = (String) context.get("config-description.uri");
         }
 
@@ -63,14 +68,30 @@ public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescri
                     + "' is invalid!", ex);
         }
 
+        // create the lists to hold parameters and groups
+        List<ConfigDescriptionParameter> configDescriptionParams = new ArrayList<ConfigDescriptionParameter>();
+        List<ConfigDescriptionParameterGroup> configDescriptionGroups = new ArrayList<ConfigDescriptionParameterGroup>();
+
         // read values
-        List<ConfigDescriptionParameter> configDescriptionParams = (List<ConfigDescriptionParameter>) context
-                .convertAnother(context, List.class);
+        List<?> nodes = (List<?>) context.convertAnother(context, List.class);
+        NodeIterator nodeIterator = new NodeIterator(nodes);
+
+        // iterate through the nodes, putting the different types into their
+        // respective arrays
+        while (nodeIterator.hasNext() == true) {
+            Object node = nodeIterator.next();
+            if (node instanceof ConfigDescriptionParameter) {
+                configDescriptionParams.add((ConfigDescriptionParameter) node);
+            }
+            if (node instanceof ConfigDescriptionParameterGroup) {
+                configDescriptionGroups.add((ConfigDescriptionParameterGroup) node);
+            }
+        }
 
         ConverterAssertion.assertEndOfType(reader);
 
         // create object
-        configDescription = new ConfigDescription(uri, configDescriptionParams);
+        configDescription = new ConfigDescription(uri, configDescriptionParams, configDescriptionGroups);
 
         return configDescription;
     }

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionParameterGroupConverter.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionParameterGroupConverter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.xml;
+
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
+import org.eclipse.smarthome.config.xml.util.ConverterValueMap;
+import org.eclipse.smarthome.config.xml.util.GenericUnmarshaller;
+
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+
+/**
+ * The {@link ConfigDescriptionParameterGroupConverter} creates a {@link ConfigDescriptionParameterGroup} instance from
+ * a {@code option} XML
+ * node.
+ *
+ * @author Chris Jackson - Initial Contribution
+ */
+public class ConfigDescriptionParameterGroupConverter extends GenericUnmarshaller<ConfigDescriptionParameterGroup> {
+
+    public ConfigDescriptionParameterGroupConverter() {
+        super(ConfigDescriptionParameterGroup.class);
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext marshallingContext) {
+        String name = reader.getAttribute("name");
+
+        // Read values
+        ConverterValueMap valueMap = new ConverterValueMap(reader, marshallingContext);
+
+        String context = valueMap.getString("context");
+        String description = valueMap.getString("description");
+        String label = valueMap.getString("label");
+        Boolean advanced = valueMap.getBoolean("advanced", false);
+
+        return new ConfigDescriptionParameterGroup(name, context, advanced, label, description);
+    }
+}

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/FilterCriteriaConverter.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/FilterCriteriaConverter.java
@@ -14,7 +14,8 @@ import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 
 /**
- * The {@link FilterCriteriaConverter} creates a {@link FilterCriteria} instance from a {@code criteria} XML node.
+ * The {@link FilterCriteriaConverter} creates a {@link FilterCriteria} instance
+ * from a {@code criteria} XML node.
  *
  * @author Alex Tugarev - Initial Contribution
  */

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/internal/ConfigDescriptionReader.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/internal/ConfigDescriptionReader.java
@@ -11,9 +11,11 @@ import java.util.List;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.core.FilterCriteria;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionConverter;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionParameterConverter;
+import org.eclipse.smarthome.config.xml.ConfigDescriptionParameterGroupConverter;
 import org.eclipse.smarthome.config.xml.FilterCriteriaConverter;
 import org.eclipse.smarthome.config.xml.util.NodeAttributes;
 import org.eclipse.smarthome.config.xml.util.NodeAttributesConverter;
@@ -33,6 +35,7 @@ import com.thoughtworks.xstream.XStream;
  *
  * @author Michael Grammling - Initial Contribution
  * @author Alex Tugarev - Extended for options and filter criteria
+ * @author Chris Jackson - Added configuration groups
  */
 public class ConfigDescriptionReader extends XmlDocumentReader<List<ConfigDescription>> {
 
@@ -50,6 +53,7 @@ public class ConfigDescriptionReader extends XmlDocumentReader<List<ConfigDescri
         xstream.registerConverter(new NodeAttributesConverter());
         xstream.registerConverter(new ConfigDescriptionConverter());
         xstream.registerConverter(new ConfigDescriptionParameterConverter());
+        xstream.registerConverter(new ConfigDescriptionParameterGroupConverter());
         xstream.registerConverter(new FilterCriteriaConverter());
     }
 
@@ -59,6 +63,7 @@ public class ConfigDescriptionReader extends XmlDocumentReader<List<ConfigDescri
         xstream.alias("config-description", ConfigDescription.class);
         xstream.alias("config-description-ref", NodeAttributes.class);
         xstream.alias("parameter", ConfigDescriptionParameter.class);
+        xstream.alias("parameter-group", ConfigDescriptionParameterGroup.class);
         xstream.alias("options", NodeList.class);
         xstream.alias("option", NodeValue.class);
         xstream.alias("filter", List.class);

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/internal/ConfigDescriptionXmlProvider.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/internal/ConfigDescriptionXmlProvider.java
@@ -16,8 +16,8 @@ import org.eclipse.smarthome.config.xml.osgi.XmlDocumentProvider;
 import org.osgi.framework.Bundle;
 
 /**
- * The {@link ConfigDescriptionXmlProvider} is responsible managing any created objects
- * by a {@link ConfigDescriptionReader} for a certain bundle.
+ * The {@link ConfigDescriptionXmlProvider} is responsible managing any created
+ * objects by a {@link ConfigDescriptionReader} for a certain bundle.
  * <p>
  * This implementation registers each {@link ConfigDescription} object at the {@link XmlConfigDescriptionProvider} which
  * is itself registered as {@link ConfigDescriptionProvider} service at the <i>OSGi</i> service registry.

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/internal/ConfigDescriptionXmlProviderFactory.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/internal/ConfigDescriptionXmlProviderFactory.java
@@ -17,8 +17,8 @@ import org.osgi.framework.Bundle;
 
 /**
  * The {@link ConfigDescriptionXmlProviderFactory} is responsible to create {@link ConfigDescriptionXmlProvider}
- * instances for a certain module.
- * The factory is <i>not</i> responsible to clean-up any created providers.
+ * instances for a certain module. The
+ * factory is <i>not</i> responsible to clean-up any created providers.
  *
  * @author Michael Grammling - Initial Contribution
  */

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/groovy/org/eclipse/smarthome/core/thing/xml/test/ConfigDescriptionsTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/groovy/org/eclipse/smarthome/core/thing/xml/test/ConfigDescriptionsTest.groovy
@@ -70,7 +70,7 @@ class ConfigDescriptionsTest extends OSGiTest {
         
         def parameters = bridgeConfigDescription.parameters
         assertThat parameters.size(), is(2)
-        
+
         def ipParameter = parameters.find { it.name.equals("ip") }
         assertThat ipParameter, is(notNullValue())
         assertThat ipParameter.type, is(Type.TEXT)
@@ -80,11 +80,14 @@ class ConfigDescriptionsTest extends OSGiTest {
             assertThat description, is("Network address of the hue bridge.")
             assertThat required, is(true)
         }
-        
-        def usernameParameter = parameters.find { it.name.equals("username") }
-        assertThat usernameParameter, is(notNullValue())
-        assertThat usernameParameter.type, is(Type.TEXT)
-        usernameParameter.with {
+
+        def userNameParameter = parameters.find { it.name.equals("username") }
+		assertThat userNameParameter, is(notNullValue())
+
+		assertThat userNameParameter.advanced, is(true)
+
+        assertThat userNameParameter.type, is(Type.TEXT)
+        userNameParameter.with {
             assertThat context, is("password")
             assertThat label, is("Username")
             assertThat description, is("Name of a registered hue bridge user, that allows to access the API.")
@@ -100,7 +103,18 @@ class ConfigDescriptionsTest extends OSGiTest {
         def lastDimValueParameter = parameters.find { it.name.equals("lastDimValue") }
         assertThat lastDimValueParameter, is(notNullValue())
         assertThat lastDimValueParameter.type, is(Type.BOOLEAN)
-        
+
+        def groups = bridgeConfigDescription.parameterGroups
+        assertThat groups.size(), is(2)
+
+        def group1 = groups.find { it.name.equals("group1") }
+        assertThat group1, is(notNullValue())
+        group1.with {
+            assertThat context, is("Group1-context")
+            assertThat label, is("Group Label 1")
+            assertThat description, is("Group description 1")
+        }
+
         // uninstall test bundle
         bundle.uninstall();
         assertThat bundle.state, is(Bundle.UNINSTALLED)

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/ESH-INF/thing/thing-types.xml
@@ -9,18 +9,31 @@
 		<description>The hue Bridge represents the Philips hue bridge.</description>
 
 		<config-description>
-			<parameter name="ip" type="text">
+			<parameter-group name="group1">
+				<label>Group Label 1</label>
+				<description>Group description 1</description>
+				<context>Group1-context</context>
+				<advanced>false</advanced>
+			</parameter-group>
+			<parameter-group name="group2">
+				<label>Group Label 2</label>
+				<description>Group description 2</description>
+				<context>Group2-context</context>
+				<advanced>true</advanced>
+			</parameter-group>
+			<parameter name="ip" type="text" groupName="group1">
 				<context>network-address</context>
 				<label>Network Address</label>
 				<description>Network address of the hue bridge.</description>
 				<required>true</required>
 			</parameter>
-			<parameter name="username" type="text">
+			<parameter name="username" type="text" groupName="group1">
 				<context>password</context>
 				<label>Username</label>
 				<description>Name of a registered hue bridge user, that allows to
 					access the API.
 				</description>
+				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</bridge-type>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingDescriptionReader.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingDescriptionReader.java
@@ -11,9 +11,11 @@ import java.util.List;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.core.FilterCriteria;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionConverter;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionParameterConverter;
+import org.eclipse.smarthome.config.xml.ConfigDescriptionParameterGroupConverter;
 import org.eclipse.smarthome.config.xml.FilterCriteriaConverter;
 import org.eclipse.smarthome.config.xml.util.NodeAttributes;
 import org.eclipse.smarthome.config.xml.util.NodeAttributesConverter;
@@ -36,6 +38,7 @@ import com.thoughtworks.xstream.XStream;
  * @author Michael Grammling - Initial Contribution
  * @author Alex Tugarev - Extended by options and filter criteria
  * @author Thomas Höfer - Added thing and thing type properties
+ * @author Chris Jackson - Added parameter groups
  */
 public class ThingDescriptionReader extends XmlDocumentReader<List<?>> {
 
@@ -59,6 +62,7 @@ public class ThingDescriptionReader extends XmlDocumentReader<List<?>> {
         xstream.registerConverter(new StateDescriptionConverter());
         xstream.registerConverter(new ConfigDescriptionConverter());
         xstream.registerConverter(new ConfigDescriptionParameterConverter());
+        xstream.registerConverter(new ConfigDescriptionParameterGroupConverter());
         xstream.registerConverter(new FilterCriteriaConverter());
     }
 
@@ -88,6 +92,7 @@ public class ThingDescriptionReader extends XmlDocumentReader<List<?>> {
         xstream.alias("config-description", ConfigDescription.class);
         xstream.alias("config-description-ref", NodeAttributes.class);
         xstream.alias("parameter", ConfigDescriptionParameter.class);
+        xstream.alias("parameter-group", ConfigDescriptionParameterGroup.class);
         xstream.alias("filter", List.class);
         xstream.alias("criteria", FilterCriteria.class);
         xstream.alias("properties", NodeList.class);

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
@@ -27,6 +27,7 @@ import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
 import org.eclipse.smarthome.config.core.FilterCriteria;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.core.ParameterOption;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.type.BridgeType;
@@ -42,6 +43,7 @@ import org.eclipse.smarthome.io.rest.core.thing.beans.ChannelDefinitionBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.ChannelGroupDefinitionBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.ConfigDescriptionParameterBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.FilterCriteriaBean;
+import org.eclipse.smarthome.io.rest.core.thing.beans.ParameterGroupBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.ParameterOptionBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.ThingTypeBean;
 
@@ -52,6 +54,7 @@ import org.eclipse.smarthome.io.rest.core.thing.beans.ThingTypeBean;
  * @author Dennis Nobel - Initial contribution
  * @author Kai Kreuzer - refactored for using the OSGi JAX-RS connector
  * @author Thomas Höfer - Added thing and thing type properties
+ * @author Chris Jackson - Added parameter groups, advanced, multipleLimit, limitToOptions
  */
 @Path("thing-types")
 public class ThingTypeResource implements RESTResource {
@@ -100,10 +103,11 @@ public class ThingTypeResource implements RESTResource {
     public List<ConfigDescriptionParameterBean> getConfigDescriptionParameterBeans(URI configDescriptionURI,
             Locale locale) {
 
-        ConfigDescription configDescription = configDescriptionRegistry.getConfigDescription(configDescriptionURI, locale);
+        ConfigDescription configDescription = configDescriptionRegistry.getConfigDescription(configDescriptionURI,
+                locale);
         if (configDescription != null) {
-            List<ConfigDescriptionParameterBean> configDescriptionParameterBeans = new ArrayList<>(
-                    configDescription.getParameters().size());
+            List<ConfigDescriptionParameterBean> configDescriptionParameterBeans = new ArrayList<>(configDescription
+                    .getParameters().size());
             for (ConfigDescriptionParameter configDescriptionParameter : configDescription.getParameters()) {
                 ConfigDescriptionParameterBean configDescriptionParameterBean = new ConfigDescriptionParameterBean(
                         configDescriptionParameter.getName(), configDescriptionParameter.getType(),
@@ -111,15 +115,17 @@ public class ThingTypeResource implements RESTResource {
                         configDescriptionParameter.getStepSize(), configDescriptionParameter.getPattern(),
                         configDescriptionParameter.isRequired(), configDescriptionParameter.isReadOnly(),
                         configDescriptionParameter.isMultiple(), configDescriptionParameter.getContext(),
-                        String.valueOf(configDescriptionParameter.getDefault()),
-                        configDescriptionParameter.getLabel(), configDescriptionParameter.getDescription(),
+                        String.valueOf(configDescriptionParameter.getDefault()), configDescriptionParameter.getLabel(),
+                        configDescriptionParameter.getDescription(),
                         createBeansForOptions(configDescriptionParameter.getOptions()),
-                        createBeansForCriteria(configDescriptionParameter.getFilterCriteria()));
+                        createBeansForCriteria(configDescriptionParameter.getFilterCriteria()),
+                        configDescriptionParameter.getGroupName(), configDescriptionParameter.isAdvanced(),
+                        configDescriptionParameter.getLimitToOptions(), configDescriptionParameter.getMultipleLimit());
                 configDescriptionParameterBeans.add(configDescriptionParameterBean);
             }
             return configDescriptionParameterBeans;
         }
-       
+
         return null;
     }
 
@@ -155,8 +161,8 @@ public class ThingTypeResource implements RESTResource {
                 getConfigDescriptionParameterBeans(thingType.getConfigDescriptionURI(), locale),
                 convertToChannelDefinitionBeans(thingType.getChannelDefinitions()),
                 convertToChannelGroupDefinitionBeans(thingType.getChannelGroupDefinitions()),
-                thingType.getSupportedBridgeTypeUIDs(), thingType.getProperties(), 
-                thingType instanceof BridgeType);
+                thingType.getSupportedBridgeTypeUIDs(), thingType.getProperties(), thingType instanceof BridgeType,
+                convertToParameterGroupBeans(thingType.getConfigDescriptionURI(), locale));
     }
 
     private List<ChannelGroupDefinitionBean> convertToChannelGroupDefinitionBeans(
@@ -198,5 +204,22 @@ public class ThingTypeResource implements RESTResource {
 
         return thingTypeBeans;
     }
-    
+
+    private List<ParameterGroupBean> convertToParameterGroupBeans(URI configDescriptionURI, Locale locale) {
+
+        ConfigDescription configDescription = configDescriptionRegistry.getConfigDescription(configDescriptionURI,
+                locale);
+        List<ParameterGroupBean> parameterGroupBeans = new ArrayList<>();
+        if (configDescription != null) {
+
+            List<ConfigDescriptionParameterGroup> parameterGroups = configDescription.getParameterGroups();
+            for (ConfigDescriptionParameterGroup parameterGroup : parameterGroups) {
+                parameterGroupBeans.add(new ParameterGroupBean(parameterGroup.getName(), parameterGroup.getContext(),
+                        parameterGroup.isAdvanced(), parameterGroup.getLabel(), parameterGroup.getDescription()));
+            }
+        }
+
+        return parameterGroupBeans;
+    }
+
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ConfigDescriptionParameterBean.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ConfigDescriptionParameterBean.java
@@ -18,6 +18,8 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Alex Tugarev - Extended for options and filter criteria
+ * @author Chris Jackson - Added group, advanced, limitToOptions, multipleLimit
+ *         attributes
  *
  */
 public class ConfigDescriptionParameterBean {
@@ -35,6 +37,10 @@ public class ConfigDescriptionParameterBean {
     public String pattern;
     public Boolean readOnly;
     public Boolean multiple;
+    public Integer multipleLimit;
+    public String groupName;
+    public Boolean advanced;
+    public Boolean limitToOptions;
 
     public List<ParameterOptionBean> options;
     public List<FilterCriteriaBean> filterCriteria;
@@ -45,7 +51,8 @@ public class ConfigDescriptionParameterBean {
     public ConfigDescriptionParameterBean(String name, Type type, BigDecimal minimum, BigDecimal maximum,
             BigDecimal stepsize, String pattern, Boolean required, Boolean readOnly, Boolean multiple, String context,
             String defaultValue, String label, String description, List<ParameterOptionBean> options,
-            List<FilterCriteriaBean> filterCriteria) {
+            List<FilterCriteriaBean> filterCriteria, String groupName, Boolean advanced, Boolean limitToOptions,
+            Integer multipleLimit) {
         this.name = name;
         this.type = type;
         this.minimum = minimum;
@@ -61,6 +68,10 @@ public class ConfigDescriptionParameterBean {
         this.description = description;
         this.options = options;
         this.filterCriteria = filterCriteria;
+        this.groupName = groupName;
+        this.advanced = advanced;
+        this.limitToOptions = limitToOptions;
+        this.multipleLimit = multipleLimit;
     }
 
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ParameterGroupBean.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ParameterGroupBean.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.rest.core.thing.beans;
+
+/**
+ * This is a java bean that is used with JAX-RS to serialize options of a
+ * parameter group to JSON.
+ *
+ * @author Chris Jackson - Initial contribution
+ *
+ */
+public class ParameterGroupBean {
+
+    public String name;
+    public String context;
+    public Boolean advanced;
+    public String label;
+    public String description;
+
+    public ParameterGroupBean() {
+    }
+
+    public ParameterGroupBean(String name, String context, Boolean advanced, String label, String description) {
+        this.name = name;
+        this.context = context;
+        this.advanced = advanced;
+        this.label = label;
+        this.description = description;
+    }
+}
+

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ThingTypeBean.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ThingTypeBean.java
@@ -15,6 +15,7 @@ import java.util.Map;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Thomas Höfer - Added thing and thing type properties
+ * @author Chris Jackson - Added parameter groups
  *
  */
 public class ThingTypeBean {
@@ -23,6 +24,7 @@ public class ThingTypeBean {
     public List<ChannelGroupDefinitionBean> channelGroups;
     public List<ConfigDescriptionParameterBean> configParameters;
     public List<String> supportedBridgeTypeUIDs;
+    public List<ParameterGroupBean> parameterGroups;
     public Map<String, String> properties;
     public String description;
     public String label;
@@ -36,7 +38,7 @@ public class ThingTypeBean {
     public ThingTypeBean(String UID, String label, String description,
             List<ConfigDescriptionParameterBean> configParameters, List<ChannelDefinitionBean> channels,
             List<ChannelGroupDefinitionBean> channelGroups, List<String> supportedBridgeTypeUIDs,
-            Map<String, String> properties, boolean bridge) {
+            Map<String, String> properties, boolean bridge, List<ParameterGroupBean> parameterGroups) {
         this.UID = UID;
         this.label = label;
         this.description = description;
@@ -46,6 +48,7 @@ public class ThingTypeBean {
         this.supportedBridgeTypeUIDs = supportedBridgeTypeUIDs;
         this.properties = properties;
         this.bridge = bridge;
+        this.parameterGroups = parameterGroups;
     }
 
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/setup/ThingSetupManagerResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/setup/ThingSetupManagerResource.java
@@ -104,7 +104,7 @@ public class ThingSetupManagerResource implements RESTResource {
                 }
             }
         }
-        
+
         if (thing != null) {
             if (bridgeUID != null) {
                 thing.setBridgeUID(bridgeUID);

--- a/docs/sources/architecture/configuration.md
+++ b/docs/sources/architecture/configuration.md
@@ -29,6 +29,13 @@ Configuration descriptions must be placed as XML file(s) (with the ending `.xml`
         http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
   <config-description uri="{binding|thing-type|bridge-type|channel-type|any_other}:bindingID:...">
+    <parameter-group name="String">
+      <label>String</label>
+      <description>String</description>
+      <context>String</description>
+      <advanced>{true|false}</advanced>
+    </parameter-group>
+
     <parameter name="String" type="{text|integer|decimal|boolean}" min="Decimal" max="Decimal" step="Decimal" pattern="String" required="{true|false}" readOnly="{true|false}" multiple="{true|false}">
       <context>{network-address|password|password-create|color|date|datetime|email|month|week|time|tel|url|item|thing|group|tag|service}</context>
       <required>{true|false}</required>
@@ -64,16 +71,33 @@ Configuration descriptions must be placed as XML file(s) (with the ending `.xml`
   <tr><td>parameter.required</td><td>Specifies whether the value is required (optional).</td></tr>
   <tr><td>parameter.readOnly</td><td>Specifies whether the value is read-only (optional).</td></tr>
   <tr><td>parameter.multiple</td><td>Specifies whether multiple selections of options are allowed (optional).</td></tr>
+(optional).</td></tr>
+  <tr><td>parameter.advanced</td><td>Specifies that this is an advanced parameter. Advanced parameters may be hidden by a UI (optional).</td></tr>
+(optional).</td></tr>
   <tr><td>context</td><td>The context of the configuration parameter (optional).</td></tr>
   <tr><td>required</td><td>The flag indicating if the configuration parameter has to be set or not (deprecated, optional, default: false).</td></tr>
+  <tr><td>group</td><td>Sets a group name for this parameter (optional).</td></tr>
   <tr><td>default</td><td>The default value of the configuration parameter (optional).</td></tr>
   <tr><td>label</td><td>A human readable label for the configuration parameter (optional).</td></tr>
   <tr><td>description</td><td>A human readable description for the configuration parameter (optional).</td></tr>
   <tr><td>option</td><td>The element definition of a static selection list (optional).</td></tr>
   <tr><td>option.value</td><td>The value of the selection list element.</td></tr>
+  <tr><td>multipleLimit</td><td>If multiple is true, sets the maximum number of options that can be selected (optional).</td></tr>
+  <tr><td>limitToOptions</td><td>If true (default) will only allow the user to select items in the options list. If false, will allow the user to enter other text (optional).</td></tr>
   <tr><td>criteria</td><td>The filter criteria for values of a dynamic selection list (optional).</td></tr>  
   <tr><td>criteria.name</td><td>The name of the context related filter.</td></tr>  
 </table>
+
+Groups allow parameters to be grouped together into logical blocks so that the user can find the parameters they are looking for. A parameter can be placed into a group so that the UI knows how to display the information.
+<table>
+  <tr><td><b>Property</b></td><td><b>Description</b></td></tr>
+  <tr><td>group.name</td><td>The group name - this is used to link the parameters into the group, along with the groupName option in the parameter (mandatory).</td></tr>
+  <tr><td>label</td><td>The human readable label of the group. (mandatory).</td></tr>
+  <tr><td>description</td><td>The description of the group. (optional).</td></tr>
+  <tr><td>context</td><td>Sets a context tag for the group. The context may be used in the UI to provide some feedback on the type of parameters in this group (optional).</td></tr>
+  <tr><td>advanced</td><td>Specifies that this is an advanced group. The UI may hide this group from the user (optional)</td></tr>
+</table>
+
 
 The full XML schema for configuration descriptions is specified in the [ESH config description XSD](http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd) file.
 

--- a/docs/sources/architecture/internationalization.md
+++ b/docs/sources/architecture/internationalization.md
@@ -40,11 +40,11 @@ ESH-INF/i18n
 
 In Eclipse SmartHome a binding developer has to provide different XML files. In these XML files label and description texts must be specified. To Internationalize these texts Java I18N properties files must be defined.
 
-For the binding definition and the thing types XML files Eclipse SmartHome defines a standard key scheme, that allows to easily reference the XML nodes. Inside the XML nodes the text must be specified in the default language english. Typically all texts for a binding are put into one file with name of the binding, but they can also be splitted into multiple files.
+For the binding definition and the thing types XML files Eclipse SmartHome defines a standard key scheme, that allows to easily reference the XML nodes. Inside the XML nodes the text must be specified in the default language English. Typically all texts for a binding are put into one file with name of the binding, but they can also be split into multiple files.
 
 ### Binding Definition
 
-The following snippet shows the binding XML file of the Yahoo Weather Binding and its language file that localizes the binding name and description for the german language.
+The following snippet shows the binding XML file of the Yahoo Weather Binding and its language file that localizes the binding name and description for the German language.
 
 XML file (binding.xml):
 ```xml
@@ -66,7 +66,7 @@ So the key for referencing the name of a binding is `binding.<binding-id>.name` 
 
 ### Thing Types
 
-The following snippet shows an excerpt of the thing type definition XML file of the Yahoo Weather Binding and its language file that localizes labels and descriptions for the german language.
+The following snippet shows an excerpt of the thing type definition XML file of the Yahoo Weather Binding and its language file that localizes labels and descriptions for the German language.
 
 XML file (thing-types.xml):
 ```xml
@@ -109,6 +109,10 @@ thing-type.yahooweather.weather.description = Stellt verschiedene Wetterdaten vo
 thing-type.config.yahooweather.weather.location.label = Ort
 thing-type.config.yahooweather.weather.location.description = Ort der Wetterinformation.
 
+thing-type.config.yahooweather.weather.group.group1.label = a label
+thing-type.config.yahooweather.weather.group.group1.description = a description
+
+
 channel-type.yahooweather.temperature.label = Temperatur
 channel-type.yahooweather.temperature.description = Aktuelle Temperatur in Grad Celsius (metrisch) oder Grad Fahrenheit (us)
 channel-type.yahooweather.temperature.pattern = %s Wert
@@ -116,11 +120,11 @@ channel-type.yahooweather.temperature.option.OPTION1 = Option Nummer 1
 channel-type.yahooweather.temperature.option.OPTION2 = Option Nummer 2
 ```
 
-So the key for referencing a label of a defined thing type is `thing-type.<binding-id>.<thing-type-id>.label`. A label of a channel can be referenced with `channel-type.<binding-id>.<channel-type-id>.label`. And finally the config description parameter key is `thing-type.config.<binding-id>.<thing-type-id>.<parameter-name>.label`.
+So the key for referencing a label of a defined thing type is `thing-type.<binding-id>.<thing-type-id>.label`. A label of a channel can be referenced with `channel-type.<binding-id>.<channel-type-id>.label`. And finally the config description parameter key is `thing-type.config.<binding-id>.<thing-type-id>.<parameter-name>.label` and the group parameter is `thing-type.config.<binding-id>.group.<thing-type-id>.<parameter-name>.label`.
 
 ### Using custom Keys
 
-In addition to the default keys the developer can also specify custom keys inside the XML file. But with this approach the XML file cannot longer contain the english texts. So it is mandatory to define a language file for the english language. The syntax for custom keys is `@text/<key>`. The keys are unqiue across the whole bundle, so a constant can reference any key in all files inside the `ESH-INF/i18n` folder.
+In addition to the default keys the developer can also specify custom keys inside the XML file. But with this approach the XML file cannot longer contain the English texts. So it is mandatory to define a language file for the English language. The syntax for custom keys is `@text/<key>`. The keys are unique across the whole bundle, so a constant can reference any key in all files inside the `ESH-INF/i18n` folder.
 
 The following snippet shows a binding XML that uses custom keys:
 
@@ -155,13 +159,13 @@ String text = i18nProvider.getText(bundleContext.getBundle(), "my.key", "Default
 
 Thing types can be retrieved through the `ThingTypeRegistry` OSGi service. Every method takes a `Locale` as last argument. If no locale is specified the thing types are returned for the default locale which is determined by `Locale.getDefault()`, or the default text, which is specified in the XML file, if no language file for the default locale exists.
 
-The following snippet shows how to retrieve the list of Thing Types for the german locale:
+The following snippet shows how to retrieve the list of Thing Types for the German locale:
 
 ```java
 List<ThingType> thingTypes = thingTypeRegistry.getThingTypes(Locale.GERMAN);
 ```
 
-If one binding supports the german language and another does not, it might occur that the languages of the returned thing types are mixed.
+If one binding supports the German language and another does not, it might occur that the languages of the returned thing types are mixed.
 
 For Binding Info and ConfigDescription, the localized objects can be retrieved via the `BindingInfoRegistry` and the `ConfigDescriptionRegistry` in the same manner as described for Thing Types.
 


### PR DESCRIPTION
This is an early PR for some changes to the config interface. It's not fully tested, but it's working with no obvious problems - I wanted to put it out there early for comment...

This adds a few features that are basically targeted towards devices with a lot of configuration - ie zwave being my focus - but I'm sure will also be useful for smaller bindings. Currently there are devices in the zwave database with 30+ configuration parameters, plus there will be additional parameters added by the binding in order to control parts of the device that don't need to be defined (eg wakeup intervals) as they are dependant on the command classes supported by the individual devices.

## Overview of Changes
1. It changes the XML config reader to use the new ConfigParameterDescriptionBuilder. This just makes good sense I think as it isolates the parameter definition, meaning changes can be made without breaking the XML reader (or any other reader).
2. I've added 3 new attributes to the configuration description.
 1. An 'advanced' flag. This allows the user interface to filter out parameters that are marked as 'advanced' - effectively highlighting parameters that are most useful.
 2. Added a 'limitToOptions' flag. This is used to say whether or not the value returned must be in the options list. The point here is that sometimes you want to have an options list of 'most used values' (or whatever) where the values are kind of hints, and other times you really want to limit to the listed values. A use case I have in zwave is a parameter may have a valid range of between (say) 50 and 100, but you can specify -1 to disable. I want to be able to set an option with value -1, and then let the user either select this, or a number of their choosing.
 3. Added a group attribute. This is a larger change, and is my attempt to solve the issues we've discussed on the ESH forum a while back about linking configuration parameters together. I feel this is a good compromise - it provides a good deal of definition, but doesn't break the current interface (and yes, I've checked that the PaperUI still works! :) ).

## Parameter Groups
Most of the changes are associated with the last point above - parameter groups. The config interface I currently have in OH1 for zwave is hierarchical, so it's easy to group things together. It was designed this way to be flexible, but in reality for a single device, and assuming the current interface in ESH, 1 level is more than enough.

So, the proposed solution is to add an (optional) group id string to each parameter so that the UI can (optionally) group the parameters.

In addition to the group id in each parameter, there is a parameterGroups list that has been added to the ConfigDescription. This has 4 members -:

1. groupid: to allow the UI to link parameters.
2. context: to allow some sort of context information - the UI might for example use it to display an icon. Ideally we'd agree a defined set (similar to the Categories) and potentially also limit them (enum) so the UI knows what they mean (which I also think should be done with Categories).
3. label: the group name for us mortals to read.
4. description: to let people know what it's all about.

These get exposed through the REST UI with the addition of the parameterGroups object in the thing. This makes it totally transparent - the UI can use it, or ignore it.

The above provides a concrete and consistent set of parameters and groups, all specified into a single object. They can be dynamically updated through the ConfigDescriptionProvider interface if the binding desires.

I've not looked at adding this to the XML provider in any detail yet. It should be considered optional so maybe it's not needed (but it would be nice I think), but for complex bindings, I think it's essential to avoid the user ending up with a list of 50+ parameters in a long list.

## More stuff to do
There's a few more bits to do - more testing for starters... 

I would like to resolve the number of selections that can be made when 'multiple' is set ([see bug 465493](https://bugs.eclipse.org/bugs/show_bug.cgi?id=465493)). Some configurations need multiple selection, but each device only allows a certain number of entries in some lists - I think it's better to limit this at the UI that in the binding and leave the user wondering why he set 10 entries, but he's only got 5.  This is an easy change but we can discuss in the bug what option is best.

I've not implemented this in the XML - I've had a quick look and given a little time I'm sure I can work that out, so I can probably add the above features into the XML config provider if desired.

I'm happy to tweak this a bit if anyone has other ideas...

Signed-off-by: Chris Jackson <chris@cd-jackson.com>