### PR TITLE
Fix for MQTT transport service: Updates in Broker URI and Client ID not propagated correctly

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnection.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnection.java
@@ -128,6 +128,17 @@ public class MqttBrokerConnection implements MqttCallback {
         }
 
         logger.info("Starting MQTT broker connection '{}'", name);
+
+        if (client != null) {
+            if (!this.url.equals(client.getServerURI()) || !this.clientId.equals(client.getClientId())) {
+                if (client.isConnected()) {
+                    logger.info("MQTT broker server URI or client ID changed. Removing previous connection.");
+                    client.disconnect();
+                }
+                client = null;
+            }
+        }
+
         openConnection();
 
         if (reconnectTimer != null) {
@@ -275,6 +286,15 @@ public class MqttBrokerConnection implements MqttCallback {
      */
     public void setClientId(String value) {
         this.clientId = value;
+    }
+
+    /**
+     * Get client id to use when connecting to the broker.
+     *
+     * @return value clientId to use.
+     */
+    public String getClientId() {
+        return clientId;
     }
 
     /**


### PR DESCRIPTION
When MQTT Broker URI or Client Id has been changed, MqttBrokerConnection fails to remove previous instance of Paho client. 

Since URI or client ID can only be set during creation of the Paho client instance, old values will be kept even after MqttBrokerConnection has been updated by owners and other values are updated on the client.

Now, updating either of those 2 values would cause new connection anyway, so deleting the old instance seems to be only solution.

This might seem like a minor deal, but I'm working on a MQTT plugin for OH2 (please see the SmartHome forum thread https://www.eclipse.org/forums/index.php/t/942318/  ), and without this patch configuring MQTT bridge dynamically won't be possible. 

Thanks!
 