### PR TITLE
Update ModuleTypeDefinitions_JSONschema.json

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.json/src/main/resources/ModuleTypeDefinitions_JSONschema.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.json/src/main/resources/ModuleTypeDefinitions_JSONschema.json
@@ -208,6 +208,48 @@
                   }
                 }
               }
+            },
+            "triggers":{  
+              "type":"array",
+              "title":"Trigger Modules",
+              "description":"List of definitions of the Trigger Modules involved in the composite type.",
+              "items":{  
+                "type":"object",
+                "title":"Trigger Module",
+                "description":"Defines the fact which triggers the Rule execution.",
+                "additionalProperties":false,
+                "required":[  
+                  "id",
+                  "type"
+                ],
+                "properties":{  
+                  "id":{  
+                    "type":"string",
+                    "title":"Trigger uid",
+                    "description":"Identifies uniquely the Module in scope of the Rule."
+                  },
+                  "type":{  
+                    "type":"string",
+                    "title":"Trigger Module Type",
+                    "description":"Identifies the Module Type used for creation of the Trigger. Must be unique in scope of concrete Rule definition."
+                  },
+                  "config":{  
+                    "type":"object",
+                    "title":"Trigger Configurations",
+                    "description":"Used to configure the Trigger. Contains pairs of Configuration Property's name and its value."
+                  },
+                  "label":{  
+                    "type":"string",
+                    "title":"Trigger Label",
+                    "description":"Short(one word) user friendly description of the Trigger Module Type."
+                  },
+                  "description":{  
+                    "type":"string",
+                    "title":"Trigger Designation",
+                    "description":"A brief description of what the Trigger is and for what it is used."
+                  }
+                }
+              }
             }
           }
         }
@@ -410,6 +452,54 @@
                       },
                       "description":"Shows how to be considered a given value. For example, as a Temperature."
                     }
+                  }
+                }
+              }
+            },
+            "conditions":{  
+              "type":"array",
+              "minItems":0,
+              "title":"Condition Modules",
+              "description":"Contains definitions of Condition Modules involved in the composite type.",
+              "items":{  
+                "type":"object",
+                "title":"Condition Module",
+                "description":"Defines the condition which permit to proceed with the Rule execution.",
+                "additionalProperties":false,
+                "required":[  
+                  "id",
+                  "type"
+                ],
+                "properties":{  
+                  "id":{  
+                    "type":"string",
+                    "title":"Condition uid",
+                    "description":"Identifies uniquely the Module in scope of the Rule."
+                  },
+                  "type":{  
+                    "type":"string",
+                    "title":"Condition Module Type",
+                    "description":"Identifies the Module Type used for creation of the Condition. Must be unique in scope of concrete Rule definition."
+                  },
+                  "config":{  
+                    "type":"object",
+                    "title":"Condition Configurations",
+                    "description":"Used to configure the Condition. Contains pairs of Configuration Property's name and its value."
+                  },
+                  "input":{  
+                    "type":"object",
+                    "title":"Condition Input",
+                    "description":"Contains pairs of Input uid and Output reference in format - ModuleUID : OutputUID."
+                  },
+                  "label":{  
+                    "type":"string",
+                    "title":"Condition Label",
+                    "description":"Short(one word) user friendly description of the Condition Module."
+                  },
+                  "description":{  
+                    "type":"string",
+                    "title":"Condition Designation",
+                    "description":"A brief description of what the Condition is and for what it is used."
                   }
                 }
               }
@@ -669,785 +759,61 @@
                   }
                 }
               }
-            }
-          }
-        }
-      }
-    },
-    "composite":{  
-      "type":"object",
-      "title":"Composite Module Types",
-      "description":"Contains definitions of the Composite Module Types.",
-      "additionalProperties":false,
-      "patternProperties":{  
-        "[A-Za-z0-9]+":{  
-          "oneOf":[  
-            {  
-              "type":"object",
-              "title":"Composite Trigger Module Type",
-              "description":"Contains definition of the Composite Trigger Module Type.",
-              "additionalProperties":false,
-              "properties":{  
-                "visibility":{  
-                  "enum":[  
-                    "public",
-                    "private"
-                  ],
-                  "default":"public"
-                },
-                "tags":{  
-                  "type":"array",
-                  "title":"Composition Module Type Tags",
-                  "description":"Non-hierarchical keywords or terms describing the Composition Module Type. They help to classify the templates and allow them to be found.",
-                  "minItems":1,
-                  "items":{  
-                    "type":"string"
-                  }
-                },
-                "description":{  
-                  "type":"string",
-                  "title":"Composite Module Type Description.",
-                  "description":"A brief description of what the Composite is and for what it is used."
-                },
-                "config":{  
-                  "type":"object",
-                  "additionalProperties":false,
-                  "title":"Composition Module Type Configurations",
-                  "description":"Used to configure the Composition Module Type. Contains objects describing Configuration Properties.",
-                  "patternProperties":{  
-                    "[A-Za-z0-9]+":{  
-                      "type":"object",
-                      "title":"Configuration Property",
-                      "description":"Property for configuring Rule or Module.",
-                      "additionalProperties":false,
-                      "required":[  
-                        "type"
-                      ],
-                      "properties":{  
-                        "type":{  
-                          "enum":[  
-                            "text",
-                            "integer",
-                            "decimal",
-                            "boolean"
-                          ],
-                          "title":"Configuration Parameter Type",
-                          "description":"Property declaring data type of the Configuration Parameter."
-                        },
-                        "label":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Label",
-                          "description":"A human understandable label of the Configuration Parameter."
-                        },
-                        "description":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Description",
-                          "description":"A human understandable description of the Configuration Parameter."
-                        },
-                        "required":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Required Configuration Parameter",
-                          "description":"Specifies whether the value is required."
-                        },
-                        "min":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Minimum Allowed Value",
-                          "description":"Minimum value of numeric types, minimal length for strings, minimal number selected options."
-                        },
-                        "max":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Maximum Allowed Value",
-                          "description":"Maximum value of numeric types, maximal length for strings, maximal number selected options."
-                        },
-                        "step":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Step",
-                          "description":"A constant value for increasing/decreasing numeric types"
-                        },
-                        "pattern":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Pattern",
-                          "description":"Regular script for subscribing text types."
-                        },
-                        "readOnly":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Readable Configuration Parameter",
-                          "description":"Specifies whether the value is read-only."
-                        },
-                        "multiple":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Multiple Configuration Parameter",
-                          "description":"Specifies whether multiple selections of options are allowed."
-                        },
-                        "context":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Context",
-                          "description":"Serves to determine how to treat the value of the Configuration Parameter."
-                        },
-                        "defaultValue":{  
-                          "title":"Configuration Parameter Default Value",
-                          "description":"Declaring a defaultValue value for the Configuration Parameter if missing."
-                        },
-                        "value":{  
-                          "title":"Configuration Parameter Value",
-                          "description":"Declaring a value for the Configuration Parameter in case of system context."
-                        },
-                        "filterCriteria":{  
-                          "type":"array",
-                          "title":"Configuration Parameter Filter",
-                          "description":"Criteria for dynamic selection of values.",
-                          "items":{  
-                            "type":"object",
-                            "additionalProperties":false,
-                            "required":[  
-                              "name",
-                              "value"
-                            ],
-                            "properties":{  
-                              "name":{  
-                                "type":"string"
-                              },
-                              "value":{  
-                                "type":"string"
-                              }
-                            }
-                          }
-                        },
-                        "options":{  
-                          "type":"array",
-                          "title":"Configuration Parameter Options",
-                          "description":"List of definitions of the parameter for static selection.",
-                          "items":{  
-                            "type":"object",
-                            "additionalProperties":false,
-                            "required":[  
-                              "label",
-                              "value"
-                            ],
-                            "properties":{  
-                              "label":{  
-                                "type":"string"
-                              },
-                              "value":{  
-                                "type":"string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "triggers":{  
-                  "type":"array",
-                  "minItems":1,
-                  "title":"Trigger Modules",
-                  "description":"Contains definitions of the Trigger Modules of the Trigger Composition.",
-                  "items":{  
-                    "type":"object",
-                    "title":"Trigger Module",
-                    "description":"Defines the fact which triggers the Rule execution.",
-                    "additionalProperties":false,
-                    "properties":{  
-                      "id":{  
-                        "type":"string",
-                        "title":"Trigger uid",
-                        "description":"Identifies uniquely the Module in scope of the Rule."
-                      },
-                      "type":{  
-                        "type":"string",
-                        "title":"Trigger Module Type",
-                        "description":"Identifies the Module Type used for creation of the Trigger Composition. Must be unique in scope of concrete Rule definition."
-                      },
-                      "config":{  
-                        "type":"object",
-                        "title":"Trigger Configurations",
-                        "description":"Used to configure the Trigger Composition. Contains pairs of Configuration Property's name and its value."
-                      }
-                    }
-                  }
-                },
-                "output":{  
-                  "type":"object",
-                  "title":"Trigger Output",
-                  "description":"Output object of the Trigger used to transfer data to other modules of the Rule.",
-                  "additionalProperties":false,
-                  "patternProperties":{  
-                    "[A-Za-z0-9]+":{  
-                      "type":"object",
-                      "title":"Output",
-                      "description":"Property for connecting modules.",
-                      "additionalProperties":false,
-                      "required":[  
-                        "type"
-                      ],
-                      "properties":{  
-                        "type":{  
-                          "type":"string",
-                          "description":"Fully qualified name of Java class."
-                        },
-                        "label":{  
-                          "type":"string"
-                        },
-                        "description":{  
-                          "type":"string"
-                        },
-                        "defaultValue":{  
-
-                        },
-                        "reference":{  
-                          "type":"string"
-                        },
-                        "tags":{  
-                          "type":"array",
-                          "minItems":1,
-                          "items":{  
-                            "type":"string"
-                          },
-                          "description":"Shows how to be considered a given value. For example, as a Temperature."
-                        }
-                      }
-                    }
-                  }
-                }
-              }
             },
-            {  
-              "type":"object",
-              "title":"Composite Action Module Type",
-              "description":"Contains definition of the Composite Action Module Type.",
-              "additionalProperties":false,
-              "properties":{  
-                "visibility":{  
-                  "enum":[  
-                    "public",
-                    "private"
-                  ],
-                  "default":"public"
-                },
-                "tags":{  
-                  "type":"array",
-                  "title":"Composition Module Type Tags",
-                  "description":"Non-hierarchical keywords or terms describing the Composition Module Type. They help to classify the templates and allow them to be found.",
-                  "minItems":1,
-                  "items":{  
-                    "type":"string"
-                  }
-                },
-                "description":{  
-                  "type":"string",
-                  "title":"Composite Module Type Description.",
-                  "description":"A brief description of what the Composite is and for what it is used."
-                },
-                "config":{  
-                  "type":"object",
-                  "additionalProperties":false,
-                  "title":"Composition Module Type Configurations",
-                  "description":"Used to configure the Composition Module Type. Contains objects describing Configuration Properties.",
-                  "patternProperties":{  
-                    "[A-Za-z0-9]+":{  
-                      "type":"object",
-                      "title":"Configuration Property",
-                      "description":"Property for configuring Rule or Module.",
-                      "additionalProperties":false,
-                      "required":[  
-                        "type"
-                      ],
-                      "properties":{  
-                        "type":{  
-                          "enum":[  
-                            "text",
-                            "integer",
-                            "decimal",
-                            "boolean"
-                          ],
-                          "title":"Configuration Parameter Type",
-                          "description":"Property declaring data type of the Configuration Parameter."
-                        },
-                        "label":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Label",
-                          "description":"A human understandable label of the Configuration Parameter."
-                        },
-                        "description":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Description",
-                          "description":"A human understandable description of the Configuration Parameter."
-                        },
-                        "required":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Required Configuration Parameter",
-                          "description":"Specifies whether the value is required."
-                        },
-                        "min":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Minimum Allowed Value",
-                          "description":"Minimum value of numeric types, minimal length for strings, minimal number selected options."
-                        },
-                        "max":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Maximum Allowed Value",
-                          "description":"Maximum value of numeric types, maximal length for strings, maximal number selected options."
-                        },
-                        "step":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Step",
-                          "description":"A constant value for increasing/decreasing numeric types"
-                        },
-                        "pattern":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Pattern",
-                          "description":"Regular script for subscribing text types."
-                        },
-                        "readOnly":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Readable Configuration Parameter",
-                          "description":"Specifies whether the value is read-only."
-                        },
-                        "multiple":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Multiple Configuration Parameter",
-                          "description":"Specifies whether multiple selections of options are allowed."
-                        },
-                        "context":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Context",
-                          "description":"Serves to determine how to treat the value of the Configuration Parameter."
-                        },
-                        "defaultValue":{  
-                          "title":"Configuration Parameter Default Value",
-                          "description":"Declaring a defaultValue value for the Configuration Parameter if missing."
-                        },
-                        "value":{  
-                          "title":"Configuration Parameter Value",
-                          "description":"Declaring a value for the Configuration Parameter in case of system context."
-                        },
-                        "filterCriteria":{  
-                          "type":"array",
-                          "title":"Configuration Parameter Filter",
-                          "description":"Criteria for dynamic selection of values.",
-                          "items":{  
-                            "type":"object",
-                            "additionalProperties":false,
-                            "required":[  
-                              "name",
-                              "value"
-                            ],
-                            "properties":{  
-                              "name":{  
-                                "type":"string"
-                              },
-                              "value":{  
-                                "type":"string"
-                              }
-                            }
-                          }
-                        },
-                        "options":{  
-                          "type":"array",
-                          "title":"Configuration Parameter Options",
-                          "description":"List of definitions of the parameter for static selection.",
-                          "items":{  
-                            "type":"object",
-                            "additionalProperties":false,
-                            "required":[  
-                              "label",
-                              "value"
-                            ],
-                            "properties":{  
-                              "label":{  
-                                "type":"string"
-                              },
-                              "value":{  
-                                "type":"string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "actions":{  
-                  "type":"array",
-                  "minItems":1,
-                  "title":"Action Modules",
-                  "description":"Contains definitions of Action Modules of the Action Composition.",
-                  "items":{  
+            "actions":{  
+              "type":"array",
+              "minItems":1,
+              "title":"Action Modules",
+              "description":"Contains definitions of Action Modules involved in the composite type.",
+              "items":{  
+                "type":"object",
+                "title":"Action Module",
+                "description":"Defines an action which has to be executed by the Rule.",
+                "additionalProperties":false,
+                "required":[  
+                  "id",
+                  "type"
+                ],
+                "properties":{  
+                  "id":{  
+                    "type":"string",
+                    "title":"Action uid",
+                    "description":"Identifies uniquely the Module in scope of the Rule."
+                  },
+                  "type":{  
+                    "type":"string",
+                    "title":"Action Module Type",
+                    "description":"Identifies the Module Type used for creation of the Action. Must be unique in scope of concrete Rule definition."
+                  },
+                  "config":{  
                     "type":"object",
-                    "title":"Action Module",
-                    "description":"Defines an action which has to be executed by the Rule.",
-                    "additionalProperties":false,
-                    "properties":{  
-                      "id":{  
-                        "type":"string",
-                        "title":"Action Id",
-                        "description":"Identifies uniquely the Module in scope of the Rule."
-                      },
-                      "type":{  
-                        "type":"string",
-                        "title":"Action Module Type",
-                        "description":"Identifies the Module Type used for creation of the Action. Must be unique in scope of concrete Rule definition."
-                      },
-                      "config":{  
-                        "type":"object",
-                        "title":"Action Configurations",
-                        "description":"Used to configure the Action. Contains pairs of Configuration Property's name and its value."
-                      },
-                      "input":{  
-                        "type":"object",
-                        "title":"Action Input",
-                        "description":"Contains pairs of Input name and Output reference in format - ModuleID : OutputName."
-                      },
-                      "output":{  
-                        "type":"object",
-                        "title":"Action Output",
-                        "description":"Contains pairs of Output name and Output reference. The reference defines what part of a complex data has to be used as value of this output."
-                      }
-                    }
-                  }
-                },
-                "input":{  
-                  "type":"object",
-                  "title":"Action Input",
-                  "description":"Input object of the Action used for binding an Output objects of other modules in order to receive data.",
-                  "additionalProperties":false,
-                  "patternProperties":{  
-                    "[A-Za-z0-9]+":{  
-                      "type":"object",
-                      "title":"Input",
-                      "description":"Property for connecting modules.",
-                      "additionalProperties":false,
-                      "required":[  
-                        "type"
-                      ],
-                      "properties":{  
-                        "type":{  
-                          "type":"string",
-                          "description":"Fully qualified name of Java class."
-                        },
-                        "label":{  
-                          "type":"string"
-                        },
-                        "required":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Required Input",
-                          "description":"Specifies whether the value is required."
-                        },
-                        "defaultValue":{  
-                          "title":"Input Default Value",
-                          "description":"Specifies the value if the Input is not required and is missing."
-                        },
-                        "description":{  
-                          "type":"string"
-                        },
-                        "tags":{  
-                          "type":"array",
-                          "minItems":1,
-                          "items":{  
-                            "type":"string"
-                          },
-                          "description":"Shows how to be considered a given value. For example, as a Temperature."
-                        }
-                      }
-                    }
-                  }
-                },
-                "output":{  
-                  "type":"object",
-                  "title":"Trigger Output",
-                  "description":"Output object of the Trigger used to transfer data to other modules of the Rule.",
-                  "additionalProperties":false,
-                  "patternProperties":{  
-                    "[A-Za-z0-9]+":{  
-                      "type":"object",
-                      "title":"Output",
-                      "description":"Property for connecting modules.",
-                      "additionalProperties":false,
-                      "required":[  
-                        "type"
-                      ],
-                      "properties":{  
-                        "type":{  
-                          "type":"string",
-                          "description":"Fully qualified name of Java class."
-                        },
-                        "label":{  
-                          "type":"string"
-                        },
-                        "description":{  
-                          "type":"string"
-                        },
-                        "defaultValue":{  
-
-                        },
-                        "reference":{  
-                          "type":"string"
-                        },
-                        "tags":{  
-                          "type":"array",
-                          "minItems":1,
-                          "items":{  
-                            "type":"string"
-                          },
-                          "description":"Shows how to be considered a given value. For example, as a Temperature."
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            {  
-              "type":"object",
-              "title":"Composite Condition Module Type",
-              "description":"Contains definition of the Composite Condition Module Type.",
-              "additionalProperties":false,
-              "properties":{  
-                "visibility":{  
-                  "enum":[  
-                    "public",
-                    "private"
-                  ],
-                  "default":"public"
-                },
-                "tags":{  
-                  "type":"array",
-                  "title":"Composition Module Type Tags",
-                  "description":"Non-hierarchical keywords or terms describing the Composition Module Type. They help to classify the templates and allow them to be found.",
-                  "minItems":1,
-                  "items":{  
-                    "type":"string"
-                  }
-                },
-                "description":{  
-                  "type":"string",
-                  "title":"Composite Module Type Description.",
-                  "description":"A brief description of what the Composite is and for what it is used."
-                },
-                "config":{  
-                  "type":"object",
-                  "additionalProperties":false,
-                  "title":"Composition Module Type Configurations",
-                  "description":"Used to configure the Composition Module Type. Contains objects describing Configuration Properties.",
-                  "patternProperties":{  
-                    "[A-Za-z0-9]+":{  
-                      "type":"object",
-                      "title":"Configuration Property",
-                      "description":"Property for configuring Rule or Module.",
-                      "additionalProperties":false,
-                      "required":[  
-                        "type"
-                      ],
-                      "properties":{  
-                        "type":{  
-                          "enum":[  
-                            "text",
-                            "integer",
-                            "decimal",
-                            "boolean"
-                          ],
-                          "title":"Configuration Parameter Type",
-                          "description":"Property declaring data type of the Configuration Parameter."
-                        },
-                        "label":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Label",
-                          "description":"A human understandable label of the Configuration Parameter."
-                        },
-                        "description":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Description",
-                          "description":"A human understandable description of the Configuration Parameter."
-                        },
-                        "required":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Required Configuration Parameter",
-                          "description":"Specifies whether the value is required."
-                        },
-                        "min":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Minimum Allowed Value",
-                          "description":"Minimum value of numeric types, minimal length for strings, minimal number selected options."
-                        },
-                        "max":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Maximum Allowed Value",
-                          "description":"Maximum value of numeric types, maximal length for strings, maximal number selected options."
-                        },
-                        "step":{  
-                          "type":"number",
-                          "title":"Configuration Parameter Step",
-                          "description":"A constant value for increasing/decreasing numeric types"
-                        },
-                        "pattern":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Pattern",
-                          "description":"Regular script for subscribing text types."
-                        },
-                        "readOnly":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Readable Configuration Parameter",
-                          "description":"Specifies whether the value is read-only."
-                        },
-                        "multiple":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Multiple Configuration Parameter",
-                          "description":"Specifies whether multiple selections of options are allowed."
-                        },
-                        "context":{  
-                          "type":"string",
-                          "title":"Configuration Parameter Context",
-                          "description":"Serves to determine how to treat the value of the Configuration Parameter."
-                        },
-                        "defaultValue":{  
-                          "title":"Configuration Parameter Default Value",
-                          "description":"Declaring a defaultValue value for the Configuration Parameter if missing."
-                        },
-                        "value":{  
-                          "title":"Configuration Parameter Value",
-                          "description":"Declaring a value for the Configuration Parameter in case of system context."
-                        },
-                        "filterCriteria":{  
-                          "type":"array",
-                          "title":"Configuration Parameter Filter",
-                          "description":"Criteria for dynamic selection of values.",
-                          "items":{  
-                            "type":"object",
-                            "additionalProperties":false,
-                            "required":[  
-                              "name",
-                              "value"
-                            ],
-                            "properties":{  
-                              "name":{  
-                                "type":"string"
-                              },
-                              "value":{  
-                                "type":"string"
-                              }
-                            }
-                          }
-                        },
-                        "options":{  
-                          "type":"array",
-                          "title":"Configuration Parameter Options",
-                          "description":"List of definitions of the parameter for static selection.",
-                          "items":{  
-                            "type":"object",
-                            "additionalProperties":false,
-                            "required":[  
-                              "label",
-                              "value"
-                            ],
-                            "properties":{  
-                              "label":{  
-                                "type":"string"
-                              },
-                              "value":{  
-                                "type":"string"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "conditions":{  
-                  "type":"array",
-                  "minItems":0,
-                  "title":"Condition Modules",
-                  "description":"Contains definitions of Condition Modules of the Condition Composite.",
-                  "items":{  
+                    "title":"Action Configurations",
+                    "description":"Used to configure the Action. Contains pairs of Configuration Property's name and its value."
+                  },
+                  "input":{  
                     "type":"object",
-                    "title":"Condition Module",
-                    "description":"Defines the condition which permit to proceed with the Rule execution.",
-                    "additionalProperties":false,
-                    "properties":{  
-                      "id":{  
-                        "type":"string",
-                        "title":"Condition Id",
-                        "description":"Identifies uniquely the Module in scope of the Rule."
-                      },
-                      "type":{  
-                        "type":"string",
-                        "title":"Condition Module Type",
-                        "description":"Identifies the Module Type used for creation of the Condition. Must be unique in scope of concrete Rule definition."
-                      },
-                      "config":{  
-                        "type":"object",
-                        "title":"Condition Configurations",
-                        "description":"Used to configure the Condition. Contains pairs of Configuration Property's name and its value."
-                      },
-                      "input":{  
-                        "type":"object",
-                        "title":"Condition Input",
-                        "description":"Contains pairs of Input name and Output reference in format - ModuleID : OutputName."
-                      }
-                    }
-                  }
-                },
-                "input":{  
-                  "type":"object",
-                  "title":"Action Input",
-                  "description":"Input object of the Action used for binding an Output objects of other modules in order to receive data.",
-                  "additionalProperties":false,
-                  "patternProperties":{  
-                    "[A-Za-z0-9]+":{  
-                      "type":"object",
-                      "title":"Input",
-                      "description":"Property for connecting modules.",
-                      "additionalProperties":false,
-                      "required":[  
-                        "type"
-                      ],
-                      "properties":{  
-                        "type":{  
-                          "type":"string",
-                          "description":"Fully qualified name of Java class."
-                        },
-                        "label":{  
-                          "type":"string"
-                        },
-                        "required":{  
-                          "type":"boolean",
-                          "default":false,
-                          "title":"Required Input",
-                          "description":"Specifies whether the value is required."
-                        },
-                        "defaultValue":{  
-                          "title":"Input Default Value",
-                          "description":"Specifies the value if the Input is not required and is missing."
-                        },
-                        "description":{  
-                          "type":"string"
-                        },
-                        "tags":{  
-                          "type":"array",
-                          "minItems":1,
-                          "items":{  
-                            "type":"string"
-                          },
-                          "description":"Shows how to be considered a given value. For example, as a Temperature."
-                        }
-                      }
-                    }
+                    "title":"Action Input",
+                    "description":"Contains pairs of Input uid and Output reference in format - ModuleUID : OutputUID."
+                  },
+                  "output":{  
+                    "type":"object",
+                    "title":"Action Output",
+                    "description":"Contains pairs of Output uid and Output reference. The reference defines what part of a complex data has to be used as value of this output."
+                  },
+                  "label":{  
+                    "type":"string",
+                    "title":"Action Label",
+                    "description":"Short(one word) user friendly description of the Action Module."
+                  },
+                  "description":{  
+                    "type":"string",
+                    "title":"Action Designation",
+                    "description":"A brief description of what the Action is and for what it is used."
                   }
                 }
               }
             }
-          ]
+          }
         }
       }
     }


### PR DESCRIPTION
Add support for composite module types. #64 - json structure is changed - "composite" is removed, "triggers", "conditions" and "actions" properties are added in definitions of trigger, condition or action accordingly.