### PR TITLE
Classic UI CSS fixes for non-webkit browsers 

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui.classic/web/WebApp/Design/Render.css
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/web/WebApp/Design/Render.css
@@ -16,23 +16,23 @@ a[rel=action],a[rel=back]{display:none}
 .iMore.__lod{color:#888}
 .iMore.__lod span{padding:0 35px;background:url(Img/loader-gray-100x12x1.png) left center no-repeat}
 #iHeader .iTab:not(.iInner){position:relative;top:6px;margin:0 4px}
-.iTab{border-width:3px 16px;-webkit-border-image:url(Img/button-light.png) 3 16}
+.iTab{border-width:3px 16px;-webkit-border-image:url(Img/button-light.png) 3 16;border-image:url(Img/button-light.png) 3 16}
 .iTab ul{margin:0 -16px;padding:0;height:26px;line-height:26px;font-size:13px;text-shadow:rgba(0,0,0,0.5) 0 -1px;color:#fff;font-weight:bold}
 .iTab li{list-style:none;padding:0;white-space:nowrap;float:left;text-align:center}
 .iTab li:first-child a{border:none}
 .iTab li a{border-left:solid 1px rgba(0,0,0,0.3);color:inherit;text-decoration:none;display:block;margin:-1px 0;line-height:28px;overflow:hidden;padding:0 8px}
-.iTab:not(.iInner) li:first-child a{-webkit-border-top-left-radius:4px;-webkit-border-bottom-left-radius:4px}
-.iTab:not(.iInner) li:last-child a{-webkit-border-top-right-radius:4px;-webkit-border-bottom-right-radius:4px}
+.iTab:not(.iInner) li:first-child a{border-top-left-radius:4px;border-bottom-left-radius:4px}
+.iTab:not(.iInner) li:last-child a{border-top-right-radius:4px;border-bottom-right-radius:4px}
 .iTab:not(.iInner) li.__act:not(.__dis) a,.iTab:not(.iInner) li:active:not(.__dis) a[rel=action]{background:rgba(0,0,25,0.25) url(Img/button-bg.png) top repeat-x}
 .iTab li.__dis a *{opacity:0.5}
 .iTab.iInner ul{margin:5px 4px}
-.iTab.iInner{margin:0;-webkit-box-sizing:border-box;padding:1px 0;-webkit-border-image:none;height:35px;background:#aebac2 url(Img/bg-tab.png) repeat-x}
+.iTab.iInner{margin:0;-webkit-box-sizing:border-box;padding:1px 0;-webkit-border-image:none;border-image:none;height:35px;background:#aebac2 url(Img/bg-tab.png) repeat-x}
 .iTab.iInner li a{line-height:26px;color:#3f5c84;text-shadow:rgba(255,255,255,0.6) 0 1px 0;border:none;padding:0 5px}
-.iTab.iInner li.__act:not(.__dis) a{-webkit-border-image:url(Img/bg-tab-sel.png) 3 3}
-.iTab.iInner li:active:not(.__act):not(.__dis) a{-webkit-border-image:url(Img/bg-tab-touch.png) 3 3}
+.iTab.iInner li.__act:not(.__dis) a{-webkit-border-image:url(Img/bg-tab-sel.png) 3 3;border-image:url(Img/bg-tab-sel.png) 3 3}
+.iTab.iInner li:active:not(.__act):not(.__dis) a{-webkit-border-image:url(Img/bg-tab-touch.png) 3 3;border-image:url(Img/bg-tab-touch.png) 3 3}
 .iTab.iInner li.__act a,.iTab.iInner li:active a{line-height:20px;padding:0 2px;color:#fff;text-shadow:rgba(0,0,0,0.5) 0 1px 0}
 .iMenu h3,.iBlock h1,.iPanel legend{color:#4c566c;margin:0 8px;font-size:16px;font-weight:bold;text-shadow:#fff 0 1px 0}
-.iMenu ul,.iPanel fieldset ul,.iBlock div,.iBlock p{padding:0;margin:10px 0 20px;font-weight:bold;border-color:#a9acaf;background-color:#fff;-webkit-border-radius:8px}
+.iMenu ul,.iPanel fieldset ul,.iBlock div,.iBlock p{padding:0;margin:10px 0 20px;font-weight:bold;border-color:#a9acaf;background-color:#fff;border-radius:8px}
 .iBlock p + h1{margin-top:20px}
 .iMenu li{white-space:nowrap}
 .iMenu li,.iPanel fieldset li{font-size:17px;list-style-type: none;border-color:inherit;line-height:20px;padding:11px 8px 12px;border-style:solid;border-width: 1px 1px 0px 1px}
@@ -40,7 +40,7 @@ a[rel=action],a[rel=back]{display:none}
 .iMenu li img{float:left;border:none;margin:-4px 11px -5px 0}
 .iMenu li.__lod:not(.iMore) span{padding-right:8px}
 .iMenu li:not(.iMore) span,.iPanel li span{float:right;color:#324f85;font-weight:normal}
-.iPanel textarea,.iPanel input[type=text],.iPanel input[type=password],.iPanel input[type=search],.iPanel input[type=tel],.iPanel input[type=number],.iPanel input[type=email]{width:100%;display:block;margin:-4px 0 -5px;padding:4px 0 5px;border:0;font-size:inherit;line-height:inherit;font-weight:normal;background:none;-webkit-border-radius:0;-webkit-appearance:none;-webkit-box-sizing:border-box}
+.iPanel textarea,.iPanel input[type=text],.iPanel input[type=password],.iPanel input[type=search],.iPanel input[type=tel],.iPanel input[type=number],.iPanel input[type=email]{width:100%;display:block;margin:-4px 0 -5px;padding:4px 0 5px;border:0;font-size:inherit;line-height:inherit;font-weight:normal;background:none;border-radius:0;-webkit-appearance:none;-webkit-box-sizing:border-box;box-sizing:border-box}
 .iPanel select{width:100%;display:block;font-size:inherit}
 .iPanel label + select,.iPanel label + textarea,.iPanel label + input[type]{margin-top:-24px}
 .iPanel legend{display:inline}
@@ -51,12 +51,12 @@ li.iRadio span{margin-right:23px}
 .iMenu li:first-child,.iPanel li:first-child{border-top-width:1px}
 .iMenu li:last-child,.iPanel li:last-child{border-bottom-width:1px}
 * li.__sel *{color:#fff !important;border-color:#fff !important}
-.iMenu li:first-child,.iMenu li:first-child a,.iPanel li:first-child,.iPanel li:first-child a{-webkit-border-top-right-radius:8px;-webkit-border-top-left-radius:8px}
-.iMenu li:last-child,.iMenu li:last-child a,.iPanel li:last-child,.iPanel li:last-child a{-webkit-border-bottom-right-radius:8px;-webkit-border-bottom-left-radius:8px}
-.iLoader,#iLoader{color:#2f343c;font-weight:bold;text-shadow:#fff 0 1px 0;text-align:center;width:100%;z-index:100;-webkit-box-sizing:border-box}
+.iMenu li:first-child,.iMenu li:first-child a,.iPanel li:first-child,.iPanel li:first-child a{border-top-right-radius:8px;border-top-left-radius:8px}
+.iMenu li:last-child,.iMenu li:last-child a,.iPanel li:last-child,.iPanel li:last-child a{border-bottom-right-radius:8px;border-bottom-left-radius:8px}
+.iLoader,#iLoader{color:#2f343c;font-weight:bold;text-shadow:#fff 0 1px 0;text-align:center;width:100%;z-index:100;-webkit-box-sizing:border-box;box-sizing:border-box}
 #iLoader{position:absolute;font-size:15px;line-height:20px;margin-top:50%;top:0;bottom:0}
 .iLoader span:first-child,#iLoader span:first-child{padding:0 35px;background:url(Img/loader-gray-100x12x1.png) left center no-repeat;display:inline-block}
-.iBlock div,.iBlock p{border-width: 1px;border-style:solid;border-color:#a9acaf;-webkit-border-radius:8px;background-color:#fff}
+.iBlock div,.iBlock p{border-width: 1px;border-style:solid;border-color:#a9acaf;border-radius:8px;background-color:#fff}
 .iBlock{margin:9px 9px 20px}
 .iBlock p,.iBlock div p{margin:8px;font-size:14px;line-height:18px;font-weight:normal}
 .iBlock p{padding:8px;margin:10px 0 0}
@@ -75,7 +75,7 @@ ul li .iSide{position:absolute;margin:0;padding:0;right:0;top:0;bottom:0;width:2
 ul.iArrow li a[rev~=media]{background-image:url(Img/bullet-media.png) !important}
 ul.iArrow li a[rev~=media] + .iSide{width:40px}
 ul.iArrow li:not(.iMore) a:not(.iButton),li.iRadio a{background-image:url(Img/chevron.png);background-position:right center;background-repeat:no-repeat}
-.iMore:not(.__lod):active,li.iRadio.__sel,.iMenu li.__sel,.iList li.__sel{background:#015de6 url(Img/select.png) top repeat-x;-webkit-background-size: auto 100%}
+.iMore:not(.__lod):active,li.iRadio.__sel,.iMenu li.__sel,.iList li.__sel{background:#015de6 url(Img/select.png) top repeat-x;-webkit-background-size: auto 100%;background-size: auto 100%}
 ul.iArrow li em,ul.iArrow li small{margin-right:23px}
 li.iRadio.__sel a,ul.iArrow li.__sel a:not(.iButton){background-image:url(Img/chevron-select.png)}
 ul.iArrow li.__lod:not(.iMore) a{background-image:url(Img/loader-gray-100x12x1.png)}
@@ -85,46 +85,46 @@ ul.iArrow li.__sel.__lod a{background-image:url(Img/loader-white-100x12x1.png)}
 .iCheck li.__dis{color:#8f8f8f}
 .iCheck li.__act.__dis a{color:#8f8f8f;background-image:url(Img/check-dis.png)}
 #iGroup .iButton{display:block;position:static}
-#waBackButton,#waHomeButton,#waLeftButton,#waRightButton,.iButton,.iLeftButton,.iRightButton{position:absolute;border-width:0 10px 0 10px;top:6px;margin:0;white-space:nowrap;overflow:hidden;display:none;text-decoration:none;max-width:15%;height:32px;line-height:32px;font-size:13px;-webkit-border-radius:4px;z-index:1}
+#waBackButton,#waHomeButton,#waLeftButton,#waRightButton,.iButton,.iLeftButton,.iRightButton{border-style:solid;border-color:transparent;position:absolute;border-width:0 10px 0 10px;top:6px;margin:0;white-space:nowrap;overflow:hidden;display:none;text-decoration:none;max-width:15%;height:32px;line-height:32px;font-size:13px;border-radius:4px;z-index:1}
 .iButton.__lod span *{visibility:hidden}
 .iButton.__lod span{color:rgba(0,0,0,0);background:url(Img/loader-white-100x12x1.png) center no-repeat;line-height:20px;display:inline-block}
-#waBackButton:active{-webkit-border-image: url(Img/button-back-touch.png) 0 10 0 15}
-#waBackButton{left:4px;border-width:0 10px 0 15px;-webkit-border-image: url(Img/button-back.png) 0 10 0 15;-webkit-border-top-left-radius:22px;-webkit-border-bottom-left-radius:22px}
-#waHomeButton:active,#waLeftButton:active,#waRightButton:active,.iButton:not(.iPush):active,.iLeftButton:active,.iRightButton:active{-webkit-border-image: url(Img/button-simple-touch.png) 0 10 0 10 !important}
-#waHomeButton{right:4px;border-width:0 10px 0 10px;-webkit-border-image: url(Img/button-simple.png) 0 10 0 10}
-#waHeadTitle{line-height:44px;text-align:center;font-size:20px;padding:0 25%;letter-spacing:-1px;white-space:nowrap;overflow:hidden;-webkit-box-sizing:border-box}
+#waBackButton:active{-webkit-border-image: url(Img/button-back-touch.png) 0 10 0 15;border-image: url(Img/button-back-touch.png) 0 10 0 15}
+#waBackButton{left:4px;border-width:0 10px 0 15px;-webkit-border-image: url(Img/button-back.png) 0 10 0 15;border-image: url(Img/button-back.png) 0 10 0 15;border-top-left-radius:22px;border-bottom-left-radius:22px}
+#waHomeButton:active,#waLeftButton:active,#waRightButton:active,.iButton:not(.iPush):active,.iLeftButton:active,.iRightButton:active{-webkit-border-image: url(Img/button-simple-touch.png) 0 10 0 10 !important;border-image: url(Img/button-simple-touch.png) 0 10 0 10 !important}
+#waHomeButton{right:4px;border-width:0 10px 0 10px;-webkit-border-image: url(Img/button-simple.png) 0 10 0 10;webkit-border-image: url(Img/button-simple.png) 0 10 0 10}
+#waHeadTitle{line-height:44px;text-align:center;font-size:20px;padding:0 25%;letter-spacing:-1px;white-space:nowrap;overflow:hidden;-webkit-box-sizing:border-box;box-sizing:border-box}
 .iLeftButton,.iRightButton,#waLeftButton,#waRightButton{left:4px;border-width:0 10px 0 10px;display:block}
 .iRightButton,#waRightButton{left:auto;right:4px}
 .iButton{float:left;display:block;padding:0}
-*:not(.iPush).iBWarn{-webkit-border-image: url(Img/button-red.png) 0 10 0 10}
-*:not(.iPush).iBClassic{-webkit-border-image: url(Img/button-simple.png) 0 10 0 10}
-*:not(.iPush).iBAction{-webkit-border-image: url(Img/button-blue.png) 0 10 0 10}
+*:not(.iPush).iBWarn{-webkit-border-image: url(Img/button-red.png) 0 10 0 10;border-image: url(Img/button-red.png) 0 10 0 10}
+*:not(.iPush).iBClassic{-webkit-border-image: url(Img/button-simple.png) 0 10 0 10;border-image: url(Img/button-simple.png) 0 10 0 10}
+*:not(.iPush).iBAction{-webkit-border-image: url(Img/button-blue.png) 0 10 0 10;border-image: url(Img/button-blue.png) 0 10 0 10}
 .iPush{margin:3px 0;border-width: 0 12px;padding: 10px;text-align: center;font-size: 20px;line-height:28px;font-weight: bold;text-decoration:none;color:#000;text-shadow: rgba(255,255,255,0.7) 0 1px 0;background:none;display:inline-block;-webkit-box-sizing:border-box}
 .iPush:active,.iPush.iBWarn,.iPush.iBCancel{color:#fff;text-shadow: rgba(0,0,0,0.7) 0 -1px 0}
-.iPush:active{-webkit-border-image:url(Img/big-button-select.png) 0 12 0 12 !important}
-.iPush.iBClassic{-webkit-border-image:url(Img/big-button-white.png) 0 12 0 12}
-.iPush.iBCancel{-webkit-border-image:url(Img/big-button-grey.png) 0 12 0 12}
-.iPush.iBWarn:active{-webkit-border-image:url(Img/big-button-red-touch.png) 0 12 0 12 !important}
-.iPush.iBWarn{-webkit-border-image:url(Img/big-button-red.png) 0 12 0 12}
+.iPush:active{-webkit-border-image:url(Img/big-button-select.png) 0 12 0 12 !important;border-image:url(Img/big-button-select.png) 0 12 0 12 !important}
+.iPush.iBClassic{-webkit-border-image:url(Img/big-button-white.png) 0 12 0 12;border-image:url(Img/big-button-white.png) 0 12 0 12}
+.iPush.iBCancel{-webkit-border-image:url(Img/big-button-grey.png) 0 12 0 12;border-image:url(Img/big-button-grey.png) 0 12 0 12}
+.iPush.iBWarn:active{-webkit-border-image:url(Img/big-button-red-touch.png) 0 12 0 12 !important;border-image:url(Img/big-button-red-touch.png) 0 12 0 12 !important}
+.iPush.iBWarn{-webkit-border-image:url(Img/big-button-red.png) 0 12 0 12;border-image:url(Img/big-button-red.png) 0 12 0 12}
 .iMenu li a.iButton{position:static;float:right;margin:-4px -2px 0 0;padding:0;color:#fff;margin-left:8px}
 .iForm{display:none;position:absolute;z-index:3000;left:0;width:100%;background-color:#6d84a2;border-top:solid 1px #95a5bc;border-bottom:solid 1px #2d3642}
 .iForm legend{display:none}
 .iForm fieldset{padding:0 5px;margin:0;border:none;position:relative;text-shadow:none;font-weight:normal;line-height:normal}
-.iForm input[type=text],.iForm input[type=password],.iForm input[type=search],.iForm input[type=tel],.iForm input[type=number],.iForm input[type=email]{width:100%;display:block;font-size:15px;line-height:24px;height:32px;margin:4px 0;padding:0;border:0;border-width:4px 6px;background:none;-webkit-border-image: url(Img/form-head.png) 4 6;-webkit-box-sizing:border-box}
+.iForm input[type=text],.iForm input[type=password],.iForm input[type=search],.iForm input[type=tel],.iForm input[type=number],.iForm input[type=email]{width:100%;display:block;font-size:15px;line-height:24px;height:32px;margin:4px 0;padding:0;border:0;border-width:4px 6px;background:none;-webkit-border-image: url(Img/form-head.png) 4 6;border-image: url(Img/form-head.png) 4 6;-webkit-box-sizing:border-box;box-sizing:border-box}
 .iForm select{font-size:15px;width:100%;display:block;margin:4px 0;height:31px;background:#fff;border-color:#49607e}
 .iForm label{display:none;position:absolute;color:#8f8f8f;text-align:right;left:16px;padding:6px 0;font-size:15px;line-height:19px}
 input.iToggle{display:none}
 b.iToggle.__dis{opacity:0.5}
-b.iToggle{border:solid 1px #979797;-webkit-border-radius:4px;line-height:25px;position:relative;width:92px;font-size:16px;font-weight:bold;background:#fff url(Img/bg-switch.png) top repeat-x;color:#7e7e7e}
+b.iToggle{border:solid 1px #979797;border-radius:4px;line-height:25px;position:relative;width:92px;font-size:16px;font-weight:bold;background:#fff url(Img/bg-switch.png) top repeat-x;color:#7e7e7e}
 b.iToggle.__sel{border-color:#2c5ba2;background-color:#4085ec;color:#fff}
-b.iToggle b{position:absolute;top:-1px;height:100%;width:37px;border:solid 1px #979797;-webkit-border-radius:4px;background:#fbfbfb url(Img/bg-switch-thumb.png) top repeat-x}
+b.iToggle b{position:absolute;top:-1px;height:100%;width:37px;border:solid 1px #979797;border-radius:4px;background:#fbfbfb url(Img/bg-switch-thumb.png) top repeat-x}
 b.iToggle i{position:absolute;width:47px;line-height:21px;padding:4px 4px 0;text-align:center;font-style:normal;overflow:hidden;background:url(Img/form-check-text.png) left repeat-y;text-shadow:#fff 0 1px 0}
 b.iToggle.__sel i{background:url(Img/form-check-texton.png) right repeat-y;text-shadow:rgba(0,0,0,0.5) 0 -1px 0}
 b.iToggle{float:right}
 .iPanel b.iToggle{float:right;margin:-2px 0 0}
 li.iRadio a label{display:none}
-.iLayer h2{margin:0;color:#fff;line-height:18px;font-size:18px;background:rgba(178,187,194,0.89) url(Img/bg-title.png) top repeat-x;padding:1px 12px;font-weight:bold;text-shadow:rgba(0,0,0,0.5) 0 1px 0;-webkit-box-sizing:border-box;height:22px;overflow:hidden;white-space:nowrap;width:100%;z-index:100}
-.iBar,#iHeader{position:relative;z-index:1;height:44px;background-color:#8195af;-webkit-box-sizing:border-box;border-width:22px 0 1px;-webkit-border-image:url(Img/bg-head.png) 22 0 1 0;color:#fff;font-weight:bold;text-shadow:rgba(0,0,0,0.7) 0 -1px 0}
+.iLayer h2{margin:0;color:#fff;line-height:18px;font-size:18px;background:rgba(178,187,194,0.89) url(Img/bg-title.png) top repeat-x;padding:1px 12px;font-weight:bold;text-shadow:rgba(0,0,0,0.5) 0 1px 0;-webkit-box-sizing:border-box;box-sizing:border-box;height:22px;overflow:hidden;white-space:nowrap;width:100%;z-index:100}
+.iBar,#iHeader{position:relative;z-index:1;height:44px;background-color:#8195af;-webkit-box-sizing:border-box;box-sizing:border-box;border-width:22px 0 1px;-webkit-border-image:url(Img/bg-head.png) 22 0 1 0;border-image:url(Img/bg-head.png) 22 0 1 0;color:#fff;font-weight:bold;text-shadow:rgba(0,0,0,0.7) 0 -1px 0}
 #iHeader a{text-decoration:none;color:inherit}
 #iHeader > div{margin-top:-22px}
 #iHeader > div,#waHeadTitle{display:none;position:absolute;width:100%;top:0;bottom:0;left:0}
@@ -137,8 +137,8 @@ li.iRadio a label{display:none}
 .iShop li em{margin:0 !important;font-size:13px;line-height:25px;color:#7f7f7f;float:none}
 .iShop li big{font-size:15px;line-height:18px;white-space:normal;display:block;overflow:hidden;height:39px;margin-top:-1px}
 .iShop li big small{font-size:13px;line-height:25px;display:block;font-weight:normal;color:#7f7f7f;margin-top:-1px}
-.iMenu .iShop li:first-child img.iFull{-webkit-border-top-left-radius:8px}
-.iMenu .iShop li:last-child img.iFull{-webkit-border-bottom-left-radius:8px}
+.iMenu .iShop li:first-child img.iFull{border-top-left-radius:8px}
+.iMenu .iShop li:last-child img.iFull{border-bottom-left-radius:8px}
 .iList .iShop li:not(.iMore) a:not(.iSide){padding-right:31px}
-#iProgressHUD{width:100%;top:0;position:absolute;z-index:1000;display:none;visibility:hidden;text-align:center;-webkit-box-sizing:border-box}
-#iProgressHUD div:first-child{background:url(Img/loader-big-white-100x12x1.png) center 24px no-repeat;background-color:rgba(0,0,0,0.75);padding:72px 12px 24px;-webkit-border-radius:8px;display:inline-block;color:#fff;font-size:24px;font-weight:bold;min-width:64px}
+#iProgressHUD{width:100%;top:0;position:absolute;z-index:1000;display:none;visibility:hidden;text-align:center;-webkit-box-sizing:border-box;box-sizing:border-box}
+#iProgressHUD div:first-child{background:url(Img/loader-big-white-100x12x1.png) center 24px no-repeat;background-color:rgba(0,0,0,0.75);padding:72px 12px 24px;border-radius:8px;display:inline-block;color:#fff;font-size:24px;font-weight:bold;min-width:64px}


### PR DESCRIPTION
As of 2015, the majority of browsers supports `border-radius` CSS property without any vendor-specific prefixes. Therefore, `-webkit-` prefix was removed from `-webkit-border-radius` property. Non-prefxed version of `border-image` was added (Android 4 only supports this property with `-webkit-` prefix).