### PR TITLE
Added not null check for given URI in ThingConfigDescriptionProvider-…

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingConfigDescriptionProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingConfigDescriptionProvider.java
@@ -22,7 +22,7 @@ import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
  * method to get updated options.
  *
  * @author Chris Jackson - Initial Implementation
- *
+ * @author Thomas Höfer - Added not null check for given URI in getConfigDescription
  */
 public class ThingConfigDescriptionProvider implements ConfigDescriptionProvider {
     private ThingTypeRegistry thingTypeRegistry;
@@ -51,8 +51,8 @@ public class ThingConfigDescriptionProvider implements ConfigDescriptionProvider
 
     @Override
     public ConfigDescription getConfigDescription(URI uri, Locale locale) {
-        // If this is not a concrete thing, then return
-        if ("thing".equals(uri.getScheme()) == false) {
+        // If this is not a concrete thing or uri is null, then return
+        if (uri == null || "thing".equals(uri.getScheme()) == false) {
             return null;
         }
 


### PR DESCRIPTION
…getConfigDescription. Although through #648 and #535 NPEs were already fixed for config description URIs there can still be stack traces that lead to a NPE in ThingConfigDescriptionProvider, e.g. if there is a null URI passed to ConfigDescriptionRegistry

Signed-off-by: Thomas Höfer <t.hoefer@telekom.de>