### PR TITLE
Only act on status changes where there is actually a change

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -136,6 +136,11 @@ public class ThingManager extends AbstractEventSubscriber implements ThingTracke
 
         @Override
         public void statusUpdated(Thing thing, ThingStatusInfo thingStatus) {
+            // Only update the status if it has changed
+            if(thing.getStatusInfo().equals(thingStatus)) {
+                return;
+            }
+            
             thing.setStatusInfo(thingStatus);
             logger.debug("Status of {} changed to {}", thing.getUID(), thingStatus.toString());
             // TODO: send event


### PR DESCRIPTION
This simply checks that the status has actually changed before performing an update.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>