### PR TITLE
Fix issues in hue binding test classes

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightHandlerOSGiTest.groovy
@@ -18,6 +18,7 @@ import org.eclipse.smarthome.binding.hue.handler.HueBridgeHandler
 import org.eclipse.smarthome.binding.hue.handler.HueLightHandler
 import org.eclipse.smarthome.config.core.Configuration
 import org.eclipse.smarthome.core.events.EventPublisher
+import org.eclipse.smarthome.core.items.events.ItemEventFactory
 import org.eclipse.smarthome.core.library.types.HSBType
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType
 import org.eclipse.smarthome.core.library.types.OnOffType
@@ -428,7 +429,7 @@ class HueLightHandlerOSGiTest extends OSGiTest {
         EventPublisher eventPublisher = getService(EventPublisher)
         assertThat eventPublisher, is(notNullValue())
 
-        eventPublisher.postCommand(item, command)
+        eventPublisher.post(ItemEventFactory.createCommandEvent(item, command))
     }
 
     private void assertJson(String expected, String actual) {

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightState.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightState.groovy
@@ -49,8 +49,7 @@ class HueLightState {
 
 
     public String toString(){
-        return
-        """
+        def state = """
         {"lights":
           {
             "1": {
@@ -87,5 +86,7 @@ class HueLightState {
           }
         }
         """
+
+        return state
     }
 }


### PR DESCRIPTION
Fixes two issues introduced to hue test classes with pull request #342:
1. HueLightState.groovy: I thought I could directly return the String instead of assigning it to a def variable first. Unfortunately the placeholder expressions are only evaluated if the toString() method is called (if anybody is interested, see [documentation here](http://docs.groovy-lang.org/latest/html/documentation/#_string_interpolation)). This doesn't happen if the String is directly returned.
2. HueLightHandlerOSGiTest.groovy: A [change commited](https://github.com/eclipse/smarthome/commit/d260f5d969a841f2ad37c5526fab76e2c90ee393) after I made the pull request had been overwritten again. This was probably not detected by git because the respective line was moved to a seperate method. I also checked that nothing else of the other commits made after my pull request was overwritten similarily.