### PR TITLE
Adjust max. brightness and saturation for Hue API

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightHandlerOSGiTest.groovy
@@ -18,8 +18,8 @@ import org.eclipse.smarthome.binding.hue.handler.HueBridgeHandler
 import org.eclipse.smarthome.binding.hue.handler.HueLightHandler
 import org.eclipse.smarthome.config.core.Configuration
 import org.eclipse.smarthome.core.events.EventPublisher
-import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.library.types.HSBType
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType
 import org.eclipse.smarthome.core.library.types.OnOffType
 import org.eclipse.smarthome.core.library.types.PercentType
 import org.eclipse.smarthome.core.thing.Bridge
@@ -27,11 +27,11 @@ import org.eclipse.smarthome.core.thing.ManagedThingProvider
 import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingProvider
 import org.eclipse.smarthome.core.thing.ThingStatus
-import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
 import org.eclipse.smarthome.core.thing.binding.ThingHandler
-import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder
 import org.eclipse.smarthome.core.thing.setup.ThingSetupManager
 import org.eclipse.smarthome.core.types.Command
 import org.eclipse.smarthome.test.AsyncResultWrapper
@@ -50,7 +50,8 @@ import org.junit.Test
 class HueLightHandlerOSGiTest extends OSGiTest {
 
     final ThingTypeUID BRIDGE_THING_TYPE_UID = new ThingTypeUID("hue", "bridge")
-    final ThingTypeUID LIGHT_THING_TYPE_UID = new ThingTypeUID("hue", "LCT001")
+    final ThingTypeUID COLOR_LIGHT_THING_TYPE_UID = new ThingTypeUID("hue", "LCT001")
+    final ThingTypeUID LUX_LIGHT_THING_TYPE_UID = new ThingTypeUID("hue", "LWB004")
 
     ManagedThingProvider managedThingProvider
     VolatileStorageService volatileStorageService = new VolatileStorageService()
@@ -81,15 +82,15 @@ class HueLightHandlerOSGiTest extends OSGiTest {
         return hueBridge
     }
 
-    Thing createLight(hueBridge) {
+    Thing createLight(hueBridge, ThingTypeUID lightUID) {
         Configuration lightConfiguration = new Configuration().with {
             put(LIGHT_ID, "1")
             it
         }
 
         Thing hueLight = managedThingProvider.createThing(
-                LIGHT_THING_TYPE_UID,
-                new ThingUID(LIGHT_THING_TYPE_UID, "Light1"),
+                lightUID,
+                new ThingUID(lightUID, "Light1"),
                 hueBridge.getUID(), lightConfiguration)
 
         assertThat hueLight, is(notNullValue())
@@ -104,7 +105,7 @@ class HueLightHandlerOSGiTest extends OSGiTest {
         HueLightHandler hueLightHandler = getService(ThingHandler, HueLightHandler)
         assertThat hueLightHandler, is(nullValue())
 
-        Thing hueLight = createLight(hueBridge)
+        Thing hueLight = createLight(hueBridge, COLOR_LIGHT_THING_TYPE_UID)
 
         // wait for HueLightHandler to be registered
         waitForAssert({
@@ -123,293 +124,338 @@ class HueLightHandlerOSGiTest extends OSGiTest {
         managedThingProvider.remove(hueBridge.getUID())
     }
 
-	@Test
-	void 'assert command for color channel: on'() {
-		def expectedBody = 
-			"""
-				{
-					"on" : true
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, OnOffType.ON, expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color temperature channel: on'() {
-		def expectedBody = 
-			"""
-				{
-					"on" : true
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, OnOffType.ON, expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color channel: off'() {
-		def expectedBody = 
-			"""
-				{
-					"on" : false
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, OnOffType.OFF, expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color temperature channel: off'() {
-		def expectedBody = 
-			"""
-				{
-					"on" : false
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, OnOffType.OFF, expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color temperature channel: 0%'() {
-		def expectedBody = 
-			"""
-				{
-					"ct" : 154
-				}
-			"""
-		assertSendCommand(CHANNEL_COLORTEMPERATURE, new PercentType(0), expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color temperature channel: 50%'() {
-		def expectedBody = 
-			"""
-				{
-					"ct" : 327
-				}
-			"""
-		assertSendCommand(CHANNEL_COLORTEMPERATURE, new PercentType(50), expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color temperature channel: 100%'() {
-		def expectedBody = 
-			"""
-				{
-					"ct" : 500
-				}
-			"""
-		assertSendCommand(CHANNEL_COLORTEMPERATURE, new PercentType(100), expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color channel: 0%'() {
-		def expectedBody = 
-			"""
-				{
-					"on" : false
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, new PercentType(0), expectedBody)	
-	}
-	
-	@Test
-	void 'assert command for color channel: 50%'() {
-		def expectedBody = 
-			"""
-				{
-					"bri" : 127,
-					"on" : true
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, new PercentType(50), expectedBody)	
-	}
-	
-	@Test
-	void 'assert command for color channel: 100%'() {
-		def expectedBody = 
-			"""
-				{
-					"bri" : 254,
-					"on" : true
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, new PercentType(100), expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color channel: black'() {
-		def expectedBody = 
-			"""
-				{
-					"on" : false
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, HSBType.BLACK, expectedBody)	
-	}
-	
-	@Test
-	void 'assert command for color channel: red'() {
-		def expectedBody = 
-			"""
-				{
-					"bri" : 254,
-					"sat" : 254,
-					"hue" : 0
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, HSBType.RED, expectedBody)	
-	}
-	
-	@Test
-	void 'assert command for color channel: blue'() {
-		def expectedBody = 
-			"""
-				{
-					"bri" : 254,
-					"sat" : 254,
-					"hue" : 43680
-				}
-			"""
-		assertSendCommand(CHANNEL_COLOR, HSBType.BLUE, expectedBody)
-	}
-	
-	@Test
-	void 'assert command for color channel: white'() {
-		def expectedBody = 
-				"""
-				{
-				"bri" : 254,
-				"sat" : 0,
-				"hue" : 0
-				}
-				"""
-				assertSendCommand(CHANNEL_COLOR, HSBType.WHITE, expectedBody)
-	}
-	
-    private void assertSendCommand(String channel, Command command, String expectedBody) {
+    @Test
+    void 'assert command for color channel: on'() {
+        def expectedReply =
+                """
+                {
+                    "on" : true
+                }
+                """
+        assertSendCommandForColor(OnOffType.ON, new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color temperature channel: on'() {
+        def expectedReply =
+                """
+                {
+                    "on" : true
+                }
+                """
+        assertSendCommandForColorTemp(OnOffType.ON, new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color channel: off'() {
+        def expectedReply =
+                """
+                {
+                    "on" : false
+                }
+                """
+        assertSendCommandForColor(OnOffType.OFF, new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color temperature channel: off'() {
+        def expectedReply =
+                """
+                {
+                    "on" : false
+                }
+                """
+        assertSendCommandForColorTemp(OnOffType.OFF, new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color temperature channel: 0%'() {
+        def expectedReply =
+                """
+                {
+                    "ct" : 153
+                }
+                """
+        assertSendCommandForColorTemp(new PercentType(0), new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color temperature channel: 50%'() {
+        def expectedReply =
+                """
+                {
+                    "ct" : 327
+                }
+                """
+        assertSendCommandForColorTemp(new PercentType(50), new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color temperature channel: 100%'() {
+        def expectedReply =
+                """
+                {
+                    "ct" : 500
+                }
+                """
+        assertSendCommandForColorTemp(new PercentType(100), new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color channel: 0%'() {
+        def expectedReply =
+                """
+                {
+                    "on" : false
+                }
+                """
+        assertSendCommandForColor(new PercentType(0), new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color channel: 50%'() {
+        def expectedReply =
+                """
+                {
+                    "bri" : 127,
+                    "on" : true
+                }
+                """
+        assertSendCommandForColor(new PercentType(50), new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color channel: 100%'() {
+        def expectedReply =
+                """
+                {
+                    "bri" : 254,
+                    "on" : true
+                }
+                """
+        assertSendCommandForColor(new PercentType(100), new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color channel: black'() {
+        def expectedBody =
+                """
+                {
+                    "on" : false
+                }
+                """
+        assertSendCommandForColor(HSBType.BLACK, new HueLightState(), expectedBody)
+    }
+
+    @Test
+    void 'assert command for color channel: red'() {
+        def expectedReply =
+                """
+                {
+                    "bri" : 254,
+                    "sat" : 254,
+                    "hue" : 0
+                }
+                """
+        assertSendCommandForColor(HSBType.RED, new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color channel: blue'() {
+        def expectedReply =
+                """
+                {
+                    "bri" : 254,
+                    "sat" : 254,
+                    "hue" : 43680
+                }
+                """
+        assertSendCommandForColor(HSBType.BLUE, new HueLightState(), expectedReply)
+    }
+
+    @Test
+    void 'assert command for color channel: white'() {
+        def expectedBody =
+                """
+                {
+                    "bri" : 254,
+                    "sat" : 0,
+                    "hue" : 0
+                }
+                """
+        assertSendCommandForColor(HSBType.WHITE, new HueLightState(), expectedBody)
+    }
+
+    @Test
+    void 'assert command for color channel: increase'() {
+        def currentState = new HueLightState().bri(1).on(false)
+        def expectedReply ='{"bri" : 30, "on" : true}'
+        assertSendCommandForColor(IncreaseDecreaseType.INCREASE, currentState, expectedReply)
+
+        currentState.bri(200).on(true)
+        expectedReply ='{"bri" : 230}'
+        assertSendCommandForColor(IncreaseDecreaseType.INCREASE, currentState, expectedReply)
+
+        currentState.bri(230)
+        expectedReply ='{"bri" : 254}'
+        assertSendCommandForColor(IncreaseDecreaseType.INCREASE, currentState, expectedReply)
+    }
+
+    @Test
+    void 'assert command for color channel: decrease'() {
+        def currentState = new HueLightState().bri(200)
+        def expectedReply ='{"bri" : 170}'
+        assertSendCommandForColor(IncreaseDecreaseType.DECREASE, currentState, expectedReply)
+
+        currentState.bri(20)
+        expectedReply ='{"on" : false}'
+        assertSendCommandForColor(IncreaseDecreaseType.DECREASE, currentState, expectedReply)
+    }
+
+    @Test
+    void 'assert command for brightness channel: 50%'() {
+        def currentState = new HueLightState()
+        def expectedReply ='{"bri" : 127, "on" : true}'
+        assertSendCommandForBrightness(new PercentType(50), currentState, expectedReply)
+    }
+
+    @Test
+    void 'assert command for brightness channel: increase'() {
+        def currentState = new HueLightState().bri(1).on(false)
+        def expectedReply ='{"bri" : 30, "on" : true}'
+        assertSendCommandForBrightness(IncreaseDecreaseType.INCREASE, currentState, expectedReply)
+
+        currentState.bri(200).on(true)
+        expectedReply ='{"bri" : 230}'
+        assertSendCommandForBrightness(IncreaseDecreaseType.INCREASE, currentState, expectedReply)
+
+        currentState.bri(230)
+        expectedReply ='{"bri" : 254}'
+        assertSendCommandForBrightness(IncreaseDecreaseType.INCREASE, currentState, expectedReply)
+    }
+
+    @Test
+    void 'assert command for brightness channel: decrease'() {
+        def currentState = new HueLightState().bri(200)
+        def expectedReply ='{"bri" : 170}'
+        assertSendCommandForBrightness(IncreaseDecreaseType.DECREASE, currentState, expectedReply)
+
+        currentState.bri(20)
+        expectedReply ='{"on" : false}'
+        assertSendCommandForBrightness(IncreaseDecreaseType.DECREASE, currentState, expectedReply)
+    }
+
+
+    private void assertSendCommandForColor(Command command, HueLightState currentState, String expectedReply) {
+        assertSendCommand(CHANNEL_COLOR, command, COLOR_LIGHT_THING_TYPE_UID, currentState, expectedReply)
+    }
+
+    private void assertSendCommandForColorTemp(Command command, HueLightState currentState, String expectedReply) {
+        assertSendCommand(CHANNEL_COLORTEMPERATURE, command, COLOR_LIGHT_THING_TYPE_UID, currentState, expectedReply)
+    }
+
+    private void assertSendCommandForBrightness(Command command, HueLightState currentState, String expectedReply) {
+        assertSendCommand(CHANNEL_BRIGHTNESS, command, LUX_LIGHT_THING_TYPE_UID, currentState, expectedReply)
+    }
+
+    private void assertSendCommand(String channel, Command command, ThingTypeUID hueLightUID, HueLightState currentState, String expectedReply) {
         Bridge hueBridge = createBridge()
 
-		HueLightHandler hueLightHandler = getService(ThingHandler, HueLightHandler)
-		assertThat hueLightHandler, is(nullValue())
+        HueLightHandler hueLightHandler = getService(ThingHandler, HueLightHandler)
+        assertThat hueLightHandler, is(nullValue())
 
-        Thing hueLight = createLight(hueBridge)
+        Thing hueLight = createLight(hueBridge, hueLightUID)
 
         try {
-	        // wait for HueLightHandler to be registered
-	        waitForAssert({
-	            hueLightHandler = getService(ThingHandler, HueLightHandler)
-	            assertThat hueLightHandler, is(notNullValue())
-	        }, 10000)
+            // wait for HueLightHandler to be registered
+            waitForAssert({
+                hueLightHandler = getService(ThingHandler, HueLightHandler)
+                assertThat hueLightHandler, is(notNullValue())
+            }, 10000)
 
-	        def AsyncResultWrapper<String> addressWrapper = new AsyncResultWrapper<String>()
-	        def AsyncResultWrapper<String> bodyWrapper = new AsyncResultWrapper<String>()
+            def AsyncResultWrapper<String> addressWrapper = new AsyncResultWrapper<String>()
+            def AsyncResultWrapper<String> bodyWrapper = new AsyncResultWrapper<String>()
 
-	        MockedHttpClient mockedHttpClient =  [
-	            put: { String address, String body ->
-	                addressWrapper.set(address)
-	                bodyWrapper.set(body)
-	                new Result("", 200)
-	            },
-	            get: { String address ->
-	                if (address.endsWith("testUserName/")) {
-	                    def body = """
-							{"lights":
-							  {
-							    "1": {
-								  "state": {
-								    "on": true,
-								    "bri": 200,
-								    "hue": 50000,
-								    "sat": 0,
-								    "xy": [
-								      0,
-								      0
-								    ],
-								    "ct": 0,
-								    "alert": "none",
-								    "effect": "none",
-								    "colormode": "hs",
-								    "reachable": true
-								  },
-								  "type": "Extended color light",
-								  "name": "Hue Light 1",
-								  "modelid": "LCT001",
-								  "swversion": "65003148",
-								  "pointsymbol": {
-								    "1": "none",
-								    "2": "none",
-								    "3": "none",
-								    "4": "none",
-								    "5": "none",
-								    "6": "none",
-								    "7": "none",
-								    "8": "none"
-								  }
-							    }
-							  }
-							}
-						"""
-	                    new Result(body, 200)
-					}
-				}
-	        ] as MockedHttpClient
-	
-			installHttpClientMock(hueLightHandler.getHueBridgeHandler(), mockedHttpClient)
-			
-            def online = ThingStatusInfoBuilder.create(ThingStatus.ONLINE, ThingStatusDetail.NONE).build()
-	        waitForAssert({
-	            assertThat hueLightHandler.getBridge().getStatusInfo(), is(online)
-	        }, 10000)
+            MockedHttpClient mockedHttpClient =  [
+                put: { String address, String body ->
+                    addressWrapper.set(address)
+                    bodyWrapper.set(body)
+                    new Result("", 200)
+                },
+                get: { String address ->
+                    if (address.endsWith("testUserName/")) {
+                        new Result(currentState.toString(), 200)
+                    }
+                }
+            ] as MockedHttpClient
 
-	        // create items and channel bindings
-	        ThingSetupManager thingSetupManager = getService(ThingSetupManager)
-	
-	        hueLight.getChannels().each {
-                thingSetupManager.enableChannel(it.UID)
-            }
-            
-	        def item = hueLight.getUID().toString().replace(":", "_") + "_" + channel
+            installHttpClientMock(hueLightHandler.getHueBridgeHandler(), mockedHttpClient)
 
-	        EventPublisher eventPublisher = getService(EventPublisher)
-	        assertThat eventPublisher, is(notNullValue())
-						
-	        eventPublisher.post(ItemEventFactory.createCommandEvent(item, command))
-			
-	        waitForAssert({assertTrue addressWrapper.isSet}, 10000)
-	        waitForAssert({assertTrue bodyWrapper.isSet}, 10000)
-			
-	        assertThat addressWrapper.wrappedObject, is("http://1.2.3.4/api/testUserName/lights/1/state")
-			assertJson(expectedBody, bodyWrapper.wrappedObject)
+            assertBridgeOnline(hueLightHandler.getBridge())
+            enableHueLightChannels(hueLight)
+            postCommand(hueLight, channel, command)
+
+            waitForAssert({assertTrue addressWrapper.isSet}, 10000)
+            waitForAssert({assertTrue bodyWrapper.isSet}, 10000)
+
+            assertThat addressWrapper.wrappedObject, is("http://1.2.3.4/api/testUserName/lights/1/state")
+            assertJson(expectedReply, bodyWrapper.wrappedObject)
         } finally {
-        	managedThingProvider.remove(hueLight.getUID())
-        	managedThingProvider.remove(hueBridge.getUID())
+            managedThingProvider.remove(hueLight.getUID())
+            managedThingProvider.remove(hueBridge.getUID())
         }
     }
-	
-	private void assertJson(String expected, String actual) {
-		def jsonSlurper = Class.forName("groovy.json.JsonSlurper").newInstance()
-		def actualResult = jsonSlurper.parseText(actual)
-		def expectedResult = jsonSlurper.parseText(expected)
 
-		assertThat actualResult, is(expectedResult)
-	}
-	
-	private void installHttpClientMock(HueBridgeHandler hueBridgeHandler,
+    private assertBridgeOnline(Bridge bridge){
+        def online = ThingStatusInfoBuilder.create(ThingStatus.ONLINE, ThingStatusDetail.NONE).build()
+        waitForAssert({
+            assertThat bridge.getStatusInfo(), is(online)
+        }, 10000)
+    }
+
+    private enableHueLightChannels(Thing hueLight){
+        ThingSetupManager thingSetupManager = getService(ThingSetupManager)
+
+        hueLight.getChannels().each {
+            thingSetupManager.enableChannel(it.UID)
+        }
+    }
+
+    private postCommand(Thing hueLight, String channel, Command command){
+
+        def item = hueLight.getUID().toString().replace(":", "_") + "_" + channel
+
+        EventPublisher eventPublisher = getService(EventPublisher)
+        assertThat eventPublisher, is(notNullValue())
+
+        eventPublisher.postCommand(item, command)
+    }
+
+    private void assertJson(String expected, String actual) {
+        def jsonSlurper = Class.forName("groovy.json.JsonSlurper").newInstance()
+        def actualResult = jsonSlurper.parseText(actual)
+        def expectedResult = jsonSlurper.parseText(expected)
+
+        assertThat actualResult, is(expectedResult)
+    }
+
+    private void installHttpClientMock(HueBridgeHandler hueBridgeHandler,
             MockedHttpClient mockedHttpClient) {
 
-		// mock HttpClient
-		def hueBridgeField = hueBridgeHandler.getClass().getDeclaredField("bridge")
-		hueBridgeField.accessible = true
-		def hueBridgeValue = hueBridgeField.get(hueBridgeHandler)
+        // mock HttpClient
+        def hueBridgeField = hueBridgeHandler.getClass().getDeclaredField("bridge")
+        hueBridgeField.accessible = true
+        def hueBridgeValue = hueBridgeField.get(hueBridgeHandler)
 
-		def httpClientField = hueBridgeValue.getClass().getDeclaredField("http")
-		httpClientField.accessible = true
-		httpClientField.set(hueBridgeValue, mockedHttpClient)
-		
-		def usernameField = hueBridgeValue.getClass().getDeclaredField("username")
-		usernameField.accessible = true
-		usernameField.set(hueBridgeValue, hueBridgeHandler.config.get(USER_NAME))
-		
-		hueBridgeHandler.initialize()
+        def httpClientField = hueBridgeValue.getClass().getDeclaredField("http")
+        httpClientField.accessible = true
+        httpClientField.set(hueBridgeValue, mockedHttpClient)
+
+        def usernameField = hueBridgeValue.getClass().getDeclaredField("username")
+        usernameField.accessible = true
+        usernameField.set(hueBridgeValue, hueBridgeHandler.config.get(USER_NAME))
+
+        hueBridgeHandler.initialize()
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightState.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightState.groovy
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.hue.test
+
+
+/**
+ * Builder for the current state of a hue light.
+ *
+ * @author Dominic Lerbs - Initial contribution
+ */
+class HueLightState {
+
+    def brightness = 200;
+    def hue = 50000;
+    def saturation = 0;
+    def colorTemperature = 153;
+    boolean isOn = true;
+
+
+    public HueLightState bri(int brightness){
+        this.brightness = brightness
+        return this
+    }
+
+    public HueLightState hue(int hue){
+        this.hue = hue
+        return this
+    }
+
+    public HueLightState sat(int saturation){
+        this.saturation = saturation
+        return this
+    }
+
+    public HueLightState ct(int colorTemperature){
+        this.colorTemperature = colorTemperature
+        return this
+    }
+
+    public HueLightState on(boolean isOn){
+        this.isOn = isOn
+        return this
+    }
+
+
+    public String toString(){
+        return
+        """
+        {"lights":
+          {
+            "1": {
+              "state": {
+                "on": ${isOn},
+                "bri": ${brightness},
+                "hue": ${hue},
+                "sat": ${saturation},
+                "xy": [
+                  0,
+                  0
+                ],
+                "ct": ${colorTemperature},
+                "alert": "none",
+                "effect": "none",
+                "colormode": "hs",
+                "reachable": true
+              },
+              "type": "Extended color light",
+              "name": "Hue Light 1",
+              "modelid": "LCT001",
+              "swversion": "65003148",
+              "pointsymbol": {
+                "1": "none",
+                "2": "none",
+                "3": "none",
+                "4": "none",
+                "5": "none",
+                "6": "none",
+                "7": "none",
+                "8": "none"
+              }
+            }
+          }
+        }
+        """
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
@@ -203,7 +203,7 @@ public class HueBridgeHandler extends BaseBridgeHandler {
             try {
                 bridge.setLightState(light, stateUpdate);
             } catch (DeviceOffException e) {
-                updateLightState(light, LightStateConverter.toColorLightState(OnOffType.ON));
+                updateLightState(light, LightStateConverter.toOnOffLightState(OnOffType.ON));
                 updateLightState(light, stateUpdate);
             } catch (IOException | ApiException e) {
                 throw new RuntimeException(e);

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
@@ -53,8 +53,6 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
             THING_TYPE_LCT003, THING_TYPE_LWB004, THING_TYPE_CLASSIC_A60_RGBW, THING_TYPE_SURFACE_LIGHT_TW,
             THING_TYPE_ZLL_LIGHT, THING_TYPE_LLC020);
 
-    private static final int DIM_STEPSIZE = 30;
-
     private String lightId;
 
     private Integer lastSentColorTemp;
@@ -128,106 +126,34 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
                 if (command instanceof PercentType) {
                     lightState = LightStateConverter.toColorTemperatureLightState((PercentType) command);
                 } else if (command instanceof OnOffType) {
-                    lightState = LightStateConverter.toColorLightState((OnOffType) command);
+                    lightState = LightStateConverter.toOnOffLightState((OnOffType) command);
                 } else if (command instanceof IncreaseDecreaseType) {
-                    Integer colorTemp = lastSentColorTemp;
-                    if (colorTemp == null) {
-                        State currentState = light.getState();
-                        if (currentState != null) {
-                            colorTemp = currentState.getColorTemperature();
-                        }
-                    }
-                    if (colorTemp != null) {
-                        if (command == IncreaseDecreaseType.DECREASE) {
-                            colorTemp -= DIM_STEPSIZE;
-                            if (colorTemp < 0)
-                                colorTemp = 0;
-                        } else {
-                            colorTemp += DIM_STEPSIZE;
-                            if (colorTemp > 255)
-                                colorTemp = 255;
-                        }
-                        lastSentColorTemp = colorTemp;
-                        lightState = new StateUpdate().setColorTemperature(colorTemp);
-                    }
+                    lightState = convertColorTempChangeToStateUpdate((IncreaseDecreaseType) command, light);
                 }
                 break;
             case CHANNEL_BRIGHTNESS:
                 if (command instanceof PercentType) {
-                    lightState = LightStateConverter.toColorLightState((PercentType) command);
+                    lightState = LightStateConverter.toBrightnessLightState((PercentType) command);
                 } else if (command instanceof OnOffType) {
-                    lightState = LightStateConverter.toColorLightState((OnOffType) command);
+                    lightState = LightStateConverter.toOnOffLightState((OnOffType) command);
                 } else if (command instanceof IncreaseDecreaseType) {
-                    Integer brightness = lastSentBrightness;
-                    if (brightness == null) {
-                        State currentState = light.getState();
-                        if (currentState != null) {
-                            if (!currentState.isOn()) {
-                                brightness = 0;
-                            } else {
-                                brightness = currentState.getBrightness();
-                            }
-                        }
-                    }
-                    if (brightness != null) {
-                        lightState = new StateUpdate();
-                        if (command == IncreaseDecreaseType.DECREASE) {
-                            brightness -= DIM_STEPSIZE;
-                            if (brightness < 1) {
-                                brightness = 1;
-                                lightState = lightState.setOn(false);
-                            }
-                        } else {
-                            brightness += DIM_STEPSIZE;
-                            if (brightness > 254) {
-                                brightness = 254;
-                            }
-                        }
-                        lastSentBrightness = brightness;
-                        lightState.setBrightness(brightness);
-                    }
+                    lightState = convertBrightnessChangeToStateUpdate((IncreaseDecreaseType) command, light);
                 }
                 break;
             case CHANNEL_COLOR:
                 if (command instanceof HSBType) {
                     HSBType hsbCommand = (HSBType) command;
                     if (hsbCommand.getBrightness().intValue() == 0) {
-                        lightState = LightStateConverter.toColorLightState(OnOffType.OFF);
+                        lightState = LightStateConverter.toOnOffLightState(OnOffType.OFF);
                     } else {
                         lightState = LightStateConverter.toColorLightState(hsbCommand);
                     }
                 } else if (command instanceof PercentType) {
-                    lightState = LightStateConverter.toColorLightState((PercentType) command);
+                    lightState = LightStateConverter.toBrightnessLightState((PercentType) command);
                 } else if (command instanceof OnOffType) {
-                    lightState = LightStateConverter.toColorLightState((OnOffType) command);
+                    lightState = LightStateConverter.toOnOffLightState((OnOffType) command);
                 } else if (command instanceof IncreaseDecreaseType) {
-                    Integer brightness = lastSentBrightness;
-                    if (brightness == null) {
-                        State currentState = light.getState();
-                        if (currentState != null) {
-                            if (!currentState.isOn()) {
-                                brightness = 0;
-                            } else {
-                                brightness = currentState.getBrightness();
-                            }
-                        }
-                    }
-                    if (brightness != null) {
-                        if (command == IncreaseDecreaseType.DECREASE) {
-                            brightness -= DIM_STEPSIZE;
-                            if (brightness < 0)
-                                brightness = 0;
-                        } else {
-                            brightness += DIM_STEPSIZE;
-                            if (brightness > 255)
-                                brightness = 255;
-                        }
-                        lastSentBrightness = brightness;
-                        lightState = new StateUpdate().setBrightness(brightness);
-                        if (brightness == 0) {
-                            lightState = lightState.setOn(false);
-                        }
-                    }
+                    lightState = convertBrightnessChangeToStateUpdate((IncreaseDecreaseType) command, light);
                 }
                 break;
         }
@@ -236,6 +162,61 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
         } else {
             logger.warn("Command send to an unknown channel id: " + channelUID);
         }
+    }
+
+    private StateUpdate convertColorTempChangeToStateUpdate(IncreaseDecreaseType command, FullLight light) {
+        StateUpdate stateUpdate = null;
+        Integer currentColorTemp = getCurrentColorTemp(light.getState());
+        if (currentColorTemp != null) {
+            int newColorTemp = LightStateConverter.toAdjustedColorTemp(command, currentColorTemp);
+            stateUpdate = new StateUpdate().setColorTemperature(newColorTemp);
+            lastSentColorTemp = newColorTemp;
+        }
+        return stateUpdate;
+    }
+
+    private Integer getCurrentColorTemp(State lightState) {
+        Integer colorTemp = lastSentColorTemp;
+        if (colorTemp == null && lightState != null) {
+            colorTemp = lightState.getColorTemperature();
+        }
+        return colorTemp;
+    }
+
+    private StateUpdate convertBrightnessChangeToStateUpdate(IncreaseDecreaseType command, FullLight light) {
+        StateUpdate stateUpdate = null;
+        Integer currentBrightness = getCurrentBrightness(light.getState());
+        if (currentBrightness != null) {
+            int newBrightness = LightStateConverter.toAdjustedBrightness(command, currentBrightness);
+            stateUpdate = createBrightnessStateUpdate(currentBrightness, newBrightness);
+            lastSentBrightness = newBrightness;
+        }
+        return stateUpdate;
+    }
+
+    private Integer getCurrentBrightness(State lightState) {
+        Integer brightness = lastSentBrightness;
+        if (brightness == null && lightState != null) {
+            if (!lightState.isOn()) {
+                brightness = 0;
+            } else {
+                brightness = lightState.getBrightness();
+            }
+        }
+        return brightness;
+    }
+
+    private StateUpdate createBrightnessStateUpdate(int currentBrightness, int newBrightness) {
+        StateUpdate lightUpdate = new StateUpdate();
+        if (newBrightness == 0) {
+            lightUpdate.turnOff();
+        } else {
+            lightUpdate.setBrightness(newBrightness);
+            if (currentBrightness == 0){
+                lightUpdate.turnOn();
+            }
+        }
+        return lightUpdate;
     }
 
     private synchronized HueBridgeHandler getHueBridgeHandler() {


### PR DESCRIPTION
Set maximum values for brightness and saturation to comply with the
official Hue API (254 instead of 255).
Extend HueLightHandlerOSGiTest test to include Increase/Decrease type.
Fix two tests of HueLightHandlerOSGiTest where incorrect channel was used.

Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=470117

Signed-off-by: Dominic Lerbs <dominicdesu@hallojapan.de>