### PR TITLE
Fix XML parsing for thing types with channels and config description

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/ESH-INF/thing/thing-types.xml
@@ -58,6 +58,10 @@
 	<thing-type id="dummy">
 		<label>Dummy thing</label>
 		
+        <channels>
+           <channel id="color" typeId="color" />
+        </channels>
+        
 		<config-description>
 			
 			<parameter name="unit" type="text">


### PR DESCRIPTION
The ChannelConverter inherited from AbstractDescriptionTypeConverter. Therefore it used to override the automatically inferred config description URI which was stored in the unmarshalling context.

As channels don't contain config descriptions themselves, this mechanism is not needed at all, so the inheritance from AbstractDescriptionTypeConverter is not required.

Bug: 470901
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>