### PR TITLE
Activates NamesAreUniqueValidator for Item files

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/GenerateItems.mwe2
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/GenerateItems.mwe2
@@ -85,7 +85,7 @@ Workflow {
 			fragment = validation.ValidatorFragment auto-inject {
 
 			// composedCheck = "org.eclipse.xtext.validation.ImportUriValidator"
-			// composedCheck = "org.eclipse.xtext.validation.NamesAreUniqueValidator"
+			   composedCheck = "org.eclipse.xtext.validation.NamesAreUniqueValidator"
 			}
 
 			// old scoping and exporting API


### PR DESCRIPTION
It doesn't consider potentially existing items that have equal names from the item provider. But for now it at least checks duplicate names within the loaded Xtext files.

Bug: 436533
Change-Id: Ibd65bc863f795729345b76029abfadfb28819ef6
Signed-off-by: Philip Langer <planger@eclipsesource.com>