### PR TITLE
Initial implementation of configuration actions

### DIFF
--- a/addons/binding/org.eclipse.smarthome.binding.yahooweather/ESH-INF/thing/thing-types.xml
+++ b/addons/binding/org.eclipse.smarthome.binding.yahooweather/ESH-INF/thing/thing-types.xml
@@ -27,6 +27,18 @@
                 <description>Specifies the refresh interval in seconds.</description>
                 <default>60</default>
             </parameter>
+
+            <action name="location" type="text">
+                <label>Location</label>
+                <description>Location for the weather information.
+                    Syntax is WOEID, see https://en.wikipedia.org/wiki/WOEID.
+                </description>
+            </action>
+            <action name="refresh" type="integer">
+                <label>Refresh interval</label>
+                <description>Specifies the refresh interval in seconds.</description>
+                <default>60</default>
+            </action>
         </config-description>
     </thing-type>
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescription.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescription.java
@@ -24,6 +24,10 @@ import java.util.List;
  * devices with larger numbers of parameters can set the group member in the {@link ConfigDescriptionParameter} and then
  * provide group information as part of the {@link ConfigDescription} class.
  * <p>
+ * The {@link ConfigDescriptionAction} provides a method to define configuration actions. These are sent as immediate
+ * actions to the thing handler rather than being handled and persisted as parameters. This allows the ThingHandler to
+ * support immediate user interaction for configuration purposes such as resetting a device.
+ * <p>
  * The description is stored within the {@link ConfigDescriptionRegistry} under the given URI. The URI has to follow the
  * syntax {@code '<scheme>:<token>[:<token>]'} (e.g. {@code "binding:hue:bridge"}).
  * <p>
@@ -31,11 +35,12 @@ import java.util.List;
  *
  * @author Michael Grammling - Initial Contribution
  * @author Dennis Nobel - Initial Contribution
- * @author Chris Jackson - Added parameter groups
+ * @author Chris Jackson - Added parameter groups and actions
  */
 public class ConfigDescription {
 
     private URI uri;
+    private List<ConfigDescriptionAction> actions;
     private List<ConfigDescriptionParameter> parameters;
     private List<ConfigDescriptionParameterGroup> parameterGroups;
 
@@ -46,7 +51,7 @@ public class ConfigDescription {
      * @throws IllegalArgumentException if the URI is null or invalid
      */
     public ConfigDescription(URI uri) throws IllegalArgumentException {
-        this(uri, null, null);
+        this(uri, null, null, null);
     }
 
     /**
@@ -61,7 +66,7 @@ public class ConfigDescription {
      * @throws IllegalArgumentException if the URI is null or invalid
      */
     public ConfigDescription(URI uri, List<ConfigDescriptionParameter> parameters) {
-        this(uri, parameters, null);
+        this(uri, parameters, null, null);
     }
 
     /**
@@ -72,13 +77,31 @@ public class ConfigDescription {
      *
      * @param parameters the description of a concrete configuration parameter
      *            (could be null or empty)
-     *            
+     *
      * @param groups the list of groups associated with the parameters
      *
      * @throws IllegalArgumentException if the URI is null or invalid
      */
     public ConfigDescription(URI uri, List<ConfigDescriptionParameter> parameters,
             List<ConfigDescriptionParameterGroup> groups) {
+        this(uri, parameters, groups, null);
+    }
+
+    /**
+     * Creates a new instance of this class with the specified parameters.
+     *
+     * @param uri the URI of this description within the {@link ConfigDescriptionRegistry} (must neither be null nor
+     *            empty)
+     *
+     * @param parameters the description of a concrete configuration parameter
+     *            (could be null or empty)
+     * 
+     * @param groups the list of groups associated with the parameters
+     *
+     * @throws IllegalArgumentException if the URI is null or invalid
+     */
+    public ConfigDescription(URI uri, List<ConfigDescriptionParameter> parameters,
+            List<ConfigDescriptionParameterGroup> groups, List<ConfigDescriptionAction> actions) {
         if (uri == null) {
             throw new IllegalArgumentException("The URI must not be null!");
         }
@@ -101,6 +124,12 @@ public class ConfigDescription {
             this.parameterGroups = Collections.unmodifiableList(groups);
         } else {
             this.parameterGroups = Collections.unmodifiableList(new ArrayList<ConfigDescriptionParameterGroup>(0));
+        }
+
+        if (actions != null) {
+            this.actions = Collections.unmodifiableList(actions);
+        } else {
+            this.actions = Collections.unmodifiableList(new ArrayList<ConfigDescriptionAction>(0));
         }
     }
 
@@ -136,9 +165,21 @@ public class ConfigDescription {
         return this.parameterGroups;
     }
 
+    /**
+     * Returns the description of a concrete configuration action.
+     * <p>
+     * The returned list is immutable.
+     *
+     * @return the description of a concrete configuration action (not null, could be empty)
+     */
+    public List<ConfigDescriptionAction> getActions() {
+        return this.actions;
+    }
+
     @Override
     public String toString() {
-        return "ConfigDescription [uri=" + uri + ", parameters=" + parameters + ", groups=" + parameterGroups + "]";
+        return "ConfigDescription [uri=" + uri + ", parameters=" + parameters + ", groups=" + parameterGroups
+                + ", actions=" + actions + "]";
     }
 
 }

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionAction.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionAction.java
@@ -1,0 +1,419 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.core;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * The {@link ConfigDescriptionAction} class contains the description of a
+ * concrete configuration action. Such actions are collected within the {@link ConfigDescription} and can be retrieved
+ * from the {@link ConfigDescriptionRegistry}.
+ *
+ * @author Chris Jackson - Initial Contribution
+ */
+public class ConfigDescriptionAction {
+
+    public enum Type {
+
+        /**
+         * The data type for a UTF8 text value.
+         */
+        TEXT,
+
+        /**
+         * The data type for a signed integer value in the range of [ {@link Integer#MIN_VALUE},
+         * {@link Integer#MAX_VALUE}].
+         */
+        INTEGER,
+
+        /**
+         * The data type for a signed floating point value (IEEE 754) in the
+         * range of [{@link Float#MIN_VALUE}, {@link Float#MAX_VALUE}].
+         */
+        DECIMAL,
+
+        /**
+         * The data type for a boolean ({@code true} or {@code false}).
+         */
+        BOOLEAN;
+
+    }
+
+    private String name;
+    private Type type;
+
+    private String groupName;
+
+    private BigDecimal min;
+    private BigDecimal max;
+    private BigDecimal step;
+    private String pattern;
+    private boolean multiple;
+    private Integer multipleLimit;
+
+    private String context;
+    private String defaultValue;
+    private String label;
+    private String description;
+
+    private List<ParameterOption> options = new ArrayList<ParameterOption>();
+    private List<FilterCriteria> filterCriteria = new ArrayList<FilterCriteria>();
+
+    private boolean limitToOptions;
+    private boolean advanced;
+
+    /**
+     * Creates a new instance of this class with the specified parameters.
+     *
+     * @param name
+     *            the name of the configuration parameter (must neither be null
+     *            nor empty)
+     * @param type
+     *            the data type of the configuration parameter (must not be
+     *            null)
+     *
+     * @throws IllegalArgumentException
+     *             if the name is null or empty, or the type is null
+     */
+    public ConfigDescriptionAction(String name, Type type) throws IllegalArgumentException {
+        this(name, type, null, null, null, null, false, null, null, null, null, null, null, null, false, true, null);
+    }
+
+    /**
+     * Creates a new instance of this class with the specified parameters.
+     *
+     * @param name
+     *            the name of the configuration parameter (must neither be null
+     *            nor empty)
+     * @param type
+     *            the data type of the configuration parameter (nullable)
+     * @param minimum
+     *            the minimal value for numeric types, or the minimal length of
+     *            strings, or the minimal number of selected options (nullable)
+     * @param maximum
+     *            the maximal value for numeric types, or the maximal length of
+     *            strings, or the maximal number of selected options (nullable)
+     * @param stepsize
+     *            the value granularity for a numeric value (nullable)
+     * @param pattern
+     *            the regular expression for a text type (nullable)
+     * @param multiple
+     *            specifies whether multiple selections of options are allowed
+     * @param context
+     *            the context of the configuration parameter (can be null or
+     *            empty)
+     * @param defaultValue
+     *            the default value of the configuration parameter (can be null)
+     * @param label
+     *            a human readable label for the configuration parameter (can be
+     *            null or empty)
+     * @param description
+     *            a human readable description for the configuration parameter
+     *            (can be null or empty)
+     * @param filterCriteria
+     *            a list of filter criteria for values of a dynamic selection
+     *            list (nullable)
+     * @param options
+     *            a list of element definitions of a static selection list
+     *            (nullable)
+     * @param groupName
+     *            a string used to group parameters together into logical blocks
+     *            so that the UI can display them together
+     * @param advanced
+     *            specifies if this is an advanced parameter. An advanced
+     *            parameter can be hidden in the UI to focus the user on
+     *            important configuration
+     * @param limitToOptions
+     *            specifies that the users input is limited to the options list.
+     *            When set to true without options, this should have no affect.
+     *            When set to true with options, the user can only select the
+     *            options from the list When set to false with options, the user
+     *            can enter values other than those in the list
+     * @param multipleLimit
+     *            specifies the maximum number of options that can be selected
+     *            when multiple is true
+     *
+     * @throws IllegalArgumentException
+     *             if the name is null or empty, or the type is null
+     */
+    public ConfigDescriptionAction(String name, Type type, BigDecimal minimum, BigDecimal maximum, BigDecimal stepsize,
+            String pattern, Boolean multiple, String context, String defaultValue, String label, String description,
+            List<ParameterOption> options, List<FilterCriteria> filterCriteria, String groupName, Boolean advanced,
+            Boolean limitToOptions, Integer multipleLimit) throws IllegalArgumentException {
+
+        if ((name == null) || (name.isEmpty())) {
+            throw new IllegalArgumentException("The name must neither be null nor empty!");
+        }
+
+        if (type == null) {
+            throw new IllegalArgumentException("The type must not be null!");
+        }
+
+        this.name = name;
+        this.type = type;
+        this.groupName = groupName;
+        this.min = minimum;
+        this.max = maximum;
+        this.step = stepsize;
+        this.pattern = pattern;
+        this.multiple = multiple;
+        this.advanced = advanced;
+
+        this.context = context;
+        this.defaultValue = defaultValue;
+        this.label = label;
+        this.description = description;
+
+        if (options != null) {
+            this.options = Collections.unmodifiableList(options);
+        } else {
+            this.options = Collections.unmodifiableList(new LinkedList<ParameterOption>());
+        }
+
+        this.limitToOptions = limitToOptions;
+        this.multipleLimit = multipleLimit;
+
+        if (filterCriteria != null) {
+            this.filterCriteria = Collections.unmodifiableList(filterCriteria);
+        } else {
+            this.filterCriteria = Collections.unmodifiableList(new LinkedList<FilterCriteria>());
+        }
+    }
+
+    /**
+     * Returns the name of the configuration parameter.
+     *
+     * @return the name of the configuration parameter (neither null, nor empty)
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Returns the data type of the configuration parameter.
+     *
+     * @return the data type of the configuration parameter (not null)
+     */
+    public Type getType() {
+        return this.type;
+    }
+
+    /**
+     * @return the minimal value for numeric types, or the minimal length of
+     *         strings, or the minimal number of selected options (nullable)
+     */
+    public BigDecimal getMinimum() {
+        return min;
+    }
+
+    /**
+     * @return the maximal value for numeric types, or the maximal length of
+     *         strings, or the maximal number of selected options (nullable)
+     */
+    public BigDecimal getMaximum() {
+        return max;
+    }
+
+    /**
+     * @return the value granularity for a numeric value (nullable)
+     */
+    public BigDecimal getStepSize() {
+        return step;
+    }
+
+    /**
+     * @return the regular expression for a text type (nullable)
+     */
+    public String getPattern() {
+        return pattern;
+    }
+
+    /**
+     * @return true if multiple selections of options are allowed, otherwise
+     *         false.
+     */
+    public Boolean isMultiple() {
+        return multiple;
+    }
+
+    /**
+     * @return the maximum number of options that can be selected from the options list
+     */
+    public Integer getMultipleLimit() {
+        return multipleLimit;
+    }
+
+    /**
+     * Returns the context of the configuration parameter.
+     * <p>
+     * The context defines an enumeration of some specific context a configuration parameter can take. A context is
+     * usually used for specific input validation or user interfaces.
+     * <p>
+     * <b>Valid values:</b>
+     *
+     * <pre>
+     * network-address, password, password-create,
+     * color, date, datetime, email, month, week, time, tel, url,
+     * item, thing, group, tag, service
+     * </pre>
+     *
+     * @return the context of the configuration parameter (could be null or
+     *         empty)
+     */
+    public String getContext() {
+        return this.context;
+    }
+
+    /**
+     * Returns the default value of the configuration parameter.
+     *
+     * @return the default value of the configuration parameter (could be null)
+     */
+    public String getDefault() {
+        return this.defaultValue;
+    }
+
+    /**
+     * Returns a human readable label for the configuration parameter.
+     *
+     * @return a human readable label for the configuration parameter (could be
+     *         null or empty)
+     */
+    public String getLabel() {
+        return this.label;
+    }
+
+    /**
+     * Returns a the group for this configuration parameter.
+     *
+     * @return a group for the configuration parameter (could be null or empty)
+     */
+    public String getGroupName() {
+        return this.groupName;
+    }
+
+    /**
+     * Returns true is the value for this parameter must be limited to the
+     * values in the options list.
+     *
+     * @return true if the value is limited to the options list
+     */
+    public boolean getLimitToOptions() {
+        return this.limitToOptions;
+    }
+
+    /**
+     * Returns true is the parameter is considered an advanced option.
+     *
+     * @return true if the value is an advanced option
+     */
+    public boolean isAdvanced() {
+        return this.advanced;
+    }
+
+    /**
+     * Returns a human readable description for the configuration parameter.
+     *
+     * @return a human readable description for the configuration parameter
+     *         (could be null or empty)
+     */
+    public String getDescription() {
+        return this.description;
+    }
+
+    /**
+     * Returns a static selection list for the value of this parameter.
+     *
+     * @return static selection list for the value of this parameter
+     */
+    public List<ParameterOption> getOptions() {
+        return this.options;
+    }
+
+    /**
+     * Returns a list of filter criteria for a dynamically created selection
+     * list.
+     * <p>
+     * The clients should consider the relation between the filter criteria and the parameter's context.
+     *
+     * @return list of filter criteria for a dynamically created selection list
+     */
+    public List<FilterCriteria> getFilterCriteria() {
+        return this.filterCriteria;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append(" [name=");
+        sb.append(name);
+        sb.append(", ");
+        sb.append("type=");
+        sb.append(type);
+        if (groupName != null) {
+            sb.append(", ");
+            sb.append("groupName=");
+            sb.append(groupName);
+        }
+        if (min != null) {
+            sb.append(", ");
+            sb.append("min=");
+            sb.append(min);
+        }
+        if (max != null) {
+            sb.append(", ");
+            sb.append("max=");
+            sb.append(max);
+        }
+        if (step != null) {
+            sb.append(", ");
+            sb.append("step=");
+            sb.append(step);
+        }
+        if (pattern != null) {
+            sb.append(", ");
+            sb.append("pattern=");
+            sb.append(pattern);
+        }
+
+        sb.append(", ");
+        sb.append("multiple=");
+        sb.append(multiple);
+        sb.append(", ");
+        sb.append("multipleLimit=");
+        sb.append(multipleLimit);
+        if (context != null) {
+            sb.append(", ");
+            sb.append("context=");
+            sb.append(context);
+        }
+        if (label != null) {
+            sb.append(", ");
+            sb.append("label=");
+            sb.append(label);
+        }
+        if (description != null) {
+            sb.append(", ");
+            sb.append("description=");
+            sb.append(description);
+        }
+        if (defaultValue != null) {
+            sb.append(", ");
+            sb.append("defaultValue=");
+            sb.append(defaultValue);
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+}

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionActionBuilder.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionActionBuilder.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.core;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction.Type;
+
+/**
+ * The {@link ConfigDescriptionActionBuilder} class provides a builder for the {@link ConfigDescriptionAction}
+ * class.
+ *
+ * @author Chris Jackson - Initial Contribution
+ *
+ */
+public class ConfigDescriptionActionBuilder {
+    private String name;
+    private Type type;
+
+    private String groupName;
+
+    private BigDecimal min;
+    private BigDecimal max;
+    private BigDecimal step;
+    private String pattern;
+    private boolean multiple;
+    private Integer multipleLimit;
+
+    private String context;
+    private String defaultValue;
+    private String label;
+    private String description;
+
+    private boolean limitToOptions;
+    private boolean advanced;
+
+    private List<ParameterOption> options = new ArrayList<ParameterOption>();
+    private List<FilterCriteria> filterCriteria = new ArrayList<FilterCriteria>();
+
+    private ConfigDescriptionActionBuilder(String name, Type type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    /**
+     * Creates a parameter builder
+     *
+     * @param name configuration parameter name
+     * @param type configuration parameter type
+     * @return parameter builder
+     */
+    public static ConfigDescriptionActionBuilder create(String name, Type type) {
+        return new ConfigDescriptionActionBuilder(name, type);
+    }
+
+    /**
+     * Set the minimum value of the configuration parameter
+     *
+     * @param min
+     */
+    public ConfigDescriptionActionBuilder withMinimum(BigDecimal min) {
+        this.min = min;
+        return this;
+    }
+
+    /**
+     * Set the maximum value of the configuration parameter
+     *
+     * @param max
+     */
+    public ConfigDescriptionActionBuilder withMaximum(BigDecimal max) {
+        this.max = max;
+        return this;
+    }
+
+    /**
+     * Set the step size of the configuration parameter
+     *
+     * @param step
+     */
+    public ConfigDescriptionActionBuilder withStepSize(BigDecimal step) {
+        this.step = step;
+        return this;
+    }
+
+    /**
+     * Set the pattern of the configuration parameter
+     *
+     * @param pattern
+     */
+    public ConfigDescriptionActionBuilder withPattern(String pattern) {
+        this.pattern = pattern;
+        return this;
+    }
+
+    /**
+     * Set the configuration parameter to allow multiple selection
+     *
+     * @param multiple
+     */
+    public ConfigDescriptionActionBuilder withMultiple(Boolean multiple) {
+        this.multiple = multiple;
+        return this;
+    }
+
+    /**
+     * Set the configuration parameter to allow multiple selection
+     *
+     * @param multiple
+     */
+    public ConfigDescriptionActionBuilder withMultipleLimit(Integer multipleLimit) {
+        this.multipleLimit = multipleLimit;
+        return this;
+    }
+
+    /**
+     * Set the context of the configuration parameter
+     *
+     * @param context
+     */
+    public ConfigDescriptionActionBuilder withContext(String context) {
+        this.context = context;
+        return this;
+    }
+
+    /**
+     * Set the default value of the configuration parameter
+     *
+     * @param defaultValue
+     */
+    public ConfigDescriptionActionBuilder withDefault(String defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+
+    /**
+     * Set the label of the configuration parameter
+     *
+     * @param label
+     */
+    public ConfigDescriptionActionBuilder withLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
+     * Set the description of the configuration parameter
+     *
+     * @param description
+     */
+    public ConfigDescriptionActionBuilder withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Set the options of the configuration parameter
+     *
+     * @param options
+     */
+    public ConfigDescriptionActionBuilder withOptions(List<ParameterOption> options) {
+        this.options = options;
+        return this;
+    }
+
+    /**
+     * Set the configuration parameter as an advanced parameter
+     *
+     * @param options
+     */
+    public ConfigDescriptionActionBuilder withAdvanced(Boolean advanced) {
+        this.advanced = advanced;
+        return this;
+    }
+
+    /**
+     * Set the configuration parameter to be limited to the values in the options list
+     *
+     * @param options
+     */
+    public ConfigDescriptionActionBuilder withLimitToOptions(Boolean limitToOptions) {
+        this.limitToOptions = limitToOptions;
+        return this;
+    }
+
+    /**
+     * Set the configuration parameter to be limited to the values in the options list
+     *
+     * @param options
+     */
+    public ConfigDescriptionActionBuilder withGroupName(String groupName) {
+        this.groupName = groupName;
+        return this;
+    }
+
+    /**
+     * Set the filter criteria of the configuration parameter
+     *
+     * @param filterCriteria
+     */
+    public ConfigDescriptionActionBuilder withFilterCriteria(List<FilterCriteria> filterCriteria) {
+        this.filterCriteria = filterCriteria;
+        return this;
+    }
+
+    /**
+     * Builds a result with the settings of this builder.
+     *
+     * @return the desired result
+     */
+    public ConfigDescriptionAction build() throws IllegalArgumentException {
+        return new ConfigDescriptionAction(name, type, min, max, step, pattern, multiple,
+                context, defaultValue, label, description, options, filterCriteria, groupName, advanced,
+                limitToOptions, multipleLimit);
+    }
+
+}

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigDescriptionActionI18nUtil.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/i18n/ConfigDescriptionActionI18nUtil.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.core.i18n;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+import org.eclipse.smarthome.core.i18n.I18nProvider;
+import org.eclipse.smarthome.core.i18n.I18nUtil;
+import org.osgi.framework.Bundle;
+
+/**
+ * The {@link ConfigDescriptionActionI18nUtil} uses the {@link I18nProvider} to
+ * resolve the localized texts. It automatically infers the key if the default
+ * text is not a constant.
+ *
+ * @author Chris Jackson - Initial contribution
+ */
+public class ConfigDescriptionActionI18nUtil {
+
+    private I18nProvider i18nProvider;
+
+    private static final Pattern delimiter = Pattern.compile("[:=\\s]");
+
+    public ConfigDescriptionActionI18nUtil(I18nProvider i18nProvider) {
+        this.i18nProvider = i18nProvider;
+    }
+
+    public String getActionPattern(Bundle bundle, URI configDescriptionURI, String actionName,
+            String defaultPattern, Locale locale) {
+        String key = I18nUtil.isConstant(defaultPattern) ? I18nUtil.stripConstant(defaultPattern) : inferKey(
+                configDescriptionURI, actionName, "pattern");
+        return i18nProvider.getText(bundle, key, defaultPattern, locale);
+    }
+
+    public String getActionDescription(Bundle bundle, URI configDescriptionURI, String actionName,
+            String defaultDescription, Locale locale) {
+        String key = I18nUtil.isConstant(defaultDescription) ? I18nUtil.stripConstant(defaultDescription) : inferKey(
+                configDescriptionURI, actionName, "description");
+        return i18nProvider.getText(bundle, key, defaultDescription, locale);
+    }
+
+    public String getActionLabel(Bundle bundle, URI configDescriptionURI, String actionName, String defaultLabel,
+            Locale locale) {
+        String key = I18nUtil.isConstant(defaultLabel) ? I18nUtil.stripConstant(defaultLabel) : inferKey(
+                configDescriptionURI, actionName, "label");
+        return i18nProvider.getText(bundle, key, defaultLabel, locale);
+    }
+
+    public String getActionOptionLabel(Bundle bundle, URI configDescriptionURI, String actionName,
+            String optionValue, String defaultOptionLabel, Locale locale) {
+        if (!isValidPropertyKey(optionValue))
+            return defaultOptionLabel;
+
+        String key = I18nUtil.isConstant(defaultOptionLabel) ? I18nUtil.stripConstant(defaultOptionLabel) : inferKey(
+                configDescriptionURI, actionName, "option." + optionValue);
+
+        return i18nProvider.getText(bundle, key, defaultOptionLabel, locale);
+    }
+
+    private String inferKey(URI configDescriptionURI, String actionName, String lastSegment) {
+        String uri = configDescriptionURI.getSchemeSpecificPart().replace(":", ".");
+        return configDescriptionURI.getScheme() + ".config." + uri + ".action." + actionName + "." + lastSegment;
+    }
+
+    private boolean isValidPropertyKey(String key) {
+        if (key != null) {
+            return !delimiter.matcher(key).find();
+        }
+        return false;
+    }
+
+}

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/groovy/org/eclipse/smarthome/config/xml/test/ConfigDescriptionsTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/groovy/org/eclipse/smarthome/config/xml/test/ConfigDescriptionsTest.groovy
@@ -12,6 +12,7 @@ import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
 import org.eclipse.smarthome.config.core.ConfigDescription
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry
@@ -165,6 +166,15 @@ class ConfigDescriptionsTest extends OSGiTest {
             assertThat description, is("Description Group 2")
             assertThat advanced, is(true)
             assertThat context, is("Context-Group2")
+        }
+        
+        // Check actions
+        def actions = dummyConfigDescription.actions
+        
+        ConfigDescriptionAction action1 = actions.find { it.name.equals("action1") }
+        assertThat action1, is(notNullValue())
+        action1.with {
+            assertThat label, is("Action 1 Label")
         }
 
         // uninstall test bundle

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/ESH-INF/config/config.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/ESH-INF/config/config.xml
@@ -12,14 +12,13 @@
 			<description>Description Group 1</description>
 			<advanced>false</advanced>
 		</parameter-group>
-
 		<parameter-group name="group2">
 			<context>Context-Group2</context>
 			<label>Group 2</label>
 			<description>Description Group 2</description>
 			<advanced>true</advanced>
 		</parameter-group>
-			
+
 		<parameter name="ip" type="text" pattern="[0-9]{3}.[0-9]{3}.[0-9]{3}.[0-9]{3}" required="true" readOnly="true">
 	        <multipleLimit>4</multipleLimit>
 			<context>network-address</context>
@@ -70,6 +69,12 @@
 	            <criteria name="binding-id">hue</criteria>
 	        </filter>
 		</parameter>
+
+	    <action name="action1" type="text">
+	    	<label>Action 1 Label</label>
+	    	<description>Action 1 Description</description>
+	        <context>item</context>
+		</action>
 
 	</config-description>
 

--- a/bundles/config/org.eclipse.smarthome.config.xml/config-description-1.0.0.xsd
+++ b/bundles/config/org.eclipse.smarthome.config.xml/config-description-1.0.0.xsd
@@ -32,6 +32,8 @@
 				minOccurs="0" maxOccurs="unbounded" />
 			<xs:element name="parameter" type="config-description:parameter"
 				minOccurs="0" maxOccurs="unbounded" />
+			<xs:element name="action" type="config-description:action"
+				minOccurs="0" maxOccurs="unbounded" />
 		</xs:sequence>
 		<xs:attribute name="uri"
 			type="config-description:uriRestrictionPattern" use="optional" />
@@ -53,7 +55,8 @@
 			<xs:element name="filter" type="config-description:filterType"
 				minOccurs="0" />
 			<xs:element name="advanced" type="xs:boolean" minOccurs="0" />
-			<xs:element name="multipleLimit" type="xs:integer" minOccurs="0" />
+			<xs:element name="multipleLimit" type="xs:integer"
+				minOccurs="0" />
 		</xs:all>
 		<xs:attribute name="name" type="xs:string" use="required" />
 		<xs:attribute name="type" type="config-description:parameterType"
@@ -76,6 +79,33 @@
 			<xs:element name="advanced" type="xs:boolean" minOccurs="0" />
 		</xs:all>
 		<xs:attribute name="name" type="xs:string" use="required" />
+	</xs:complexType>
+
+	<xs:complexType name="action">
+		<xs:all>
+			<xs:element name="context" type="xs:string" minOccurs="0" />
+			<xs:element name="default" type="xs:string" minOccurs="0" />
+			<xs:element name="label" type="xs:string" minOccurs="0" />
+			<xs:element name="description" type="xs:string" minOccurs="0" />
+			<xs:element name="options" type="config-description:optionsType"
+				minOccurs="0" />
+			<xs:element name="limitToOptions" type="xs:boolean"
+				minOccurs="0" />
+			<xs:element name="filter" type="config-description:filterType"
+				minOccurs="0" />
+			<xs:element name="advanced" type="xs:boolean" minOccurs="0" />
+			<xs:element name="multipleLimit" type="xs:integer"
+				minOccurs="0" />
+		</xs:all>
+		<xs:attribute name="name" type="xs:string" use="required" />
+		<xs:attribute name="type" type="config-description:parameterType"
+			use="required" />
+		<xs:attribute name="groupName" type="xs:string" />
+		<xs:attribute name="min" type="xs:decimal" />
+		<xs:attribute name="max" type="xs:decimal" />
+		<xs:attribute name="step" type="xs:decimal" />
+		<xs:attribute name="pattern" type="xs:string" />
+		<xs:attribute name="multiple" type="xs:boolean" />
 	</xs:complexType>
 
 	<xs:complexType name="optionsType">

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionActionConverter.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionActionConverter.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.xml;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction;
+import org.eclipse.smarthome.config.core.ConfigDescriptionActionBuilder;
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction.Type;
+import org.eclipse.smarthome.config.core.FilterCriteria;
+import org.eclipse.smarthome.config.core.ParameterOption;
+import org.eclipse.smarthome.config.xml.util.ConverterAttributeMapValidator;
+import org.eclipse.smarthome.config.xml.util.ConverterValueMap;
+import org.eclipse.smarthome.config.xml.util.GenericUnmarshaller;
+import org.eclipse.smarthome.config.xml.util.NodeValue;
+
+import com.thoughtworks.xstream.converters.ConversionException;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+
+/**
+ * The {@link ConfigDescriptionActionConverter} is a concrete implementation
+ * of the {@code XStream} {@link Converter} interface used to convert config
+ * description actions within an XML document into a {@link ConfigDescriptionAction} object.
+ * <p>
+ * This converter converts {@code parameter} XML tags.
+ *
+ * @author Chris Jackson - Initial Contribution
+ */
+public class ConfigDescriptionActionConverter extends GenericUnmarshaller<ConfigDescriptionAction> {
+
+    private ConverterAttributeMapValidator attributeMapValidator;
+
+    public ConfigDescriptionActionConverter() {
+        super(ConfigDescriptionAction.class);
+
+        this.attributeMapValidator = new ConverterAttributeMapValidator(new String[][] { { "name", "true" },
+                { "type", "true" }, { "min", "false" }, { "max", "false" }, { "step", "false" },
+                { "pattern", "false" }, { "multiple", "false" }, { "groupName", "false" } });
+    }
+
+    private Type toType(String xmlType) {
+        if (xmlType != null) {
+            return Type.valueOf(xmlType.toUpperCase());
+        }
+
+        return null;
+    }
+
+    private BigDecimal toNumber(String value) {
+        try {
+            if (value != null)
+                return new BigDecimal(value);
+        } catch (NumberFormatException e) {
+            throw new ConversionException("The value '" + value + "' could not be converted to a decimal number.", e);
+        }
+        return null;
+    }
+
+    private Boolean toBoolean(String val) {
+        if (val == null)
+            return null;
+        return new Boolean(val);
+    }
+
+    private Boolean falseIfNull(Boolean b) {
+        return (b != null) ? b : false;
+    }
+
+    @Override
+    public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+        ConfigDescriptionAction configDescriptionAction = null;
+
+        // read attributes
+        Map<String, String> attributes = this.attributeMapValidator.readValidatedAttributes(reader);
+        String name = attributes.get("name");
+        Type type = toType(attributes.get("type"));
+        BigDecimal min = toNumber(attributes.get("min"));
+        BigDecimal max = toNumber(attributes.get("max"));
+        BigDecimal step = toNumber(attributes.get("step"));
+        String patternString = attributes.get("pattern");
+        Boolean multiple = falseIfNull(toBoolean(attributes.get("multiple")));
+        String groupName = attributes.get("groupName");
+
+        // read values
+        ConverterValueMap valueMap = new ConverterValueMap(reader, context);
+        String parameterContext = valueMap.getString("context");
+
+        String defaultValue = valueMap.getString("default");
+        String label = valueMap.getString("label");
+        String description = valueMap.getString("description");
+
+        Boolean advanced = valueMap.getBoolean("advanced", false);
+        Boolean limitToOptions = valueMap.getBoolean("limitToOptions", true);
+        Integer multipleLimit = valueMap.getInteger("multipleLimit");
+
+        // read options and filter criteria
+        List<ParameterOption> options = readParameterOptions(valueMap.getObject("options"));
+        @SuppressWarnings("unchecked")
+        List<FilterCriteria> filterCriteria = (List<FilterCriteria>) valueMap.getObject("filter");
+
+        // create object
+        configDescriptionAction = ConfigDescriptionActionBuilder.create(name, type).withMinimum(min).withMaximum(max)
+                .withStepSize(step).withPattern(patternString).withMultiple(multiple).withContext(parameterContext)
+                .withDefault(defaultValue).withLabel(label).withDescription(description).withOptions(options)
+                .withFilterCriteria(filterCriteria).withGroupName(groupName).withAdvanced(advanced)
+                .withLimitToOptions(limitToOptions).withMultipleLimit(multipleLimit).build();
+
+        return configDescriptionAction;
+    }
+
+    private List<ParameterOption> readParameterOptions(Object rawNodeValueList) {
+        if (rawNodeValueList instanceof List<?>) {
+            List<?> list = (List<?>) rawNodeValueList;
+            List<ParameterOption> result = new ArrayList<>();
+            for (Object object : list) {
+                if (object instanceof NodeValue) {
+                    NodeValue nodeValue = (NodeValue) object;
+                    String value = nodeValue.getAttributes().get("value");
+                    String label = nodeValue.getValue().toString();
+                    result.add(new ParameterOption(value, label));
+                }
+            }
+            return result;
+        }
+        return null;
+    }
+
+}

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionConverter.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionConverter.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.xml.util.ConverterAssertion;
@@ -34,7 +35,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
  * This converter converts {@code config-description} XML tags.
  *
  * @author Michael Grammling - Initial Contribution
- * @author Chris Jackson - Added configuration groups
+ * @author Chris Jackson - Added configuration groups and actions
  */
 public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescription> {
 
@@ -68,7 +69,8 @@ public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescri
                     + "' is invalid!", ex);
         }
 
-        // create the lists to hold parameters and groups
+        // create the lists to hold parameters, groups and actions
+        List<ConfigDescriptionAction> configDescriptionActions = new ArrayList<ConfigDescriptionAction>();
         List<ConfigDescriptionParameter> configDescriptionParams = new ArrayList<ConfigDescriptionParameter>();
         List<ConfigDescriptionParameterGroup> configDescriptionGroups = new ArrayList<ConfigDescriptionParameterGroup>();
 
@@ -86,12 +88,15 @@ public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescri
             if (node instanceof ConfigDescriptionParameterGroup) {
                 configDescriptionGroups.add((ConfigDescriptionParameterGroup) node);
             }
+            if (node instanceof ConfigDescriptionAction) {
+                configDescriptionActions.add((ConfigDescriptionAction) node);
+            }
         }
 
         ConverterAssertion.assertEndOfType(reader);
 
         // create object
-        configDescription = new ConfigDescription(uri, configDescriptionParams, configDescriptionGroups);
+        configDescription = new ConfigDescription(uri, configDescriptionParams, configDescriptionGroups, configDescriptionActions);
 
         return configDescription;
     }

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/internal/ConfigDescriptionReader.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/internal/ConfigDescriptionReader.java
@@ -10,9 +10,11 @@ package org.eclipse.smarthome.config.xml.internal;
 import java.util.List;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.core.FilterCriteria;
+import org.eclipse.smarthome.config.xml.ConfigDescriptionActionConverter;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionConverter;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionParameterConverter;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionParameterGroupConverter;
@@ -35,7 +37,7 @@ import com.thoughtworks.xstream.XStream;
  *
  * @author Michael Grammling - Initial Contribution
  * @author Alex Tugarev - Extended for options and filter criteria
- * @author Chris Jackson - Added configuration groups
+ * @author Chris Jackson - Added configuration groups and actions
  */
 public class ConfigDescriptionReader extends XmlDocumentReader<List<ConfigDescription>> {
 
@@ -52,6 +54,7 @@ public class ConfigDescriptionReader extends XmlDocumentReader<List<ConfigDescri
         xstream.registerConverter(new NodeListConverter());
         xstream.registerConverter(new NodeAttributesConverter());
         xstream.registerConverter(new ConfigDescriptionConverter());
+        xstream.registerConverter(new ConfigDescriptionActionConverter());
         xstream.registerConverter(new ConfigDescriptionParameterConverter());
         xstream.registerConverter(new ConfigDescriptionParameterGroupConverter());
         xstream.registerConverter(new FilterCriteriaConverter());
@@ -62,6 +65,7 @@ public class ConfigDescriptionReader extends XmlDocumentReader<List<ConfigDescri
         xstream.alias("config-descriptions", List.class);
         xstream.alias("config-description", ConfigDescription.class);
         xstream.alias("config-description-ref", NodeAttributes.class);
+        xstream.alias("action", ConfigDescriptionAction.class);
         xstream.alias("parameter", ConfigDescriptionParameter.class);
         xstream.alias("parameter-group", ConfigDescriptionParameterGroup.class);
         xstream.alias("options", NodeList.class);

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingDescriptionReader.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingDescriptionReader.java
@@ -10,9 +10,11 @@ package org.eclipse.smarthome.core.thing.xml.internal;
 import java.util.List;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterGroup;
 import org.eclipse.smarthome.config.core.FilterCriteria;
+import org.eclipse.smarthome.config.xml.ConfigDescriptionActionConverter;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionConverter;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionParameterConverter;
 import org.eclipse.smarthome.config.xml.ConfigDescriptionParameterGroupConverter;
@@ -61,6 +63,7 @@ public class ThingDescriptionReader extends XmlDocumentReader<List<?>> {
         xstream.registerConverter(new ChannelGroupTypeConverter());
         xstream.registerConverter(new StateDescriptionConverter());
         xstream.registerConverter(new ConfigDescriptionConverter());
+        xstream.registerConverter(new ConfigDescriptionActionConverter());
         xstream.registerConverter(new ConfigDescriptionParameterConverter());
         xstream.registerConverter(new ConfigDescriptionParameterGroupConverter());
         xstream.registerConverter(new FilterCriteriaConverter());
@@ -91,6 +94,7 @@ public class ThingDescriptionReader extends XmlDocumentReader<List<?>> {
         xstream.alias("config-descriptions", NodeList.class);
         xstream.alias("config-description", ConfigDescription.class);
         xstream.alias("config-description-ref", NodeAttributes.class);
+        xstream.alias("action", ConfigDescriptionAction.class);
         xstream.alias("parameter", ConfigDescriptionParameter.class);
         xstream.alias("parameter-group", ConfigDescriptionParameterGroup.class);
         xstream.alias("filter", List.class);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingConfigAction.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingConfigAction.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.binding;
+
+import org.eclipse.smarthome.core.thing.Thing;
+
+
+/**
+ * This class defines the action configuration interface of Eclipse SmartHome
+ *
+ * @author Chris Jackson - Initial contribution and API
+ */
+public interface ThingConfigAction {
+
+    /**
+     * Notifies the handler when there is a {@link ConfigurationAction} to be processed.
+     *
+     * @param thing
+     *            thing of the config description
+     * @param action
+     *            the name of the action
+     * @param value
+     *            the value to be configured
+     */
+    void handleConfigurationAction(Thing thing, String action, String value);
+
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -39,6 +39,7 @@ import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.ThingConfigAction;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.link.ManagedItemChannelLinkProvider;
@@ -198,6 +199,28 @@ public class ThingResource implements RESTResource {
         managedThingProvider.update(thing);
 
         return Response.ok().build();
+    }
+    
+    @PUT
+    @Path("/{thingUID}/action/{actionId}")
+    @Consumes(MediaType.TEXT_PLAIN)
+    public Response action(@PathParam("thingUID") String thingUID, @PathParam("actionId") String actionId,
+            String actionValue) {
+
+        Thing thing = thingRegistry.get(new ThingUID(thingUID));
+        if (thing == null) {
+            logger.warn("Received HTTP PUT request at '{}' for the unknown thing '{}'.", uriInfo.getPath(), thingUID);
+            return Response.status(Status.NOT_FOUND).build();
+        }
+
+        if(thing instanceof ThingConfigAction) {
+            ((ThingConfigAction)thing).handleConfigurationAction(thing, actionId, actionValue);
+            return Response.ok().build();
+        }
+        else {
+            logger.warn("Received HTTP PUT request at '{}' but thing does not support actions '{}'.", uriInfo.getPath(), thingUID);
+            return Response.status(Status.NOT_FOUND).build();
+        }
     }
 
     protected void setItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
 import org.eclipse.smarthome.config.core.FilterCriteria;
@@ -41,6 +42,7 @@ import org.eclipse.smarthome.io.rest.RESTResource;
 import org.eclipse.smarthome.io.rest.core.LocaleUtil;
 import org.eclipse.smarthome.io.rest.core.thing.beans.ChannelDefinitionBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.ChannelGroupDefinitionBean;
+import org.eclipse.smarthome.io.rest.core.thing.beans.ConfigActionBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.ConfigDescriptionParameterBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.FilterCriteriaBean;
 import org.eclipse.smarthome.io.rest.core.thing.beans.ParameterGroupBean;
@@ -162,7 +164,8 @@ public class ThingTypeResource implements RESTResource {
                 convertToChannelDefinitionBeans(thingType.getChannelDefinitions()),
                 convertToChannelGroupDefinitionBeans(thingType.getChannelGroupDefinitions()),
                 thingType.getSupportedBridgeTypeUIDs(), thingType.getProperties(), thingType instanceof BridgeType,
-                convertToParameterGroupBeans(thingType.getConfigDescriptionURI(), locale));
+                convertToParameterGroupBeans(thingType.getConfigDescriptionURI(), locale),
+                convertToParameterActionBeans(thingType.getConfigDescriptionURI(), locale));
     }
 
     private List<ChannelGroupDefinitionBean> convertToChannelGroupDefinitionBeans(
@@ -222,4 +225,26 @@ public class ThingTypeResource implements RESTResource {
         return parameterGroupBeans;
     }
 
+    private List<ConfigActionBean> convertToParameterActionBeans(URI configDescriptionURI, Locale locale) {
+
+        ConfigDescription configDescription = configDescriptionRegistry.getConfigDescription(configDescriptionURI,
+                locale);
+        List<ConfigActionBean> actionBeans = new ArrayList<>();
+        if (configDescription != null) {
+
+            List<ConfigDescriptionAction> configActions = configDescription.getActions();
+            for (ConfigDescriptionAction configAction : configActions) {
+                ConfigActionBean configActionBean = new ConfigActionBean(configAction.getName(),
+                        configAction.getType(), configAction.getMinimum(), configAction.getMaximum(),
+                        configAction.getStepSize(), configAction.getPattern(), configAction.isMultiple(),
+                        configAction.getContext(), String.valueOf(configAction.getDefault()), configAction.getLabel(),
+                        configAction.getDescription(), createBeansForOptions(configAction.getOptions()),
+                        createBeansForCriteria(configAction.getFilterCriteria()), configAction.getGroupName(),
+                        configAction.isAdvanced(), configAction.getLimitToOptions(), configAction.getMultipleLimit());
+                actionBeans.add(configActionBean);
+            }
+        }
+
+        return actionBeans;
+    }
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ConfigActionBean.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ConfigActionBean.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.rest.core.thing.beans;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.eclipse.smarthome.config.core.ConfigDescriptionAction.Type;
+
+/**
+ * This is a java bean that is used with JAX-RS to serialize parameter of a
+ * configuration action to JSON.
+ *
+ * @author Chris Jackson - Initial contribution
+ */
+public class ConfigActionBean {
+
+    public String context;
+    public String defaultValue;
+    public String description;
+    public String label;
+    public String name;
+    public Type type;
+    public BigDecimal minimum;
+    public BigDecimal maximum;
+    public BigDecimal stepsize;
+    public String pattern;
+    public Boolean multiple;
+    public Integer multipleLimit;
+    public String groupName;
+    public Boolean advanced;
+    public Boolean limitToOptions;
+
+    public List<ParameterOptionBean> options;
+    public List<FilterCriteriaBean> filterCriteria;
+
+    public ConfigActionBean() {
+    }
+
+    public ConfigActionBean(String name, Type type, BigDecimal minimum, BigDecimal maximum,
+            BigDecimal stepsize, String pattern, Boolean multiple, String context,
+            String defaultValue, String label, String description, List<ParameterOptionBean> options,
+            List<FilterCriteriaBean> filterCriteria, String groupName, Boolean advanced, Boolean limitToOptions,
+            Integer multipleLimit) {
+        this.name = name;
+        this.type = type;
+        this.minimum = minimum;
+        this.maximum = maximum;
+        this.stepsize = stepsize;
+        this.pattern = pattern;
+        this.multiple = multiple;
+        this.context = context;
+        this.defaultValue = defaultValue;
+        this.label = label;
+        this.description = description;
+        this.options = options;
+        this.filterCriteria = filterCriteria;
+        this.groupName = groupName;
+        this.advanced = advanced;
+        this.limitToOptions = limitToOptions;
+        this.multipleLimit = multipleLimit;
+    }
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ThingTypeBean.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/beans/ThingTypeBean.java
@@ -23,6 +23,7 @@ public class ThingTypeBean {
     public List<ChannelDefinitionBean> channels;
     public List<ChannelGroupDefinitionBean> channelGroups;
     public List<ConfigDescriptionParameterBean> configParameters;
+    public List<ConfigActionBean> actions;
     public List<String> supportedBridgeTypeUIDs;
     public List<ParameterGroupBean> parameterGroups;
     public Map<String, String> properties;
@@ -38,7 +39,8 @@ public class ThingTypeBean {
     public ThingTypeBean(String UID, String label, String description,
             List<ConfigDescriptionParameterBean> configParameters, List<ChannelDefinitionBean> channels,
             List<ChannelGroupDefinitionBean> channelGroups, List<String> supportedBridgeTypeUIDs,
-            Map<String, String> properties, boolean bridge, List<ParameterGroupBean> parameterGroups) {
+            Map<String, String> properties, boolean bridge, List<ParameterGroupBean> parameterGroups,
+            List<ConfigActionBean> actions) {
         this.UID = UID;
         this.label = label;
         this.description = description;
@@ -49,6 +51,7 @@ public class ThingTypeBean {
         this.properties = properties;
         this.bridge = bridge;
         this.parameterGroups = parameterGroups;
+        this.actions = actions;
     }
 
 }


### PR DESCRIPTION
As per the discussion [here](https://www.eclipse.org/forums/index.php/t/1066252/)

This is an initial suggestion for configuration actions. The actions are intended as immediate 'commands' for Thing configuration purposes - for example, to reset a device, exclude it from the network, perform some other function needed to initialise/configure/administer a device.

As per the discussion on the Eclipse forum, my current use case, and what I implemented for HABmin in OH1 was just a simple action::value command - basically implemented as buttons. I've implemented this similarly to parameters - you might consider that overkill, and I might agree, but I can also see that someone might come along with a use case for something a little more detailed than a simple button...

In the XML, in the parameter-descriptions, I've added ```<action>```. This builds the action list alongside the parameters and can be retrieved as part of the config registry and hence into the REST interface for the thing type. It adds a ```actions{}``` element to the REST json which lists all the actions.

In the other direction, I've added a thing/action interface to REST. There's then a ThingConfigAction which is expected to be implemented by the ThingHandler. This has a single method ```handleConfigurationAction(Thing thing, String action, String value)```.

I've not tested the sending of actions yet - only the XML and definitions into the REST interface. Before I go too far I wanted to see if you're happy with this approach...

The questions I can see are -:
* If the action definition is a bit too much (filters could probably be removed, maybe some other stuff)
* If the types are right for an action - maybe it should be more description like BUTTON or something. However in the API I would potentially ignore this anyway as this can probably be established in other ways.

Comments welcome :)

Signed-off-by: Chris Jackson <chris@cd-jackson.com>