### PR TITLE
handle unauthenticated bridges on initial scan for lights

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - improved state handling
  * @author Andre Fuechsel - implemented getFullLights(), startSearch()
  * @author Thomas Höfer - added thing properties
- * @author Stefan Bußweiler - Added new thing status handling 
+ * @author Stefan Bußweiler - Added new thing status handling
  */
 public class HueBridgeHandler extends BaseBridgeHandler {
 
@@ -337,8 +337,14 @@ public class HueBridgeHandler extends BaseBridgeHandler {
         List<FullLight> lights = null;
         if (bridge != null) {
             try {
-                lights = bridge.getFullConfig().getLights();
-            } catch (IOException | ApiException e) {
+                try {
+                    lights = bridge.getFullConfig().getLights();
+                } catch (UnauthorizedException | IllegalStateException e) {
+                    lastBridgeConnectionState = false;
+                    onNotAuthenticated(bridge);
+                    lights = bridge.getFullConfig().getLights();
+                }
+            } catch (Exception e) {
                 logger.error("Bridge cannot search for new lights.", e);
             }
         }
@@ -349,7 +355,7 @@ public class HueBridgeHandler extends BaseBridgeHandler {
         if (bridge != null) {
             try {
                 bridge.startSearch();
-            } catch (IOException | ApiException e) {
+            } catch (Exception e) {
                 logger.error("Bridge cannot start search mode", e);
             }
         }
@@ -359,7 +365,7 @@ public class HueBridgeHandler extends BaseBridgeHandler {
         if (bridge != null) {
             try {
                 bridge.startSearch(serialNumbers);
-            } catch (IOException | ApiException e) {
+            } catch (Exception e) {
                 logger.error("Bridge cannot start search mode", e);
             }
         }


### PR DESCRIPTION
When approving a hue bridge, the following call of the HueLightDiscoveryService resulted in an exception due to the fact that there hasn't been any authentication call before:

``` 
2015-07-10 12:02:23.042 [ERROR] [i.DiscoveryServiceRegistryImpl] - Cannot trigger scan for thing types '[hue:Classic_A60_RGBW, hue:LCT001, hue:LCT002, hue:LCT003, hue:LWB004, hue:Surface_Light_TW, hue:LLC007, hue:LLC006, hue:LST001, hue:LWL001, hue:ZLL_Light, hue:LLC013, hue:LLC001, hue:LLC012, hue:LLC011, hue:LLC010, hue:LLC020]' on 'HueLightDiscoveryService'!
java.lang.IllegalStateException: linking is required before interacting with the bridge
    at nl.q42.jue.HueBridge.requireAuthentication(HueBridge.java:783) ~[na:na]
    at nl.q42.jue.HueBridge.getFullConfig(HueBridge.java:771) ~[na:na]
    at org.eclipse.smarthome.binding.hue.handler.HueBridgeHandler.getFullLights(HueBridgeHandler.java:340) ~[na:na]
    at org.eclipse.smarthome.binding.hue.internal.discovery.HueLightDiscoveryService.startScan(HueLightDiscoveryService.java:71) ~[na:na]
    at org.eclipse.smarthome.config.discovery.AbstractDiscoveryService.startScan(AbstractDiscoveryService.java:196) ~[org.eclipse.smarthome.config.discovery_0.8.0.2015
```

This PR fixes this problem.
