### PR TITLE
Fixed #477351: ThingBuilder creates copy of given channel list.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/GenericThingBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/GenericThingBuilder.java
@@ -25,20 +25,20 @@ public class GenericThingBuilder<T extends GenericThingBuilder<T>> {
     protected GenericThingBuilder(ThingImpl thing) {
         this.thing = thing;
     }
-    
+
     public T withChannel(Channel channel) {
         List<Channel> channels = this.thing.getChannelsMutable();
         channels.add(channel);
         return self();
     }
-    
+
     public T withChannels(Channel... channels) {
         this.thing.setChannels(Lists.newArrayList(channels));
         return self();
     }
 
     public T withChannels(List<Channel> channels) {
-        this.thing.setChannels(channels);
+        this.thing.setChannels(Lists.newArrayList(channels));
         return self();
     }
 


### PR DESCRIPTION
Bug: 477351
Signed-off-by: Dennis Nobel d.nobel@external.telekom.de
