### PR TITLE
improve testing

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
@@ -12,5 +12,5 @@ Import-Package: groovy.lang,
  org.codehaus.groovy.runtime.callsite,
  org.codehaus.groovy.runtime.typehandling,
  org.eclipse.smarthome.test,
- org.hamcrest;core=split
-Require-Bundle: org.junit;bundle-version="4.0.0"
+ org.hamcrest;core=split,
+ org.junit

--- a/bundles/config/org.eclipse.smarthome.config.core.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/pom.xml
@@ -20,17 +20,24 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
@@ -18,5 +18,5 @@ Import-Package: com.google.gson,
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.test,
- org.hamcrest;core=split
-Require-Bundle: org.junit;bundle-version="4.0.0"
+ org.hamcrest;core=split,
+ org.junit

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Import-Package: groovy.lang,
  org.codehaus.groovy.runtime.typehandling,
  org.eclipse.smarthome.test,
  org.hamcrest;core=split,
+ org.junit,
  org.osgi.service.component
-Require-Bundle: org.junit;bundle-version="4.0.0"

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/pom.xml
@@ -20,32 +20,39 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.core</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.config.core</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.config.xml</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.config.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.config.xml</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Import-Package: groovy.lang,
  org.codehaus.groovy.runtime.typehandling,
  org.eclipse.smarthome.core.binding,
  org.eclipse.smarthome.test,
- org.hamcrest;core=split
-Require-Bundle: org.junit;bundle-version="4.0.0"
+ org.hamcrest;core=split,
+ org.junit

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/pom.xml
@@ -20,22 +20,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.core</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
@@ -14,5 +14,6 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
+ org.junit,
  org.osgi.framework
-Require-Bundle: org.junit;bundle-version="4.0.0"
+

--- a/bundles/core/org.eclipse.smarthome.core.id.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.id.test/pom.xml
@@ -15,9 +15,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
         <configuration>
           <bundleStartLevel>
             <bundle>

--- a/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.test,
- org.hamcrest;core=split
-Require-Bundle: org.junit;bundle-version="4.0.0"
+ org.hamcrest;core=split,
+ org.junit

--- a/bundles/core/org.eclipse.smarthome.core.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.test/pom.xml
@@ -23,22 +23,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunctionTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunctionTest.java
@@ -11,8 +11,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import junit.framework.Assert;
-
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupFunction;
 import org.eclipse.smarthome.core.items.Item;
@@ -21,6 +19,7 @@ import org.eclipse.smarthome.core.library.items.SwitchItem;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PercentTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PercentTypeTest.java
@@ -7,8 +7,7 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
-import static junit.framework.Assert.assertEquals;
-
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -29,13 +28,13 @@ public class PercentTypeTest {
     @Test
     public void DoubleValue() {
         PercentType pt = new PercentType("0.0001");
-        assertEquals("0.0001", pt.toString());
+        Assert.assertEquals("0.0001", pt.toString());
     }
 
     @Test
     public void IntValue() {
         PercentType pt = new PercentType(100);
-        assertEquals("100", pt.toString());
+        Assert.assertEquals("100", pt.toString());
     }
 
     @Test
@@ -45,8 +44,8 @@ public class PercentTypeTest {
         PercentType pt3 = new PercentType(0);
         PercentType pt4 = new PercentType(0);
 
-        assertEquals(true, pt1.equals(pt2));
-        assertEquals(true, pt3.equals(pt4));
-        assertEquals(false, pt3.equals(pt1));
+        Assert.assertEquals(true, pt1.equals(pt2));
+        Assert.assertEquals(true, pt3.equals(pt4));
+        Assert.assertEquals(false, pt3.equals(pt1));
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
+ org.junit,
  org.osgi.framework
-Require-Bundle: org.junit;bundle-version="4.0.0"

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
@@ -21,22 +21,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
@@ -14,5 +14,5 @@ Import-Package: groovy.lang,
  org.codehaus.groovy.runtime.typehandling,
  org.eclipse.smarthome.test,
  org.hamcrest;core=split,
+ org.junit,
  org.osgi.service.component
-Require-Bundle: org.junit;bundle-version="4.0.0"

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
@@ -20,17 +20,24 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.io.net
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.8.1"
 Import-Package: org.apache.commons.httpclient,
- org.apache.commons.httpclient.methods
+ org.apache.commons.httpclient.methods,
+ org.junit

--- a/bundles/io/org.eclipse.smarthome.io.net.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/pom.xml
@@ -23,9 +23,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/bundles/io/org.eclipse.smarthome.io.net.test/src/test/java/org/eclipse/smarthome/io/net/http/HttpUtilTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/src/test/java/org/eclipse/smarthome/io/net/http/HttpUtilTest.java
@@ -7,13 +7,12 @@
  */
 package org.eclipse.smarthome.io.net.http;
 
-import junit.framework.Assert;
-
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
@@ -17,5 +17,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.test,
- org.hamcrest;core=split
-Require-Bundle: org.junit;bundle-version="4.0.0"
+ org.hamcrest;core=split,
+ org.junit

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/pom.xml
@@ -1,16 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.eclipse.smarthome.io</groupId>
-  <artifactId>org.eclipse.smarthome.io.rest.core.test</artifactId>
-  <packaging>eclipse-test-plugin</packaging>
-  <name>Eclipse SmartHome IO REST Core Tests</name>
+
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
     <version>0.8.0-SNAPSHOT</version>
   </parent>
 
+  <groupId>org.eclipse.smarthome.io</groupId>
+  <artifactId>org.eclipse.smarthome.io.rest.core.test</artifactId>
+  <packaging>eclipse-test-plugin</packaging>
+
+  <name>Eclipse SmartHome IO REST Core Tests</name>
 
   <properties>
     <bundle.symbolicName>org.eclipse.smarthome.io.rest.core.test</bundle.symbolicName>
@@ -20,22 +22,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
@@ -19,5 +19,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.test,
- org.hamcrest;core=split
-Require-Bundle: org.junit;bundle-version="4.0.0"
+ org.hamcrest;core=split,
+ org.junit

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/pom.xml
@@ -20,22 +20,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
@@ -18,5 +18,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.test,
  org.glassfish.jersey.uri.internal,
- org.hamcrest;core=split
-Require-Bundle: org.junit;bundle-version="4.0.0"
+ org.hamcrest;core=split,
+ org.junit

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/pom.xml
@@ -1,16 +1,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.eclipse.smarthome.io</groupId>
-  <artifactId>org.eclipse.smarthome.io.rest.test</artifactId>
-  <packaging>eclipse-test-plugin</packaging>
-  <name>Eclipse SmartHome IO REST Tests</name>
+
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
     <version>0.8.0-SNAPSHOT</version>
   </parent>
 
+  <groupId>org.eclipse.smarthome.io</groupId>
+  <artifactId>org.eclipse.smarthome.io.rest.test</artifactId>
+  <packaging>eclipse-test-plugin</packaging>
+
+  <name>Eclipse SmartHome IO REST Tests</name>
 
   <properties>
     <bundle.symbolicName>org.eclipse.smarthome.io.rest.test</bundle.symbolicName>
@@ -20,22 +22,29 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/pom.xml
@@ -23,37 +23,44 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.model.core</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.model.item</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.model.item.runtime</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.core</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.model.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.model.item</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.model.item.runtime</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
@@ -12,9 +12,9 @@ Import-Package: org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.model.persistence.extensions,
  org.eclipse.smarthome.model.persistence.tests,
  org.joda.time,
- org.joda.time.base
-Require-Bundle: org.junit;bundle-version="4.0.0"
-Export-Package: org.eclipse.smarthome.model.persistence.extensions,org
- .eclipse.smarthome.model.persistence.tests
+ org.joda.time.base,
+ org.junit
+Export-Package: org.eclipse.smarthome.model.persistence.extensions,
+ org.eclipse.smarthome.model.persistence.tests
 Bundle-ClassPath: .
 Fragment-Host: org.eclipse.smarthome.model.persistence

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/pom.xml
@@ -23,22 +23,34 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.model.script.runtime</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.model.script.runtime</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/pom.xml
@@ -23,37 +23,44 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.model.core</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.model.thing.runtime</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.model.item.runtime</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.core</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.model.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.model.item.runtime</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.model.thing.runtime</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
@@ -15,6 +15,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.test,
  org.hamcrest;core=split,
- org.junit;version="4.0.0",
- org.junit.matchers;version="4.0.0"
-Require-Bundle: org.junit;bundle-version="4.0.0"
+ org.junit,
+ org.junit.matchers

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/pom.xml
@@ -23,17 +23,24 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Fragment-Host: org.eclipse.smarthome.ui
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-SymbolicName: org.eclipse.smarthome.ui.test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.8.1"
 Bundle-ClassPath: .
-Import-Package: org.mockito,
+Import-Package: org.junit,
+ org.mockito,
  org.mockito.stubbing

--- a/bundles/ui/org.eclipse.smarthome.ui.test/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/pom.xml
@@ -23,9 +23,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/bundles/ui/org.eclipse.smarthome.ui.test/src/test/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/src/test/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
@@ -7,15 +7,11 @@
  */
 package org.eclipse.smarthome.ui.internal.items;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.text.DecimalFormatSymbols;
-
-import junit.framework.Assert;
 
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemNotFoundException;
@@ -29,6 +25,7 @@ import org.eclipse.smarthome.model.sitemap.Sitemap;
 import org.eclipse.smarthome.model.sitemap.SitemapFactory;
 import org.eclipse.smarthome.model.sitemap.Widget;
 import org.eclipse.smarthome.ui.items.ItemUIProvider;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
@@ -21,6 +21,6 @@ Import-Package: com.google.gson,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
+ org.junit,
  org.jupnp.model.types,
  org.osgi.service.device
-Require-Bundle: org.junit;bundle-version="4.0.0"

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
@@ -22,37 +22,44 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <dependencies>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.event</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.equinox.ds</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.config.xml</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.core.thing.xml</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-            <dependency>
-              <type>eclipse-plugin</type>
-              <artifactId>org.eclipse.smarthome.core.binding.xml</artifactId>
-              <version>0.0.0</version>
-            </dependency>
-          </dependencies>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.config.xml</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core.binding.xml</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core.thing.xml</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
           <bundleStartLevel>
             <bundle>
               <id>org.eclipse.equinox.ds</id>

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.jsonpath
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.8.1"
+Import-Package: org.junit

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/pom.xml
@@ -18,9 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.map
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit
+Import-Package: org.junit

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/pom.xml
@@ -18,9 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.regex
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.8.1"
+Import-Package: org.junit

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/pom.xml
@@ -18,9 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/src/test/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/src/test/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationServiceTest.java
@@ -7,10 +7,8 @@
  */
 package org.eclipse.smarthome.transform.regex.internal;
 
-import junit.framework.Assert;
-
 import org.eclipse.smarthome.core.transform.TransformationException;
-import org.eclipse.smarthome.transform.regex.internal.RegExTransformationService;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,8 +48,8 @@ public class RegExTransformationServiceTest extends AbstractTransformationServic
     public void testTransformByRegex_moreThanOneGroup() throws TransformationException {
 
         // method under test
-        String transformedResponse = processor
-                .transform(".*?<current_conditions>.*?<temp_c data=\"(.*?)\"(.*)", source);
+        String transformedResponse = processor.transform(".*?<current_conditions>.*?<temp_c data=\"(.*?)\"(.*)",
+                source);
 
         // Asserts
         Assert.assertEquals("8", transformedResponse);

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.scale
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.8.1"
+Import-Package: org.junit

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/pom.xml
@@ -18,9 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.xpath
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.8.1"
+Import-Package: org.junit

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/pom.xml
@@ -18,9 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/src/test/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/src/test/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationServiceTest.java
@@ -7,9 +7,8 @@
  */
 package org.eclipse.smarthome.transform.xpath.internal;
 
-import junit.framework.Assert;
-
 import org.eclipse.smarthome.core.transform.TransformationException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
@@ -6,4 +6,4 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.xslt
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.8.1"
+Import-Package: org.junit

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/pom.xml
@@ -18,9 +18,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/src/test/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/src/test/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationServiceTest.java
@@ -7,9 +7,8 @@
  */
 package org.eclipse.smarthome.transform.xslt.internal;
 
-import junit.framework.Assert;
-
 import org.eclipse.smarthome.core.transform.TransformationException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
   <description>This is the Eclipse SmartHome project</description>
 
   <properties>
-    <tycho-version>0.20.0</tycho-version>
+    <tycho-version>0.23.1</tycho-version>
     <tycho-groupid>org.eclipse.tycho</tycho-groupid>
     <xtext-version>2.6.2</xtext-version>
     <build.helper.maven.plugin.version>1.8</build.helper.maven.plugin.version>
@@ -76,59 +76,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
-        <version>${tycho-version}</version>
-        <configuration>
-          <resolver>p2</resolver>
-          <ignoreTychoRepositories>true</ignoreTychoRepositories>
-          <pomDependencies>consider</pomDependencies>
-          <target>
-            <artifact>
-              <groupId>org.eclipse.smarthome</groupId>
-              <artifactId>targetplatform</artifactId>
-              <version>${project.version}</version>
-              <classifier>smarthome</classifier>
-            </artifact>
-          </target>
-          <environments>
-            <environment>
-              <os>linux</os>
-              <ws>gtk</ws>
-              <arch>x86</arch>
-            </environment>
-            <environment>
-              <os>linux</os>
-              <ws>gtk</ws>
-              <arch>x86_64</arch>
-            </environment>
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-              <arch>x86</arch>
-            </environment>
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-              <arch>x86_64</arch>
-            </environment>
-            <environment>
-              <os>macosx</os>
-              <ws>cocoa</ws>
-              <arch>x86_64</arch>
-            </environment>
-          </environments>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>${tycho-groupid}</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
-        <configuration>
-          <failIfNoTests>false</failIfNoTests>
-          <includes>
-            <include>**/*.java</include>
-            <include>**/*.groovy</include>
-          </includes>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -161,53 +108,15 @@
         <groupId>org.eclipse.xtend</groupId>
         <artifactId>xtend-maven-plugin</artifactId>
         <configuration>
-        	<javaSourceVersion>1.7</javaSourceVersion>
+          <javaSourceVersion>1.7</javaSourceVersion>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>${build.helper.maven.plugin.version}</version>
-        <executions>
-          <execution>
-            <id>add-source</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>src/main/groovy</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven.compiler.version}</version>
-        <configuration>
-          <compilerId>groovy-eclipse-compiler</compilerId>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-eclipse-compiler</artifactId>
-            <version>${groovy.eclipse.compiler.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-eclipse-batch</artifactId>
-            <version>${groovy.eclipse.batch.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
     </plugins>
 
@@ -223,6 +132,120 @@
             <target>1.7</target>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>${tycho-groupid}</groupId>
+          <artifactId>target-platform-configuration</artifactId>
+          <version>${tycho-version}</version>
+          <configuration>
+            <resolver>p2</resolver>
+            <ignoreTychoRepositories>true</ignoreTychoRepositories>
+            <pomDependencies>consider</pomDependencies>
+            <target>
+              <artifact>
+                <groupId>org.eclipse.smarthome</groupId>
+                <artifactId>targetplatform</artifactId>
+                <version>${project.version}</version>
+                <classifier>smarthome</classifier>
+              </artifact>
+            </target>
+            <environments>
+              <environment>
+                <os>linux</os>
+                <ws>gtk</ws>
+                <arch>x86</arch>
+              </environment>
+              <environment>
+                <os>linux</os>
+                <ws>gtk</ws>
+                <arch>x86_64</arch>
+              </environment>
+              <environment>
+                <os>win32</os>
+                <ws>win32</ws>
+                <arch>x86</arch>
+              </environment>
+              <environment>
+                <os>win32</os>
+                <ws>win32</ws>
+                <arch>x86_64</arch>
+              </environment>
+              <environment>
+                <os>macosx</os>
+                <ws>cocoa</ws>
+                <arch>x86_64</arch>
+              </environment>
+            </environments>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>${tycho-groupid}</groupId>
+          <artifactId>tycho-surefire-plugin</artifactId>
+          <version>${tycho-version}</version>
+          <configuration>
+            <failIfNoTests>false</failIfNoTests>
+            <!--<includes>
+              <include>**/*</include>
+            </includes>-->
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build.helper.maven.plugin.version}</version>
+          <executions>
+            <execution>
+              <id>add-source</id>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>add-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>src/main/groovy</source>
+                </sources>
+              </configuration>
+            </execution>
+            <execution>
+              <id>add-test-source</id>
+              <phase>generate-test-sources</phase>
+              <goals>
+                <goal>add-test-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>src/test/groovy</source>
+                </sources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>${maven.compiler.version}</version>
+          <configuration>
+            <compilerId>groovy-eclipse-compiler</compilerId>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+            </execution>
+          </executions>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>groovy-eclipse-compiler</artifactId>
+              <version>${groovy.eclipse.compiler.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.codehaus.groovy</groupId>
+              <artifactId>groovy-eclipse-batch</artifactId>
+              <version>${groovy.eclipse.batch.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -20,9 +20,8 @@ Import-Package: ${package},
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
+ org.junit,
  org.osgi.service.device,
  org.osgi.framework
-Require-Bundle: org.junit;bundle-version="4.11.0"
 Export-Package: ${package}.internal;x-internal:=true,
  ${package};uses:="org.eclipse.smarthome.test"
-


### PR DESCRIPTION
* remove Require-Bundle in favour of Import-Package
* bump Tycho
* use new dependency resolution for Tycho
* for Tycho bump there are two things that are improved / solved for
  testing:
  * https://wiki.eclipse.org/Tycho/Release_Notes/0.21
    (INCOMPATIBLE CHANGE) In case you have used test-runtime only
    dependencies in the tycho-surefire-plugin configuration, you may need
    to replace them with
    target-platform-configuration/dependency-resolution/extraRequirements
    instead. See bug 436617 comment 11 for details.
  * https://wiki.eclipse.org/Tycho/Release_Notes/0.22
    Tycho Surefire was updated to use Maven Surefire version 2.17. This
    enabled us to consume the fix for long-standing bug 369266

https://bugs.eclipse.org/bugs/show_bug.cgi?id=476024
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>