### PR TITLE
Add GroupItemStateChangeEvent #596

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GenericItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GenericItemTest.groovy
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.items
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+
+import java.util.List
+import java.util.Set
+import javax.management.InstanceOfQueryExp
+import org.eclipse.smarthome.core.events.Event
+import org.eclipse.smarthome.core.events.EventPublisher
+import org.eclipse.smarthome.core.events.EventSubscriber
+import org.eclipse.smarthome.core.items.events.GroupItemStateChangedEvent
+import org.eclipse.smarthome.core.items.events.ItemEventFactory
+import org.eclipse.smarthome.core.items.events.ItemStateChangedEvent
+import org.eclipse.smarthome.core.items.events.ItemStateEvent
+import org.eclipse.smarthome.core.library.items.NumberItem
+import org.eclipse.smarthome.core.library.items.SwitchItem
+import org.eclipse.smarthome.core.library.types.RawType
+import org.eclipse.smarthome.core.types.Command
+import org.eclipse.smarthome.core.types.RefreshType
+import org.eclipse.smarthome.core.types.State
+import org.eclipse.smarthome.core.types.UnDefType
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.eclipse.smarthome.core.events.Event
+import org.eclipse.smarthome.core.items.TestItem
+import org.eclipse.smarthome.core.events.EventPublisher
+import org.junit.Before
+
+/**
+ * The GenericItemTest tests functionality of the GenericItem.
+ *
+ * @author Christoph Knauf - Initial contribution, event tests 
+ */
+class GenericItemTest {
+
+    List<Event> events = []
+    EventPublisher publisher
+
+    @Before
+    void setUp() {
+        publisher = [
+            post : { event ->
+                events.add(event)
+            }
+        ] as EventPublisher
+    }
+
+    @Test
+    void 'assert that item posts events for updates and changes correctly'() {
+        def item = new TestItem("member1")
+        item.setEventPublisher(publisher)
+        def oldState = item.getState()
+
+        //State changes -> one change event is fired
+        item.setState(new RawType())
+
+        def changes = events.findAll{it instanceof ItemStateChangedEvent}
+        def updates = events.findAll{it instanceof ItemStateEvent}
+
+        assertThat events.size(), is(1)
+        assertThat changes.size(), is(1)
+        assertThat updates.size(), is(0)
+
+        def change = changes.getAt(0) as ItemStateChangedEvent
+        assertTrue change.getItemName().equals(item.getName())
+        assertTrue change.getTopic().equals(
+                ItemEventFactory.ITEM_STATE_CHANGED_EVENT_TOPIC.replace("{itemName}", item.getName())
+                )
+        assertTrue change.getOldItemState().equals(oldState)
+        assertTrue change.getItemState().equals(item.getState())
+        assertTrue change.getType().equals(ItemStateChangedEvent.TYPE)
+
+        events.clear()
+
+        //State doesn't change -> no event is fired
+        item.setState(item.getState())
+        assertThat events.size(), is(0)
+    }
+
+
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/TestItem.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/TestItem.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.items; 
+
+import java.util.List;
+
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+
+/**
+ * {@link GenericItem} implementation used for testing. 
+ *
+ * @author Christoph Knauf - Initial contribution
+ */
+public class TestItem extends GenericItem {
+
+    public TestItem( String name) {
+        super("Test", name);
+    }
+
+    @Override
+    public List<Class<? extends State>> getAcceptedDataTypes() {
+        return null;
+    }
+
+    @Override
+    public List<Class<? extends Command>> getAcceptedCommandTypes() {
+        return null;
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemUpdater.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemUpdater.java
@@ -79,14 +79,7 @@ public class ItemUpdater extends AbstractItemEventSubscriber {
                     }
                 }
                 if (isAccepted) {
-                    State oldState = item.getState();
                     item.setState(newState);
-                    if (!oldState.equals(newState)) {
-                        EventPublisher eventPublisher = this.eventPublisher;
-                        if (eventPublisher != null) {
-                            eventPublisher.post(ItemEventFactory.createStateChangedEvent(itemName, newState, oldState));
-                        }
-                    }
                 } else {
                     logger.debug("Received update of a not accepted type (" + newState.getClass().getSimpleName()
                             + ") for item " + itemName);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -174,7 +174,7 @@ abstract public class GenericItem implements ActiveItem {
     }
 
     /**
-     * Sets new state and notifies listeners.
+     * Sets new state, notifies listeners and sends events.
      *
      * @param state
      *            new state of this item
@@ -183,20 +183,29 @@ abstract public class GenericItem implements ActiveItem {
         State oldState = this.state;
         this.state = state;
         notifyListeners(oldState, state);
+        if (!oldState.equals(state)) {
+            sendStateChangedEvent(state, oldState);
+        }
+    }
+
+    private void sendStateChangedEvent(State newState, State oldState) {
+        if (eventPublisher != null) {
+            eventPublisher.post(ItemEventFactory.createStateChangedEvent(this.name, newState, oldState));
+        }
     }
 
     public void send(RefreshType command) {
         internalSend(command);
     }
 
-    private void notifyListeners(State oldState, State newState) {
+    protected void notifyListeners(State oldState, State newState) {
         // if nothing has changed, we send update notifications
         Set<StateChangeListener> clonedListeners = null;
         clonedListeners = new CopyOnWriteArraySet<StateChangeListener>(listeners);
         for (StateChangeListener listener : clonedListeners) {
             listener.stateUpdated(this, newState);
         }
-        if (newState!=null && !newState.equals(oldState)) {
+        if (newState != null && !newState.equals(oldState)) {
             for (StateChangeListener listener : clonedListeners) {
                 listener.stateChanged(this, oldState, newState);
             }
@@ -244,58 +253,56 @@ abstract public class GenericItem implements ActiveItem {
         }
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((category == null) ? 0 : category.hashCode());
+        result = prime * result + ((label == null) ? 0 : label.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((tags == null) ? 0 : tags.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
 
     @Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result
-				+ ((category == null) ? 0 : category.hashCode());
-		result = prime * result + ((label == null) ? 0 : label.hashCode());
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		result = prime * result + ((tags == null) ? 0 : tags.hashCode());
-		result = prime * result + ((type == null) ? 0 : type.hashCode());
-		return result;
-	}
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        GenericItem other = (GenericItem) obj;
+        if (category == null) {
+            if (other.category != null)
+                return false;
+        } else if (!category.equals(other.category))
+            return false;
+        if (label == null) {
+            if (other.label != null)
+                return false;
+        } else if (!label.equals(other.label))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (tags == null) {
+            if (other.tags != null)
+                return false;
+        } else if (!tags.equals(other.tags))
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        return true;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		GenericItem other = (GenericItem) obj;
-		if (category == null) {
-			if (other.category != null)
-				return false;
-		} else if (!category.equals(other.category))
-			return false;
-		if (label == null) {
-			if (other.label != null)
-				return false;
-		} else if (!label.equals(other.label))
-			return false;
-		if (name == null) {
-			if (other.name != null)
-				return false;
-		} else if (!name.equals(other.name))
-			return false;
-		if (tags == null) {
-			if (other.tags != null)
-				return false;
-		} else if (!tags.equals(other.tags))
-			return false;
-		if (type == null) {
-			if (other.type != null)
-				return false;
-		} else if (!type.equals(other.type))
-			return false;
-		return true;
-	}
-
-	@Override
+    @Override
     public Set<String> getTags() {
         return ImmutableSet.copyOf(tags);
     }
@@ -357,10 +364,10 @@ abstract public class GenericItem implements ActiveItem {
 
     @Override
     public StateDescription getStateDescription(Locale locale) {
-        if(stateDescriptionProviders != null) {
+        if (stateDescriptionProviders != null) {
             for (StateDescriptionProvider stateDescriptionProvider : stateDescriptionProviders) {
                 StateDescription stateDescription = stateDescriptionProvider.getStateDescription(this.name, locale);
-                if(stateDescription != null) {
+                if (stateDescription != null) {
                     return stateDescription;
                 }
             }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -130,8 +130,8 @@ public class GroupItem extends GenericItem implements StateChangeListener {
                     acceptedDataTypes.retainAll(item.getAcceptedDataTypes());
                 }
             }
-            return acceptedDataTypes == null ? Collections.unmodifiableList(Collections.EMPTY_LIST) : Collections
-                    .unmodifiableList(acceptedDataTypes);
+            return acceptedDataTypes == null ? Collections.unmodifiableList(Collections.EMPTY_LIST)
+                    : Collections.unmodifiableList(acceptedDataTypes);
         }
     }
 
@@ -157,8 +157,8 @@ public class GroupItem extends GenericItem implements StateChangeListener {
                     acceptedCommandTypes.retainAll(item.getAcceptedCommandTypes());
                 }
             }
-            return acceptedCommandTypes == null ? Collections.unmodifiableList(Collections.EMPTY_LIST) : Collections
-                    .unmodifiableList(acceptedCommandTypes);
+            return acceptedCommandTypes == null ? Collections.unmodifiableList(Collections.EMPTY_LIST)
+                    : Collections.unmodifiableList(acceptedCommandTypes);
         }
     }
 
@@ -242,8 +242,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @{inheritDoc
      */
     @Override
-    public void stateChanged(Item item, State oldState, State newState) {
-        setState(function.calculate(members));
+    public void stateChanged(Item item, State oldState, State newState) { 
     }
 
     /**
@@ -251,7 +250,24 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      */
     @Override
     public void stateUpdated(Item item, State state) {
+        State oldState = this.state;
         setState(function.calculate(members));
+        if (!oldState.equals(this.state)) {
+            sendGroupStateChangedEvent(item.getName(), this.state, oldState);
+        }
+    }
+
+    public void setState(State state) {
+        State oldState = this.state;
+        this.state = state;
+        notifyListeners(oldState, state);
+    }
+
+    private void sendGroupStateChangedEvent(String memberName, State newState, State oldState) {
+        if (eventPublisher != null) {
+            eventPublisher.post(
+                    ItemEventFactory.createGroupStateChangedEvent(this.getName(), memberName, newState, oldState));
+        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.items.events;
+
+import org.eclipse.smarthome.core.types.State;
+
+/**
+ * {@link GroupItemStateChangedEvent}s can be used to deliver group item state changes through the Eclipse SmartHome
+ * event bus. In
+ * contrast to the {@link GroupItemStateEvent} the {@link GroupItemStateChangedEvent} is only sent if the state changed.
+ * State events must be created with the {@link ItemEventFactory}.
+ *
+ * @author Christoph Knauf - Initial contribution
+ */
+public class GroupItemStateChangedEvent extends ItemStateChangedEvent {
+
+    /**
+     * The group item state changed event type.
+     */
+    public final static String TYPE = GroupItemStateChangedEvent.class.getSimpleName();
+
+    private final String memberName;
+
+    protected GroupItemStateChangedEvent(String topic, String payload, String itemName, String memberName,
+            State newItemState, State oldItemState) {
+        super(topic, payload, itemName, newItemState, oldItemState);
+        this.memberName = memberName;
+    }
+
+    /**
+     * @return the name of the changed group member
+     */
+    public String getMemberName() {
+        return this.memberName;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return itemName + " changed from " + oldItemState.toString() + " to " + itemState.toString() + " through "
+                + memberName;
+
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java
@@ -24,11 +24,11 @@ public class ItemStateChangedEvent extends AbstractEvent {
      */
     public final static String TYPE = ItemStateChangedEvent.class.getSimpleName();
 
-    private final String itemName;
+    protected final String itemName;
 
-    private final State itemState;
+    protected final State itemState;
 
-    private final State oldItemState;
+    protected final State oldItemState;
 
     /**
      * Constructs a new item state changed event.


### PR DESCRIPTION
Assertions:
If a member of a group is changed then notify the observers of the member as well as the observers of the group about the changes.
If a member is added or removed from a group then notify the observers of the group about the added or removed member.
Observers of the group are informed about the name of the changed, added or removed member.
If one member is added or removed then one group change is fired.
If one member changes two changes are fired: one change for the member itself and one for the group.

Implementation:
GroupItems hold a State of type GroupType which contains the name of the added, removed or changed member and the type of the change as enumeration constant of type GroupChange (ADDED, REMOVED, CHANGED)
If a member is added, removed or changed the group notifies its observers about the changes. Therefore the method notifyObservers of class GenericItem is used. In order to use this method the visibility was changed from private to protected.
Extended the GroupItemTest to test the notification of observers.

Bug: Add GroupItemStateChangeEvent #596
Signed-off-by: Christoph Knauf  <christoph.knauf@itemis.de>