### PR TITLE
Initial commit of configuration description templates

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescription.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescription.java
@@ -31,13 +31,14 @@ import java.util.List;
  *
  * @author Michael Grammling - Initial Contribution
  * @author Dennis Nobel - Initial Contribution
- * @author Chris Jackson - Added parameter groups
+ * @author Chris Jackson - Added parameter groups and template
  */
 public class ConfigDescription {
 
     private URI uri;
     private List<ConfigDescriptionParameter> parameters;
     private List<ConfigDescriptionParameterGroup> parameterGroups;
+    private boolean template;
 
     /**
      * Creates a new instance of this class with the specified parameter.
@@ -46,7 +47,7 @@ public class ConfigDescription {
      * @throws IllegalArgumentException if the URI is null or invalid
      */
     public ConfigDescription(URI uri) throws IllegalArgumentException {
-        this(uri, null, null);
+        this(uri, null, null, false);
     }
 
     /**
@@ -61,7 +62,7 @@ public class ConfigDescription {
      * @throws IllegalArgumentException if the URI is null or invalid
      */
     public ConfigDescription(URI uri, List<ConfigDescriptionParameter> parameters) {
-        this(uri, parameters, null);
+        this(uri, parameters, null, false);
     }
 
     /**
@@ -72,13 +73,13 @@ public class ConfigDescription {
      *
      * @param parameters the description of a concrete configuration parameter
      *            (could be null or empty)
-     *            
+     * 
      * @param groups the list of groups associated with the parameters
      *
      * @throws IllegalArgumentException if the URI is null or invalid
      */
     public ConfigDescription(URI uri, List<ConfigDescriptionParameter> parameters,
-            List<ConfigDescriptionParameterGroup> groups) {
+            List<ConfigDescriptionParameterGroup> groups, boolean template) {
         if (uri == null) {
             throw new IllegalArgumentException("The URI must not be null!");
         }
@@ -90,6 +91,8 @@ public class ConfigDescription {
         }
 
         this.uri = uri;
+
+        this.template = template;
 
         if (parameters != null) {
             this.parameters = Collections.unmodifiableList(parameters);
@@ -136,9 +139,19 @@ public class ConfigDescription {
         return this.parameterGroups;
     }
 
+    /**
+     * Returns true if this is defined as a template
+     * 
+     * @return true if this is a template
+     */
+    public boolean isTemplate() {
+        return this.template;
+    }
+
     @Override
     public String toString() {
-        return "ConfigDescription [uri=" + uri + ", parameters=" + parameters + ", groups=" + parameterGroups + "]";
+        return "ConfigDescription [uri=" + uri + ", template=" + template + ", parameters=" + parameters + ", groups="
+                + parameterGroups + "]";
     }
 
 }

--- a/bundles/config/org.eclipse.smarthome.config.xml/config-description-1.0.0.xsd
+++ b/bundles/config/org.eclipse.smarthome.config.xml/config-description-1.0.0.xsd
@@ -35,6 +35,7 @@
 		</xs:sequence>
 		<xs:attribute name="uri"
 			type="config-description:uriRestrictionPattern" use="optional" />
+		<xs:attribute name="template" type="xs:boolean" use="optional" />
 	</xs:complexType>
 
 	<xs:complexType name="parameter">

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionConverter.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/ConfigDescriptionConverter.java
@@ -34,7 +34,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
  * This converter converts {@code config-description} XML tags.
  *
  * @author Michael Grammling - Initial Contribution
- * @author Chris Jackson - Added configuration groups
+ * @author Chris Jackson - Added configuration groups and template attribute
  */
 public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescription> {
 
@@ -43,7 +43,8 @@ public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescri
     public ConfigDescriptionConverter() {
         super(ConfigDescription.class);
 
-        this.attributeMapValidator = new ConverterAttributeMapValidator(new String[][] { { "uri", "false" } });
+        this.attributeMapValidator = new ConverterAttributeMapValidator(new String[][] { { "uri", "false" },
+                { "template", "false" } });
     }
 
     @SuppressWarnings("unchecked")
@@ -66,6 +67,11 @@ public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescri
         } catch (NullPointerException | URISyntaxException ex) {
             throw new ConversionException("The URI '" + uriText + "' in node '" + reader.getNodeName()
                     + "' is invalid!", ex);
+        }
+
+        boolean template = false;
+        if (Boolean.parseBoolean(attributes.get("template")) == true) {
+            template = true;
         }
 
         // create the lists to hold parameters and groups
@@ -91,7 +97,7 @@ public class ConfigDescriptionConverter extends GenericUnmarshaller<ConfigDescri
         ConverterAssertion.assertEndOfType(reader);
 
         // create object
-        configDescription = new ConfigDescription(uri, configDescriptionParams, configDescriptionGroups);
+        configDescription = new ConfigDescription(uri, configDescriptionParams, configDescriptionGroups, template);
 
         return configDescription;
     }

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/XmlConfigDescriptionProvider.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/XmlConfigDescriptionProvider.java
@@ -39,7 +39,7 @@ import org.osgi.framework.Bundle;
  * @author Michael Grammling - Initial Contribution
  * @author Dennis Nobel - Added locale support
  * @author Alex Tugarev - Extended for pattern and options
- * @author Chris Jackson - Modify to use config parameter builder
+ * @author Chris Jackson - Modify to use config parameter builder and add configuration templates
  */
 public class XmlConfigDescriptionProvider implements ConfigDescriptionProvider {
 
@@ -212,13 +212,14 @@ public class XmlConfigDescriptionProvider implements ConfigDescriptionProvider {
                     .getParameterGroups().size());
 
             // Loop through all the configuration groups and localize them
-            for (ConfigDescriptionParameterGroup configDescriptionParameterGroup : configDescription.getParameterGroups()) {
+            for (ConfigDescriptionParameterGroup configDescriptionParameterGroup : configDescription
+                    .getParameterGroups()) {
                 ConfigDescriptionParameterGroup localizedConfigDescriptionGroup = getLocalizedConfigDescriptionGroup(
                         bundle, configDescription, configDescriptionParameterGroup, locale);
                 localizedConfigDescriptionGroups.add(localizedConfigDescriptionGroup);
             }
             return new ConfigDescription(configDescription.getURI(), localizedConfigDescriptionParameters,
-                    localizedConfigDescriptionGroups);
+                    localizedConfigDescriptionGroups, configDescription.isTemplate());
         } else {
             return configDescription;
         }
@@ -230,8 +231,8 @@ public class XmlConfigDescriptionProvider implements ConfigDescriptionProvider {
         URI configDescriptionURI = configDescription.getURI();
         String parameterName = parameter.getName();
 
-        String label = this.configDescriptionParamI18nUtil.getParameterLabel(bundle, configDescriptionURI, parameterName,
-                parameter.getLabel(), locale);
+        String label = this.configDescriptionParamI18nUtil.getParameterLabel(bundle, configDescriptionURI,
+                parameterName, parameter.getLabel(), locale);
 
         String description = this.configDescriptionParamI18nUtil.getParameterDescription(bundle, configDescriptionURI,
                 parameterName, parameter.getDescription(), locale);
@@ -264,8 +265,8 @@ public class XmlConfigDescriptionProvider implements ConfigDescriptionProvider {
         String label = this.configDescriptionGroupI18nUtil.getGroupLabel(bundle, configDescriptionURI, name,
                 group.getLabel(), locale);
 
-        String description = this.configDescriptionGroupI18nUtil.getGroupDescription(bundle, configDescriptionURI, name,
-                group.getDescription(), locale);
+        String description = this.configDescriptionGroupI18nUtil.getGroupDescription(bundle, configDescriptionURI,
+                name, group.getDescription(), locale);
 
         ConfigDescriptionParameterGroup localizedGroup = new ConfigDescriptionParameterGroup(name, group.getContext(),
                 group.isAdvanced(), label, description);

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlProvider.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.smarthome.core.thing.xml.internal;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ import com.thoughtworks.xstream.converters.ConversionException;
  * 
  * @author Michael Grammling - Initial Contribution
  * @author Ivan Iliev - Added support for system wide channel types
+ * @author Chris Jackson - Added configuration template concept
  * 
  * @see ThingTypeXmlProviderFactory
  */
@@ -125,7 +127,15 @@ public class ThingTypeXmlProvider implements XmlDocumentProvider<List<?>> {
     private void addConfigDescription(ConfigDescription configDescription) {
         if (configDescription != null) {
             try {
-                this.configDescriptionProvider.addConfigDescription(this.bundle, configDescription);
+                if (configDescription.isTemplate() == true) {
+                    // This config description is set as a template so update the URI
+                    this.configDescriptionProvider.addConfigDescription(this.bundle, new ConfigDescription(new URI(
+                            configDescription.getURI() + "#template"), configDescription.getParameters(),
+                            configDescription.getParameterGroups(), true));
+
+                } else {
+                    this.configDescriptionProvider.addConfigDescription(this.bundle, configDescription);
+                }
             } catch (Exception ex) {
                 this.logger.error("Could not register ConfigDescription!", ex);
             }


### PR DESCRIPTION
As discussed on the [Eclipse forum](https://www.eclipse.org/forums/index.php/t/1066227/).

This allows configuration descriptions to be tagged as a template. A template then allows a binding to register it's own ```ConfigDescriptionProvider``` to intercept the config description requests and provide it's own response.

Internally, if the template attribute is set in the XML, the ```#template``` fragment gets set in the URI. The ```ConfigDescriptionProvider``` can then test for this an provide an alternative/updated ```ConfigDescription```.

Examples -:

```xml
<config-description template="true">
    ...
</config-description>
```

```java
    @Override
    public ConfigDescription getConfigDescription(URI uri, Locale locale) {

        logger.debug("getConfigDescription called: uri={}", uri);

        if (this.configDescriptionRegistry == null || uri == null) {
            return null;
        }
        
        // If this is a template, then ignore to avoid recursive loop
        if (uri.getFragment() == "template") {
            return null;
        }

        List<ConfigDescriptionParameterGroup> groups = new ArrayList<ConfigDescriptionParameterGroup>();
        List<ConfigDescriptionParameter> parameters = new ArrayList<ConfigDescriptionParameter>();

        try {
            ConfigDescription configDescription = configDescriptionRegistry.getConfigDescription(new URI(uri + "#template"), locale);
            groups.addAll(configDescription.getParameterGroups());
            parameters.addAll(configDescription.getParameters());
        } catch (URISyntaxException e) {
            e.printStackTrace();
        }

        parameters.add(ConfigDescriptionParameterBuilder.create("name", Type.INTEGER)
                .withLabel("A Parameter + ")
                .build());

        parameters.add(ConfigDescriptionParameterBuilder.create("name", Type.INTEGER)
                .withLabel("B Parameter + ")
                .withReadOnly(true).build());

        return new ConfigDescription(uri, parameters, groups, false);
    }
```

Signed-off-by: Chris Jackson <chris@cd-jackson.com>
