### PR TITLE
ignore the core.id.test userdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ distribution/smarthome/*.zip
 distribution/smarthome/runtime/etc/mapdb/storage.mapdb
 distribution/smarthome/runtime/etc/mapdb/storage.mapdb.p
 distribution/smarthome/runtime/etc/mapdb/storage.mapdb.t
+bundles/core/org.eclipse.smarthome.core.id.test/userdata/
 bundles/storage/org.eclipse.smarthome.storage.mapdb.test/userdata/mapdb/storage.mapdb
 bundles/storage/org.eclipse.smarthome.storage.mapdb.test/userdata/mapdb/storage.mapdb.p
 bundles/storage/org.eclipse.smarthome.storage.mapdb.test/userdata/mapdb/storage.mapdb.t


### PR DESCRIPTION
The directory is created and an uuid is placed there at test execution.
Git should ignore the whole userdata directory of that module.