### PR TITLE
Configuration added to event logger to skip unchanged state updates.

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
@@ -11,6 +11,8 @@ Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.items,
+ org.eclipse.smarthome.core.items.dto,
+ org.eclipse.smarthome.core.items.events,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.types,

--- a/bundles/io/org.eclipse.smarthome.io.monitor/OSGI-INF/eventlogger.xml
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/OSGI-INF/eventlogger.xml
@@ -8,7 +8,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.smarthome.io.monitor.eventlogger">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="updateProperties" modified="updateProperties" name="org.eclipse.smarthome.io.monitor.eventlogger">
    <implementation class="org.eclipse.smarthome.io.monitor.internal.EventLogger"/>
    <service>
       <provide interface="org.eclipse.smarthome.core.events.EventSubscriber"/>

--- a/distribution/smarthome/conf/smarthome.cfg
+++ b/distribution/smarthome/conf/smarthome.cfg
@@ -18,3 +18,6 @@ org.eclipse.smarthome.threadpool:discovery=3
 
 # Non-scheduled thread pools can also provide a max size
 org.eclipse.smarthome.threadpool:safeCall=3,10
+
+# Logging of state change events can be skipped if the state value did not change (disabled by default)
+org.eclipse.smarthome.io.monitor.eventlogger:skipUnchangedStateEvents=false


### PR DESCRIPTION
By default, the event logger logs each state update as an info item,
even though the state value did not change. This adds a configuration
entry to skip logging info items of state updates whose state did not
change.
This avoids cluttering the event log e.g. with periodic state updates
whose values do not change.