### PR TITLE
Fix config parameter thing tests

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameter.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameter.java
@@ -97,8 +97,8 @@ public class ConfigDescriptionParameter {
      *             if the name is null or empty, or the type is null
      */
     public ConfigDescriptionParameter(String name, Type type) throws IllegalArgumentException {
-        this(name, type, null, null, null, null, false, false, false, null, null, null, null, null, null, null, null,
-                null, null);
+        this(name, type, null, null, null, null, false, false, false, null, null, null, null, null, null, null, false,
+                true, null);
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.groovy
@@ -96,7 +96,7 @@ class ThingFactoryTest {
             ConfigDescription getConfigDescription( URI uri) {
                 def parameters = [
                     new ConfigDescriptionParameter("testProperty",
-                        ConfigDescriptionParameter.Type.TEXT, null, null, null, null, false, false, false, "context", "default", "label", "description", null, null)
+                        ConfigDescriptionParameter.Type.TEXT, null, null, null, null, false, false, false, "context", "default", "label", "description", null, null, null, false, true, null)
                 ]
                 return new ConfigDescription(uri, parameters)
             }
@@ -121,13 +121,13 @@ class ThingFactoryTest {
             ConfigDescription getConfigDescription( URI uri) {
                 def parameters = [
                     new ConfigDescriptionParameter("p1",
-                        ConfigDescriptionParameter.Type.BOOLEAN, null, null, null, null, false, false, false, "context", "true", "label", "description", null, null),
+                        ConfigDescriptionParameter.Type.BOOLEAN, null, null, null, null, false, false, false, "context", "true", "label", "description", null, null, null, false, true, null),
                     new ConfigDescriptionParameter("p2",
-                        ConfigDescriptionParameter.Type.INTEGER, null, null, null, null, false, false, false, "context", "5", "label", "description", null, null),
+                        ConfigDescriptionParameter.Type.INTEGER, null, null, null, null, false, false, false, "context", "5", "label", "description", null, null, null, false, true, null),
                     new ConfigDescriptionParameter("p3",
-                        ConfigDescriptionParameter.Type.DECIMAL, null, null, null, null, false, false, false, "context", "2.3", "label", "description", null, null),
+                        ConfigDescriptionParameter.Type.DECIMAL, null, null, null, null, false, false, false, "context", "2.3", "label", "description", null, null, null, false, true, null),
                     new ConfigDescriptionParameter("p4",
-                        ConfigDescriptionParameter.Type.DECIMAL, null, null, null, null, false, false, false, "context", "invalid", "label", "description", null, null)
+                        ConfigDescriptionParameter.Type.DECIMAL, null, null, null, null, false, false, false, "context", "invalid", "label", "description", null, null, null, false, true, null)
                 ]
                 return new ConfigDescription(uri, parameters)
             }


### PR DESCRIPTION
This fixes a bug in one of the constructors of ConfigDescriptionParameter which is probably only used in this test since I modified most of the rest of the code to use the builder.
It also fixes the failed tests.

However I note that other tests are failing, but I reverted back to an older code and they still fail so I don't think it's associated with my change.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>