### PR TITLE
Add additional xstream export to manifest

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Import-Package: org.eclipse.smarthome.config.core,
  javax.security.auth
 Bundle-Activator: org.eclipse.smarthome.config.xml.internal.Activator
 Export-Package: com.thoughtworks.xstream,
+ com.thoughtworks.xstream.annotations,
  com.thoughtworks.xstream.converters,
  com.thoughtworks.xstream.io,
  com.thoughtworks.xstream.io.xml,


### PR DESCRIPTION
This package is used by the zwave binding, so adding this avoids having to include xstream library into the bundle.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>