### PR TITLE
Improve Classic UI cross-browser compatibility

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/buttons.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/buttons.html
@@ -1,1 +1,5 @@
-<li>%buttons%<img src="../icon/%icon%.png" width=29 height=29 class="iFull" /><label style="%labelstyle%">%label%</label></li>
+<li>
+    <img src="../icon/%icon%.png" width=29 height=29 class="iFull" />
+    %label%
+    %buttons%
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/colorpicker.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/colorpicker.html
@@ -1,3 +1,7 @@
-<li><img src="../icon/%icon%.png" width=29 height=29 class="iFull" /><span class="options"><img src="images/_down.png" ontouchstart="repeatedRequest('CMD?%item%=DECREASE', %frequency%, 1)" onmousedown="repeatedRequest('CMD?%item%=DECREASE', %frequency%, 1)" onmouseup="stopRepeatedRequest('CMD?%item%=OFF')" />
-<img src="images/colorwheel.png" width=29 height=29 border=0 onclick="colorItem='%item%';document.getElementById('waColorpicker').title='%purelabel%';document.getElementById('colorPickerInput').value='%state%';$.minicolors.refresh();document.location.href='#_Colorpicker'" />
-<img src="images/_up.png" ontouchstart="repeatedRequest('CMD?%item%=INCREASE', %frequency%, 1)" onmousedown="repeatedRequest('CMD?%item%=INCREASE', %frequency%, 1)" onmouseup="stopRepeatedRequest('CMD?%item%=ON')" /></span style="%labelstyle%">%label%</li>
+<li>
+	<img src="../icon/%icon%.png" width=28 height=28 class="iFull" />
+	%label%
+	<img src="images/_down.png" ontouchstart="repeatedRequest('CMD?%item%=DECREASE', %frequency%, 1)" onmousedown="repeatedRequest('CMD?%item%=DECREASE', %frequency%, 1)" onmouseup="stopRepeatedRequest('CMD?%item%=OFF')" />
+	<img src="images/colorwheel.png" width=28 height=28 border=0 onclick="colorItem='%item%';document.getElementById('waColorpicker').title='%purelabel%';document.getElementById('colorPickerInput').value='%state%';$.minicolors.refresh();document.location.href='#_Colorpicker'" />
+	<img src="images/_up.png" ontouchstart="repeatedRequest('CMD?%item%=INCREASE', %frequency%, 1)" onmousedown="repeatedRequest('CMD?%item%=INCREASE', %frequency%, 1)" onmouseup="stopRepeatedRequest('CMD?%item%=ON')" />
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/group.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/group.html
@@ -1,1 +1,6 @@
-<li><a href="#_%id%" onclick="AsyncLoad('%id%')"><img src="../icon/%icon%.png" width=29 height=29 style="%labelstyle%"/>%label%</a></li>
+<li class="iGroup">
+    <a href="#_%id%" onclick="AsyncLoad('%id%')">
+        <img src="../icon/%icon%.png" width=29 height=29 />
+        %label%
+    </a>
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/rollerblind.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/rollerblind.html
@@ -1,2 +1,6 @@
-<li><img src="../icon/%icon%.png" width=29 height=29 class="iFull" /><span class="options"><img src="images/_down.png" ontouchstart="buttonPressed('CMD?%item%=DOWN')" onMouseDown="buttonPressed('CMD?%item%=DOWN')" onMouseUp="buttonReleased('CMD?%item%=DOWN', 'CMD?%item%=STOP')" /><img src="images/_stop.png" onclick="ChangeState('CMD?%item%=STOP')" /><img src="images/_up.png" ontouchstart="buttonPressed('CMD?%item%=UP')" onMouseDown="buttonPressed('CMD?%item%=UP')" onMouseUp="buttonReleased('CMD?%item%=UP', 'CMD?%item%=STOP')" /></span style="%labelstyle%">%label%</li>
-
+<li>
+	<img src="../icon/%icon%.png" width=29 height=29 class="iFull" />
+	%label%
+	<img src="images/_down.png" ontouchstart="buttonPressed('CMD?%item%=DOWN')" onMouseDown="buttonPressed('CMD?%item%=DOWN')" onMouseUp="buttonReleased('CMD?%item%=DOWN', 'CMD?%item%=STOP')" />
+	<img src="images/_stop.png" onclick="ChangeState('CMD?%item%=STOP')" /><img src="images/_up.png" ontouchstart="buttonPressed('CMD?%item%=UP')" onMouseDown="buttonPressed('CMD?%item%=UP')" onMouseUp="buttonReleased('CMD?%item%=UP', 'CMD?%item%=STOP')" />
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/selection.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/selection.html
@@ -1,1 +1,3 @@
-<li style="%labelstyle%" class="iRadio" value="autoback"><img src="../icon/%icon%.png" width=29 height=29 class="iFull" />%label_header%%rows%</li>
+<li style="%labelstyle%" class="iRadio iGroup" value="autoback">
+	<img src="../icon/%icon%.png" width=29 height=29 class="iFull" />%label_header%%rows%
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/selection_row.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/selection_row.html
@@ -1,1 +1,4 @@
-<label><input type="radio" name="%item%" value="%cmd%" %checked% onClick="ChangeState('CMD?%item%=%cmd%')" />%label%</label>
+<label>
+    <input type="radio" name="%item%" value="%cmd%" %checked% onClick="ChangeState('CMD?%item%=%cmd%')" />
+    %label%
+</label>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/setpoint.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/setpoint.html
@@ -1,2 +1,6 @@
-<li style="%labelstyle%"><img src="../icon/%icon%.png" width=29 height=29 class="iFull" /><span class="options"><img src="images/_down.png" ontouchstart="ChangeState('CMD?%item%=%newlowerstate%')" onmousedown="ChangeState('CMD?%item%=%newlowerstate%')" /><img src="images/_up.png" ontouchstart="ChangeState('CMD?%item%=%newhigherstate%')" onmousedown="ChangeState('CMD?%item%=%newhigherstate%')" /></span>%label%</li>
-
+<li style="%labelstyle%">
+	<img src="../icon/%icon%.png" width=29 height=29 class="iFull" />
+	%label%
+	<img src="images/_down.png" ontouchstart="ChangeState('CMD?%item%=%newlowerstate%')" onmousedown="ChangeState('CMD?%item%=%newlowerstate%')" />
+	<img src="images/_up.png" ontouchstart="ChangeState('CMD?%item%=%newhigherstate%')" onmousedown="ChangeState('CMD?%item%=%newhigherstate%')" />
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/slider.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/slider.html
@@ -1,2 +1,6 @@
-<li style="%labelstyle%"><img src="../icon/%icon%.png" width=29 height=29 class="iFull" /><span class="options"><img src="images/_down.png" ontouchstart="repeatedRequest('CMD?%item%=DECREASE', %frequency%, %switch%)" onmousedown="repeatedRequest('CMD?%item%=DECREASE', %frequency%, %switch%)" onmouseup="stopRepeatedRequest('CMD?%item%=OFF')" /><img src="images/_up.png" ontouchstart="repeatedRequest('CMD?%item%=INCREASE', %frequency%, %switch%)" onmousedown="repeatedRequest('CMD?%item%=INCREASE', %frequency%, %switch%)" onmouseup="stopRepeatedRequest('CMD?%item%=ON')" /></span>%label%</li>
-
+<li style="%labelstyle%">
+    <img src="../icon/%icon%.png" width=29 height=29 class="iFull" />
+    %label%
+    <img src="images/_down.png" ontouchstart="repeatedRequest('CMD?%item%=DECREASE', %frequency%, %switch%)" onmousedown="repeatedRequest('CMD?%item%=DECREASE', %frequency%, %switch%)" onmouseup="stopRepeatedRequest('CMD?%item%=OFF')" />
+    <img src="images/_up.png" ontouchstart="repeatedRequest('CMD?%item%=INCREASE', %frequency%, %switch%)" onmousedown="repeatedRequest('CMD?%item%=INCREASE', %frequency%, %switch%)" onmouseup="stopRepeatedRequest('CMD?%item%=ON')" />
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/switch.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/switch.html
@@ -1,1 +1,5 @@
-<li><input type="checkbox" id="%item%" class="iToggle" title="I|O" %checked% onclick="ChangeState('CMD?%item%=TOGGLE')"/><img src="../icon/%icon%.png" width=29 height=29 class="iFull" /><label style="%labelstyle%">%label%</label></li>
+<li>
+	<img src="../icon/%icon%.png" width=29 height=29 class="iFull" />
+	%label%
+	<input type="checkbox" id="%item%" class="iToggle" title="I|O" %checked% onclick="ChangeState('CMD?%item%=TOGGLE')"/>
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/text.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/snippets/text.html
@@ -1,1 +1,4 @@
-<li style="%labelstyle%"><img src="../icon/%icon%.png" width=29 height=29 />%label%</li>
+<li style="%labelstyle%">
+    <img src="../icon/%icon%.png" width=29 height=29 />
+    %label%
+</li>

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/AbstractWidgetRenderer.java
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/AbstractWidgetRenderer.java
@@ -105,10 +105,16 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
     public String getLabel(Widget w) {
 
         String label = itemUIRegistry.getLabel(w);
-
-        // insert the span between the left and right side of the label, if state section exists
-        label = label.replaceAll("\\[", "<span style=\"%valuestyle%\">").replaceAll("\\]", "</span>");
-
+        int index = label.indexOf('[');
+        
+        if (index != -1) {
+        	label = "<span style=\"%labelstyle%\" class=\"iLabel\">" + label.substring(0, index) + "</span>" + label.substring(index);
+        	// insert the span between the left and right side of the label, if state section exists
+            label = label.replaceAll("\\[", "<span class=\"iValue\" style=\"%valuestyle%\">").replaceAll("\\]", "</span>");
+        } else {
+        	label = "<span style=\"%labelstyle%\" class=\"iLabel\">" + label + "</span>";
+        }
+        
         return label;
     }
 

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ColorpickerRenderer.java
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ColorpickerRenderer.java
@@ -63,10 +63,7 @@ public class ColorpickerRenderer extends AbstractWidgetRenderer {
             hexValue = "#" + Integer.toHexString(hsbState.getRGB()).substring(2);
         }
         String label = getLabel(cp);
-        String purelabel = label;
-        if (label.contains("<span>")) {
-            purelabel = purelabel.substring(0, label.indexOf("<span>"));
-        }
+        String purelabel = itemUIRegistry.getLabel(w);
 
         snippet = StringUtils.replace(snippet, "%id%", itemUIRegistry.getWidgetId(cp));
         snippet = StringUtils.replace(snippet, "%icon%", escapeURLPath(itemUIRegistry.getIcon(cp)));

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/FrameRenderer.java
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/FrameRenderer.java
@@ -39,7 +39,7 @@ public class FrameRenderer extends AbstractWidgetRenderer {
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("frame");
 
-        snippet = StringUtils.replace(snippet, "%label%", StringEscapeUtils.escapeHtml(getLabel(w)));
+        snippet = StringUtils.replace(snippet, "%label%", StringEscapeUtils.escapeHtml(itemUIRegistry.getLabel(w)));
 
         // Process the color tags
         snippet = processColor(w, snippet);

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/web/WebApp/Action/Logic.js
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/web/WebApp/Action/Logic.js
@@ -195,7 +195,7 @@ function _XX(){var o=$$("ul");for(var i=0;i<o.length;i++){var p=o[i].parentNode;
 }
 function _YY(r,p){for(var j=0;j<r.length;j++){with(r[j]){if(type=="radio"&&(checked||getAttribute("checked"))){checked=true;p=$$("span",p||_b(r[j],"li"))[0];p.innerHTML=_e(parentNode);break}}
 }}
-function _ZZ(p){var o=$$("li",p);for(var i=0;i<o.length;i++){if(_X(o[i],"iRadio")&&!_X(o[i],"__done")){var lnk=_R("a");var sel=_R("span");var inp=$$("input",o[i]);lnk.appendChild(sel);while(o[i].hasChildNodes()){lnk.appendChild(o[i].firstChild)}
+function _ZZ(p){var o=$$("li",p);for(var i=0;i<o.length;i++){if(_X(o[i],"iRadio")&&!_X(o[i],"__done")){var lnk=_R("a");var sel=_R("span");var inp=$$("input",o[i]);sel.setAttribute("class","iValue");lnk.appendChild(sel);while(o[i].hasChildNodes()){lnk.appendChild(o[i].firstChild)}
 o[i].appendChild(lnk);lnk.href="#";_Z(o[i],"__done");_YY(inp,o[i])}}
 var s="wa__22";if(!$(s)){_HH(s)}}
 function _aa(a,u){var p=_22;var x=$$("input",p);var y=$$("a",u);for(var i=0;i<y.length;i++){if(y[i]==a){if(x[i].disabled){return false}

--- a/bundles/ui/org.eclipse.smarthome.ui.classic/web/WebApp/Design/Render.css
+++ b/bundles/ui/org.eclipse.smarthome.ui.classic/web/WebApp/Design/Render.css
@@ -16,7 +16,11 @@ a[rel=action],a[rel=back]{display:none}
 .iMore.__lod{color:#888}
 .iMore.__lod span{padding:0 35px;background:url(Img/loader-gray-100x12x1.png) left center no-repeat}
 #iHeader .iTab:not(.iInner){position:relative;top:6px;margin:0 4px}
-.iTab{border-width:3px 16px;-webkit-border-image:url(Img/button-light.png) 3 16;border-image:url(Img/button-light.png) 3 16}
+.iTab{
+	border-width:3px 16px;
+	-webkit-border-image:url(Img/button-light.png) 3 16;
+	border-image:url(Img/button-light.png) 3 16 fill;
+}
 .iTab ul{margin:0 -16px;padding:0;height:26px;line-height:26px;font-size:13px;text-shadow:rgba(0,0,0,0.5) 0 -1px;color:#fff;font-weight:bold}
 .iTab li{list-style:none;padding:0;white-space:nowrap;float:left;text-align:center}
 .iTab li:first-child a{border:none}
@@ -28,8 +32,14 @@ a[rel=action],a[rel=back]{display:none}
 .iTab.iInner ul{margin:5px 4px}
 .iTab.iInner{margin:0;-webkit-box-sizing:border-box;padding:1px 0;-webkit-border-image:none;border-image:none;height:35px;background:#aebac2 url(Img/bg-tab.png) repeat-x}
 .iTab.iInner li a{line-height:26px;color:#3f5c84;text-shadow:rgba(255,255,255,0.6) 0 1px 0;border:none;padding:0 5px}
-.iTab.iInner li.__act:not(.__dis) a{-webkit-border-image:url(Img/bg-tab-sel.png) 3 3;border-image:url(Img/bg-tab-sel.png) 3 3}
-.iTab.iInner li:active:not(.__act):not(.__dis) a{-webkit-border-image:url(Img/bg-tab-touch.png) 3 3;border-image:url(Img/bg-tab-touch.png) 3 3}
+.iTab.iInner li.__act:not(.__dis) a{
+	-webkit-border-image:url(Img/bg-tab-sel.png) 3 3;
+	border-image:url(Img/bg-tab-sel.png) 3 3 fill;
+}
+.iTab.iInner li:active:not(.__act):not(.__dis) a{
+	-webkit-border-image:url(Img/bg-tab-touch.png) 3 3;
+	border-image:url(Img/bg-tab-touch.png) 3 3 fill;
+}
 .iTab.iInner li.__act a,.iTab.iInner li:active a{line-height:20px;padding:0 2px;color:#fff;text-shadow:rgba(0,0,0,0.5) 0 1px 0}
 .iMenu h3,.iBlock h1,.iPanel legend{color:#4c566c;margin:0 8px;font-size:16px;font-weight:bold;text-shadow:#fff 0 1px 0}
 .iMenu ul,.iPanel fieldset ul,.iBlock div,.iBlock p{padding:0;margin:10px 0 20px;font-weight:bold;border-color:#a9acaf;background-color:#fff;border-radius:8px}
@@ -37,17 +47,83 @@ a[rel=action],a[rel=back]{display:none}
 .iMenu li{white-space:nowrap}
 .iMenu li,.iPanel fieldset li{font-size:17px;list-style-type: none;border-color:inherit;line-height:20px;padding:11px 8px 12px;border-style:solid;border-width: 1px 1px 0px 1px}
 .iMenu a:not(.iPush),.iPanel a:not(.iPush){margin:-11px -8px -12px;padding:inherit;color:inherit;text-decoration:none;display:block;overflow:hidden}
-.iMenu li img{float:left;border:none;margin:-4px 11px -5px 0}
+.iMenu li img{
+	border:none;
+	margin:-4px 11px -5px 0;
+}
 .iMenu li.__lod:not(.iMore) span{padding-right:8px}
-.iMenu li:not(.iMore) span,.iPanel li span{float:right;color:#324f85;font-weight:normal}
+.iMenu li:not(.iMore) span.iValue,
+.iPanel li span.iValue {
+	color:#324f85;
+	font-weight:normal;
+	order: 10;
+}
+.iPanel li,
+.iMenu li:not(.iGroup),
+.iMenu li.iGroup a {
+	display: -webkit-box;
+	display: -moz-box;
+	display: box;
+	
+	box-orient: horizontal;
+	-webkit-box-orient: horizontal;
+	-moz-box-orient: horizontal;
+	
+	display: -ms-flexbox;
+	display: -webkit-flex;
+	display: flex;
+	
+	flex-direction: row;
+	flex-wrap: nowrap;
+}
+.iMenu .iCheck li a {
+	display: block;
+    width: 100%;
+}
+.iMenu li span {
+	display: block;	
+}
+.iMenu li img,
+.iMenu li b.iToggle,
+.iMenu li a.iButton {
+	display: block;
+	float: none;
+	
+	-moz-flex-shrink: 0;
+    -webkit-flex-shrink: 0;
+    flex-shrink: 0;
+    
+    -moz-box-flex: 0;
+    -webkit-box-flex: 0;
+    box-flex: 0;
+}
+.iMenu li:not(.iMore) .iLabel,
+.iPanel li .iLabel {
+	-moz-flex-shrink: 2;
+    -webkit-flex-shrink: 2;
+    flex-shrink: 2;
+    
+    -moz-flex-grow: 2;
+    -webkit-flex-grow: 2;
+    flex-grow: 2;
+    
+    -moz-box-flex: 2;
+    -webkit-box-flex: 2;
+    box-flex: 2;
+
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
 .iPanel textarea,.iPanel input[type=text],.iPanel input[type=password],.iPanel input[type=search],.iPanel input[type=tel],.iPanel input[type=number],.iPanel input[type=email]{width:100%;display:block;margin:-4px 0 -5px;padding:4px 0 5px;border:0;font-size:inherit;line-height:inherit;font-weight:normal;background:none;border-radius:0;-webkit-appearance:none;-webkit-box-sizing:border-box;box-sizing:border-box}
 .iPanel select{width:100%;display:block;font-size:inherit}
 .iPanel label + select,.iPanel label + textarea,.iPanel label + input[type]{margin-top:-24px}
 .iPanel legend{display:inline}
 .iPanel fieldset{margin:0;padding:0;border:none}
-.iMenu ul.iArrow li:not(.iMore) a:not(.iSide):not(.iButton){padding-right:31px}
+.iMenu ul.iArrow li:not(.iMore) a:not(.iSide):not(.iButton){
+	padding-right: 31px;
+}
 .iMenu ul.iArrow li:not(.iMore) a[rev=media]:not(.iSide) span{padding-right:10px}
-li.iRadio span{margin-right:23px}
 .iMenu li:first-child,.iPanel li:first-child{border-top-width:1px}
 .iMenu li:last-child,.iPanel li:last-child{border-bottom-width:1px}
 * li.__sel *{color:#fff !important;border-color:#fff !important}
@@ -88,34 +164,109 @@ ul.iArrow li.__sel.__lod a{background-image:url(Img/loader-white-100x12x1.png)}
 #waBackButton,#waHomeButton,#waLeftButton,#waRightButton,.iButton,.iLeftButton,.iRightButton{border-style:solid;border-color:transparent;position:absolute;border-width:0 10px 0 10px;top:6px;margin:0;white-space:nowrap;overflow:hidden;display:none;text-decoration:none;max-width:15%;height:32px;line-height:32px;font-size:13px;border-radius:4px;z-index:1}
 .iButton.__lod span *{visibility:hidden}
 .iButton.__lod span{color:rgba(0,0,0,0);background:url(Img/loader-white-100x12x1.png) center no-repeat;line-height:20px;display:inline-block}
-#waBackButton:active{-webkit-border-image: url(Img/button-back-touch.png) 0 10 0 15;border-image: url(Img/button-back-touch.png) 0 10 0 15}
-#waBackButton{left:4px;border-width:0 10px 0 15px;-webkit-border-image: url(Img/button-back.png) 0 10 0 15;border-image: url(Img/button-back.png) 0 10 0 15;border-top-left-radius:22px;border-bottom-left-radius:22px}
-#waHomeButton:active,#waLeftButton:active,#waRightButton:active,.iButton:not(.iPush):active,.iLeftButton:active,.iRightButton:active{-webkit-border-image: url(Img/button-simple-touch.png) 0 10 0 10 !important;border-image: url(Img/button-simple-touch.png) 0 10 0 10 !important}
-#waHomeButton{right:4px;border-width:0 10px 0 10px;-webkit-border-image: url(Img/button-simple.png) 0 10 0 10;webkit-border-image: url(Img/button-simple.png) 0 10 0 10}
+#waBackButton:active{
+	-webkit-border-image: url(Img/button-back-touch.png) 0 10 0 15;
+	border-image: url(Img/button-back-touch.png) 0 10 0 15 fill;
+}
+#waBackButton{
+	left:4px;
+	border-width:0 10px 0 15px;
+	-webkit-border-image: url(Img/button-back.png) 0 10 0 15;
+	border-image: url(Img/button-back.png) 0 10 0 15 fill;
+	border-top-left-radius:22px;
+	border-bottom-left-radius:22px;
+}
+#waHomeButton:active,#waLeftButton:active,#waRightButton:active,.iButton:not(.iPush):active,.iLeftButton:active,.iRightButton:active{
+	-webkit-border-image: url(Img/button-simple-touch.png) 0 10 0 10 !important;
+	border-image: url(Img/button-simple-touch.png) 0 10 0 10 fill !important;
+}
+#waHomeButton{
+	right:4px;
+	border-width:0 10px 0 10px;
+	-webkit-border-image: url(Img/button-simple.png) 0 10 0 10;
+	border-image: url(Img/button-simple.png) 0 10 0 10 fill;
+}
 #waHeadTitle{line-height:44px;text-align:center;font-size:20px;padding:0 25%;letter-spacing:-1px;white-space:nowrap;overflow:hidden;-webkit-box-sizing:border-box;box-sizing:border-box}
 .iLeftButton,.iRightButton,#waLeftButton,#waRightButton{left:4px;border-width:0 10px 0 10px;display:block}
 .iRightButton,#waRightButton{left:auto;right:4px}
 .iButton{float:left;display:block;padding:0}
-*:not(.iPush).iBWarn{-webkit-border-image: url(Img/button-red.png) 0 10 0 10;border-image: url(Img/button-red.png) 0 10 0 10}
-*:not(.iPush).iBClassic{-webkit-border-image: url(Img/button-simple.png) 0 10 0 10;border-image: url(Img/button-simple.png) 0 10 0 10}
-*:not(.iPush).iBAction{-webkit-border-image: url(Img/button-blue.png) 0 10 0 10;border-image: url(Img/button-blue.png) 0 10 0 10}
+*:not(.iPush).iBWarn{
+	-webkit-border-image: url(Img/button-red.png) 0 10 0 10;
+	border-image: url(Img/button-red.png) 0 10 0 10 fill;
+}
+*:not(.iPush).iBClassic{
+	-webkit-border-image: url(Img/button-simple.png) 0 10 0 10;
+	border-image: url(Img/button-simple.png) 0 10 0 10 fill;
+}
+*:not(.iPush).iBAction{
+	-webkit-border-image: url(Img/button-blue.png) 0 10 0 10;
+	border-image: url(Img/button-blue.png) 0 10 0 10 fill;
+}
 .iPush{margin:3px 0;border-width: 0 12px;padding: 10px;text-align: center;font-size: 20px;line-height:28px;font-weight: bold;text-decoration:none;color:#000;text-shadow: rgba(255,255,255,0.7) 0 1px 0;background:none;display:inline-block;-webkit-box-sizing:border-box}
 .iPush:active,.iPush.iBWarn,.iPush.iBCancel{color:#fff;text-shadow: rgba(0,0,0,0.7) 0 -1px 0}
-.iPush:active{-webkit-border-image:url(Img/big-button-select.png) 0 12 0 12 !important;border-image:url(Img/big-button-select.png) 0 12 0 12 !important}
-.iPush.iBClassic{-webkit-border-image:url(Img/big-button-white.png) 0 12 0 12;border-image:url(Img/big-button-white.png) 0 12 0 12}
-.iPush.iBCancel{-webkit-border-image:url(Img/big-button-grey.png) 0 12 0 12;border-image:url(Img/big-button-grey.png) 0 12 0 12}
-.iPush.iBWarn:active{-webkit-border-image:url(Img/big-button-red-touch.png) 0 12 0 12 !important;border-image:url(Img/big-button-red-touch.png) 0 12 0 12 !important}
-.iPush.iBWarn{-webkit-border-image:url(Img/big-button-red.png) 0 12 0 12;border-image:url(Img/big-button-red.png) 0 12 0 12}
-.iMenu li a.iButton{position:static;float:right;margin:-4px -2px 0 0;padding:0;color:#fff;margin-left:8px}
+.iPush:active{
+	-webkit-border-image:url(Img/big-button-select.png) 0 12 0 12 !important;
+	border-image:url(Img/big-button-select.png) 0 12 0 12 fill !important;
+}
+.iPush.iBClassic{
+	-webkit-border-image:url(Img/big-button-white.png) 0 12 0 12;
+	border-image:url(Img/big-button-white.png) 0 12 0 12 fill;
+}
+.iPush.iBCancel{
+	-webkit-border-image:url(Img/big-button-grey.png) 0 12 0 12;
+	border-image:url(Img/big-button-grey.png) 0 12 0 12 fill;
+}
+.iPush.iBWarn:active{
+	-webkit-border-image:url(Img/big-button-red-touch.png) 0 12 0 12 !important;
+	border-image:url(Img/big-button-red-touch.png) 0 12 0 12 fill !important;
+}
+.iPush.iBWarn{
+	-webkit-border-image:url(Img/big-button-red.png) 0 12 0 12;
+	border-image:url(Img/big-button-red.png) 0 12 0 12 fill;
+}
+.iMenu li a.iButton{
+	position:static;
+	margin: -5px 0px -10px 0;
+	padding:0;
+	color:#fff;
+	margin-left:8px
+}
 .iForm{display:none;position:absolute;z-index:3000;left:0;width:100%;background-color:#6d84a2;border-top:solid 1px #95a5bc;border-bottom:solid 1px #2d3642}
 .iForm legend{display:none}
 .iForm fieldset{padding:0 5px;margin:0;border:none;position:relative;text-shadow:none;font-weight:normal;line-height:normal}
-.iForm input[type=text],.iForm input[type=password],.iForm input[type=search],.iForm input[type=tel],.iForm input[type=number],.iForm input[type=email]{width:100%;display:block;font-size:15px;line-height:24px;height:32px;margin:4px 0;padding:0;border:0;border-width:4px 6px;background:none;-webkit-border-image: url(Img/form-head.png) 4 6;border-image: url(Img/form-head.png) 4 6;-webkit-box-sizing:border-box;box-sizing:border-box}
+.iForm input[type=text],.iForm input[type=password],.iForm input[type=search],.iForm input[type=tel],.iForm input[type=number],.iForm input[type=email]{
+	width:100%;
+	display:block;
+	font-size:15px;
+	line-height:24px;
+	height:32px;
+	margin:4px 0;
+	padding:0;
+	border:0;
+	border-width:4px 6px;
+	background:none;
+	-webkit-border-image: url(Img/form-head.png) 4 6;
+	border-image: url(Img/form-head.png) 4 6 fill;
+	-webkit-box-sizing:border-box;
+	box-sizing:border-box
+}
 .iForm select{font-size:15px;width:100%;display:block;margin:4px 0;height:31px;background:#fff;border-color:#49607e}
 .iForm label{display:none;position:absolute;color:#8f8f8f;text-align:right;left:16px;padding:6px 0;font-size:15px;line-height:19px}
 input.iToggle{display:none}
 b.iToggle.__dis{opacity:0.5}
-b.iToggle{border:solid 1px #979797;border-radius:4px;line-height:25px;position:relative;width:92px;font-size:16px;font-weight:bold;background:#fff url(Img/bg-switch.png) top repeat-x;color:#7e7e7e}
+b.iToggle{
+	border:solid 1px #979797;
+	border-radius:4px;
+	line-height:25px;
+	position:relative;
+	width:92px;
+	font-size:16px;
+	font-weight:bold;
+	background:#fff url(Img/bg-switch.png) top repeat-x;
+	color:#7e7e7e;
+	margin-top: -3px;
+	margin-bottom: -3px;
+}
 b.iToggle.__sel{border-color:#2c5ba2;background-color:#4085ec;color:#fff}
 b.iToggle b{position:absolute;top:-1px;height:100%;width:37px;border:solid 1px #979797;border-radius:4px;background:#fbfbfb url(Img/bg-switch-thumb.png) top repeat-x}
 b.iToggle i{position:absolute;width:47px;line-height:21px;padding:4px 4px 0;text-align:center;font-style:normal;overflow:hidden;background:url(Img/form-check-text.png) left repeat-y;text-shadow:#fff 0 1px 0}
@@ -124,7 +275,21 @@ b.iToggle{float:right}
 .iPanel b.iToggle{float:right;margin:-2px 0 0}
 li.iRadio a label{display:none}
 .iLayer h2{margin:0;color:#fff;line-height:18px;font-size:18px;background:rgba(178,187,194,0.89) url(Img/bg-title.png) top repeat-x;padding:1px 12px;font-weight:bold;text-shadow:rgba(0,0,0,0.5) 0 1px 0;-webkit-box-sizing:border-box;box-sizing:border-box;height:22px;overflow:hidden;white-space:nowrap;width:100%;z-index:100}
-.iBar,#iHeader{position:relative;z-index:1;height:44px;background-color:#8195af;-webkit-box-sizing:border-box;box-sizing:border-box;border-width:22px 0 1px;-webkit-border-image:url(Img/bg-head.png) 22 0 1 0;border-image:url(Img/bg-head.png) 22 0 1 0;color:#fff;font-weight:bold;text-shadow:rgba(0,0,0,0.7) 0 -1px 0}
+.iBar,#iHeader{
+	position:relative;
+	z-index:1;height:44px;
+	background-color:#8195af;
+	-webkit-box-sizing:border-box;
+	box-sizing:border-box;
+	border-width:22px 0 1px;
+	-webkit-border-image:url(Img/bg-head.png) 22 0 1 0;
+	border-image:url(Img/bg-head.png) 22 0 1 0;
+	color:#fff;
+	font-weight:bold;
+	text-shadow:rgba(0,0,0,0.7) 0 -1px 0;
+	border-style: solid;
+	border-color: transparent;
+}
 #iHeader a{text-decoration:none;color:inherit}
 #iHeader > div{margin-top:-22px}
 #iHeader > div,#waHeadTitle{display:none;position:absolute;width:100%;top:0;bottom:0;left:0}


### PR DESCRIPTION
This commit improves Classic UI browser compatibility. After this fix, Classic UI should be displayed correctly in Firefox. Flexbox model (both old and new syntax) is used to lay out elements. When element label is too long, ellipsis (…) is shown.

### Changes overview

* `AbstractWidgetRenderer.java`: wrap label name in a `<span>`. It is hard to apply any styles to a text node in between of other blocks.
* `FrameRenderer.java`: instead of trying to remove html tags from label, this function may just call item registry. Also, previously mentioned change requires this change too.
* `ColorpickerRenderer.java`: same as above.
* `snippets/*.html`: Layout changes, mostly additional classes and element order. Changed snippets also were reformatted (it's hard to edit and debug one-line code).
* `Render.css`: stylesheet changes
* `Logic.js`: add class to a value `span` element. 

Album with browser screenshots: http://imgur.com/a/xkCoA (oldest browser tested is Android 2.3 stock browser)

Followup to #360 