### PR TITLE
Fixed linked item reference at the thing, if an item is updated.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -35,13 +36,13 @@ public class Channel {
     private String acceptedItemType;
 
     private ChannelUID uid;
-    
+
     private String label;
-    
+
     private String description;
 
     private Configuration configuration;
-    
+
     private Map<String, String> properties;
 
     private Set<String> defaultTags;
@@ -69,11 +70,14 @@ public class Channel {
         this(uid, acceptedItemType, null, defaultTags == null ? new HashSet<String>(0) : defaultTags, null, null, null);
     }
 
-    public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags, Map<String, String> properties) {
-        this(uid, acceptedItemType, null, defaultTags == null ? new HashSet<String>(0) : defaultTags, properties, null, null);
+    public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags,
+            Map<String, String> properties) {
+        this(uid, acceptedItemType, null, defaultTags == null ? new HashSet<String>(0) : defaultTags, properties, null,
+                null);
     }
 
-    public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags, Map<String, String> properties, String label, String description) {
+    public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags,
+            Map<String, String> properties, String label, String description) {
         this.uid = uid;
         this.acceptedItemType = acceptedItemType;
         this.configuration = configuration;
@@ -84,7 +88,7 @@ public class Channel {
         if (this.configuration == null) {
             this.configuration = new Configuration();
         }
-        if(this.properties == null) {
+        if (this.properties == null) {
             this.properties = Collections.unmodifiableMap(new HashMap<String, String>(0));
         }
     }
@@ -110,7 +114,7 @@ public class Channel {
     /**
      * Returns the label (if set).
      * If no label is set, getLabel will return null and the default label for the {@link Channel} is used.
-     * 
+     *
      * @return the label for the channel. Can be null.
      */
     public String getLabel() {
@@ -119,8 +123,9 @@ public class Channel {
 
     /**
      * Returns the description (if set).
-     * If no description is set, getDescription will return null and the default description for the {@link Channel} is used.
-     * 
+     * If no description is set, getDescription will return null and the default description for the {@link Channel} is
+     * used.
+     *
      * @return the description for the channel. Can be null.
      */
     public String getDescription() {
@@ -177,8 +182,12 @@ public class Channel {
     /**
      * Returns a set of items, which are linked to the channel.
      *
+     * @deprecated Will be removed soon, because it is dynamic data which does not belong to the thing. Use
+     *             {@link ItemChannelLinkRegistry} instead.
+     *
      * @return Set of items, which are linked to the channel
      */
+    @Deprecated
     public Set<Item> getLinkedItems() {
         return ImmutableSet.copyOf(this.linkedItems);
     }
@@ -186,9 +195,13 @@ public class Channel {
     /**
      * Returns whether at least one item is linked to the channel.
      *
+     * @deprecated Will be removed soon, because it is dynamic data which does not belong to the thing. Use
+     *             {@link ItemChannelLinkRegistry} instead.
+     * 
      * @return true if at least one item is linked to the channel, false
      *         otherwise
      */
+    @Deprecated
     public boolean isLinked() {
         return !getLinkedItems().isEmpty();
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Thing.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Thing.java
@@ -14,6 +14,7 @@ import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.link.ItemThingLinkRegistry;
 
 /**
  * A {@link Thing} is a representation of a connected part (e.g. physical device
@@ -62,15 +63,15 @@ public interface Thing {
 
     /**
      * Gets the status of a thing.
-     * In order to get all status information (status, status detail and status description)  
+     * In order to get all status information (status, status detail and status description)
      * please use {@link Thing#getStatusInfo()}.
      *
      * @return the status
      */
     ThingStatus getStatus();
-    
+
     /**
-     * Gets the status info of a thing. 
+     * Gets the status info of a thing.
      * The status info consists of the status itself, the status detail and a status description.
      *
      * @return the status info
@@ -140,20 +141,28 @@ public interface Thing {
      * Returns the group item, which is linked to the thing or null if no item is
      * linked.
      *
+     * @deprecated Will be removed soon, because it is dynamic data which does not belong to the thing. Use
+     *             {@link ItemThingLinkRegistry} instead.
+     *
      * @return group item , which is linked to the thing or null
      */
+    @Deprecated
     GroupItem getLinkedItem();
 
     /**
      * Returns whether the thing is linked to an item.
      *
+     * @deprecated Will be removed soon, because it is dynamic data which does not belong to the thing. Use
+     *             {@link ItemThingLinkRegistry} instead.
+     *
      * @return true if thing is linked, false otherwise.
      */
+    @Deprecated
     public boolean isLinked();
 
     /**
      * Returns an immutable copy of the {@link Thing} properties.
-     * 
+     *
      * @return an immutable copy of the {@link Thing} properties (not null)
      */
     Map<String, String> getProperties();
@@ -161,11 +170,11 @@ public interface Thing {
     /**
      * Sets the property value for the property identified by the given name. If the value to be set is null then the
      * property will be removed.
-     * 
+     *
      * @param name the name of the property to be set (must not be null or empty)
-     * 
+     *
      * @param value the value of the property (if null then the property with the given name is removed)
-     * 
+     *
      * @return the previous value associated with the name, or null if there was no mapping for the name
      */
     String setProperty(String name, String value);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManager.java
@@ -22,6 +22,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
+import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.UID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
@@ -68,6 +69,15 @@ public class ThingLinkManager {
                     }
                 }
             }
+            if (element instanceof GroupItem) {
+                Set<ThingUID> linkedThings = itemThingLinkRegistry.getLinkedThings(element.getName());
+                for (ThingUID thingUID : linkedThings) {
+                    Thing thing = thingRegistry.get(thingUID);
+                    if (thing instanceof ThingImpl) {
+                        ((ThingImpl) thing).setLinkedItem(null);
+                    }
+                }
+            }
         }
 
         @Override
@@ -80,6 +90,15 @@ public class ThingLinkManager {
                     if (channel != null) {
                         channel.addLinkedItem(element);
                         informHandlerAboutLinkedChannel(thing, channel);
+                    }
+                }
+            }
+            if (element instanceof GroupItem) {
+                Set<ThingUID> linkedThings = itemThingLinkRegistry.getLinkedThings(element.getName());
+                for (ThingUID thingUID : linkedThings) {
+                    Thing thing = thingRegistry.get(thingUID);
+                    if (thing instanceof ThingImpl) {
+                        ((ThingImpl) thing).setLinkedItem((GroupItem) element);
                     }
                 }
             }
@@ -353,10 +372,10 @@ public class ThingLinkManager {
     }
 
     private void removeLinkedItemFromThing(ThingImpl thing) {
-    	if(thing.getLinkedItem() != null) {
-	    	logger.debug("Removing linked group item from thing '{}'.", thing.getUID());
-	        thing.setLinkedItem(null);
-    	}
+        if (thing.getLinkedItem() != null) {
+            logger.debug("Removing linked group item from thing '{}'.", thing.getUID());
+            thing.setLinkedItem(null);
+        }
     }
 
     private String getFirstLinkedItem(UID uid) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemThingLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemThingLinkRegistry.java
@@ -7,6 +7,11 @@
  */
 package org.eclipse.smarthome.core.thing.link;
 
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.ThingUID;
+
 /**
  * {@link ItemThingLinkRegistry} tracks all {@link ItemThingLinkProvider}s and
  * aggregates all {@link ItemThingLink}s.
@@ -15,4 +20,20 @@ package org.eclipse.smarthome.core.thing.link;
  */
 public class ItemThingLinkRegistry extends AbstractLinkRegistry<ItemThingLink> {
 
+    /**
+     * Returns the list of linked thing UIDs, which are linked to the given item name.
+     *
+     * @param itemName
+     *            item name
+     * @return list of linked thing UIDs or an empty list of no thing is linked to the item
+     */
+    public Set<ThingUID> getLinkedThings(String itemName) {
+        Set<ThingUID> linkedThings = new LinkedHashSet<>();
+        for (ItemThingLink link : getAll()) {
+            if (link.getItemName().equals(itemName)) {
+                linkedThings.add(link.getUID());
+            }
+        }
+        return linkedThings;
+    }
 }


### PR DESCRIPTION
Marked getLinkedItems and isLinked as deprecated.

Bug: 473567
Signed-off-by: Dennis Nobel <d.nobel@external.telekom.de>