### PR TITLE
model.*.runtime must not use lazy activation

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
@@ -4,7 +4,6 @@ Bundle-Name: Eclipse SmartHome Item Model Runtime
 Bundle-SymbolicName: org.eclipse.smarthome.model.item.runtime;singleton:=true
 Bundle-Version: 0.8.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Bundle-ActivationPolicy: lazy
 Bundle-Vendor: Eclipse.org/SmartHome
 Import-Package: org.osgi.framework,
  org.slf4j

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.persistence

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/ruleengine.xml
 Import-Package: org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.events,

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
@@ -11,4 +11,3 @@ Import-Package: org.eclipse.smarthome.core.scriptengine,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.script
 Bundle-Activator: org.eclipse.smarthome.model.script.runtime.internal.ScriptRuntimeActivator
-Bundle-ActivationPolicy: lazy

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.sitemap

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: org.eclipse.smarthome.model.thing.runtime;singleton:=true
 Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Bundle-ActivationPolicy: lazy
 Import-Package: org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.thing


### PR DESCRIPTION
The model.*.runtime bundles must be started automatically, we need them
running for ESH.
The lazy bundle activation will retain the execution of the activator's
start method until a class is accessed first. This will result in not
started bundles and missing functionality (e.g. a bundle does not export
a package or no one use an exported package).

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=477075
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>