### PR TITLE
channel group id can contain illegal item chars

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
@@ -680,7 +680,7 @@ public class ThingSetupManager implements EventSubscriber {
     }
 
     private String getChannelGroupItemName(String itemName, String channelGroupId) {
-        return itemName + "_" + channelGroupId;
+        return itemName + "_" + toItemName(channelGroupId);
     }
 
     private ItemFactory getItemFactoryForItemType(String itemType) {
@@ -706,8 +706,12 @@ public class ThingSetupManager implements EventSubscriber {
         return null;
     }
 
-    private String toItemName(UID uid) {
-        String itemName = uid.getAsString().replaceAll("[^a-zA-Z0-9_]", "_");
+    private String toItemName(final UID uid) {
+        return toItemName(uid.getAsString());
+    }
+
+    private String toItemName(final String uid) {
+        String itemName = uid.replaceAll("[^a-zA-Z0-9_]", "_");
         return itemName;
     }
 


### PR DESCRIPTION
If we use a channel group type multiple times in a thing type, we assign
different channel group ids to them.
Let's consider a thing that is using the channel group type "magic"
twice.

```text
...
<channel-groups>
    <channel-group id="magic-1" typeId="magic" />
    <channel-group id="magic-2" typeId="magic" />
</channel-groups>
...
```

A hyphen is a valid character for an ID, but it is not a valid character
for an item name.
If we are using the channel-group ID to generate an item name, we have
to call toItemName also for the ID.