### PR TITLE
Channel label/description override

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelConverter.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelConverter.java
@@ -29,10 +29,12 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
  * 
  * @author Chris Jackson - Initial Contribution
  * @author Simon Kaufmann - Fixing wrong inheritance
+ * @author Chris Jackson - Added label and description
  */
 public class ChannelConverter extends GenericUnmarshaller<ChannelXmlResult> {
 
     private ConverterAttributeMapValidator attributeMapValidator;
+
     public ChannelConverter() {
         super(ChannelXmlResult.class);
 
@@ -50,13 +52,15 @@ public class ChannelConverter extends GenericUnmarshaller<ChannelXmlResult> {
 
         String id = attributes.get("id");
         String typeId = attributes.get("typeId");
+        String label = (String) nodeIterator.nextValue("label", false);
+        String description = (String) nodeIterator.nextValue("description", false);
         List<NodeValue> properties = getProperties(nodeIterator);
 
-        ChannelXmlResult channelXmlResult = new ChannelXmlResult(id, typeId, properties);
+        ChannelXmlResult channelXmlResult = new ChannelXmlResult(id, typeId, label, description, properties);
 
         return channelXmlResult;
     }
-    
+
     @Override
     public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
         // read attributes
@@ -72,5 +76,5 @@ public class ChannelConverter extends GenericUnmarshaller<ChannelXmlResult> {
         nodeIterator.assertEndOfType();
 
         return object;
-    }    
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelXmlResult.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelXmlResult.java
@@ -21,11 +21,24 @@ public class ChannelXmlResult {
 
     private String id;
     private String typeId;
+    String label;
+    String description;
     List<NodeValue> properties;
 
-    public ChannelXmlResult(String id, String typeId, List<NodeValue> properties) {
+    /**
+     * Constructs a new {@link ChannelXmlResult}
+     * 
+     * @param id the channel id
+     * @param typeId the channel type id
+     * @param label the channel label
+     * @param description the channel description
+     * @param properties a {@link List} of channel properties
+     */
+    public ChannelXmlResult(String id, String typeId, String label, String description, List<NodeValue> properties) {
         this.id = id;
         this.typeId = typeId;
+        this.label = label;
+        this.description = description;
         this.properties = properties;
     }
 
@@ -57,6 +70,24 @@ public class ChannelXmlResult {
             return new ArrayList<>(0);
         }
         return this.properties;
+    }
+
+    /**
+     * Get the label for this channel
+     * 
+     * @return the channel label. Can be null
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * Get the description for this channel
+     * 
+     * @return the channel description. Can be null
+     */
+    public String getDescription() {
+        return description;
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlResult.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingTypeXmlResult.java
@@ -31,7 +31,7 @@ import com.thoughtworks.xstream.converters.ConversionException;
  * contains all fields needed to create a concrete {@link ThingType} object.
  * <p>
  * If a {@link ConfigDescription} object exists, it must be added to the according {@link ConfigDescriptionProvider}.
- * 
+ *
  * @author Michael Grammling - Initial Contribution
  * @author Ivan Iliev - Added support for system wide channel types
  * @author Thomas Höfer - Added thing and thing type properties
@@ -96,7 +96,8 @@ public class ThingTypeXmlResult {
                             propertiesMap.put(property.getAttributes().get("name"), (String) property.getValue());
                         }
 
-                        ChannelDefinition channelDefinition = new ChannelDefinition(id, channelType, propertiesMap);
+                        ChannelDefinition channelDefinition = new ChannelDefinition(id, channelType, propertiesMap,
+                                channelTypeReference.getLabel(), channelTypeReference.getDescription());
                         channelTypeDefinitions.add(channelDefinition);
                     } else {
                         throw new ConversionException("The channel type for '" + typeUID + "' is missing!");
@@ -128,7 +129,8 @@ public class ThingTypeXmlResult {
                     ChannelGroupType channelGroupType = channelGroupTypes.get(typeUID);
 
                     if (channelGroupType != null) {
-                        ChannelGroupDefinition channelGroupDefinition = new ChannelGroupDefinition(id, channelGroupType);
+                        ChannelGroupDefinition channelGroupDefinition = new ChannelGroupDefinition(id,
+                                channelGroupType);
 
                         channelGroupTypeDefinitions.add(channelGroupDefinition);
                     } else {

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlThingTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlThingTypeProvider.java
@@ -40,7 +40,7 @@ import org.osgi.util.tracker.ServiceTracker;
  * <p>
  * This implementation manages any {@link ThingType} objects associated to specific modules. If a specific module
  * disappears, any registered {@link ThingType} objects associated with that module are released.
- * 
+ *
  * @author Michael Grammling - Initial Contribution
  * @author Dennis Nobel - Added locale support
  * @author Ivan Iliev - Added support for system wide channel types
@@ -83,7 +83,7 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
      * specified module.
      * <p>
      * This method returns silently, if any of the parameters is {@code null}.
-     * 
+     *
      * @param bundle
      *            the module to which the Thing type to be added
      * @param thingType
@@ -119,7 +119,8 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
                     state, channelType.getConfigDescriptionURI());
 
             return new ChannelDefinition(channelDefinition.getId(), localizedChannelType,
-                    channelDefinition.getProperties());
+                    channelDefinition.getProperties(), channelDefinition.getLabel(),
+                    channelDefinition.getDescription());
         }
         return channelDefinition;
     }
@@ -180,8 +181,8 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
             String description = this.thingTypeI18nUtil.getDescription(bundle, thingType.getUID(),
                     thingType.getDescription(), locale);
 
-            List<ChannelDefinition> localizedChannelDefinitions = new ArrayList<>(thingType.getChannelDefinitions()
-                    .size());
+            List<ChannelDefinition> localizedChannelDefinitions = new ArrayList<>(
+                    thingType.getChannelDefinitions().size());
 
             for (ChannelDefinition channelDefinition : thingType.getChannelDefinitions()) {
                 ChannelDefinition localizedChannelDefinition = createLocalizedChannelDefinition(bundle,
@@ -189,8 +190,8 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
                 localizedChannelDefinitions.add(localizedChannelDefinition);
             }
 
-            List<ChannelGroupDefinition> localizedChannelGroupDefinitions = new ArrayList<>(thingType
-                    .getChannelGroupDefinitions().size());
+            List<ChannelGroupDefinition> localizedChannelGroupDefinitions = new ArrayList<>(
+                    thingType.getChannelGroupDefinitions().size());
             for (ChannelGroupDefinition channelGroupDefinition : thingType.getChannelGroupDefinitions()) {
                 ChannelGroupDefinition localizedchannelGroupDefinition = createLocalizedChannelGroupDefinition(bundle,
                         channelGroupDefinition, locale);
@@ -251,7 +252,7 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
      * with the specified module.
      * <p>
      * This method returns silently if the module is {@code null}.
-     * 
+     *
      * @param bundle
      *            the module for which all associated Thing types to be removed
      */

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/thing-description-1.0.0.xsd
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/thing-description-1.0.0.xsd
@@ -95,6 +95,8 @@
 
     <xs:complexType name="channel">
         <xs:sequence>
+            <xs:element name="label" type="xs:string" minOccurs="0"/>
+            <xs:element name="description" type="xs:string" minOccurs="0"/>
             <xs:element name="properties" type="thing-description:properties" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="id" type="config-description:idRestrictionPattern" use="required"/>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
@@ -28,13 +28,17 @@ import com.google.common.collect.ImmutableSet;
  * @author Alex Tugarev - Extended about default tags
  * @author Benedikt Niehues - fix for Bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=445137 considering default
  *         values
- * @author Chris Jackson - Added properties
+ * @author Chris Jackson - Added properties, label, description
  */
 public class Channel {
 
     private String acceptedItemType;
 
     private ChannelUID uid;
+    
+    private String label;
+    
+    private String description;
 
     private Configuration configuration;
     
@@ -58,17 +62,23 @@ public class Channel {
     }
 
     public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration) {
-        this(uid, acceptedItemType, configuration, new HashSet<String>(0), null);
+        this(uid, acceptedItemType, configuration, new HashSet<String>(0), null, null, null);
     }
 
     public Channel(ChannelUID uid, String acceptedItemType, Set<String> defaultTags) {
-        this(uid, acceptedItemType, null, defaultTags == null ? new HashSet<String>(0) : defaultTags, null);
+        this(uid, acceptedItemType, null, defaultTags == null ? new HashSet<String>(0) : defaultTags, null, null, null);
     }
 
     public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags, Map<String, String> properties) {
+        this(uid, acceptedItemType, null, defaultTags == null ? new HashSet<String>(0) : defaultTags, properties, null, null);
+    }
+
+    public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags, Map<String, String> properties, String label, String description) {
         this.uid = uid;
         this.acceptedItemType = acceptedItemType;
         this.configuration = configuration;
+        this.label = label;
+        this.description = description;
         this.properties = properties;
         this.defaultTags = Collections.<String> unmodifiableSet(new HashSet<String>(defaultTags));
         if (this.configuration == null) {
@@ -95,6 +105,26 @@ public class Channel {
      */
     public ChannelUID getUID() {
         return this.uid;
+    }
+
+    /**
+     * Returns the label (if set).
+     * If no label is set, getLabel will return null and the default label for the {@link Channel} is used.
+     * 
+     * @return the label for the channel. Can be null.
+     */
+    public String getLabel() {
+        return this.label;
+    }
+
+    /**
+     * Returns the description (if set).
+     * If no description is set, getDescription will return null and the default description for the {@link Channel} is used.
+     * 
+     * @return the description for the channel. Can be null.
+     */
+    public String getDescription() {
+        return this.description;
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactory.java
@@ -42,7 +42,7 @@ import com.google.common.collect.Lists;
  * @author Benedikt Niehues - fix for Bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=445137 considering default
  *         values
  * @author Thomas Höfer - added thing and thing type properties
- * @author Chris Jackson - Added properties
+ * @author Chris Jackson - Added properties, label, description
  */
 public class ThingFactory {
 
@@ -176,7 +176,17 @@ public class ThingFactory {
                 new ChannelUID(thingUID, groupId, channelDefinition.getId()), type.getItemType()).withDefaultTags(
                 type.getTags());
 
-        // initializing channels with default-values
+        // If we want to override the label, add it...
+        if(channelDefinition.getLabel() != null) {
+            channelBuilder = channelBuilder.withLabel(channelDefinition.getLabel());
+        }
+
+        // If we want to override the description, add it...
+        if(channelDefinition.getDescription() != null) {
+            channelBuilder = channelBuilder.withDescription(channelDefinition.getDescription());
+        }
+
+        // Initialize channel configuration with default-values
         if (configDescriptionRegistry != null) {
             ConfigDescription cd = configDescriptionRegistry.getConfigDescription(type.getConfigDescriptionURI());
             if (cd != null) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ChannelBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ChannelBuilder.java
@@ -20,7 +20,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Alex Tugarev - Extended about default tags
- * @author Chris Jackson - Added properties
+ * @author Chris Jackson - Added properties and label/description
  */
 public class ChannelBuilder {
 
@@ -29,6 +29,8 @@ public class ChannelBuilder {
     private Configuration configuration;
     private Set<String> defaultTags;
     private Map<String, String> properties;
+    private String label;
+    private String description;
 
     private ChannelBuilder(ChannelUID channelUID, String acceptedItemType, Set<String> defaultTags) {
         this.channelUID = channelUID;
@@ -72,6 +74,26 @@ public class ChannelBuilder {
     }
 
     /**
+     * Sets the channel label. This allows overriding of the default label set in the {@link ChannelType}
+     * @param label the channel label to override the label set in the {@link ChannelType}
+     * @return channel builder
+     */
+    public ChannelBuilder withLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
+     * Sets the channel label. This allows overriding of the default label set in the {@link ChannelType}
+     * @param label the channel label to override the label set in the {@link ChannelType}
+     * @return channel builder
+     */
+    public ChannelBuilder withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
      * Appends default tags to the channel to build.
      *
      * @param defaultTags
@@ -89,6 +111,6 @@ public class ChannelBuilder {
      * @return channel
      */
     public Channel build() {
-        return new Channel(channelUID, acceptedItemType, configuration, defaultTags, properties);
+        return new Channel(channelUID, acceptedItemType, configuration, defaultTags, properties, label, description);
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelDefinition.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelDefinition.java
@@ -22,13 +22,15 @@ import org.eclipse.smarthome.core.thing.Thing;
  * <b>Hint:</b> This class is immutable.
  *
  * @author Michael Grammling - Initial Contribution
- * @author Chris Jackson - Added properties
+ * @author Chris Jackson - Added properties and label/description
  */
 public class ChannelDefinition {
 
     private String id;
     private ChannelType type;
     private final Map<String, String> properties;
+    private final String label;
+    private final String description;
 
     /**
      * Creates a new instance of this class with the specified parameters.
@@ -39,7 +41,7 @@ public class ChannelDefinition {
      * @throws IllegalArgumentException if the ID is null or empty, or the type is null
      */
     public ChannelDefinition(String id, ChannelType type) throws IllegalArgumentException {
-        this(id, type, null);
+        this(id, type, null, null, null);
     }
 
     /**
@@ -48,11 +50,13 @@ public class ChannelDefinition {
      * @param id the identifier of the channel (must neither be null nor empty)
      * @param type the type of the channel (must not be null)
      * @param properties the properties this Channel provides (could be null)
+     * @param label the label for the channel to override channelType (could be null)
+     * @param description the description for the channel to override channelType (could be null)
      *
      * @throws IllegalArgumentException if the ID is null or empty, or the type is null
      */
-    public ChannelDefinition(String id, ChannelType type, Map<String, String> properties)
-            throws IllegalArgumentException {
+    public ChannelDefinition(String id, ChannelType type, Map<String, String> properties, String label,
+            String description) throws IllegalArgumentException {
         if ((id == null) || (id.isEmpty())) {
             throw new IllegalArgumentException("The ID must neither be null nor empty!");
         }
@@ -69,6 +73,8 @@ public class ChannelDefinition {
 
         this.id = id;
         this.type = type;
+        this.label = label;
+        this.description = description;
     }
 
     /**
@@ -90,8 +96,29 @@ public class ChannelDefinition {
     }
 
     /**
+     * Returns the label (if set).
+     * If no label is set, getLabel will return null and the default label for the {@link ChannelType} is used.
+     *
+     * @return the label for the channel. Can be null.
+     */
+    public String getLabel() {
+        return this.label;
+    }
+
+    /**
+     * Returns the description (if set).
+     * If no description is set, getDescription will return null and the default description for the {@link ChannelType}
+     * is used.
+     *
+     * @return the description for the channel. Can be null.
+     */
+    public String getDescription() {
+        return this.description;
+    }
+
+    /**
      * Returns the properties for this {@link ChannelDefinition}
-     * 
+     *
      * @return the properties for this {@link ChannelDefinition} (not null)
      */
     public Map<String, String> getProperties() {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
@@ -187,10 +187,22 @@ public class ThingTypeResource implements RESTResource {
         List<ChannelDefinitionDTO> channelDefinitionBeans = new ArrayList<>();
         for (ChannelDefinition channelDefinition : channelDefinitions) {
             ChannelType channelType = channelDefinition.getType();
-            ChannelDefinitionDTO channelDefinitionBean = new ChannelDefinitionDTO(channelDefinition.getId(),
-                    channelType.getLabel(), channelType.getDescription(), channelType.getTags(),
-                    channelType.getCategory(), channelType.getState(), channelType.isAdvanced(),
-                    channelDefinition.getProperties());
+
+            // Default to the channelDefinition label to override the channelType
+            String label = channelDefinition.getLabel();
+            if (label == null) {
+                label = channelType.getLabel();
+            }
+
+            // Default to the channelDefinition description to override the channelType
+            String description = channelDefinition.getDescription();
+            if (description == null) {
+                description = channelType.getDescription();
+            }
+
+            ChannelDefinitionDTO channelDefinitionBean = new ChannelDefinitionDTO(channelDefinition.getId(), label,
+                    description, channelType.getTags(), channelType.getCategory(), channelType.getState(),
+                    channelType.isAdvanced(), channelDefinition.getProperties());
             channelDefinitionBeans.add(channelDefinitionBean);
         }
         return channelDefinitionBeans;
@@ -206,7 +218,8 @@ public class ThingTypeResource implements RESTResource {
         return thingTypeBeans;
     }
 
-    private List<ConfigDescriptionParameterGroupDTO> convertToParameterGroupBeans(URI configDescriptionURI, Locale locale) {
+    private List<ConfigDescriptionParameterGroupDTO> convertToParameterGroupBeans(URI configDescriptionURI,
+            Locale locale) {
 
         ConfigDescription configDescription = configDescriptionRegistry.getConfigDescription(configDescriptionURI,
                 locale);
@@ -215,8 +228,9 @@ public class ThingTypeResource implements RESTResource {
 
             List<ConfigDescriptionParameterGroup> parameterGroups = configDescription.getParameterGroups();
             for (ConfigDescriptionParameterGroup parameterGroup : parameterGroups) {
-                parameterGroupBeans.add(new ConfigDescriptionParameterGroupDTO(parameterGroup.getName(), parameterGroup.getContext(),
-                        parameterGroup.isAdvanced(), parameterGroup.getLabel(), parameterGroup.getDescription()));
+                parameterGroupBeans.add(new ConfigDescriptionParameterGroupDTO(parameterGroup.getName(), parameterGroup
+                        .getContext(), parameterGroup.isAdvanced(), parameterGroup.getLabel(), parameterGroup
+                        .getDescription()));
             }
         }
 


### PR DESCRIPTION
This allows the label and description in the channelType to be overridden in the channel. This allows the same channelType to be used for multiple channels.

The XML reader reads the new members and passes this into the channel description. When a thing is created, and the channels enabled, we first read the channel description to see if there is a label set - if so, it's used for the linked item, otherwise the info in the channelType is used.

There is a problem in that if the channel is disabled, and then re-enabled, there is no reference to the thing, and therefore no reference to the channel description, so we can only use the label from the channelType when re-creating the item.

I personally think that disabling channels should be done in a different way (ie by disabling the channel, rather than deleting its linked items) which will avoid this problem, and other issues associated with removing an item just because the channel is disabled.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>