### PR TITLE
added path to swagger annotations

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.id/src/main/java/org/eclipse/smarthome/core/id/internal/UUIDResource.java
+++ b/bundles/core/org.eclipse.smarthome.core.id/src/main/java/org/eclipse/smarthome/core/id/internal/UUIDResource.java
@@ -7,11 +7,6 @@
  */
 package org.eclipse.smarthome.core.id.internal;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -21,13 +16,18 @@ import javax.ws.rs.core.Response;
 import org.eclipse.smarthome.core.id.InstanceUUID;
 import org.eclipse.smarthome.io.rest.RESTResource;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 /**
  * This class acts as a REST resource for accessing the UUID of the instance
  *
  * @author Kai Kreuzer - Initial contribution and API
  */
 @Path(UUIDResource.PATH_UUID)
-@Api
+@Api(value = UUIDResource.PATH_UUID)
 public class UUIDResource implements RESTResource {
 
     public static final String PATH_UUID = "uuid";

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/binding/BindingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/binding/BindingResource.java
@@ -53,7 +53,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Yordan Zhelev - Added Swagger annotations
  */
 @Path(BindingResource.PATH_BINDINGS)
-@Api
+@Api(value = BindingResource.PATH_BINDINGS)
 public class BindingResource implements RESTResource {
 
     /** The URI path to this resource */

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/config/ConfigDescriptionResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/config/ConfigDescriptionResource.java
@@ -42,7 +42,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Dennis Nobel - Initial contribution
  */
 @Path(ConfigDescriptionResource.PATH_CONFIG_DESCRIPTIONS)
-@Api
+@Api(value = ConfigDescriptionResource.PATH_CONFIG_DESCRIPTIONS)
 public class ConfigDescriptionResource implements RESTResource {
 
     /** The URI path to this resource */

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/discovery/DiscoveryResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/discovery/DiscoveryResource.java
@@ -7,12 +7,6 @@
  */
 package org.eclipse.smarthome.io.rest.core.discovery;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
@@ -32,6 +26,12 @@ import org.eclipse.smarthome.io.rest.RESTResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 /**
  * This class acts as a REST resource for discovery and is registered with the
  * Jersey servlet.
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author Yordan Zhelev - Added Swagger annotations
  */
 @Path(DiscoveryResource.PATH_DISCOVERY)
-@Api
+@Api(value = DiscoveryResource.PATH_DISCOVERY)
 public class DiscoveryResource implements RESTResource {
 
     /** The URI path to this resource */

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/discovery/InboxResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/discovery/InboxResource.java
@@ -53,7 +53,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Yordan Zhelev - Added Swagger annotations
  */
 @Path(InboxResource.PATH_INBOX)
-@Api
+@Api(value = InboxResource.PATH_INBOX)
 public class InboxResource implements RESTResource {
 
     /** The URI path to this resource */

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/extensions/ExtensionResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/extensions/ExtensionResource.java
@@ -32,6 +32,7 @@ import org.eclipse.smarthome.io.rest.RESTResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
@@ -43,6 +44,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Kai Kreuzer - Initial contribution and API
  */
 @Path(ExtensionResource.PATH_EXTENSIONS)
+@Api(value = ExtensionResource.PATH_EXTENSIONS)
 public class ExtensionResource implements RESTResource {
 
     private static final String THREAD_POOL_NAME = "extensionService";

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
@@ -7,11 +7,6 @@
  */
 package org.eclipse.smarthome.io.rest.core.item;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -57,6 +52,12 @@ import org.eclipse.smarthome.io.rest.RESTResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 /**
  * <p>
  * This class acts as a REST resource for items and provides different methods to interact with them, like retrieving
@@ -80,7 +81,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @Path(ItemResource.PATH_ITEMS)
-@Api
+@Api(value = ItemResource.PATH_ITEMS)
 public class ItemResource implements RESTResource {
 
     private final Logger logger = LoggerFactory.getLogger(ItemResource.class);
@@ -132,8 +133,7 @@ public class ItemResource implements RESTResource {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get all available items.", response = EnrichedItemDTO.class, responseContainer = "List")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
-    public Response getItems(
-            @QueryParam("type") @ApiParam(value = "item type filter", required = false) String type,
+    public Response getItems(@QueryParam("type") @ApiParam(value = "item type filter", required = false) String type,
             @QueryParam("tags") @ApiParam(value = "item tag filter", required = false) String tags,
             @DefaultValue("false") @QueryParam("recursive") @ApiParam(value = "get member items recursivly", required = false) boolean recursive) {
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
@@ -166,7 +166,8 @@ public class ItemResource implements RESTResource {
     @ApiOperation(value = "Gets a single item.", response = EnrichedItemDTO.class)
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item not found") })
-    public Response getItemData(@PathParam("itemname") @ApiParam(value = "item name", required = true) String itemname) {
+    public Response getItemData(
+            @PathParam("itemname") @ApiParam(value = "item name", required = true) String itemname) {
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
 
         final Object responseObject = getItemDataBean(itemname);
@@ -178,9 +179,9 @@ public class ItemResource implements RESTResource {
     @Consumes(MediaType.TEXT_PLAIN)
     @ApiOperation(value = "Updates the state of an item.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 404, message = "Item not found"), @ApiResponse(code = 400, message = "Item state null") })
-    public Response putItemState(
-            @PathParam("itemname") @ApiParam(value = "item name", required = true) String itemname,
+            @ApiResponse(code = 404, message = "Item not found"),
+            @ApiResponse(code = 400, message = "Item state null") })
+    public Response putItemState(@PathParam("itemname") @ApiParam(value = "item name", required = true) String itemname,
             @ApiParam(value = "valid item state (e.g. ON, OFF)", required = true) String value) {
         Item item = getItem(itemname);
         if (item != null) {
@@ -286,8 +287,7 @@ public class ItemResource implements RESTResource {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 404, message = "Item or member item not found or item is not of type group item."),
             @ApiResponse(code = 405, message = "Member item is not editable.") })
-    public Response removeMember(
-            @PathParam("itemName") @ApiParam(value = "item name", required = true) String itemName,
+    public Response removeMember(@PathParam("itemName") @ApiParam(value = "item name", required = true) String itemName,
             @PathParam("memberItemName") @ApiParam(value = "member item name", required = true) String memberItemName) {
         try {
             Item item = itemRegistry.getItem(itemName);
@@ -387,7 +387,7 @@ public class ItemResource implements RESTResource {
 
     /**
      * Create or Update an item by supplying an item bean.
-     * 
+     *
      * @param itemname
      * @param item the item bean.
      * @return

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/link/ItemChannelLinkResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/link/ItemChannelLinkResource.java
@@ -31,8 +31,6 @@ import org.eclipse.smarthome.core.thing.link.dto.AbstractLinkDTO;
 import org.eclipse.smarthome.core.thing.link.dto.ItemChannelLinkDTO;
 import org.eclipse.smarthome.core.thing.link.dto.ItemThingLinkDTO;
 import org.eclipse.smarthome.io.rest.RESTResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Iterables;
 
@@ -48,14 +46,12 @@ import io.swagger.annotations.ApiResponses;
  * @author Dennis Nobel - Initial contribution
  * @author Yordan Zhelev - Added Swagger annotations
  */
-@Path(ItemChannelLinkResource.PATH_LLINKS)
-@Api
+@Path(ItemChannelLinkResource.PATH_LINKS)
+@Api(value = ItemChannelLinkResource.PATH_LINKS)
 public class ItemChannelLinkResource implements RESTResource {
 
-    private final Logger logger = LoggerFactory.getLogger(ItemChannelLinkResource.class);
-
     /** The URI path to this resource */
-    public static final String PATH_LLINKS = "links";
+    public static final String PATH_LINKS = "links";
 
     private ItemChannelLinkRegistry itemChannelLinkRegistry;
     private ItemThingLinkRegistry itemThingLinkRegistry;

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/service/ConfigurableServiceResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/service/ConfigurableServiceResource.java
@@ -49,7 +49,7 @@ import io.swagger.annotations.ApiResponses;
  *
  */
 @Path(ConfigurableServiceResource.PATH_SERVICES)
-@Api
+@Api(value = ConfigurableServiceResource.PATH_SERVICES)
 public class ConfigurableServiceResource implements RESTResource {
 
     /** The URI path to this resource */

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -75,7 +75,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Yordan Zhelev - Added Swagger annotations
  */
 @Path(ThingResource.PATH_THINGS)
-@Api
+@Api(value = ThingResource.PATH_THINGS)
 public class ThingResource implements RESTResource {
 
     private final Logger logger = LoggerFactory.getLogger(ThingResource.class);

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingTypeResource.java
@@ -59,7 +59,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Yordan Zhelev - Added Swagger annotations
  */
 @Path(ThingTypeResource.PATH_THINGS_TYPES)
-@Api
+@Api(value = ThingTypeResource.PATH_THINGS_TYPES)
 public class ThingTypeResource implements RESTResource {
 
     /** The URI path to this resource */

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/setup/ThingSetupManagerResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/setup/ThingSetupManagerResource.java
@@ -57,7 +57,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Yordan Zhelev - Added Swagger annotations
  */
 @Path(ThingSetupManagerResource.PATH_SETUP)
-@Api
+@Api(value = ThingSetupManagerResource.PATH_SETUP, hidden = true)
 public class ThingSetupManagerResource implements RESTResource {
 
     private final Logger logger = LoggerFactory.getLogger(ThingSetupManagerResource.class);
@@ -117,6 +117,7 @@ public class ThingSetupManagerResource implements RESTResource {
             String label = thingBean.item.label;
             List<String> groupNames = thingBean.item.groupNames;
 
+            @SuppressWarnings("deprecation")
             GroupItem thingGroupItem = thing.getLinkedItem();
             if (thingGroupItem != null) {
                 boolean labelChanged = false;
@@ -206,6 +207,7 @@ public class ThingSetupManagerResource implements RESTResource {
         Thing thing = thingSetupManager.getThing(new ThingUID(thingUID));
 
         if (thing != null) {
+            @SuppressWarnings("deprecation")
             GroupItem thingGroupItem = thing.getLinkedItem();
             if (thingGroupItem != null) {
                 boolean groupsChanged = setGroupNames(thingGroupItem, groupNames);

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -75,7 +75,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Yordan Zhelev - Added Swagger annotations
  */
 @Path(SitemapResource.PATH_SITEMAPS)
-@Api
+@Api(value = SitemapResource.PATH_SITEMAPS)
 public class SitemapResource implements RESTResource {
 
     private final Logger logger = LoggerFactory.getLogger(SitemapResource.class);

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/SseResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/SseResource.java
@@ -7,12 +7,6 @@
  */
 package org.eclipse.smarthome.io.rest.sse;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -37,17 +31,25 @@ import org.glassfish.jersey.media.sse.EventOutput;
 import org.glassfish.jersey.media.sse.SseBroadcaster;
 import org.glassfish.jersey.media.sse.SseFeature;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
 /**
  * SSE Resource for pushing events to currently listening clients.
- * 
+ *
  * @author Ivan Iliev - Initial Contribution and API
  * @author Yordan Zhelev - Added Swagger annotations
- * 
+ *
  */
-@Path("events")
+@Path(SseResource.PATH_EVENTS)
 @Singleton
-@Api
+@Api(value = SseResource.PATH_EVENTS, hidden = true)
 public class SseResource {
+
+    public final static String PATH_EVENTS = "events";
 
     private final SseBroadcaster broadcaster;
 
@@ -70,7 +72,7 @@ public class SseResource {
     /**
      * Subscribes the connecting client to the stream of events filtered by the
      * given eventFilter.
-     * 
+     *
      * @param eventFilter
      * @return {@link EventOutput} object associated with the incoming
      *         connection.
@@ -82,8 +84,8 @@ public class SseResource {
     @ApiOperation(value = "Get all events.", response = EventOutput.class)
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 400, message = "Topic is empty or contains invalid characters") })
-    public Object getEvents(@QueryParam("topics") @ApiParam(value = "topics") String eventFilter) throws IOException,
-            InterruptedException {
+    public Object getEvents(@QueryParam("topics") @ApiParam(value = "topics") String eventFilter)
+            throws IOException, InterruptedException {
 
         if (!SseUtil.isValidTopicFilter(eventFilter)) {
             return Response.status(Status.BAD_REQUEST).build();
@@ -116,7 +118,7 @@ public class SseResource {
     /**
      * Broadcasts an event described by the given parameter to all currently
      * listening clients.
-     * 
+     *
      * @param sseEventType
      *            the SSE event type
      * @param event


### PR DESCRIPTION
The Swagger UI requires the "value" parameter on the API annotation in order to group the methods of a resource within the UI.

Signed-off-by: Kai Kreuzer <kai@openhab.org>