### PR TITLE
fix for missing bindings in karaf build extensions view

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/controllers.extension.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web/js/controllers.extension.js
@@ -13,7 +13,9 @@ angular.module('PaperUI.controllers.extension', ['PaperUI.constants']).controlle
             extensionService.getAll(function(extensions) {
                 angular.forEach(extensions, function(extension) {
                     var extensionType = $scope.getType(extension.type);
-                    extensionType.extensions.push(extension);
+                    if (extensionType !== undefined) {
+                        extensionType.extensions.push(extension);
+                    }
                 });
             });
         });


### PR DESCRIPTION
Avoid error that prevents the display of all the extensions

TypeError: Cannot read property 'extensions' of undefined
    at controllers.extension.js:16
    at Object.r [as forEach] (angular.min.js:7)
    at controllers.extension.js:14
    at angular-resource.min.js:10
    at angular.min.js:112
    at n.$eval (angular.min.js:126)
    at n.$digest (angular.min.js:123)
    at n.$apply (angular.min.js:127)
    at l (angular.min.js:81)
    at F (angular.min.js:85)