### PR TITLE
Fixed a few things in the Paper UI:

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/app.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/app.js
@@ -12,7 +12,7 @@ angular.module('PaperUI', [
   'ngRoute',
   'ngResource',
   'ngMaterial'
-]).config(['$routeProvider', '$httpProvider', function($routeProvider) {
+]).config(['$routeProvider', '$httpProvider', 'globalConfig', function($routeProvider, httpProvider, globalConfig) {
   $routeProvider.
 	when('/control', {templateUrl: 'partials/control.html', controller: 'ControlPageController', title: 'Control', simpleHeader: true}).
 	when('/setup', {redirectTo: '/setup/search'}).
@@ -36,8 +36,12 @@ angular.module('PaperUI', [
 	when('/rules/new', {templateUrl: 'partials/rules.html', controller: 'RulesPageController', title: 'Rules'}).
 	when('/rules/view/:ruleUID', {templateUrl: 'partials/rules.html', controller: 'RulesPageController', title: 'Rules'}).
 	when('/rules/configure/:ruleUID', {templateUrl: 'partials/rules.html', controller: 'RulesPageController', title: 'Rules'}).
-	when('/preferences', {templateUrl: 'partials/preferences.html', controller: 'PreferencesPageController', title: 'Preferences'}).
-	otherwise({redirectTo: '/control'});
+	when('/preferences', {templateUrl: 'partials/preferences.html', controller: 'PreferencesPageController', title: 'Preferences'});
+    if(globalConfig.defaultRoute) {  
+        $routeProvider.otherwise({redirectTo: globalConfig.defaultRoute});
+    } else {
+        $routeProvider.otherwise({redirectTo: '/control'});
+    }
 }]).directive('editableitemstate', function(){
     return function($scope, $element) {
         $element.context.addEventListener('focusout', function(e){

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/constants.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/constants.js
@@ -1,7 +1,8 @@
 /* This file can be be overridden by fragments for customization */
 angular.module('PaperUI.constants', [])
 .constant('globalConfig', {
-   'advancedDefault': false 
+   'advancedDefault': false,
+   'defaultRoute': '/control'
 }).constant('restConfig', {
   'restPath': '/rest',
   'eventPath': $('#authentication').data('access-token') != '{{ACCESS_TOKEN}}' ? '/rest/events?access_token=' + $('#authentication').data('access-token') : '/rest/events'

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/controllers.configuration.js
@@ -328,18 +328,26 @@ angular.module('PaperUI.controllers.configuration',
         });
     }
 	
-	$scope.enableChannel = function(thingUID, channelID) {
-		thingSetupService.enableChannel({channelUID: thingUID + ':' + channelID}, function() {
-			$scope.getThing(true);
-			toastService.showDefaultToast('Channel enabled');
-		});
+	$scope.enableChannel = function(thingUID, channelID, event) {
+	    if($scope.advancedMode) {
+	        $scope.linkChannel(channelID, event);
+	    } else {
+            thingSetupService.enableChannel({channelUID: thingUID + ':' + channelID}, function() {
+    		    $scope.getThing(true);
+    		    toastService.showDefaultToast('Channel enabled');
+    	    });
+	    }
 	};
 	
-	$scope.disableChannel = function(thingUID, channelID) {
-		thingSetupService.disableChannel({channelUID: thingUID + ':' + channelID}, function() {
-			$scope.getThing(true);
-			toastService.showDefaultToast('Channel disabled');
-		});
+	$scope.disableChannel = function(thingUID, channelID, event) {
+	    if($scope.advancedMode) {
+            $scope.unlinkChannel(channelID, event);
+        } else {
+    	    thingSetupService.disableChannel({channelUID: thingUID + ':' + channelID}, function() {
+    			$scope.getThing(true);
+    			toastService.showDefaultToast('Channel disabled');
+    		});
+        }
 	};
 	
 	$scope.linkChannel = function(channelID, event) {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/controllers.extension.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/controllers.extension.js
@@ -1,27 +1,20 @@
 angular.module('PaperUI.controllers.extension', ['PaperUI.constants']).controller('ExtensionPageController', function($scope, 
-        extensionService, eventService, toastService) {
+        extensionService, bindingRepository, thingTypeRepository, eventService, toastService) {
 	$scope.navigateTo = function(path) {
 		$location.path('extensions/' + path);
     };
     $scope.extensionTypes = [];
-    $scope.extensionTypeLabels = {};
     $scope.refresh = function() {
-        extensionService.getAll(function(extensions) {
-            $scope.extensionTypes = [];
-        	angular.forEach(extensions, function(extension) {
-        	    var extensionType = $scope.getType(extension.type);
-        	    if(extensionType) {
-        	        extensionType.extensions.push(extension);
-        	    } else {
-        	        extensionType = {typeId: extension.type, extensions: [extension], inProgress: false};
-        	        $scope.extensionTypes.push(extensionType);
-        	    }
-        	});
-        });
         extensionService.getAllTypes(function(extensionTypes) {
-            $scope.extensionTypeLabels = {};
-            angular.forEach(extensionTypes, function(extensioType) {
-                $scope.extensionTypeLabels[extensioType.id] = extensioType.label;
+            $scope.extensionTypes = [];
+            angular.forEach(extensionTypes, function(extensionType) {
+                $scope.extensionTypes.push({typeId: extensionType.id, label: extensionType.label, extensions: [], inProgress: false});
+            });
+            extensionService.getAll(function(extensions) {
+                angular.forEach(extensions, function(extension) {
+                    var extensionType = $scope.getType(extension.type);
+                    extensionType.extensions.push(extension);
+                });
             });
         });
     }
@@ -51,11 +44,15 @@ angular.module('PaperUI.controllers.extension', ['PaperUI.constants']).controlle
         var extension = $scope.getExtension(extensionId);
         extension.inProgress = true;
         extensionService.install({id: extensionId});
+        bindingRepository.setDirty(true);
+        thingTypeRepository.setDirty(true);
     };
     $scope.uninstall = function(extensionId) {
         var extension = $scope.getExtension(extensionId);
         extension.inProgress = true;
         extensionService.uninstall({id: extensionId});
+        bindingRepository.setDirty(true);
+        thingTypeRepository.setDirty(true);
     };
     eventService.onEvent('smarthome/extensions/*', function(topic, extensionId) {
         var extension = $scope.getExtension(extensionId);

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/services.repositories.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/services.repositories.js
@@ -28,7 +28,7 @@ var Repository = function($q, $rootScope, remoteService, dataType, staticData) {
                 return;
             }
         });
-		if(cacheEnabled && staticData && self.initialFetch && !refresh) {
+		if(cacheEnabled && staticData && self.initialFetch && !refresh && !self.dirty) {
 		    deferred.resolve($rootScope.data[dataType]);
 		} else {
     		remoteService.getAll(function(data) {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/configuration.html
@@ -1,4 +1,4 @@
-<section id="main" ng-controller="ConfigurationPageController">
+<section id="main">
 	<div class="bindings tab-panel content" ng-if="page === 'bindings'"
 		ng-controller="BindingController">
 		<div class="header-toolbar">
@@ -191,22 +191,14 @@
 					ng-repeat="channel in getChannels(false)">
 					<md-button ng-if="channel.linkedItems.length == 0"
 						class="md-fab md-icon-radio-button-off"
-						ng-click="enableChannel(thing.UID, channel.id)" aria-label="Off"></md-button>
+						ng-click="enableChannel(thing.UID, channel.id, $event)" aria-label="Off"></md-button>
 					<md-button ng-if="channel.linkedItems.length > 0"
 						class="md-fab md-icon-radio-button-on"
-						ng-click="disableChannel(thing.UID, channel.id)" aria-label="On"></md-button>
+						ng-click="disableChannel(thing.UID, channel.id, $event)" aria-label="On"></md-button>
 					<div class="item-content">
 						<h3>{{getChannelTypeById(channel.id).label}}</h3>
 						<p>{{thing.UID + ':' + channel.id}}</p>
 						<p>{{getChannelTypeById(channel.id).description}}</p>
-						<div class="actions" ng-show="advancedMode">
-							<md-button ng-if="channel.linkedItems.length == 0"
-								class="md-raised md-icon-link"
-								ng-click="linkChannel(channel.id, $event)" aria-label="Link"></md-button>
-							<md-button ng-if="channel.linkedItems.length > 0"
-								class="md-raised md-icon-content-cut"
-								ng-click="unlinkChannel(channel.id)" aria-label="Unlink"></md-button>
-						</div>
 					</div>
 					<hr class="border-line" />
 				</div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/control.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/control.html
@@ -3,17 +3,18 @@
 		<md-button class="md-icon-refresh" ng-click="refresh()"
 			aria-label="Refresh"></md-button>
 	</div>
-
+    
+    <p class="text-center" ng-show="tabs.length == 0" style="margin-top: 20px;">
+        No groups defined yet.
+        <button class="md-button"
+            ng-click="$location.path('configuration/groups')">Add Group</button>
+    </p>
+    
 	<md-tabs md-stretch-tabs="always" class="section-tabs"
-		md-selected="selectedIndex"> <md-tab ng-repeat="tab in tabs"
+		md-selected="selectedIndex" ng-show="tabs.length > 0"> <md-tab ng-repeat="tab in tabs"
 		ng-disabled="tab.disabled" label="{{tab.label}}" layout-fill>
 	<md-tab-content layout-fill="">
 
-	<p class="text-center" ng-show="tabs.length == 0">
-		No groups defined yet.
-		<button class="md-button"
-			ng-click="$location.path('configuration/groups')">Add Group</button>
-	</p>
 	<p class="text-center"
 		ng-show="getItem(tabs[selectedIndex].name).members.length == 0">
 		Group is empty.

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/extensions.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/extensions.html
@@ -6,7 +6,7 @@
 	<md-tabs md-stretch-tabs="always" class="section-tabs"
 		md-selected="selectedIndex"> <md-tab
 		ng-repeat="extensionType in extensionTypes" ng-disabled="tab.disabled"
-		label="{{extensionTypeLabels[extensionType.typeId]}}" layout-fill>
+		label="{{extensionType.label}}" layout-fill>
 	<md-tab-content layout-fill="">
 	<div class="search" layout="row" layout-align="center center">
 		<md-icon ng-style="{'font-size': '24px'}" class="md-icon-search"></md-icon>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/preferences.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/preferences.html
@@ -30,7 +30,7 @@
 				<div class="form-group">
 					<md-checkbox ng-model="advancedMode">Advanced Mode</md-checkbox>
 					<p class="hint">
-						<small>When using AdvancedMode mode channels will not be enabled
+						<small>When using advanced mode mode channels will not be enabled
 							automatically.</small>
 					</p>
 				</div>


### PR DESCRIPTION
* Default route can be configured
* Installing and Uninstalling extensions clears binding and thing type cache
* Extension type tabs are sorted by the type definition from REST
* Existing enable/disable channel buttons are also used to link and unlink channels
* Further small fixes

Signed-off-by: Dennis Nobel <d.nobel@external.telekom.de>