### PR TITLE
generating all models at once

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.codegen/Generate All Models.launch
+++ b/bundles/model/org.eclipse.smarthome.model.codegen/Generate All Models.launch
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.emf.mwe2.launch.Mwe2LaunchConfigurationType">
+<stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.eclipse.smarthome.model.codegen"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<listAttribute key="org.eclipse.jdt.launching.CLASSPATH">
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry containerPath=&quot;org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7&quot; javaProject=&quot;org.eclipse.smarthome.model.codegen&quot; path=&quot;1&quot; type=&quot;4&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry id=&quot;org.eclipse.jdt.launching.classpathentry.defaultClasspath&quot;&gt;&#10;&lt;memento exportedEntriesOnly=&quot;false&quot; project=&quot;org.eclipse.smarthome.model.codegen&quot;/&gt;&#10;&lt;/runtimeClasspathEntry&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/org.eclipse.smarthome.model.item/src&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/org.eclipse.smarthome.model.persistence/src&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/org.eclipse.smarthome.model.rule/src&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/org.eclipse.smarthome.model.script/src&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/org.eclipse.smarthome.model.sitemap/src&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+<listEntry value="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?&gt;&#10;&lt;runtimeClasspathEntry internalArchive=&quot;/org.eclipse.smarthome.model.thing/src&quot; path=&quot;3&quot; type=&quot;2&quot;/&gt;&#10;"/>
+</listAttribute>
+<booleanAttribute key="org.eclipse.jdt.launching.DEFAULT_CLASSPATH" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="workflows/GenerateAllLanguages.mwe2"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.model.codegen"/>
+</launchConfiguration>

--- a/bundles/model/org.eclipse.smarthome.model.codegen/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.codegen/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Require-Bundle: org.eclipse.emf.mwe2.launch;bundle-version="2.2.0",
  org.eclipse.smarthome.model.rule,
  org.eclipse.smarthome.model.script,
  org.eclipse.smarthome.model.sitemap,
+ org.eclipse.smarthome.model.thing,
  org.eclipse.xtext.generator,
  org.eclipse.smarthome.model.persistence,
  org.objectweb.asm;bundle-version="3.3.1";resolution:=optional

--- a/bundles/model/org.eclipse.smarthome.model.codegen/workflows/GenerateAllLanguages.mwe2
+++ b/bundles/model/org.eclipse.smarthome.model.codegen/workflows/GenerateAllLanguages.mwe2
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+module all
+
+/**
+ * Executes the model generation for all languages.
+ * 
+ * @author Simon Kaufmann - Initial contribution and API
+ *
+ */
+Workflow {
+    component = @org.eclipse.smarthome.model.Items{}
+    component = @org.eclipse.smarthome.model.Sitemap{}
+    component = @org.eclipse.smarthome.model.script.GenerateScript{}
+    component = @org.eclipse.smarthome.model.rule.GenerateRules{}
+    component = @org.eclipse.smarthome.model.persistence.GeneratePersistence{}
+    component = @org.eclipse.smarthome.model.thing.GenerateThing{}
+}

--- a/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.emf.common,
  org.antlr.runtime,
- org.eclipse.xtext.common.types
+ org.eclipse.xtext.common.types,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.smarthome.model,org.eclipse.smarthome.mode
  l.formatting,org.eclipse.smarthome.model.generator,org.eclipse.smarth

--- a/bundles/model/org.eclipse.smarthome.model.item/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>org.eclipse.xtext.xbase</artifactId>
             <version>${xtext-version}</version>
           </dependency>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>org.eclipse.smarthome.model.lazygen</artifactId>
+            <version>${project.version}</version>
+          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/GenerateItems.mwe2
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/GenerateItems.mwe2
@@ -3,6 +3,7 @@ module org.eclipse.smarthome.model.Items
 import org.eclipse.emf.mwe.utils.*
 import org.eclipse.xtext.generator.*
 import org.eclipse.xtext.ui.generator.*
+import org.eclipse.smarthome.model.lazygen.*
 
 var fileExtensions = "items"
 var projectName = "org.eclipse.smarthome.model.item"
@@ -13,18 +14,7 @@ var encoding = "UTF-8"
 
 Workflow {
 	bean = StandaloneSetup {
-	// use an XtextResourceset throughout the process, which is able to resolve classpath:/ URIs.
-		resourceSet = org.eclipse.xtext.resource.XtextResourceSet : theResourceSet {}
-
-		// add mappings from platform:/resource to classpath:/
-//		uriMap = {
-//			from = "platform:/resource/org.eclipse.xtext.xbase/"
-//			to = "classpath:/"
-//		}
-//		uriMap = {
-//			from = "platform:/resource/org.eclipse.xtext.common.types/"
-//			to = "classpath:/"
-//		}
+        scanClassPath = true
 
 		// register current projects and its siblings for platform URI map, as they are not on the classpath.
 		platformUri = "${runtimeProject}/.."// The following two lines can be removed, if Xbase is not used.
@@ -32,6 +22,10 @@ Workflow {
 //registerGenModelFile = "platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel"
 	}
 
+    component = LazyStandaloneSetup {
+        
+    }
+    
 	component = DirectoryCleaner {
 		directory = "${runtimeProject}/src-gen"
 	}
@@ -44,15 +38,13 @@ Workflow {
 		directory = "${runtimeProject}.ui/src-gen"
 	}
 
-	component = Generator {
+	component = LazyGenerator {
 		pathRtProject = runtimeProject
 		pathUiProject = "${runtimeProject}.ui"// pathTestProject = "${runtimeProject}.tests"
 		projectNameRt = projectName
 		projectNameUi = "${projectName}.ui"
 		encoding = encoding
-		language = auto-inject {
-		// make sure we use the resourceSet created during standalone setup.
-			forcedResourceSet = theResourceSet
+		lazyLanguage = auto-inject {
 			uri = grammarURI
 			fileExtensions = fileExtensions
 			// Java API to access grammar elements (required by several other fragments)

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/.classpath
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/.project
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.model.lazygen</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.7

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Model Lazy Generation
+Bundle-SymbolicName: org.eclipse.smarthome.model.lazygen
+Bundle-Version: 0.8.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-Vendor: Eclipse.org/SmartHome
+Require-Bundle: org.eclipse.xtext,
+ org.apache.commons.logging,
+ org.eclipse.emf.codegen,
+ org.eclipse.emf.codegen.ecore,
+ org.eclipse.xtext.generator,
+ org.eclipse.xtext.ecore
+Import-Package: org.apache.log4j

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/about.html
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 5, 2006</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/build.properties
@@ -1,0 +1,5 @@
+source.. = src/main/java/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .,\
+               about.html

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.eclipse.smarthome.bundles</groupId>
+    <artifactId>model</artifactId>
+    <version>0.8.0-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <bundle.symbolicName>org.eclipse.smarthome.model.lazygen</bundle.symbolicName>
+    <bundle.namespace>org.eclipse.smarthome.model.lazygen</bundle.namespace>
+  </properties>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eclipse.smarthome.model</groupId>
+  <artifactId>org.eclipse.smarthome.model.lazygen</artifactId>
+
+  <name>Eclipse SmartHome Model Lazy Generation</name>
+
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/src/main/java/org/eclipse/smarthome/model/lazygen/GlobalResourceSet.java
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/src/main/java/org/eclipse/smarthome/model/lazygen/GlobalResourceSet.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.model.lazygen;
+
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtext.resource.XtextResourceSet;
+
+/**
+ *
+ * @author Holger Schill, Simon Kaufmann - Initial contribution and API
+ *
+ */
+public class GlobalResourceSet {
+
+	private static ResourceSet INSTANCE = null;
+
+	public static ResourceSet getINSTANCE() {
+		if (INSTANCE == null)
+			INSTANCE = new XtextResourceSet();
+		return INSTANCE;
+	}
+}

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/src/main/java/org/eclipse/smarthome/model/lazygen/LazyGenerator.java
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/src/main/java/org/eclipse/smarthome/model/lazygen/LazyGenerator.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.model.lazygen;
+
+import org.eclipse.emf.mwe.core.WorkflowContext;
+import org.eclipse.emf.mwe.core.issues.Issues;
+import org.eclipse.emf.mwe.core.monitor.ProgressMonitor;
+import org.eclipse.xtext.generator.Generator;
+
+/**
+ *
+ * @author Holger Schill, Simon Kaufmann - Initial contribution and API
+ *
+ */
+public class LazyGenerator extends Generator {
+	
+	LazyLanguageConfig langConfig = null;
+
+	public void addLazyLanguage(LazyLanguageConfig langConfig) {
+		this.langConfig = langConfig;
+		super.addLanguage(langConfig);
+	}
+
+	@Override
+	protected void invokeInternal(WorkflowContext ctx, ProgressMonitor monitor, Issues issues) {
+		super.checkConfigurationInternal(issues);
+		super.invokeInternal(ctx, monitor, issues);
+	}
+
+	@Override
+	protected void checkConfigurationInternal(Issues issues) {
+
+	}
+
+}

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/src/main/java/org/eclipse/smarthome/model/lazygen/LazyLanguageConfig.java
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/src/main/java/org/eclipse/smarthome/model/lazygen/LazyLanguageConfig.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.model.lazygen;
+
+import static org.eclipse.xtext.util.Strings.equal;
+
+import org.apache.log4j.Logger;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.util.EcoreUtil;
+import org.eclipse.xpand2.XpandExecutionContext;
+import org.eclipse.xtext.Grammar;
+import org.eclipse.xtext.ecore.EcoreSupportStandaloneSetup;
+import org.eclipse.xtext.generator.CompositeGeneratorException;
+import org.eclipse.xtext.generator.LanguageConfig;
+import org.eclipse.xtext.resource.IResourceServiceProvider;
+import org.eclipse.xtext.resource.XtextResource;
+
+/**
+ *
+ * @author Holger Schill, Simon Kaufmann - Initial contribution and API
+ *
+ */
+public class LazyLanguageConfig extends LanguageConfig {
+	
+	private final static Logger LOG = Logger.getLogger(LazyLanguageConfig.class);
+	String uri = null;
+	boolean isUI = false;
+
+	@Override
+	public void setUri(String uri) {
+		this.uri = uri;
+	}
+
+	private Grammar grammar;
+
+	@Override
+	public Grammar getGrammar() {
+		setUriReally(uri);
+		return grammar;
+	}
+
+	@Override
+	public void initialize(boolean isUi) {
+		this.isUI = isUi;
+	}
+
+	public void initializeReally() {
+		super.initialize(isUI);
+	}
+
+	@Override
+	protected void validateGrammar(Grammar grammar) {
+	}
+
+	@Override
+	public void generate(Grammar grammar, XpandExecutionContext ctx) {
+		initializeReally();
+		super.generate(grammar, ctx);
+	}
+
+	@Override
+	public void generate(LanguageConfig config, XpandExecutionContext ctx) throws CompositeGeneratorException {
+		initializeReally();
+		super.generate(config, ctx);
+	}
+
+	public void setUriReally(String uri) {
+		ResourceSet rs = GlobalResourceSet.getINSTANCE();
+		for (String loadedResource : getLoadedResources()) {
+			URI loadedResourceUri = URI.createURI(loadedResource);
+			if (equal(loadedResourceUri.fileExtension(), "ecore")) {
+				IResourceServiceProvider resourceServiceProvider = IResourceServiceProvider.Registry.INSTANCE
+						.getResourceServiceProvider(loadedResourceUri);
+				if (resourceServiceProvider == null) {
+					EcoreSupportStandaloneSetup.setup();
+				}
+			} else if (equal(loadedResourceUri.fileExtension(), "xcore")) {
+				IResourceServiceProvider resourceServiceProvider = IResourceServiceProvider.Registry.INSTANCE
+						.getResourceServiceProvider(loadedResourceUri);
+				if (resourceServiceProvider == null) {
+					try {
+						Class<?> xcore = Class.forName("org.eclipse.emf.ecore.xcore.XcoreStandaloneSetup");
+						xcore.getDeclaredMethod("doSetup", new Class[0]).invoke(null);
+					} catch (ClassNotFoundException e) {
+						LOG.error("Couldn't initialize Xcore support. Is it on the classpath?");
+					} catch (Exception e) {
+						LOG.error("Couldn't initialize Xcore support.", e);
+					}
+				}
+			}
+			Resource res = rs.getResource(loadedResourceUri, true);
+			if (res == null || res.getContents().isEmpty())
+				LOG.error("Error loading '" + loadedResource + "'");
+			else if (!res.getErrors().isEmpty())
+				LOG.error("Error loading '" + loadedResource + "': " + res.getErrors().toString());
+		}
+		EcoreUtil.resolveAll(rs);
+		XtextResource resource = (XtextResource) rs.getResource(URI.createURI(uri), true);
+		if (resource.getContents().isEmpty()) {
+			throw new IllegalArgumentException("Couldn't load grammar for '" + uri + "'.");
+		}
+		if (!resource.getErrors().isEmpty()) {
+			LOG.error(resource.getErrors());
+			throw new IllegalStateException("Problem parsing '" + uri + "':" + resource.getErrors().toString());
+		}
+
+		final Grammar grammar = (Grammar) resource.getContents().get(0);
+		validateGrammar(grammar);
+		this.grammar = grammar;
+	}
+}

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/src/main/java/org/eclipse/smarthome/model/lazygen/LazyStandaloneSetup.java
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/src/main/java/org/eclipse/smarthome/model/lazygen/LazyStandaloneSetup.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.model.lazygen;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.emf.common.util.TreeIterator;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EPackage;
+import org.eclipse.emf.ecore.EPackage.Registry;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.mwe.core.ConfigurationException;
+import org.eclipse.emf.mwe.core.WorkflowContext;
+import org.eclipse.emf.mwe.core.issues.Issues;
+import org.eclipse.emf.mwe.core.lib.AbstractWorkflowComponent2;
+import org.eclipse.emf.mwe.core.monitor.ProgressMonitor;
+import org.eclipse.emf.mwe.core.resources.ResourceLoaderFactory;
+import org.eclipse.emf.mwe.utils.GenModelHelper;
+
+import com.google.common.collect.Sets;
+
+/**
+ *
+ * @author Holger Schill, Simon Kaufmann - Initial contribution and API
+ *
+ */
+public class LazyStandaloneSetup extends AbstractWorkflowComponent2 {
+
+	private static ResourceSet resourceSet = GlobalResourceSet.getINSTANCE();
+	private Registry registry = EPackage.Registry.INSTANCE;
+
+	Set<String> allgeneratedEPackages = Sets.newHashSet();
+	Set<String> allGenModelFiles = Sets.newHashSet();
+	Set<String> allEcoreFiles = Sets.newHashSet();
+
+	public void addGeneratedPackage(String packageName) {
+		allgeneratedEPackages.add(packageName);
+	}
+
+	public void addGenModelFile(String modelFile) {
+		allGenModelFiles.add(modelFile);
+	}
+
+	public void addEcoreModelFile(String modelFile) {
+		allEcoreFiles.add(modelFile);
+	}
+
+	@Override
+	protected void invokeInternal(WorkflowContext ctx, ProgressMonitor monitor, Issues issues) {
+		for (String generatedEPackage : allgeneratedEPackages) {
+			addRegisterGeneratedEPackage(generatedEPackage);
+		}
+		for (String genModelFile : allGenModelFiles) {
+			addRegisterGenModelFile(genModelFile);
+		}
+		for (String ecoreFile : allEcoreFiles) {
+			addRegisterEcoreFile(ecoreFile);
+		}
+
+	}
+
+	private org.apache.commons.logging.Log log = LogFactory.getLog(getClass());
+
+	private void addRegisterGeneratedEPackage(String interfacename) {
+		Class<?> clazz = ResourceLoaderFactory.createResourceLoader().loadClass(interfacename);
+		if (clazz == null)
+			throw new ConfigurationException("Couldn't find an interface " + interfacename);
+		try {
+			EPackage pack = (EPackage) clazz.getDeclaredField("eINSTANCE").get(null);
+			if (registry.get(pack.getNsURI()) == null) {
+				registry.put(pack.getNsURI(), pack);
+				log.info("Adding generated EPackage '" + interfacename + "'");
+			}
+
+		} catch (Exception e) {
+			throw new ConfigurationException("Couldn't register " + interfacename
+					+ ". Is it the generated EPackage interface? : " + e.getMessage());
+		}
+	}
+
+	private void addRegisterEcoreFile(String fileName) throws IllegalArgumentException, SecurityException {
+		Resource res = resourceSet.getResource(createURI(fileName), true);
+		if (res == null)
+			throw new ConfigurationException("Couldn't find resource under  " + fileName);
+		if (!res.isLoaded()) {
+			try {
+				res.load(null);
+			} catch (IOException e) {
+				throw new ConfigurationException("Couldn't load resource under  " + fileName + " : " + e.getMessage());
+			}
+		}
+		List<EObject> result = res.getContents();
+		for (EObject object : result) {
+			if (object instanceof EPackage) {
+				registerPackage(fileName, object);
+			}
+			for (final TreeIterator<EObject> it = object.eAllContents(); it.hasNext();) {
+				EObject child = it.next();
+				if (child instanceof EPackage) {
+					registerPackage(fileName, child);
+				}
+			}
+		}
+	}
+
+	private GenModelHelper createGenModelHelper() {
+		return new GenModelHelper();
+	}
+
+	private void addRegisterGenModelFile(String fileName) {
+		createGenModelHelper().registerGenModel(resourceSet, createURI(fileName));
+	}
+
+	private void registerPackage(String fileName, EObject object) {
+		String nsUri = ((EPackage) object).getNsURI();
+		if (registry.get(nsUri) == null) {
+			registry.put(nsUri, object);
+			log.info("Adding dynamic EPackage '" + nsUri + "' from '" + fileName + "'");
+		} else if (log.isDebugEnabled()) {
+			log.debug("Dynamic EPackage '" + nsUri + "' from '" + fileName + "' already in the registry!");
+		}
+	}
+
+	private URI createURI(String path) {
+		if (path == null)
+			throw new IllegalArgumentException();
+
+		URI uri = URI.createURI(path);
+		if (uri.isRelative()) {
+			URI resolvedURI = URI.createFileURI(new File(path).getAbsolutePath());
+			return resolvedURI;
+		}
+		return uri;
+	}
+
+}

--- a/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.xtext;bundle-version="2.1.0";visibility:=reexport,
  org.eclipse.emf.ecore,
  org.eclipse.emf.common,
  org.antlr.runtime,
- org.eclipse.xtext.common.types
+ org.eclipse.xtext.common.types,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional
 Import-Package: com.google.common.base,
  com.google.common.collect,
  org.apache.commons.logging,

--- a/bundles/model/org.eclipse.smarthome.model.persistence/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>org.eclipse.xtext.xbase</artifactId>
             <version>${xtext-version}</version>
           </dependency>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>org.eclipse.smarthome.model.lazygen</artifactId>
+            <version>${project.version}</version>
+          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/GeneratePersistence.mwe2
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/GeneratePersistence.mwe2
@@ -3,6 +3,7 @@ module org.eclipse.smarthome.model.persistence.GeneratePersistence
 import org.eclipse.emf.mwe.utils.*
 import org.eclipse.xtext.generator.*
 import org.eclipse.xtext.ui.generator.*
+import org.eclipse.smarthome.model.lazygen.*
 
 var projectName = "org.eclipse.smarthome.model.persistence"
 var fileExtensions = "persist"
@@ -13,18 +14,7 @@ var encoding = "UTF-8"
 
 Workflow {
 	bean = StandaloneSetup {
-	// use an XtextResourceset throughout the process, which is able to resolve classpath:/ URIs.
-		resourceSet = org.eclipse.xtext.resource.XtextResourceSet : theResourceSet {}
-
-		// add mappings from platform:/resource to classpath:/
-		//		uriMap = {
-		//			from = "platform:/resource/org.eclipse.xtext.xbase/"
-		//			to = "classpath:/"
-		//		}
-//		uriMap = {
-//			from = "platform:/resource/org.eclipse.smarthome.model.item/"
-//			to = "classpath:/"
-//		}
+        scanClassPath = true
 
 		// register current projects and its siblings for platform URI map, as they are not on the classpath.
 		platformUri = "${runtimeProject}/.."
@@ -32,10 +22,12 @@ Workflow {
 		// The following two lines can be removed, if Xbase is not used.
 		//registerGeneratedEPackage = "org.eclipse.xtext.xbase.XbasePackage"
 		//registerGenModelFile = "platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel"
-//		registerGeneratedEPackage = "org.eclipse.smarthome.model.items.ItemsPackage"
-//		registerGenModelFile = "platform:/resource/org.eclipse.smarthome.model.item/model/generated/Items.genmodel"
 	}
 
+    component = LazyStandaloneSetup {
+        
+    }
+    
 	component = DirectoryCleaner {
 		directory = "${runtimeProject}/src-gen"
 	}
@@ -48,15 +40,13 @@ Workflow {
 		directory = "${runtimeProject}.ui/src-gen"
 	}
 
-	component = Generator {
+	component = LazyGenerator {
 		pathRtProject = runtimeProject
 		pathUiProject = "${runtimeProject}.ui"// pathTestProject = "${runtimeProject}.tests"
 		projectNameRt = projectName
 		projectNameUi = "${projectName}.ui"
 		encoding = encoding
-		language = auto-inject {
-		// make sure we use the resourceSet created during standalone setup.
-			forcedResourceSet = theResourceSet
+		lazyLanguage = auto-inject {
 			uri = grammarURI
 			fileExtensions = fileExtensions
 			// Java API to access grammar elements (required by several other fragments)

--- a/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.smarthome.model.item,
  org.eclipse.smarthome.model.script,
  org.eclipse.xtext.xbase.lib,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional
 Import-Package: com.google.common.collect,
  org.apache.commons.lang,
  org.apache.commons.logging,

--- a/bundles/model/org.eclipse.smarthome.model.rule/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>org.eclipse.smarthome.model.script</artifactId>
             <version>${project.version}</version>
           </dependency>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>org.eclipse.smarthome.model.lazygen</artifactId>
+            <version>${project.version}</version>
+          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/GenerateRules.mwe2
+++ b/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/GenerateRules.mwe2
@@ -3,6 +3,7 @@ module org.eclipse.smarthome.model.rule.GenerateRules
 import org.eclipse.emf.mwe.utils.*
 import org.eclipse.xtext.generator.*
 import org.eclipse.xtext.ui.generator.*
+import org.eclipse.smarthome.model.lazygen.*
 
 var projectName = "org.eclipse.smarthome.model.rule"
 var fileExtensions = "rules"
@@ -14,22 +15,7 @@ var encoding = "UTF-8"
 
 Workflow {
 	bean = StandaloneSetup {
-	// use an XtextResourceset throughout the process, which is able to resolve classpath:/ URIs.
-		resourceSet = org.eclipse.xtext.resource.XtextResourceSet : theResourceSet {}
-
-		// add mappings from platform:/resource to classpath:/
-		uriMap = {
-			from = "platform:/resource/org.eclipse.xtext.xbase/"
-			to = "classpath:/"
-		}
-	     uriMap = {
-		     from = "platform:/resource/org.eclipse.xtext.common.types/"
-		     to = "classpath:/"
-	     }
-//		uriMap = {
-//			from = "platform:/resource/org.eclipse.smarthome.model.item/"
-//			to = "classpath:/"
-//		}
+        scanClassPath = true
 
 		// register current projects and its siblings for platform URI map, as they are not on the classpath.
 		platformUri = "${runtimeProject}/.."
@@ -37,10 +23,13 @@ Workflow {
 		// The following two lines can be removed, if Xbase is not used.
 		registerGeneratedEPackage = "org.eclipse.xtext.xbase.XbasePackage"
 		registerGenModelFile = "platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel"
-		registerGeneratedEPackage = "org.eclipse.smarthome.model.script.script.ScriptPackage"
-		registerGenModelFile = "platform:/resource/org.eclipse.smarthome.model.script/model/generated/Script.genmodel"
 	}
 
+    component = LazyStandaloneSetup {
+        ecoreModelFile = "platform:/resource/org.eclipse.smarthome.model.script/model/generated/Script.ecore"
+        genModelFile = "platform:/resource/org.eclipse.smarthome.model.script/model/generated/Script.genmodel"
+    }
+    
 	component = DirectoryCleaner {
 		directory = "${runtimeProject}/src-gen"
 	}
@@ -53,16 +42,14 @@ Workflow {
 		directory = "${runtimeProject}.ui/src-gen"
 	}
 
-	component = Generator {
+	component = LazyGenerator {
 		pathRtProject = runtimeProject
 		pathUiProject = "${runtimeProject}.ui"
 		//pathTestProject = "${runtimeProject}.tests"
 		projectNameRt = projectName
 		projectNameUi = "${projectName}.ui"
 		encoding = encoding
-		language = auto-inject {
-		// make sure we use the resourceSet created during standalone setup.
-			forcedResourceSet = theResourceSet
+		lazyLanguage = auto-inject {
 			uri = grammarURI
 			fileExtensions = fileExtensions
 			// Java API to access grammar elements (required by several other fragments)

--- a/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.emf.mwe2.launch;resolution:=optional,
  org.eclipse.xtext.generator;resolution:=optional,
  org.eclipse.xtext.xbase.lib,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional
 Import-Package: com.google.common.base,
  com.google.common.collect,
  org.apache.commons.lang,

--- a/bundles/model/org.eclipse.smarthome.model.script/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script/pom.xml
@@ -61,6 +61,11 @@
             <artifactId>org.eclipse.xtext.xbase</artifactId>
             <version>${xtext-version}</version>
           </dependency>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>org.eclipse.smarthome.model.lazygen</artifactId>
+            <version>${project.version}</version>
+          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/GenerateScript.mwe2
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/GenerateScript.mwe2
@@ -3,6 +3,7 @@ module org.eclipse.smarthome.model.script.GenerateScript
 import org.eclipse.emf.mwe.utils.*
 import org.eclipse.xtext.generator.*
 import org.eclipse.xtext.ui.generator.*
+import org.eclipse.smarthome.model.lazygen.*
 
 var projectName = "org.eclipse.smarthome.model.script"
 var fileExtensions = "script"
@@ -14,22 +15,7 @@ var encoding = "UTF-8"
 
 Workflow {
 	bean = StandaloneSetup {
-	// use an XtextResourceset throughout the process, which is able to resolve classpath:/ URIs.
-		resourceSet = org.eclipse.xtext.resource.XtextResourceSet : theResourceSet {}
-
-		// add mappings from platform:/resource to classpath:/
-		uriMap = {
-			from = "platform:/resource/org.eclipse.xtext.xbase/"
-			to = "classpath:/"
-		}
-	     uriMap = {
-		     from = "platform:/resource/org.eclipse.xtext.common.types/"
-		     to = "classpath:/"
-	     }
-//		uriMap = {
-//			from = "platform:/resource/org.eclipse.smarthome.model.item/"
-//			to = "classpath:/"
-//		}
+        scanClassPath = true
 
 		// register current projects and its siblings for platform URI map, as they are not on the classpath.
 		platformUri = "${runtimeProject}/.."
@@ -37,10 +23,12 @@ Workflow {
 		// The following two lines can be removed, if Xbase is not used.
 		registerGeneratedEPackage = "org.eclipse.xtext.xbase.XbasePackage"
 		registerGenModelFile = "platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel"
-//		registerGeneratedEPackage = "org.eclipse.smarthome.model.items.ItemsPackage"
-//		registerGenModelFile = "platform:/resource/org.eclipse.smarthome.model.item/model/generated/Items.genmodel"
 	}
 
+    component = LazyStandaloneSetup {
+        
+    }
+    
 	component = DirectoryCleaner {
 		directory = "${runtimeProject}/src-gen"
 	}
@@ -53,16 +41,14 @@ Workflow {
 		directory = "${runtimeProject}.ui/src-gen"
 	}
 
-	component = Generator {
+	component = LazyGenerator {
 		pathRtProject = runtimeProject
 		pathUiProject = "${runtimeProject}.ui"
 	    //pathTestProject = "${runtimeProject}.tests"
 		projectNameRt = projectName
 		projectNameUi = "${projectName}.ui"
 		encoding = encoding
-		language = auto-inject {
-		// make sure we use the resourceSet created during standalone setup.
-			forcedResourceSet = theResourceSet
+		lazyLanguage = auto-inject {
 			uri = grammarURI
 			fileExtensions = fileExtensions
 			// Java API to access grammar elements (required by several other fragments)

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.emf.mwe2.launch;resolution:=optional,
  org.eclipse.emf.ecore,
  org.eclipse.emf.common,
- org.antlr.runtime
+ org.antlr.runtime,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional
 Import-Package: org.apache.commons.lang,
  org.apache.log4j,
  org.eclipse.smarthome.model.core,

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/pom.xml
@@ -59,6 +59,16 @@
             <artifactId>org.eclipse.xtext.xbase</artifactId>
             <version>${xtext-version}</version>
           </dependency>
+          <dependency>
+            <groupId>org.eclipse.smarthome.model</groupId>
+            <artifactId>org.eclipse.smarthome.model.lazygen</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>org.eclipse.smarthome.model.lazygen</artifactId>
+            <version>${project.version}</version>
+          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/GenerateSitemap.mwe2
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/GenerateSitemap.mwe2
@@ -3,6 +3,7 @@ module org.eclipse.smarthome.model.Sitemap
 import org.eclipse.emf.mwe.utils.*
 import org.eclipse.xtext.generator.*
 import org.eclipse.xtext.ui.generator.*
+import org.eclipse.smarthome.model.lazygen.*
 
 var projectName = "org.eclipse.smarthome.model.sitemap"
 var fileExtensions = "sitemap"
@@ -13,18 +14,7 @@ var encoding = "UTF-8"
 
 Workflow {
 	bean = StandaloneSetup {
-	// use an XtextResourceset throughout the process, which is able to resolve classpath:/ URIs.
-		resourceSet = org.eclipse.xtext.resource.XtextResourceSet : theResourceSet {}
-
-		// add mappings from platform:/resource to classpath:/
-		//		uriMap = {
-		//			from = "platform:/resource/org.eclipse.xtext.xbase/"
-		//			to = "classpath:/"
-		//		}
-//		uriMap = {
-//			from = "platform:/resource/org.eclipse.smarthome.model.item/"
-//			to = "classpath:/"
-//		}
+        scanClassPath = true
 
 		// register current projects and its siblings for platform URI map, as they are not on the classpath.
 		platformUri = "${runtimeProject}/.."
@@ -32,10 +22,12 @@ Workflow {
 		// The following two lines can be removed, if Xbase is not used.
 		//registerGeneratedEPackage = "org.eclipse.xtext.xbase.XbasePackage"
 		//registerGenModelFile = "platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel"
-//		registerGeneratedEPackage = "org.eclipse.smarthome.model.items.ItemsPackage"
-//		registerGenModelFile = "platform:/resource/org.eclipse.smarthome.model.item/model/generated/Items.genmodel"
 	}
 
+    component = LazyStandaloneSetup {
+        
+    }
+    
 	component = DirectoryCleaner {
 		directory = "${runtimeProject}/src-gen"
 	}
@@ -48,15 +40,13 @@ Workflow {
 		directory = "${runtimeProject}.ui/src-gen"
 	}
 
-	component = Generator {
+	component = LazyGenerator {
 		pathRtProject = runtimeProject
 		pathUiProject = "${runtimeProject}.ui"// pathTestProject = "${runtimeProject}.tests"
 		projectNameRt = projectName
 		projectNameUi = "${projectName}.ui"
 		encoding = encoding
-		language = auto-inject {
-		// make sure we use the resourceSet created during standalone setup.
-			forcedResourceSet = theResourceSet
+		lazyLanguage = auto-inject {
 			uri = grammarURI
 			fileExtensions = fileExtensions
 			// Java API to access grammar elements (required by several other fragments)

--- a/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.emf.common,
  org.antlr.runtime,
  org.eclipse.xtext.common.types,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
+ org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional
 Import-Package: org.apache.log4j,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.common.registry,

--- a/bundles/model/org.eclipse.smarthome.model.thing/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>org.eclipse.xtext.xbase</artifactId>
             <version>${xtext-version}</version>
           </dependency>
+          <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>org.eclipse.smarthome.model.lazygen</artifactId>
+            <version>${project.version}</version>
+          </dependency>
         </dependencies>
       </plugin>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/GenerateThing.mwe2
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/GenerateThing.mwe2
@@ -3,6 +3,7 @@ module org.eclipse.smarthome.model.thing.GenerateThing
 import org.eclipse.emf.mwe.utils.*
 import org.eclipse.xtext.generator.*
 import org.eclipse.xtext.ui.generator.*
+import org.eclipse.smarthome.model.lazygen.*
 
 var fileExtensions = "things"
 var projectName = "org.eclipse.smarthome.model.thing"
@@ -20,6 +21,10 @@ Workflow {
     	//registerGenModelFile = "platform:/resource/org.eclipse.xtext.xbase/model/Xbase.genmodel"
     }
     
+    component = LazyStandaloneSetup {
+        
+    }
+    
     component = DirectoryCleaner {
     	directory = "${runtimeProject}/src-gen"
     }
@@ -33,13 +38,13 @@ Workflow {
     }
 
     
-    component = Generator {
+    component = LazyGenerator {
     	pathRtProject = runtimeProject
     	pathUiProject = "${runtimeProject}.ui"
     	projectNameRt = projectName
     	projectNameUi = "${projectName}.ui"
     	encoding = encoding
-    	language = auto-inject {
+    	lazyLanguage = auto-inject {
     		uri = grammarURI
     
     		// Java API to access grammar elements (required by several other fragments)

--- a/bundles/model/pom.xml
+++ b/bundles/model/pom.xml
@@ -16,6 +16,7 @@
   <packaging>pom</packaging>
 
   <modules>
+    <module>org.eclipse.smarthome.model.lazygen</module>
     <module>org.eclipse.smarthome.model.core</module>
     <module>org.eclipse.smarthome.model.item</module>
     <module>org.eclipse.smarthome.model.item.runtime</module>


### PR DESCRIPTION
This change introduces a lazy dependency resolution for the MWE2 model
generation workflow.
It enables the generation of all language models at once and therefore
is a prerequisite for providing a nice and clean automated workspace
provisioning.
Run the "Generate All Models" launch configuration in order to (re)generate all languages at once.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>
Also-by: Holger Schill <holger.schill@itemis.de>
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>