### PR TITLE
check for config description URI

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
@@ -120,8 +120,13 @@ public class ThingTypeResource implements RESTResource {
 
     private ThingTypeDTO convertToThingTypeDTO(ThingType thingType, Locale locale) {
 
-        ConfigDescription configDescription = this.configDescriptionRegistry
-                .getConfigDescription(thingType.getConfigDescriptionURI(), locale);
+        final ConfigDescription configDescription;
+        if (thingType.hasConfigDescriptionURI()) {
+            configDescription = this.configDescriptionRegistry.getConfigDescription(thingType.getConfigDescriptionURI(),
+                    locale);
+        } else {
+            configDescription = null;
+        }
 
         List<ConfigDescriptionParameterDTO> parameters;
         List<ConfigDescriptionParameterGroupDTO> parameterGroups;


### PR DESCRIPTION
The argument uri for the function getConfigDescription of the
ConfigDescriptionRegistry must not be null.
So if we want to use the configu description URI of a thing type, we
have to check if there is one first.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>