### PR TITLE
fixed potential NPE if mDNS client cannot be started

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
@@ -36,7 +36,8 @@ public class MDNSClientImpl implements MDNSClient {
             jmdns = JmDNS.create();
             logger.debug("mDNS service has been started");
         } catch (IOException e) {
-            logger.error(e.getMessage());
+            // we must cancel the activation of this component here
+            throw new IllegalStateException(e);
         }
     }
 


### PR DESCRIPTION
I had the following errors in my log (because somehow the mDNS port was already in use):

```
2015-05-07 14:00:07.192 [ERROR] [.i.t.m.internal.MDNSClientImpl] - Can't assign requested address
Exception in thread "pool-5-thread-1" Exception in thread "pool-6-thread-1" java.lang.NullPointerException
    at org.eclipse.smarthome.io.transport.mdns.internal.MDNSServiceImpl$2.run(MDNSServiceImpl.java:87)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:744)
```

This fix should make sure that the service is not registered at all, if something goes wrong with it.
