### PR TITLE
Add constructor to create HSB from RGB.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/HSBTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/HSBTypeTest.java
@@ -7,18 +7,21 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 
 import org.junit.Test;
 
+/**
+ *
+ * @author Chris Jackson - added fromRGB() test
+ *
+ */
 public class HSBTypeTest {
 
     @Test
     public void testEquals() {
-
         HSBType hsb1 = new HSBType("53,86,1");
         HSBType hsb2 = new HSBType("53,86,1");
         assertTrue(hsb1.equals(hsb2));
@@ -26,23 +29,20 @@ public class HSBTypeTest {
         hsb1 = new HSBType("0,0,0");
         hsb2 = new HSBType("0,0,0");
         assertTrue(hsb1.equals(hsb2));
-
     }
 
     @Test
     public void testHsbToRgbConversion() {
-
-        compareValues("0,100,100", 255, 0, 0); // red
-        compareValues("360,100,100", 255, 0, 0); // red
-        compareValues("0,0,0", 0, 0, 0); // black
-        compareValues("0,0,100", 255, 255, 255); // white
-        compareValues("120,100,100", 0, 255, 0); // green
-        compareValues("240,100,100", 0, 0, 255); // blue
-        compareValues("229,37,62", 99, 110, 158); // blueish
-        compareValues("316,69,47", 119, 37, 97); // purple
-        compareValues("60,60,60", 153, 153, 61); // green
-        compareValues("300,100,40", 102, 0, 102);
-
+        compareHsbToRgbValues("0,100,100", 255, 0, 0); // red
+        compareHsbToRgbValues("360,100,100", 255, 0, 0); // red
+        compareHsbToRgbValues("0,0,0", 0, 0, 0); // black
+        compareHsbToRgbValues("0,0,100", 255, 255, 255); // white
+        compareHsbToRgbValues("120,100,100", 0, 255, 0); // green
+        compareHsbToRgbValues("240,100,100", 0, 0, 255); // blue
+        compareHsbToRgbValues("229,37,62", 99, 110, 158); // blueish
+        compareHsbToRgbValues("316,69,47", 119, 37, 97); // purple
+        compareHsbToRgbValues("60,60,60", 153, 153, 61); // green
+        compareHsbToRgbValues("300,100,40", 102, 0, 102);
     }
 
     private int convertPercentToByte(PercentType percent) {
@@ -50,8 +50,7 @@ public class HSBTypeTest {
                 .divide(BigDecimal.valueOf(100), 2, BigDecimal.ROUND_HALF_UP).intValue();
     }
 
-    private void compareValues(String hsbValues, int red, int green, int blue) {
-
+    private void compareHsbToRgbValues(String hsbValues, int red, int green, int blue) {
         HSBType hsb = new HSBType(hsbValues);
 
         System.out.println("HSB INPUT: " + hsbValues);
@@ -63,6 +62,31 @@ public class HSBTypeTest {
         assertEquals(red, convertPercentToByte(hsb.getRed()));
         assertEquals(green, convertPercentToByte(hsb.getGreen()));
         assertEquals(blue, convertPercentToByte(hsb.getBlue()));
+    }
 
+    @Test
+    public void testRgbToHsbConversion() {
+        compareRgbToHsbValues("0,100,100", 255, 0, 0); // red
+        compareRgbToHsbValues("0,0,0", 0, 0, 0); // black
+        compareRgbToHsbValues("0,0,100", 255, 255, 255); // white
+        compareRgbToHsbValues("120,100,100", 0, 255, 0); // green
+        compareRgbToHsbValues("240,100,100", 0, 0, 255); // blue
+        compareRgbToHsbValues("60,60,60", 153, 153, 61); // green
+        compareRgbToHsbValues("300,100,40", 102, 0, 102);
+        compareRgbToHsbValues("228,37,61", 99, 110, 158); // blueish
+        compareRgbToHsbValues("316,68,46", 119, 37, 97); // purple
+    }
+
+    private void compareRgbToHsbValues(String hsbValues, int red, int green, int blue) {
+        HSBType hsb = new HSBType(hsbValues);
+        HSBType hsbRgb = HSBType.fromRGB(red, green, blue);
+
+        System.out.println("HSB EXPECTED: " + hsbValues);
+        System.out.println(
+                "HSB ACTUAL  : " + hsbRgb.getHue() + "," + hsbRgb.getSaturation() + "," + hsbRgb.getBrightness());
+
+        assertEquals(hsb.getHue(), hsbRgb.getHue());
+        assertEquals(hsb.getSaturation(), hsbRgb.getSaturation());
+        assertEquals(hsb.getBrightness(), hsbRgb.getBrightness());
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.types.State;
  * brightness and can be used for color items.
  *
  * @author Kai Kreuzer - Initial contribution and API
+ * @author Chris Jackson - Added fromRGB
  *
  */
 public class HSBType extends PercentType implements ComplexType, State, Command {
@@ -65,6 +66,48 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
 
     public static HSBType valueOf(String value) {
         return new HSBType(value);
+    }
+
+    /**
+     * Create HSB from RGB
+     *
+     * @param r red 0-255
+     * @param g green 0-255
+     * @param b blue 0-255
+     */
+    public static HSBType fromRGB(int r, int g, int b) {
+        float tmpHue, tmpSaturation, tmpBrightness;
+        int max = (r > g) ? r : g;
+        if (b > max) {
+            max = b;
+        }
+        int min = (r < g) ? r : g;
+        if (b < min) {
+            min = b;
+        }
+        tmpBrightness = max / 2.55f;
+        tmpSaturation = (max != 0 ? ((float) (max - min)) / ((float) max) : 0) * 100;
+        if (tmpSaturation == 0) {
+            tmpHue = 0;
+        } else {
+            float red = ((float) (max - r)) / ((float) (max - min));
+            float green = ((float) (max - g)) / ((float) (max - min));
+            float blue = ((float) (max - b)) / ((float) (max - min));
+            if (r == max) {
+                tmpHue = blue - green;
+            } else if (g == max) {
+                tmpHue = 2.0f + red - blue;
+            } else {
+                tmpHue = 4.0f + green - red;
+            }
+            tmpHue = tmpHue / 6.0f * 360;
+            if (tmpHue < 0) {
+                tmpHue = tmpHue + 360.0f;
+            }
+        }
+
+        return new HSBType(new DecimalType((int) tmpHue), new PercentType((int) tmpSaturation),
+                new PercentType((int) tmpBrightness));
     }
 
     @Override
@@ -199,5 +242,4 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
         return percent.value.multiply(BigDecimal.valueOf(255))
                 .divide(BigDecimal.valueOf(100), 2, BigDecimal.ROUND_HALF_UP).intValue();
     }
-
 }


### PR DESCRIPTION
Currently there are methods to return RGB from HSB, but no constructor/method to create HSB from RGB.

I've found myself needing this for ZWave and BLE lights recently, so it seems like it might be useful as a constructor rather than putting it into my bindings...

Signed-off-by: Chris Jackson <chris@cd-jackson.com>