### PR TITLE
Allow multiple config description providers

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigDescriptionRegistryOSGiTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigDescriptionRegistryOSGiTest.groovy
@@ -12,6 +12,7 @@ import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
 import org.eclipse.smarthome.config.core.ConfigDescription
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
 import org.eclipse.smarthome.config.core.ConfigDescriptionProvider
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry
 import org.eclipse.smarthome.test.OSGiTest
@@ -23,31 +24,38 @@ class ConfigDescriptionRegistryOSGiTest extends OSGiTest {
     ConfigDescriptionRegistry configDescriptionRegistry
     ConfigDescription configDescription
     ConfigDescriptionProvider configDescriptionProviderMock
+    ConfigDescription configDescription1
+    ConfigDescriptionProvider configDescriptionProviderMock1
+    ConfigDescription configDescription2
+    ConfigDescriptionProvider configDescriptionProviderMock2
 
     @Before
     void setUp() {
         configDescriptionRegistry = getService(ConfigDescriptionRegistry)
-        configDescription = new ConfigDescription(new URI("config:Dummy"))
+        ConfigDescriptionParameter parm1 = new ConfigDescriptionParameter("Parm1", ConfigDescriptionParameter.Type.INTEGER)
+        List<ConfigDescriptionParameter> pList1 = new ArrayList<ConfigDescriptionParameter>();
+        pList1.add(parm1);
+        configDescription = new ConfigDescription(new URI("config:Dummy"), pList1)
+        
         configDescriptionProviderMock = [
             getConfigDescriptions: {p -> [configDescription]},
             getConfigDescription: {p1,p2 -> configDescription }
         ] as ConfigDescriptionProvider
-    }
 
-    @Test
-    void 'assert ConfigDescriptionRegistry tracks registered ConfigDescriptionProvider'() {
+        configDescription1 = new ConfigDescription(new URI("config:Dummy1"))
+        configDescriptionProviderMock1 = [
+            getConfigDescriptions: {p -> [configDescription1]},
+            getConfigDescription: {p1,p2 -> configDescription1 }
+        ] as ConfigDescriptionProvider
 
-        assertThat configDescriptionRegistry.getConfigDescriptions().size(), is(0)
-
-        registerService configDescriptionProviderMock
-
-        def configDescriptions = configDescriptionRegistry.getConfigDescriptions()
-        assertThat configDescriptions.size(), is(1)
-        assertThat configDescriptions[0].uri, is(equalTo(new URI("config:Dummy")))
-
-        unregisterService configDescriptionProviderMock
-
-        assertThat configDescriptionRegistry.getConfigDescriptions().size(), is(0)
+        ConfigDescriptionParameter parm2 = new ConfigDescriptionParameter("Parm2", ConfigDescriptionParameter.Type.INTEGER)
+        List<ConfigDescriptionParameter> pList2 = new ArrayList<ConfigDescriptionParameter>();
+        pList2.add(parm2);
+        configDescription2 = new ConfigDescription(new URI("config:Dummy"), pList2)
+        configDescriptionProviderMock2 = [
+            getConfigDescriptions: {p -> [configDescription2]},
+            getConfigDescription: {p1,p2 -> configDescription2 }
+        ] as ConfigDescriptionProvider
     }
 
     @Test
@@ -58,5 +66,51 @@ class ConfigDescriptionRegistryOSGiTest extends OSGiTest {
         def configDescription = configDescriptionRegistry.getConfigDescription(new URI("config:Dummy"))
         assertThat configDescription, is(not(null))
         assertThat configDescription.uri, is(equalTo(new URI("config:Dummy")))
+    }
+    
+    @Test
+    void 'assert ConfigDescriptionRegistry tracks registered ConfigDescriptionProvider'() {
+
+        assertThat "Registery is empty to start", configDescriptionRegistry.getConfigDescriptions().size(), is(0)
+
+        configDescriptionRegistry.addConfigDescriptionProvider(configDescriptionProviderMock)
+        assertThat "Registery added first description", configDescriptionRegistry.getConfigDescriptions().size(), is(1)
+
+        def configDescriptions = configDescriptionRegistry.getConfigDescriptions()
+        assertThat configDescriptions[0].uri, is(equalTo(new URI("config:Dummy")))
+
+        configDescriptionRegistry.addConfigDescriptionProvider(configDescriptionProviderMock1)
+        assertThat "Registery added second description", configDescriptionRegistry.getConfigDescriptions().size(), is(2)
+
+        configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderMock)
+        assertThat "Registery removed first description", configDescriptionRegistry.getConfigDescriptions().size(), is(1)
+
+        configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderMock1)
+        assertThat "Registery is empty to finish", configDescriptionRegistry.getConfigDescriptions().size(), is(0)
+    }
+    
+    @Test
+    void 'assert ConfigDescriptionRegistry merges multiple providers'() {
+
+        assertThat "Registery is empty to start", configDescriptionRegistry.getConfigDescriptions().size(), is(0)
+
+        configDescriptionRegistry.addConfigDescriptionProvider(configDescriptionProviderMock)
+        assertThat "First description added ok", configDescriptionRegistry.getConfigDescriptions().size(), is(1)
+
+        configDescriptionRegistry.addConfigDescriptionProvider(configDescriptionProviderMock2)
+        assertThat "Second description merged ok", configDescriptionRegistry.getConfigDescriptions().size(), is(1)
+
+        def configDescriptions = configDescriptionRegistry.getConfigDescriptions()
+        assertThat "Config is found", configDescriptions[0].uri, is(equalTo(new URI("config:Dummy")))
+
+        assertThat "Config contains both parameters", configDescriptions[0].getParameters().size(), is(2)
+        assertThat "Config parameter 1 found", configDescriptions[0].getParameters().get(0).getName(), is(equalTo("Parm1"))
+        assertThat "Config parameter 2 found", configDescriptions[0].getParameters().get(1).getName(), is(equalTo("Parm2"))
+
+        configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderMock)
+        assertThat "First description removed ok", configDescriptionRegistry.getConfigDescriptions().size(), is(1)
+        
+        configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderMock2)
+        assertThat "Registery is empty to finish", configDescriptionRegistry.getConfigDescriptions().size(), is(0)
     }
 }

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistry.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistry.java
@@ -11,8 +11,10 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -23,6 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * @author Dennis Nobel - Initial contribution, added locale support
  * @author Michael Grammling - Initial contribution
+ * @author Chris Jackson - Added compatibility with multiple ConfigDescriptionProviders
  */
 public class ConfigDescriptionRegistry {
 
@@ -44,6 +47,13 @@ public class ConfigDescriptionRegistry {
 
     /**
      * Returns all config descriptions.
+     * <p>
+     * If more than one {@link ConfigDescriptionProvider} is registered for a specific URI, then the returned
+     * {@link ConfigDescription} collection will contain the data from all providers.
+     * <p>
+     * No checking is performed to ensure that multiple providers don't provide the same configuration data. It is up to
+     * the binding to ensure that multiple sources (eg static XML and dynamic binding data) do not contain overlapping
+     * information.
      *
      * @param locale
      *            locale
@@ -51,10 +61,40 @@ public class ConfigDescriptionRegistry {
      *         description exists
      */
     public Collection<ConfigDescription> getConfigDescriptions(Locale locale) {
-        Collection<ConfigDescription> configDescriptions = new ArrayList<>(10);
+        Map<URI, ConfigDescription> configMap = new HashMap<URI, ConfigDescription>(); 
+        
+        // Loop over all providers
         for (ConfigDescriptionProvider configDescriptionProvider : this.configDescriptionProviders) {
-            configDescriptions.addAll(configDescriptionProvider.getConfigDescriptions(locale));
+            // And for each provider, loop over all their config descriptions
+            for(ConfigDescription configDescription : configDescriptionProvider.getConfigDescriptions(locale)) {
+                // See if there already exists a configuration for this URI in the map
+                ConfigDescription configFromMap = configMap.get(configDescription.getURI());
+                if(configFromMap != null) {
+                    // Yes - Merge the groups and parameters
+                    List<ConfigDescriptionParameter> parameters = new ArrayList<ConfigDescriptionParameter>();
+                    parameters.addAll(configFromMap.getParameters());
+                    parameters.addAll(configDescription.getParameters());
+
+                    List<ConfigDescriptionParameterGroup> parameterGroups = new ArrayList<ConfigDescriptionParameterGroup>();
+                    parameterGroups.addAll(configFromMap.getParameterGroups());
+                    parameterGroups.addAll(configDescription.getParameterGroups());
+
+                    // And add the combined configuration to the map
+                    configMap.put(configDescription.getURI(), new ConfigDescription(configDescription.getURI(), parameters, parameterGroups));
+                }
+                else {
+                    // No - Just add the new configuration to the map
+                    configMap.put(configDescription.getURI(), configDescription);
+                }
+            }
         }
+
+        // Now convert the map into the collection
+        Collection<ConfigDescription> configDescriptions = new ArrayList<ConfigDescription>(configMap.size());
+        for (ConfigDescription configDescription : configMap.values()) {
+            configDescriptions.add(configDescription);
+        }
+        
         return Collections.unmodifiableCollection(configDescriptions);
     }
 
@@ -70,6 +110,13 @@ public class ConfigDescriptionRegistry {
 
     /**
      * Returns a config description for a given URI.
+     * <p>
+     * If more than one {@link ConfigDescriptionProvider} is registered for the requested URI, then the returned
+     * {@link ConfigDescription} will contain the data from all providers.
+     * <p>
+     * No checking is performed to ensure that multiple providers don't provide the same configuration data. It is up to
+     * the binding to ensure that multiple sources (eg static XML and dynamic binding data) do not contain overlapping
+     * information.
      *
      * @param uri
      *            the URI to which the config description to be returned (must
@@ -80,14 +127,29 @@ public class ConfigDescriptionRegistry {
      *         the given name
      */
     public ConfigDescription getConfigDescription(URI uri, Locale locale) {
-        for (ConfigDescriptionProvider configDescriptionProvider : this.configDescriptionProviders) {
-            ConfigDescription configDescription = configDescriptionProvider.getConfigDescription(uri, locale);
+        List<ConfigDescriptionParameter> parameters = new ArrayList<ConfigDescriptionParameter>();
+        List<ConfigDescriptionParameterGroup> parameterGroups = new ArrayList<ConfigDescriptionParameterGroup>();
 
-            if (configDescription != null) {
-                return configDescription;
+        boolean found = false;
+        for (ConfigDescriptionProvider configDescriptionProvider : this.configDescriptionProviders) {
+            ConfigDescription config = configDescriptionProvider.getConfigDescription(uri, locale);
+
+            if (config != null) {
+                found = true;
+
+                // Simply merge the groups and parameters
+                parameters.addAll(config.getParameters());
+                parameterGroups.addAll(config.getParameterGroups());
             }
         }
-        return null;
+
+        if (found) {
+            // Return the new configuration description
+            return new ConfigDescription(uri, parameters, parameterGroups);
+        } else {
+            // Otherwise null
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
This will merge configuration from the same URI from multiple config description providers
As discussed on the [Eclipse forum](https://www.eclipse.org/forums/index.php/m/1699697/#msg_1699697)

This hasn't yet undergone intensive testing. I checked that the existing tests work, and made a quick test to see that multiple providers for the same URI result in a single response, and this works ok. I suspect it therefore works, but it needs more tests to ensure the data is really merged.

Please let me know what you think - if you're generally happy with this approach (finally :) ) then I'll finish it off...

Signed-off-by: Chris Jackson <chris@cd-jackson.com>