### PR TITLE
Paper UI: control, add support for channel groups

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/control.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/partials/control.html
@@ -1,45 +1,47 @@
 <section id="main" class="control header-tabs">
 	<div class="header-toolbar">
-		<md-button class="md-icon-refresh" ng-click="refresh()"
-			aria-label="Refresh"></md-button>
+		<md-button class="md-icon-refresh" ng-click="refresh()" aria-label="Refresh"></md-button>
 	</div>
-    
-    <p class="text-center" ng-show="tabs.length == 0" style="margin-top: 20px;">
-        No groups defined yet.
-        <button class="md-button"
-            ng-click="$location.path('configuration/groups')">Add Group</button>
-    </p>
-    
-	<md-tabs md-stretch-tabs="always" class="section-tabs"
-		md-selected="selectedIndex" ng-show="tabs.length > 0"> <md-tab ng-repeat="tab in tabs"
-		ng-disabled="tab.disabled" label="{{tab.label}}" layout-fill>
-	<md-tab-content layout-fill="">
 
-	<p class="text-center"
-		ng-show="getItem(tabs[selectedIndex].name).members.length == 0">
-		Group is empty.
-		<button class="md-button" ng-click="$location.path('setup/wizard')">Add
-			Thing</button>
+	<p class="text-center" ng-show="tabs.length == 0" style="margin-top: 20px;">
+		No groups defined yet.
+		<button class="md-button" ng-click="$location.path('configuration/groups')">Add Group</button>
 	</p>
-	<div ng-controller="ControlController" class="items row"
-		md-swipe-left="next()" md-swipe-right="prev()" ng-if="tabs[selectedIndex] === tab" ng-attr-id="{{'items-' + tabs.indexOf(tab)}}">
+
+	<md-tabs md-stretch-tabs="always" class="section-tabs" md-selected="selectedIndex" ng-show="tabs.length > 0">
+	<md-tab ng-repeat="tab in tabs" ng-disabled="tab.disabled" label="{{tab.label}}" layout-fill> <md-tab-content
+		layout-fill="">
+
+	<p class="text-center" ng-show="getItem(tabs[selectedIndex].name).members.length == 0">
+		Group is empty.
+		<button class="md-button" ng-click="$location.path('setup/wizard')">Add Thing</button>
+	</p>
+	<div ng-controller="ControlController" class="items row" md-swipe-left="next()" md-swipe-right="prev()"
+		ng-if="tabs[selectedIndex] === tab" ng-attr-id="{{'items-' + tabs.indexOf(tab)}}">
 		<div class="col-lg-4 col-sm-6 col-xs-12 item-wrapper"
 			ng-repeat="groupMemberItem in getItem(tabs[selectedIndex].name).members" on-finish-render="ngRepeatFinished">
-			<div class="card item {{groupMemberItem.type}}"
-				data-item-name="{{groupMemberItem.name}}">
+			<div class="card item {{groupMemberItem.type}}" data-item-name="{{groupMemberItem.name}}">
 				<div class="ibadge">
 					<span class="icon-x">
 				</div>
 				<div class="clabel" ng-if="groupMemberItem.type === 'GroupItem'">
 					<h3>{{groupMemberItem.label}}</h3>
 				</div>
-				<div class="" ng-repeat="item in groupMemberItem.members"
-					ng-if="groupMemberItem.type === 'GroupItem'">
-					<div ng-include="'partials/include.itemcontrol.html'"></div>
+				<div class="" ng-repeat="itemMember in groupMemberItem.members" ng-if="groupMemberItem.type === 'GroupItem'">
+					<div ng-if="itemMember.type === 'GroupItem'">
+						<h2>{{itemMember.label}}</h2>
+						<hr />
+					</div>
+					<div class="" ng-repeat="item in itemMember.members" ng-if="itemMember.type === 'GroupItem'">
+						<div ng-include="'partials/include.itemcontrol.html'"></div>
+						<hr ng-if="!$last" />
+					</div>
+					<div ng-init="item = itemMember" ng-if="itemMember.type !== 'GroupItem'">
+						<div ng-include="'partials/include.itemcontrol.html'"></div>
+					</div>
 					<hr ng-if="!$last" />
 				</div>
-				<div ng-init="item = groupMemberItem"
-					ng-if="groupMemberItem.type !== 'GroupItem'">
+				<div ng-init="item = groupMemberItem" ng-if="groupMemberItem.type !== 'GroupItem'">
 					<div ng-include="'partials/include.itemcontrol.html'"></div>
 				</div>
 			</div>


### PR DESCRIPTION
The control view of the Paper UI cannot handle items that has been created for Things with channel groups correctly.
Instead of display the channels of the channel group, only the channel group themselves is visible, no channel of that group.
This has been fixed by this commit.
It also using the formatter, so some indentation has been changed.