### PR TITLE
Initial implementation of ConfigOptionProvider interface

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigOptionRegistryOSGiTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigOptionRegistryOSGiTest.groovy
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.core.test
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+import static org.junit.matchers.JUnitMatchers.*
+
+import org.eclipse.smarthome.config.core.ConfigDescription
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
+import org.eclipse.smarthome.config.core.ConfigDescriptionProvider
+import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry
+import org.eclipse.smarthome.config.core.ConfigOptionProvider
+import org.eclipse.smarthome.config.core.ParameterOption
+import org.eclipse.smarthome.test.OSGiTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Test the ConfigOptionRegistry
+ *
+ * @author Chris Jackson
+ *
+ */
+class ConfigOptionRegistryOSGiTest extends OSGiTest {
+
+    ConfigDescriptionRegistry configDescriptionRegistry
+    ConfigDescription configDescription
+    ConfigDescriptionProvider configDescriptionProviderMock
+    ConfigOptionProvider configOptionsProviderMock
+    ParameterOption parameterOption
+
+    @Before
+    void setUp() {
+        // Register config registry
+        configDescriptionRegistry = getService(ConfigDescriptionRegistry)
+        ConfigDescriptionParameter parm1 = new ConfigDescriptionParameter("Parm1", ConfigDescriptionParameter.Type.INTEGER)
+        List<ConfigDescriptionParameter> pList1 = new ArrayList<ConfigDescriptionParameter>();
+        pList1.add(parm1);
+        configDescription = new ConfigDescription(new URI("config:Dummy"), pList1)
+
+        // Create config option list
+        List<ParameterOption> oList1 = new ArrayList<ConfigDescriptionParameter>();
+        parameterOption = new ParameterOption("Option1", "Option1")
+        oList1.add(parameterOption);
+        parameterOption = new ParameterOption("Option2", "Option2")
+        oList1.add(parameterOption);
+
+        configOptionsProviderMock = [
+            getParameterOptions: {p1, p2, p3 -> oList1}
+        ] as ConfigOptionProvider
+
+        configDescriptionProviderMock = [
+            getConfigDescriptions: {p -> [configDescription]},
+            getConfigDescription: {p1,p2 -> configDescription }
+        ] as ConfigDescriptionProvider
+    }
+
+    @Test
+    void 'assert ConfigDescriptionRegistry merges options'() {
+
+        assertThat "Registery is empty to start", configDescriptionRegistry.getConfigDescriptions().size(), is(0)
+
+        configDescriptionRegistry.addConfigDescriptionProvider(configDescriptionProviderMock)
+        assertThat "Config description added ok", configDescriptionRegistry.getConfigDescriptions().size(), is(1)
+
+        configDescriptionRegistry.addConfigOptionProvider(configOptionsProviderMock)
+
+        def configDescriptions = configDescriptionRegistry.getConfigDescription(new URI("config:Dummy"))
+        assertThat "Config is found", configDescriptions.uri, is(equalTo(new URI("config:Dummy")))
+
+        assertThat "Config contains parameter", configDescriptions.getParameters().size(), is(1)
+        assertThat "Config parameter found", configDescriptions.getParameters().get(0).getName(), is(equalTo("Parm1"))
+        assertThat "Config parameter contains options", configDescriptions.getParameters().get(0).getOptions().size(), is(2)
+
+        configDescriptionRegistry.removeConfigOptionProvider(configOptionsProviderMock)
+
+        configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderMock)
+        assertThat "Description registery is empty to finish", configDescriptionRegistry.getConfigDescriptions().size(), is(0)
+    }
+}

--- a/bundles/config/org.eclipse.smarthome.config.core/OSGI-INF/ConfigDescriptionRegistry.xml
+++ b/bundles/config/org.eclipse.smarthome.config.core/OSGI-INF/ConfigDescriptionRegistry.xml
@@ -14,8 +14,7 @@
    <service>
       <provide interface="org.eclipse.smarthome.config.core.ConfigDescriptionRegistry"/>
    </service>
+   <reference bind="addConfigOptionProvider" cardinality="0..n" interface="org.eclipse.smarthome.config.core.ConfigOptionProvider" name="ConfigOptionProvider" policy="dynamic" unbind="removeConfigOptionProvider"/>
    <reference bind="addConfigDescriptionProvider" cardinality="0..n" interface="org.eclipse.smarthome.config.core.ConfigDescriptionProvider" name="ConfigDescriptionProvider" policy="dynamic" unbind="removeConfigDescriptionProvider"/>
-   
-   
-   
+
 </scr:component>

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigOptionProvider.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigOptionProvider.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.core;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Locale;
+
+/**
+ * The {@link ConfigOptionProvider} can be implemented and registered as an <i>OSGi</i>
+ * service to provide {@link ConfigDescription}s options.
+ *
+ * @author Chris Jackson - Initial contribution
+ */
+public interface ConfigOptionProvider {
+
+    /**
+     * Provides a collection of {@link ParameterOptions}s.
+     *
+     * @param uri
+     *            the uri of the config description
+     * @param param
+     *            the parameter name for which the requested options shall be returned
+     * @param locale
+     *            locale
+     * @return the configuration options provided by this provider (not
+     *         null, could be empty)
+     */
+    Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale);
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingConfigDescriptionProvider.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingConfigDescriptionProvider.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.smarthome.core.thing.internal.ThingConfigDescriptionProvider">
+   <implementation class="org.eclipse.smarthome.core.thing.internal.ThingConfigDescriptionProvider"/>
+   
+   <service>
+      <provide interface="org.eclipse.smarthome.config.core.ConfigDescriptionProvider"/>
+   </service>
+   
+   <reference bind="setThingRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="static" unbind="unsetThingRegistry"/>
+   <reference bind="setThingTypeRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.type.ThingTypeRegistry" name="ThingTypeRegistry" policy="static" unbind="unsetThingTypeRegistry"/>
+   <reference bind="setConfigDescriptionRegistry" cardinality="1..1" interface="org.eclipse.smarthome.config.core.ConfigDescriptionRegistry" name="ConfigDescriptionRegistry" policy="static" unbind="unsetConfigDescriptionRegistry"/>
+</scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingConfigDescriptionProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingConfigDescriptionProvider.java
@@ -1,0 +1,82 @@
+package org.eclipse.smarthome.core.thing.internal;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
+
+import org.eclipse.smarthome.config.core.ConfigDescription;
+import org.eclipse.smarthome.config.core.ConfigDescriptionProvider;
+import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
+import org.eclipse.smarthome.config.core.ConfigOptionProvider;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.type.ThingType;
+import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
+
+/**
+ * Provides a proxy for thing configuration descriptions.
+ *
+ * If a thing config description is requested, the provider will look up the thingType
+ * to get the configURI, get the config description for the thingType. If the thingHandler
+ * supports the {@link ConfigOptionProvider} interface, it will call the getParameterOptions
+ * method to get updated options.
+ *
+ * @author Chris Jackson - Initial Implementation
+ *
+ */
+public class ThingConfigDescriptionProvider implements ConfigDescriptionProvider {
+    private ThingTypeRegistry thingTypeRegistry;
+    private ConfigDescriptionRegistry configDescriptionRegistry;
+
+    protected void setConfigDescriptionRegistry(ConfigDescriptionRegistry configDescriptionRegistry) {
+        this.configDescriptionRegistry = configDescriptionRegistry;
+    }
+
+    protected void unsetConfigDescriptionRegistry(ConfigDescriptionRegistry configDescriptionRegistry) {
+        this.configDescriptionRegistry = null;
+    }
+
+    protected void setThingTypeRegistry(ThingTypeRegistry thingTypeRegistry) {
+        this.thingTypeRegistry = thingTypeRegistry;
+    }
+
+    protected void unsetThingTypeRegistry(ThingTypeRegistry thingTypeRegistry) {
+        this.thingTypeRegistry = null;
+    }
+
+    @Override
+    public Collection<ConfigDescription> getConfigDescriptions(Locale locale) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public ConfigDescription getConfigDescription(URI uri, Locale locale) {
+        // If this is not a concrete thing, then return
+        if ("thing".equals(uri.getScheme()) == false) {
+            return null;
+        }
+
+        // First, get the thing type so we get the generic config descriptions
+        ThingUID thingUID = new ThingUID(uri.getSchemeSpecificPart());
+        ThingType thingType = thingTypeRegistry.getThingType(thingUID.getThingTypeUID());
+        if (thingType == null) {
+            return null;
+        }
+
+        // Get the config description URI for this thing type
+        URI configURI = thingType.getConfigDescriptionURI();
+        if (configURI == null) {
+            return null;
+        }
+
+        // Now call this again for the thing
+        ConfigDescription config = configDescriptionRegistry.getConfigDescription(configURI, locale);
+        if (config == null) {
+            return null;
+        }
+
+        // Return the new configuration description
+        return config;
+    }
+
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -163,7 +163,8 @@ public class ThingResource implements RESTResource {
         }
 
         if (removedThing == null) {
-            logger.info("Received HTTP DELETE request at '{}' for the unknown thing '{}'.", uriInfo.getPath(), thingUID);
+            logger.info("Received HTTP DELETE request at '{}' for the unknown thing '{}'.", uriInfo.getPath(),
+                    thingUID);
             return Response.status(Status.NOT_FOUND).build();
         }
 


### PR DESCRIPTION
As described [here](https://www.eclipse.org/forums/index.php?t=msg&th=1066227&goto=1711614&#msg_1711614).

This PR allows a binding to provide custom options in a config description. This information is provided within the CD request through a `GET thing/{thingUID}/config` REST interface.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>