### PR TITLE
fix xtend generator to generate 1.7 compliant sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,9 @@
       <plugin>
         <groupId>org.eclipse.xtend</groupId>
         <artifactId>xtend-maven-plugin</artifactId>
+        <configuration>
+        	<javaSourceVersion>1.7</javaSourceVersion>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Fix the xtend generator to generate java classes with source level 1.7, so that it matches the tycho compiler configuration.
This happens only when running maven with JDK 8.

Bug: 470282
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>