### PR TITLE
Bug 482684 - ConfigDescriptionParameter methods should not return null

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigDescriptionParameterBuilderTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigDescriptionParameterBuilderTest.groovy
@@ -10,9 +10,7 @@ package org.eclipse.smarthome.config.core.test
 
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
-import static org.junit.matchers.JUnitMatchers
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
Fix for import error in ConfigDescriptionParameterBuilderTest.groovy

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=482684
Signed-off-by: Christoph Knauf  <christoph.knauf@itemis.de>