### PR TITLE
remove-handling of things

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/setup/RemovalTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/setup/RemovalTest.groovy
@@ -1,0 +1,227 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.setup
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+import static org.junit.matchers.JUnitMatchers.*
+
+import java.util.concurrent.locks.Condition
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+
+import org.eclipse.smarthome.config.core.Configuration
+import org.eclipse.smarthome.core.items.ItemRegistry
+import org.eclipse.smarthome.core.thing.ChannelUID
+import org.eclipse.smarthome.core.thing.ManagedThingProvider
+import org.eclipse.smarthome.core.thing.Thing
+import org.eclipse.smarthome.core.thing.ThingRegistry
+import org.eclipse.smarthome.core.thing.ThingStatus
+import org.eclipse.smarthome.core.thing.ThingTypeUID
+import org.eclipse.smarthome.core.thing.ThingUID
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory
+import org.eclipse.smarthome.core.thing.binding.ThingHandler
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory
+import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider
+import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry
+import org.eclipse.smarthome.core.thing.link.ItemThingLinkRegistry
+import org.eclipse.smarthome.core.thing.type.BridgeType
+import org.eclipse.smarthome.core.thing.type.ThingType
+import org.eclipse.smarthome.core.types.Command
+import org.eclipse.smarthome.test.OSGiTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.osgi.service.component.ComponentContext
+
+
+/**
+ * RemovalTest is a test for the framework's behavior regarding the removal of things.
+ *
+ * @author Simon Kaufmann - Initial contribution
+ */
+class RemovalTest extends OSGiTest {
+
+    def ThingSetupManager thingSetupManager
+    def ThingRegistry thingRegistry
+    def ItemRegistry itemRegistry
+    def ItemChannelLinkRegistry itemChannelLinkRegistry
+    def ItemThingLinkRegistry itemThingLinkRegistry
+
+    def Lock lock = new ReentrantLock()
+    def Condition removalDone = lock.newCondition()
+    def int removalCount
+
+    class DefaultThingHandler extends BaseThingHandler {
+
+        public DefaultThingHandler(Thing thing) {
+            super(thing)
+        }
+
+        @Override
+        public void handleCommand(ChannelUID channelUID, Command command) {
+        }
+
+        @Override
+        public void handleRemoval() {
+            def thread = new Thread(new Runnable() {
+                        public void run() {
+                            try {
+                                RemovalTest.this.lock.lock()
+                                RemovalTest.this.removalDone.await()
+                                RemovalTest.this.removalCount++
+                            } finally {
+                                RemovalTest.this.lock.unlock()
+                            }
+                            DefaultThingHandler.this.signalRemovalDone()
+                        }
+                    })
+            thread.start()
+        }
+
+        public void signalRemovalDone() {
+            super.handleRemoval()
+        }
+    }
+
+    class DefaultThingHandlerFactory extends BaseThingHandlerFactory {
+
+        @Override
+        public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+            return true;
+        }
+
+        @Override
+        protected ThingHandler createHandler(Thing thing) {
+            return new DefaultThingHandler(thing);
+        }
+    }
+
+    @Before
+    void setup() {
+        registerVolatileStorageService()
+        thingSetupManager = getService(ThingSetupManager)
+        thingRegistry = getService(ThingRegistry)
+        itemRegistry = getService(ItemRegistry)
+        itemChannelLinkRegistry = getService(ItemChannelLinkRegistry)
+        itemThingLinkRegistry = getService(ItemThingLinkRegistry)
+        def componentContext = [getBundleContext: {bundleContext}] as ComponentContext
+        def thingHandlerFactory = new DefaultThingHandlerFactory()
+        thingHandlerFactory.activate(componentContext)
+        registerService(thingHandlerFactory, ThingHandlerFactory.class.getName())
+
+        def thingTypeUID1 = new ThingTypeUID("removal-binding:thing-type")
+        def bridgeTypeUID = new ThingTypeUID("removal-binding:bridge-type")
+
+        registerService([
+            getThingTypes: {
+                return [
+                    new ThingType(thingTypeUID1, null, "label", null, null, null, null, null),
+                    new BridgeType(bridgeTypeUID, null, "label", null, null, null, null, null)
+                ]
+            }
+        ] as ThingTypeProvider)
+    }
+
+    @After
+    void tearDown() {
+        def managedThingProvider = getService(ManagedThingProvider)
+        managedThingProvider.getAll().each {
+            managedThingProvider.remove(it.getUID())
+        }
+    }
+
+    @Test
+    void 'removeThing'() {
+        def thingUID = new ThingUID("removal-binding", "thing-type", "thingToRemove")
+        thingSetupManager.addThing(thingUID, new Configuration(), null, "MyThing", [] as List, true)
+
+        assertThat thingRegistry.getAll().size(), is(1)
+        assertThat itemThingLinkRegistry.getAll().size(), is(1)
+        assertThat itemRegistry.getItems().size(), is(1)
+        removalCount = 0
+
+        thingSetupManager.removeThing(thingUID)
+
+        assertThat thingRegistry.getAll().size(), is(1)
+        assertThat itemThingLinkRegistry.getAll().size(), is(1)
+        assertThat itemRegistry.getItems().size(), is(1)
+
+        assertThat thingRegistry.getAll()[0].getStatus(), is(ThingStatus.REMOVING)
+
+        def c = 0
+        while (thingRegistry.getAll().size() > 0 && c++ < 100) {
+            Thread.sleep(100)
+            try {
+                lock.lock()
+                removalDone.signal()
+            } finally {
+                lock.unlock()
+            }
+        }
+
+        waitForAssert({
+            ->
+            assertThat removalCount, is(1)
+            assertThat thingRegistry.getAll().size(), is(0)
+            assertThat itemThingLinkRegistry.getAll().size(), is(0)
+            assertThat itemRegistry.getItems().size(), is(0)
+            assertThat itemChannelLinkRegistry.getAll().size(), is(0)
+        }, 10000, 100)
+    }
+
+
+    @Test
+    void 'remove Bridge with Things recursively'() {
+        def bridgeUID = new ThingUID("removal-binding", "bridge-type", "thing")
+        thingSetupManager.addThing(bridgeUID, new Configuration(), null, "MyBridge", [] as List, true)
+
+        def thingUID1 = new ThingUID("removal-binding", "thing-type", "thing1")
+        thingSetupManager.addThing(thingUID1, new Configuration(), bridgeUID, "MyThing", [] as List, true)
+
+        def thingUID2 = new ThingUID("removal-binding", "thing-type", "thing2")
+        thingSetupManager.addThing(thingUID2, new Configuration(), bridgeUID, "MyThing", [] as List, true)
+
+        assertThat thingRegistry.getAll().size(), is(3)
+        assertThat itemThingLinkRegistry.getAll().size(), is(3)
+        assertThat itemRegistry.getItems().size(), is(3)
+        removalCount = 0
+
+        // if bridge is removed, things are removed recursively, too
+        thingSetupManager.removeThing(bridgeUID)
+
+        assertThat thingRegistry.getAll().size(), is(3)
+        assertThat itemThingLinkRegistry.getAll().size(), is(3)
+        assertThat itemRegistry.getItems().size(), is(3)
+
+        assertThat thingRegistry.getAll()[0].getStatus(), is(ThingStatus.REMOVING)
+        assertThat thingRegistry.getAll()[1].getStatus(), is(ThingStatus.REMOVING)
+
+        def c = 0
+        while (thingRegistry.getAll().size() > 0 && c++ < 100) {
+            Thread.sleep(100)
+            try {
+                lock.lock()
+                removalDone.signalAll()
+            } finally {
+                lock.unlock()
+            }
+        }
+
+        waitForAssert({
+            ->
+            assertThat removalCount, is(3)
+            assertThat thingRegistry.getAll().size(), is(0)
+            assertThat itemThingLinkRegistry.getAll().size(), is(0)
+            assertThat itemRegistry.getItems().size(), is(0)
+            assertThat itemChannelLinkRegistry.getAll().size(), is(0)
+        }, 10000, 100)
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/setup/ThingSetupManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/setup/ThingSetupManagerOSGiTest.groovy
@@ -15,6 +15,7 @@ import org.eclipse.smarthome.config.core.Configuration
 import org.eclipse.smarthome.core.items.GroupItem
 import org.eclipse.smarthome.core.items.ItemRegistry
 import org.eclipse.smarthome.core.thing.ChannelUID
+import org.eclipse.smarthome.core.thing.ManagedThingProvider
 import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingRegistry
 import org.eclipse.smarthome.core.thing.ThingTypeUID
@@ -36,6 +37,7 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeUID
 import org.eclipse.smarthome.core.thing.type.ThingType
 import org.eclipse.smarthome.core.types.Command
 import org.eclipse.smarthome.test.OSGiTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.osgi.service.component.ComponentContext
@@ -43,30 +45,29 @@ import org.osgi.service.component.ComponentContext
 
 /**
  * ThingSetupManagerTest is a test for the ThingSetupManager class.
- * 
+ *
  * @author Dennis Nobel - Initial contribution
  * @author Thomas Höfer - Thing type constructor modified because of thing properties introduction
  */
 class ThingSetupManagerOSGiTest extends OSGiTest {
-    
+
     def ThingSetupManager thingSetupManager
     def ThingRegistry thingRegistry
     def ItemRegistry itemRegistry
     def ItemChannelLinkRegistry itemChannelLinkRegistry
     def ItemThingLinkRegistry itemThingLinkRegistry
-    
+
     class DefaultThingHandler extends BaseThingHandler {
 
         public DefaultThingHandler(Thing thing) {
             super(thing)
         }
-        
+
         @Override
         public void handleCommand(ChannelUID channelUID, Command command) {
         }
-        
-    } 
-    
+    }
+
     class DefaultThingHandlerFactory extends BaseThingHandlerFactory {
 
         @Override
@@ -78,9 +79,8 @@ class ThingSetupManagerOSGiTest extends OSGiTest {
         protected ThingHandler createHandler(Thing thing) {
             return new DefaultThingHandler(thing);
         }
-        
-    } 
-    
+    }
+
     @Before
     void setup() {
         registerVolatileStorageService()
@@ -93,126 +93,140 @@ class ThingSetupManagerOSGiTest extends OSGiTest {
         def thingHandlerFactory = new DefaultThingHandlerFactory()
         thingHandlerFactory.activate(componentContext)
         registerService(thingHandlerFactory, ThingHandlerFactory.class.getName())
-        
+
         def thingTypeUID1 = new ThingTypeUID("binding:thing-type")
         def thingTypeUID2 = new ThingTypeUID("binding:thing-type-with-channel-groups")
         def bridgeTypeUID = new ThingTypeUID("binding:bridge-type")
-        
+
         def channelType1 = new ChannelType(new ChannelTypeUID("binding:channelType1"), false, "String", "label", "", "light", [] as Set, null, null)
         def channelType2 = new ChannelType(new ChannelTypeUID("binding:channelType2"), true, "String", "label", "", "light", [] as Set, null, null)
-        
-        
+
+
         def channelDefinitions = [
             new ChannelDefinition("1", channelType1),
             new ChannelDefinition("2", channelType1),
             new ChannelDefinition("3", channelType2),
         ] as List
-        
+
         def ChannelGroupType channelGroupType = new ChannelGroupType(new ChannelGroupTypeUID("binding:channelGroupType"), false, "Group", null, channelDefinitions)
-    
+
         def channelGroupDefinitions = [
             new ChannelGroupDefinition("group1", channelGroupType),
             new ChannelGroupDefinition("group2", channelGroupType),
         ] as List
-    
+
         registerService([
             getThingTypes: {
                 return [
                     new ThingType(thingTypeUID1, null, "label", null, channelDefinitions, null, null, null),
                     new ThingType(thingTypeUID2, null, "label", null, null, channelGroupDefinitions, null, null),
                     new BridgeType(bridgeTypeUID, null, "label", null, null, null, null, null)
-                 ]
-            } 
+                ]
+            }
         ] as ThingTypeProvider)
-    } 
-    
-	@Test
-	void 'addThingWithoutChannelsItems'() {
+    }
+
+    @After
+    void tearDown() {
+        def managedThingProvider = getService(ManagedThingProvider)
+        managedThingProvider.getAll().each {
+            managedThingProvider.remove(it.getUID())
+        }
+    }
+
+    @Test
+    void 'addThingWithoutChannelsItems'() {
         def thingUID = new ThingUID("binding", "thing-type", "thing")
         thingSetupManager.addThing(thingUID, new Configuration(), null, "MyThing", [] as List, false)
         def items = itemRegistry.getItems();
         assertThat items.size(), is(1)
         assertThat itemThingLinkRegistry.isLinked(items[0].name, thingUID), is(true)
-	}
-    
+    }
+
     @Test
     void 'addThingWithChannelsItems'() {
         def thingUID = new ThingUID("binding", "thing-type", "thing")
         thingSetupManager.addThing(thingUID, new Configuration(), null, "MyThing", [] as List, true)
-        
+
         def items = itemRegistry.getItems();
         assertThat items.size(), is(3)
-        
+
         def linkedThingGroupItemName = itemThingLinkRegistry.getLinkedItems(thingUID).first()
         def linkedThingGroupItem = itemRegistry.get(linkedThingGroupItemName)
         assertThat linkedThingGroupItem.label, is(equalTo("MyThing"))
-        
+
         def linkedItemName = itemChannelLinkRegistry.getLinkedItems(new ChannelUID(thingUID, "1")).first()
         def linkedItem = itemRegistry.get(linkedItemName)
-        
+
         assertThat linkedItem.label, is(equalTo("label"))
         assertThat linkedItem.type, is(equalTo("String"))
         assertThat linkedItem.category, is(equalTo("light"))
     }
-    
+
     @Test
     void 'addThingWithChannelsGroups'() {
         def thingUID = new ThingUID("binding", "thing-type-with-channel-groups", "thing")
         thingSetupManager.addThing(thingUID, new Configuration(), null, "MyThing", [] as List, true)
-        
+
         assertThat itemRegistry.getItems().size(), is(7)
         assertThat itemChannelLinkRegistry.getAll().size(), is(4)
-        
+
         def thing = thingSetupManager.getThing(thingUID)
         def item = thing.linkedItem
-        
+
         assertThat item.getMembers().size(), is(2)
         def firstChannelGroupItem = item.getMembers().first()
         assertThat firstChannelGroupItem, is(instanceOf(GroupItem))
         assertThat firstChannelGroupItem.getMembers().size(), is(2)
     }
-    
+
     @Test
     void 'removeThing'() {
         def thingUID = new ThingUID("binding", "thing-type", "thing")
         thingSetupManager.addThing(thingUID, new Configuration(), null, "MyThing", [] as List, true)
-               
+
         assertThat thingRegistry.getAll().size(), is(1)
         assertThat itemThingLinkRegistry.getAll().size(), is(1)
         assertThat itemRegistry.getItems().size(), is(3)
         assertThat itemChannelLinkRegistry.getAll().size(), is(2)
-        
+
         thingSetupManager.removeThing(thingUID)
-        
-        assertThat thingRegistry.getAll().size(), is(0)
-        assertThat itemThingLinkRegistry.getAll().size(), is(0)
-        assertThat itemRegistry.getItems().size(), is(0)
-        assertThat itemChannelLinkRegistry.getAll().size(), is(0)
+
+        waitForAssert({
+            ->
+            assertThat thingRegistry.getAll().size(), is(0)
+            assertThat itemThingLinkRegistry.getAll().size(), is(0)
+            assertThat itemRegistry.getItems().size(), is(0)
+            assertThat itemChannelLinkRegistry.getAll().size(), is(0)
+        }, 10000, 100)
     }
-    
-    
+
+
     @Test
     void 'remove Bridge with Things recursively'() {
         def bridgeUID = new ThingUID("binding", "bridge-type", "thing")
         thingSetupManager.addThing(bridgeUID, new Configuration(), null, "MyBridge", [] as List, true)
-        
+
         def thingUID = new ThingUID("binding", "thing-type", "thing")
         thingSetupManager.addThing(thingUID, new Configuration(), bridgeUID, "MyThing", [] as List, true)
-               
+
         assertThat thingRegistry.getAll().size(), is(2)
         assertThat itemThingLinkRegistry.getAll().size(), is(2)
         assertThat itemRegistry.getItems().size(), is(4)
         assertThat itemChannelLinkRegistry.getAll().size(), is(2)
-        
+
         // if bridge is removed, things are removed recursively, too
         thingSetupManager.removeThing(bridgeUID)
-        
-        assertThat thingRegistry.getAll().size(), is(0)
-        assertThat itemThingLinkRegistry.getAll().size(), is(0)
-        assertThat itemRegistry.getItems().size(), is(0)
-        assertThat itemChannelLinkRegistry.getAll().size(), is(0)
+
+        waitForAssert({
+            ->
+            assertThat thingRegistry.getAll().size(), is(0)
+            assertThat itemThingLinkRegistry.getAll().size(), is(0)
+            assertThat itemRegistry.getItems().size(), is(0)
+            assertThat itemChannelLinkRegistry.getAll().size(), is(0)
+        }, 10000, 100)
     }
-    
+
     @Test
     void 'enableAndDisableChannel'() {
         def thingUID = new ThingUID("binding", "thing-type", "thing")
@@ -223,40 +237,40 @@ class ThingSetupManagerOSGiTest extends OSGiTest {
         thingSetupManager.enableChannel(new ChannelUID(thingUID, "1"))
         assertThat itemRegistry.getItems().size(), is(3)
     }
-    
+
     @Test
     void 'addAndRemoveHomeGroup'() {
-        
+
         assertThat thingSetupManager.getHomeGroups().size(), is(0)
         thingSetupManager.addHomeGroup("group_1", "Home Group1")
-        
+
         def homeGroups = thingSetupManager.getHomeGroups()
         assertThat homeGroups.size(), is(1)
         assertThat homeGroups[0].name, is(equalTo("group_1"))
         assertThat homeGroups[0].label, is(equalTo("Home Group1"))
-        
+
         assertThat itemRegistry.get("group_1"), is(not(null))
-        
+
         thingSetupManager.removeHomeGroup("group_1")
         assertThat thingSetupManager.getHomeGroups().size(), is(0)
         assertThat itemRegistry.get("group_1"), is(null)
     }
-    
+
     @Test
     void 'addAndRemoveFromHomeGroup'() {
-        
+
         def thingUID = new ThingUID("binding", "thing-type", "thing")
         thingSetupManager.addThing(thingUID, new Configuration(), null, "MyThing", [] as List, true)
         thingSetupManager.addHomeGroup("group_1", "Home Group1")
-        
+
         thingSetupManager.addToHomeGroup(thingUID, "group_1")
-        
+
         GroupItem homeGroup = itemRegistry.get("group_1")
         assertThat homeGroup.members.size(), is(1)
         assertThat homeGroup.members.find({ it.label == "MyThing"}), is(not(null))
-        
+
         thingSetupManager.removeFromHomeGroup(thingUID, "group_1")
-        
+
         homeGroup = itemRegistry.get("group_1")
         assertThat homeGroup.members.size(), is(0)
         assertThat homeGroup.members.find({ it.label == "MyThing"}), is(null)
@@ -264,11 +278,11 @@ class ThingSetupManagerOSGiTest extends OSGiTest {
 
     @Test
     void 'setLabel'() {
-        
+
         def thingUID = new ThingUID("binding", "thing-type", "thing")
         thingSetupManager.addThing(thingUID, new Configuration(), null, "MyThing", [] as List, true)
         thingSetupManager.setLabel(thingUID, "Another Label")
-        
+
         assertThat thingSetupManager.getThing(thingUID).linkedItem.label, is(equalTo("Another Label"))
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingSetupManager.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingSetupManager.xml
@@ -19,5 +19,6 @@
    <reference bind="setItemRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
    <service>
       <provide interface="org.eclipse.smarthome.core.thing.setup.ThingSetupManager"/>
+      <provide interface="org.eclipse.smarthome.core.events.EventSubscriber"/>
    </service>
 </scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
@@ -11,6 +11,7 @@ import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 
@@ -67,6 +68,14 @@ public interface ThingHandler {
     /**
      * This method is called before a thing will be removed.
      * An implementing class can handle the removal in order to trigger some tidying work for a thing.
+     * <p>
+     * The framework expects this method to return quickly. 
+     * For longer running tasks, the implementation has to take care of spawning another thread.
+     * <p>
+     * The {@link Thing} is in {@link ThingStatus#REMOVING} when this method is called.
+     * Implementations of this method must signal to the framework that the handling has been 
+     * completed by setting the {@link Thing}s state to {@link ThingStatus#REMOVED}.
+     * Only then it will be removed completely.  
      */
     void handleRemoval();
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingTracker.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingTracker.java
@@ -18,11 +18,12 @@ import org.eclipse.smarthome.core.thing.ThingRegistryChangeListener;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Michael Grammling - Added dynamic configuration update
+ * @author Simon Kaufmann - Added THING_REMOVING state
  */
 public interface ThingTracker {
 
     public enum ThingTrackerEvent {
-        THING_ADDED, THING_REMOVED, THING_UPDATED, TRACKER_ADDED, TRACKER_REMOVED
+        THING_ADDED, THING_REMOVING, THING_REMOVED, THING_UPDATED, TRACKER_ADDED, TRACKER_REMOVED
     }
 
     /**
@@ -32,6 +33,17 @@ public interface ThingTracker {
      * @param thingTrackerEvent the event that occurred
      */
     void thingAdded(Thing thing, ThingTrackerEvent thingTrackerEvent);
+
+    /**
+     * This method is called for every thing that is going to be removed from the {@link ThingRegistryImpl}. Moreover the method is
+     * called for every thing,
+     * that exists in the {@link ThingRegistryImpl}, when the tracker is
+     * unregistered.
+     *
+     * @param thing the thing which was removed
+     * @param thingTrackerEvent the event that occurred
+     */
+    void thingRemoving(Thing thing, ThingTrackerEvent thingTrackerEvent);
 
     /**
      * This method is called for every thing that was removed from the {@link ThingRegistryImpl}. Moreover the method is


### PR DESCRIPTION
with this change, ThingHandlers get the chance to handle the removal of things explicitly before they actually get removed from the ThingRegistry.

Bug: 471761
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>