### PR TITLE
updated jmdns url

### DIFF
--- a/targetplatform/smarthome.target
+++ b/targetplatform/smarthome.target
@@ -131,7 +131,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="javax.jmdns.feature.feature.group" version="3.4.2"/>
-<repository location="http://www.openhab.org/jmdns/update-site/3.4.2/"/>
+<repository location="http://www.jmdns.org/update-site/3.4.2/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
The url of the jmDNS update site has changed, it is therefore important to update the target platform.

Signed-off-by: Kai Kreuzer <kai@openhab.org>