### PR TITLE
improve localization support

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/console/InboxConsoleCommandExtension.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/console/InboxConsoleCommandExtension.java
@@ -62,14 +62,13 @@ public class InboxConsoleCommandExtension extends AbstractConsoleCommandExtensio
                                 Thing thing = inbox.approve(thingUID, null);
                                 if (fullSetup) {
                                     thingSetupManager.createGroupItems(null, new ArrayList<String>(), thing,
-                                            result.getThingTypeUID());
+                                            result.getThingTypeUID(), null);
                                 }
                             } catch (Exception e) {
                                 console.println(e.getMessage());
                             }
                         } else {
-                            console.println(
-                                    "Cannot approve thing as setup manager is missing.");
+                            console.println("Cannot approve thing as setup manager is missing.");
                         }
                     } else {
                         console.println(

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/setup/ThingSetupManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/setup/ThingSetupManagerOSGiTest.groovy
@@ -250,7 +250,7 @@ class ThingSetupManagerOSGiTest extends OSGiTest {
         assertThat itemRegistry.getItems().size(), is(3)
         thingSetupManager.disableChannel(new ChannelUID(thingUID, "1"))
         assertThat itemRegistry.getItems().size(), is(2)
-        thingSetupManager.enableChannel(new ChannelUID(thingUID, "1"))
+        thingSetupManager.enableChannel(new ChannelUID(thingUID, "1"), null)
         assertThat itemRegistry.getItems().size(), is(3)
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/console/SetupConsoleCommandExtension.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/console/SetupConsoleCommandExtension.java
@@ -118,7 +118,7 @@ public class SetupConsoleCommandExtension extends AbstractConsoleCommandExtensio
     }
 
     private void enableChannel(Console console, String channelUID) {
-        thingSetupManager.enableChannel(new ChannelUID(channelUID));
+        thingSetupManager.enableChannel(new ChannelUID(channelUID), null);
         console.println("The channel \"" + channelUID + "\" was enabled.");
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
@@ -10,6 +10,7 @@ package org.eclipse.smarthome.core.thing.setup;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -160,6 +161,24 @@ public class ThingSetupManager implements EventSubscriber {
     @Deprecated
     public Thing addThing(ThingUID thingUID, Configuration configuration, ThingUID bridgeUID, String label,
             List<String> groupNames, boolean enableChannels) {
+        return addThing(thingUID, configuration, bridgeUID, label, groupNames, enableChannels, null);
+    }
+
+    /**
+     * Adds a new thing to the system and creates the according items and links.
+     *
+     * @param thingUID UID of the thing (must not be null)
+     * @param configuration configuration (must not be null)
+     * @param bridgeUID bridge UID (can be null)
+     * @param label label (can be null)
+     * @param groupNames list of group names, in which the thing should be added as member (must not be null)
+     * @param enableChannels defines if all not 'advanced' channels should be enabled directly
+     * @param locale locale
+     * @return created {@link Thing} instance (can be null)
+     */
+    @Deprecated
+    public Thing addThing(ThingUID thingUID, Configuration configuration, ThingUID bridgeUID, String label,
+            List<String> groupNames, boolean enableChannels, Locale locale) {
 
         if (thingUID == null) {
             throw new IllegalArgumentException("Thing UID must not be null");
@@ -167,7 +186,8 @@ public class ThingSetupManager implements EventSubscriber {
 
         ThingTypeUID thingTypeUID = thingUID.getThingTypeUID();
 
-        return addThing(thingTypeUID, thingUID, configuration, bridgeUID, label, groupNames, enableChannels);
+        return addThing(thingTypeUID, thingUID, configuration, bridgeUID, label, groupNames, enableChannels, null,
+                locale);
     }
 
     /**
@@ -194,8 +214,6 @@ public class ThingSetupManager implements EventSubscriber {
             List<String> groupNames, boolean enableChannels) {
         return addThing(thingTypeUID, null, configuration, bridgeUID, label, groupNames, enableChannels);
     }
-
-
 
     /**
      * Adds the given item to the given group.
@@ -254,10 +272,10 @@ public class ThingSetupManager implements EventSubscriber {
     /**
      * Enables the channel with the given UID (adds a linked item).
      *
-     * @param channelUID
-     *            channel UID (must not be null)
+     * @param channelUID channel UID (must not be null)
+     * @param locale the locale used for localized stuff
      */
-    public void enableChannel(ChannelUID channelUID) {
+    public void enableChannel(ChannelUID channelUID, Locale locale) {
         // Get the thing so we can check if channel labels are defined
         Thing thing = getThing(channelUID.getThingUID());
         if (thing == null) {
@@ -273,7 +291,7 @@ public class ThingSetupManager implements EventSubscriber {
         }
 
         // Enable the channel
-        ChannelType channelType = thingTypeRegistry.getChannelType(channel);
+        ChannelType channelType = thingTypeRegistry.getChannelType(channel, locale);
         if (channelType != null) {
             String itemType = channelType.getItemType();
             ItemFactory itemFactory = getItemFactoryForItemType(itemType);
@@ -540,14 +558,16 @@ public class ThingSetupManager implements EventSubscriber {
 
     private Thing addThing(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration,
             ThingUID bridgeUID, String label, List<String> groupNames, boolean enableChannels) {
-        return addThing(thingTypeUID, thingUID, configuration, bridgeUID, label, groupNames, enableChannels, null);
+        return addThing(thingTypeUID, thingUID, configuration, bridgeUID, label, groupNames, enableChannels, null,
+                null);
     }
 
     private Thing addThing(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration,
             ThingUID bridgeUID, String label, List<String> groupNames, boolean enableChannels,
-            Map<String, String> properties) {
+            Map<String, String> properties, Locale locale) {
 
-        Thing thing = ThingFactory.createThing(thingUID, configuration, properties,  bridgeUID, thingTypeUID, this.thingHandlerFactories);
+        Thing thing = ThingFactory.createThing(thingUID, configuration, properties, bridgeUID, thingTypeUID,
+                this.thingHandlerFactories);
 
         if (thing == null) {
             logger.warn("Cannot create thing. No binding found that supports creating a thing" + " of type {}.",
@@ -561,9 +581,9 @@ public class ThingSetupManager implements EventSubscriber {
             }
         }
         addThingSafely(thing);
-        createGroupItems(label, groupNames, thing, thingTypeUID);
+        createGroupItems(label, groupNames, thing, thingTypeUID, locale);
         if (enableChannels) {
-            enableChannels(thing, thingTypeUID);
+            enableChannels(thing, thingTypeUID, locale);
         }
         return thing;
     }
@@ -643,11 +663,12 @@ public class ThingSetupManager implements EventSubscriber {
 
     /**
      * Enables channels for given {@link Thing}
-     * 
+     *
      * @param thing the Thing
      * @param thingTypeUID the type UID of the thing
+     * @param locale the locale used for localized stuff
      */
-    public void enableChannels(Thing thing, ThingTypeUID thingTypeUID) {
+    public void enableChannels(Thing thing, ThingTypeUID thingTypeUID, Locale locale) {
         ThingType thingType = thingTypeRegistry.getThingType(thingTypeUID);
         if (thingType != null) {
             List<Channel> channels = thing.getChannels();
@@ -657,7 +678,7 @@ public class ThingSetupManager implements EventSubscriber {
                     // Enable the channel.
                     // Pass the channel label. This will be null if it's not set, and the enableChannel method will use
                     // the label from the channelType
-                    enableChannel(channel.getUID());
+                    enableChannel(channel.getUID(), locale);
                 } else if (channelType == null) {
                     logger.warn("Could not enable channel '{}', because no channel type was found.", channel.getUID());
                 }
@@ -667,13 +688,14 @@ public class ThingSetupManager implements EventSubscriber {
 
     /**
      * Add items for given Thing
-     * 
+     *
      * @param label the thing label
      * @param groupNames the item group names
      * @param thing the thing
      * @param typeUID the thing type UID
      */
-    public void createGroupItems(String label, List<String> groupNames, Thing thing, ThingTypeUID typeUID) {
+    public void createGroupItems(String label, List<String> groupNames, Thing thing, ThingTypeUID typeUID,
+            Locale locale) {
         ThingType thingType = thingTypeRegistry.getThingType(typeUID);
         String itemName = toItemName(thing.getUID());
         GroupItem groupItem = new GroupItem(itemName);
@@ -685,10 +707,13 @@ public class ThingSetupManager implements EventSubscriber {
         if (thingType != null) {
             List<ChannelGroupDefinition> channelGroupDefinitions = thingType.getChannelGroupDefinitions();
             for (ChannelGroupDefinition channelGroupDefinition : channelGroupDefinitions) {
+                final ChannelGroupType channelGroupType = channelTypeRegistry
+                        .getChannelGroupType(channelGroupDefinition.getTypeUID(), locale);
                 GroupItem channelGroupItem = new GroupItem(
                         getChannelGroupItemName(itemName, channelGroupDefinition.getId()));
                 channelGroupItem.addTag(TAG_CHANNEL_GROUP);
                 channelGroupItem.addGroupName(itemName);
+                channelGroupItem.setLabel(channelGroupType.getLabel());
                 addItemSafely(channelGroupItem);
             }
         }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/groovy/org/eclipse/smarthome/io/rest/core/discovery/InboxResourceOSGITest.groovy
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/groovy/org/eclipse/smarthome/io/rest/core/discovery/InboxResourceOSGITest.groovy
@@ -9,43 +9,20 @@ package org.eclipse.smarthome.io.rest.core.discovery
 
 import static org.junit.Assert.*
 
-import java.net.URI
-import java.net.URISyntaxException
-import java.util.ArrayList
-import java.util.Arrays
-import java.util.HashMap
-import java.util.List
-import java.util.Map
-
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.Response.*
 
-import org.eclipse.smarthome.config.core.ConfigDescription
-import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
-import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry
 import org.eclipse.smarthome.config.core.Configuration
-import org.eclipse.smarthome.config.discovery.DiscoveryResult
-import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder
-import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag
 import org.eclipse.smarthome.config.discovery.inbox.Inbox
-import org.eclipse.smarthome.config.discovery.inbox.InboxFilterCriteria
-import org.eclipse.smarthome.config.discovery.inbox.InboxListener
 import org.eclipse.smarthome.core.items.GroupItem
-import org.eclipse.smarthome.core.thing.Channel
 import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingRegistry
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
-import org.eclipse.smarthome.core.thing.link.ItemThingLink
 import org.eclipse.smarthome.core.thing.setup.ThingSetupManager
-import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition
-import org.eclipse.smarthome.core.thing.type.ChannelType
-import org.eclipse.smarthome.core.thing.type.ThingType
 import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry
-import org.eclipse.smarthome.core.thing.type.TypeResolver
-import org.eclipse.smarthome.io.rest.core.discovery.InboxResource
 import org.eclipse.smarthome.test.OSGiTest
 import org.junit.Before
 import org.junit.Test
@@ -72,36 +49,34 @@ class InboxResourceOSGITest extends OSGiTest {
         assertFalse thingTypeRegistry == null
         assertFalse configDescRegistry == null
         assertFalse resource == null
-   }
+    }
 
     @Test
     void 'assert that approve approves Things which are in the Inbox' () {
         inbox = [
-            approve :{
-                thingUID, label -> return testThing
-            }
+            approve :{ thingUID, label -> return testThing }
         ] as Inbox
         resource.setInbox(inbox)
         ThingSetupManager thingSetupManager = new ThingSetupManager(){
-            public void enableChannels(Thing thing, ThingTypeUID thingTypeUID) {
-            }
-            public void createGroupItems(String label, List<String> groupNames, Thing thing, ThingTypeUID typeUID) {
-            }
-        }
+                    public void enableChannels(Thing thing, ThingTypeUID thingTypeUID, Locale locale) {
+                    }
+                    public void createGroupItems(String label, List<String> groupNames, Thing thing, ThingTypeUID typeUID, Locale locale) {
+                    }
+                }
         resource.setThingSetupManager(thingSetupManager)
-        Response reponse = resource.approve(testThing.getUID().toString(), testThingLabel, false)
+        Response reponse = resource.approve(null, testThing.getUID().toString(), testThingLabel, false)
         assertTrue reponse.getStatusInfo() == Status.OK
     }
-    
+
     @Test
     void 'assert that approve dont approves Things which are not in the Inbox' () {
         inbox = [
-            approve :{
-                thingUID, label -> throw new IllegalArgumentException()
+            approve :{ thingUID, label ->
+                throw new IllegalArgumentException()
             }
         ] as Inbox
         resource.setInbox(inbox)
-        Response reponse = resource.approve(testThing.getUID().toString(), testThingLabel, false)
+        Response reponse = resource.approve(null, testThing.getUID().toString(), testThingLabel, false)
         assertTrue reponse.getStatusInfo() == Status.NOT_FOUND
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/setup/ThingSetupManagerResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/setup/ThingSetupManagerResource.java
@@ -79,9 +79,11 @@ public class ThingSetupManagerResource implements RESTResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Adds a new thing to the registry.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
-    public Response addThing(@ApiParam(value = "thing data", required = true) EnrichedThingDTO thingBean,
+    public Response addThing(@HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @ApiParam(value = "language") String language,
+            @ApiParam(value = "thing data", required = true) EnrichedThingDTO thingBean,
             @QueryParam("enableChannels") @DefaultValue("true") @ApiParam(value = "enable channels", required = false) boolean enableChannels)
                     throws IOException {
+        final Locale locale = LocaleUtil.getLocale(language);
 
         ThingUID thingUIDObject = new ThingUID(thingBean.UID);
         ThingUID bridgeUID = null;
@@ -93,7 +95,7 @@ public class ThingSetupManagerResource implements RESTResource {
         Configuration configuration = ThingResource.getConfiguration(thingBean);
 
         thingSetupManager.addThing(thingUIDObject, configuration, bridgeUID, thingBean.item.label,
-                thingBean.item.groupNames, enableChannels);
+                thingBean.item.groupNames, enableChannels, locale);
 
         return Response.ok().build();
     }
@@ -170,8 +172,11 @@ public class ThingSetupManagerResource implements RESTResource {
     @Path("/things/channels/{channelUID}")
     @ApiOperation(value = "Adds corresponding item and the link for the channel.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
-    public Response enableChannel(@PathParam("channelUID") @ApiParam(value = "channelUID") String channelUID) {
-        thingSetupManager.enableChannel(new ChannelUID(channelUID));
+    public Response enableChannel(
+            @HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) @ApiParam(value = "language") String language,
+            @PathParam("channelUID") @ApiParam(value = "channelUID") String channelUID) {
+        final Locale locale = LocaleUtil.getLocale(language);
+        thingSetupManager.enableChannel(new ChannelUID(channelUID), locale);
         return Response.ok().build();
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightHandlerOSGiTest.groovy
@@ -422,7 +422,7 @@ class HueLightHandlerOSGiTest extends OSGiTest {
         ThingSetupManager thingSetupManager = getService(ThingSetupManager)
 
         hueLight.getChannels().each {
-            thingSetupManager.enableChannel(it.UID)
+            thingSetupManager.enableChannel(it.UID, null)
         }
     }
 


### PR DESCRIPTION
Taken from: https://github.com/eclipse/smarthome/pull/671#issuecomment-162810507

> Note that the whole "SetupManager" is a functionality that I consider something optional (and e.g. not relevant for openHAB 2). Items should imho not be automatically created and there specifically should not be a "shadow structure" of a thing and its channels as items.

First note: It is relevant for the openHAB 2 auto approve service.

The ThingSetupManager contains seven public constructors (and one private) to allow to not explicitly set optional parameters.
If we want to add another optional attribute, we have to create a bunch of new constructors.
I created a class that holds that parameters and no there is only one public constructor.
If you create an object of that class you need only to give the two mandatory arguments but you can set the other ones, too.

I extended the enableChannel and the addThing implementation of the setup manager, so the caller could add a locale. If item labels are set automatically a localized one can be used now.

I added also the language support for them rest calls.

It is at least a nice feature if you want to use the setup manager to create items automatically.
If I do it with a set german locale, the items are using german labels (if supported by i18n binding stuff), too.