### PR TITLE
Add tests for item state conversion - i.e. getStateAs()

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.library.test/src/test/java/org/eclipse/smarthome/core/library/items/DimmerItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.library.test/src/test/java/org/eclipse/smarthome/core/library/items/DimmerItemTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.library.items;
+
+import static junit.framework.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.junit.Test;
+
+/**
+ * @author Chris Jackson - Initial contribution
+ */
+public class DimmerItemTest {
+
+    @Test
+    public void GetAsPercentFromPercent() {
+        DimmerItem item = new DimmerItem("Test");
+        item.setState(new PercentType("25"));
+        String res = item.getStateAs(PercentType.class).toString();
+        assertEquals("0.25000000", res);
+    }
+
+    @Test
+    public void GetAsPercentFromOnOff() {
+        DimmerItem item = new DimmerItem("Test");
+        item.setState(OnOffType.ON);
+        String res = item.getStateAs(PercentType.class).toString();
+        assertEquals("100", res);
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.library.test/src/test/java/org/eclipse/smarthome/core/library/items/SwitchItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.library.test/src/test/java/org/eclipse/smarthome/core/library/items/SwitchItemTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.library.items;
+
+import static junit.framework.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.junit.Test;
+
+/**
+ * @author Chris Jackson - Initial contribution
+ */
+public class SwitchItemTest {
+
+    @Test
+    public void GetAsPercentFromSwitch() {
+        SwitchItem item = new SwitchItem("Test");
+        item.setState(OnOffType.ON);
+        assertEquals("100", item.getStateAs(PercentType.class).toString());
+    }
+}


### PR DESCRIPTION
This adds some tests (that mostly fail at the moment!) to get the state of an item using the getStateAs() method.

My current issue is that I want to get the state of a DimmerItem as a PercentType - this doesn't work as I would expect.

Maybe my interpretation of this method is wrong - the tests show what I think should work...

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=467739

Signed-off-by: Chris Jackson <chris@cd-jackson.com>