### PR TITLE
removed reference to outdated bundle

### DIFF
--- a/products/org.eclipse.smarthome.designer.product/org.eclipse.smarthome.designer.product.product
+++ b/products/org.eclipse.smarthome.designer.product/org.eclipse.smarthome.designer.product.product
@@ -127,7 +127,6 @@ This Agreement is governed by the laws of the State of New York and the intellec
       <plugin id="org.eclipse.equinox.simpleconfigurator.manipulator" autoStart="true" startLevel="3" />
       <plugin id="org.eclipse.smarthome.config.core" autoStart="true" startLevel="3" />
       <plugin id="org.eclipse.smarthome.core" autoStart="true" startLevel="0" />
-      <plugin id="org.eclipse.smarthome.core.library" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.smarthome.core.thing" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.smarthome.model.item" autoStart="true" startLevel="3" />
       <plugin id="org.eclipse.smarthome.model.rule" autoStart="true" startLevel="0" />


### PR DESCRIPTION
This should fix the broken build by https://github.com/eclipse/smarthome/pull/439

Signed-off-by: Kai Kreuzer kai@openhab.org
