### PR TITLE
check for config description URI

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingFactory.java
@@ -110,15 +110,17 @@ public class ThingFactory {
 
         if (configDescriptionRegistry != null) {
             // Set default values to thing-configuration
-            ConfigDescription thingConfigDescription = configDescriptionRegistry
-                    .getConfigDescription(thingType.getConfigDescriptionURI());
-            if (thingConfigDescription != null) {
-                for (ConfigDescriptionParameter parameter : thingConfigDescription.getParameters()) {
-                    String defaultValue = parameter.getDefault();
-                    if (defaultValue != null && configuration.get(parameter.getName()) == null) {
-                        Object value = getDefaultValueAsCorrectType(parameter.getType(), defaultValue);
-                        if (value != null) {
-                            configuration.put(parameter.getName(), value);
+            if (thingType.hasConfigDescriptionURI()) {
+                ConfigDescription thingConfigDescription = configDescriptionRegistry
+                        .getConfigDescription(thingType.getConfigDescriptionURI());
+                if (thingConfigDescription != null) {
+                    for (ConfigDescriptionParameter parameter : thingConfigDescription.getParameters()) {
+                        String defaultValue = parameter.getDefault();
+                        if (defaultValue != null && configuration.get(parameter.getName()) == null) {
+                            Object value = getDefaultValueAsCorrectType(parameter.getType(), defaultValue);
+                            if (value != null) {
+                                configuration.put(parameter.getName(), value);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The argument uri for the function getConfigDescription of the
ConfigDescriptionRegistry must not be null.
So if we want to use the config description URI of a thing type, we
have to check if there is one first.