### PR TITLE
Reorder events when thing added

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Michael Grammling - Added dynamic configuration update
  * @author Simon Kaufmann - Added forceRemove
+ * @author Chris Jackson - ensure thing added event is sent before linked events
  */
 public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID> implements ThingRegistry {
 
@@ -105,8 +106,8 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID> impleme
     @Override
     protected void notifyListenersAboutAddedElement(Thing element) {
         super.notifyListenersAboutAddedElement(element);
-        notifyTrackers(element, ThingTrackerEvent.THING_ADDED);
         postEvent(ThingEventFactory.createAddedEvent(element));
+        notifyTrackers(element, ThingTrackerEvent.THING_ADDED);
     }
 
     @Override


### PR DESCRIPTION
This posts the event that the thing has been added before notifying listeners. This ensures that the events are sent in the correct order (ie thing added, then items added).

https://bugs.eclipse.org/bugs/show_bug.cgi?id=473565
Signed-off-by: Chris Jackson <chris@cd-jackson.com>