### PR TITLE
avoid ConcurrentModificationException

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
@@ -6,22 +6,16 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.model.core.internal.ModelCoreActivator
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Import-Package: com.google.common.base,
- com.google.common.collect,
- com.google.inject,
+Import-Package: com.google.common.collect,
  org.apache.commons.collections,
  org.apache.commons.io,
  org.apache.commons.lang,
- org.eclipse.core.runtime;registry=split,
- org.eclipse.emf.common.notify,
  org.eclipse.emf.common.util,
  org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.resource,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.service,
- org.eclipse.xtext.common.types.impl,
  org.eclipse.xtext.resource,
- org.eclipse.xtext.resource.impl,
  org.osgi.framework,
  org.osgi.service.cm,
  org.slf4j


### PR DESCRIPTION
The functions called for the resources will result on a change of the
resource set (at least on my special system setup).
Using the logic of this PR without using a copy of the resource set
(use getResources() for the for each loop) will result in a CME, too.
I cannot reproduce my CME using the copy.
As long as there is no Xtext guru, I cannot identify if this copy fix
the problem for all possible timing cases.

This PR also remove the usage of some Guava code, that is not really
necessary (we do not need to create two iterators).

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=479215
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>