### PR TITLE
set label for channel group items

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingSetupManager.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingSetupManager.xml
@@ -13,6 +13,7 @@
    <reference bind="addThingHandlerFactory" cardinality="0..n" interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory" name="ThingHandlerFactory" policy="dynamic" unbind="removeThingHandlerFactory"/>
    <reference bind="addItemFactory" cardinality="0..n" interface="org.eclipse.smarthome.core.items.ItemFactory" name="ItemFactory" policy="dynamic" unbind="removeItemFactory"/>
    <reference bind="setThingTypeRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.type.ThingTypeRegistry" name="ThingTypeRegistry" policy="static" unbind="unsetThingTypeRegistry"/>
+   <reference bind="setChannelTypeRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry" name="ChannelTypeRegistry" policy="static" unbind="unsetChannelTypeRegistry"/>
    <reference bind="setItemChannelLinkRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry" name="ItemChannelLinkRegistry" policy="static" unbind="unsetItemChannelLinkRegistry"/>
    <reference bind="setThingRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="static" unbind="unsetThingRegistry"/>
    <reference bind="setItemThingLinkRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.link.ItemThingLinkRegistry" name="ItemThingLinkRegistry" policy="static" unbind="unsetItemThingLinkRegistry"/>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
@@ -42,7 +42,9 @@ import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.link.ItemThingLink;
 import org.eclipse.smarthome.core.thing.link.ItemThingLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.TypeResolver;
@@ -67,6 +69,7 @@ public class ThingSetupManager implements EventSubscriber {
     public static final String TAG_HOME_GROUP = "home-group";
     public static final String TAG_THING = "thing";
 
+    private ChannelTypeRegistry channelTypeRegistry;
     private ItemChannelLinkRegistry itemChannelLinkRegistry;
     private List<ItemFactory> itemFactories = new CopyOnWriteArrayList<>();
     private ItemRegistry itemRegistry;
@@ -538,6 +541,10 @@ public class ThingSetupManager implements EventSubscriber {
         this.thingHandlerFactories.remove(thingHandlerFactory);
     }
 
+    protected void setChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
+        this.channelTypeRegistry = channelTypeRegistry;
+    }
+
     protected void setItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
         this.itemChannelLinkRegistry = itemChannelLinkRegistry;
     }
@@ -556,6 +563,10 @@ public class ThingSetupManager implements EventSubscriber {
 
     protected void setThingTypeRegistry(ThingTypeRegistry thingTypeRegistry) {
         this.thingTypeRegistry = thingTypeRegistry;
+    }
+
+    protected void unsetChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
+        this.channelTypeRegistry = null;
     }
 
     protected void unsetItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
@@ -614,10 +625,13 @@ public class ThingSetupManager implements EventSubscriber {
         if (thingType != null) {
             List<ChannelGroupDefinition> channelGroupDefinitions = thingType.getChannelGroupDefinitions();
             for (ChannelGroupDefinition channelGroupDefinition : channelGroupDefinitions) {
-                GroupItem channelGroupItem = new GroupItem(
+                final ChannelGroupType channelGroupType = channelTypeRegistry
+                        .getChannelGroupType(channelGroupDefinition.getTypeUID());
+                final GroupItem channelGroupItem = new GroupItem(
                         getChannelGroupItemName(itemName, channelGroupDefinition.getId()));
                 channelGroupItem.addTag(TAG_CHANNEL_GROUP);
                 channelGroupItem.addGroupName(itemName);
+                channelGroupItem.setLabel(channelGroupType.getLabel());
                 addItemSafely(channelGroupItem);
             }
         }


### PR DESCRIPTION
A label is assigned to the channel group type. But that label is not
assigned to the created items for a specific group.
If we want to show a label for every item group, we need that
information.

Preparation for e.g. #561