### PR TITLE
fix missing imports

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
@@ -4,7 +4,8 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.apache.commons.io,
+Import-Package: javax.script,
+ org.apache.commons.io,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.transform,
  org.slf4j

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
@@ -4,8 +4,12 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.eclipse.smarthome.core.transform,
- org.slf4j
+Import-Package: javax.xml.parsers,
+ javax.xml.xpath,
+ org.eclipse.smarthome.core.transform,
+ org.slf4j,
+ org.w3c.dom,
+ org.xml.sax
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/xpathservice.xml

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
@@ -4,7 +4,9 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.eclipse.smarthome.config.core,
+Import-Package: javax.xml.transform,
+ javax.xml.transform.stream,
+ org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.transform,
  org.slf4j
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt


### PR DESCRIPTION
The OSGi specification mandates that a bundle declare all package
depenencies using either Import-Package or Require-Bundle. The one
exception to this rule is the java.* packages which is always delegated
to the boot classpath. All other packages dependencies must be declared
in the bundle's manifest file.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=474843
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>