### PR TITLE
new ThingTypeUID for WeMo motion.

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/ESH-INF/thing/thing-types.xml
@@ -76,6 +76,23 @@
         	</parameter>
          </config-description>
     </thing-type>
+    
+     <thing-type id="sensor">
+        <label>WeMo Sensor</label>
+        <description>This is a WeMo MotionSensor</description>
+
+        <channels>
+            <channel id="state" typeId="state"/>
+        </channels>
+
+        <config-description>
+            <parameter name="udn" type="text">
+                <label>Unique Device Name</label>
+                <description>The UDN identifies the WeMo Device</description>
+                <required>true</required>
+            </parameter>
+         </config-description>
+    </thing-type>
 
      <channel-type id="state">
         <item-type>Switch</item-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/WemoBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/WemoBindingConstants.java
@@ -24,6 +24,7 @@ public class WemoBindingConstants {
     public final static ThingTypeUID WEMO_INSIGHT_TYPE_UID = new ThingTypeUID(BINDING_ID, "insight");
     public final static ThingTypeUID WEMO_LIGHTSWITCH_TYPE_UID = new ThingTypeUID(BINDING_ID, "lightswitch");
     public final static ThingTypeUID WEMO_MOTION_TYPE_UID = new ThingTypeUID(BINDING_ID, "motion");
+    public final static ThingTypeUID WEMO_SENSOR_TYPE_UID = new ThingTypeUID(BINDING_ID, "sensor");
 
     // List of all Channel ids
     public final static String CHANNEL_STATE = "state";

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoHandler.java
@@ -18,6 +18,7 @@ import static org.eclipse.smarthome.binding.wemo.WemoBindingConstants.WEMO_INSIG
 import static org.eclipse.smarthome.binding.wemo.WemoBindingConstants.WEMO_LIGHTSWITCH_TYPE_UID;
 import static org.eclipse.smarthome.binding.wemo.WemoBindingConstants.WEMO_MOTION_TYPE_UID;
 import static org.eclipse.smarthome.binding.wemo.WemoBindingConstants.WEMO_SOCKET_TYPE_UID;
+import static org.eclipse.smarthome.binding.wemo.WemoBindingConstants.WEMO_SENSOR_TYPE_UID;
 
 import java.io.OutputStream;
 import java.math.BigDecimal;
@@ -60,8 +61,7 @@ public class WemoHandler extends BaseThingHandler {
     private final Logger logger = LoggerFactory.getLogger(WemoHandler.class);
 
     public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Sets.newHashSet(WEMO_SOCKET_TYPE_UID,
-            WEMO_INSIGHT_TYPE_UID, WEMO_LIGHTSWITCH_TYPE_UID, WEMO_MOTION_TYPE_UID);
-
+            WEMO_INSIGHT_TYPE_UID, WEMO_LIGHTSWITCH_TYPE_UID, WEMO_MOTION_TYPE_UID, WEMO_SENSOR_TYPE_UID);
     private static String getInsightParamsXML;
     private static String getRequestXML;
     private static String setRequestXML;


### PR DESCRIPTION
== Fixes Wemo motion sensors not showing up in Thing discovery ==

Wemo motion sensors changed from 'Motion' to 'Sensor' ThingID.
Verfied with local Openhab2 + ESH setup.

== Testing Done ==
Verified that the new device is showing up in the Openhab console.
```
2015-11-13 21:39:24 [DEBUG] [e.s.b.wemo.handler.WemoHandler:232  ] - item 'wemo:motion:Sensor-1_0-221219L0101073' is located at 'http://192.168.2.49:49153'
2015-11-13 21:39:24 [DEBUG] [e.s.b.wemo.handler.WemoHandler:276  ] - New binary state '0' for device 'wemo:motion:Sensor-1_0-221219L0101073' received
2015-11-13 21:39:24 [INFO ] [ome.event.ThingStatusInfoEvent:43   ] - 'wemo:motion:Sensor-1_0-221219L0101073' updated: ONLINE
2015-11-13 21:39:24 [DEBUG] [e.s.b.wemo.handler.WemoHandler:285  ] - New state 'OFF' for device 'wemo:motion:Sensor-1_0-221219L0101073' received
2015-11-13 21:39:24 [DEBUG] [e.s.b.wemo.handler.WemoHandler:177  ] - State 'OFF' for device 'wemo:motion:Sensor-1_0-221219L0101073' received
2015-11-13 21:39:24 [INFO ] [smarthome.event.ItemStateEvent:43   ] - wemo_motion_Sensor_1_0_221219L0101073_state updated to OFF
```
