### PR TITLE
fix timing dependend test execution

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/internal/items/ItemUpdaterOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/internal/items/ItemUpdaterOSGiTest.groovy
@@ -11,6 +11,8 @@ import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
+import java.util.concurrent.ConcurrentLinkedQueue
+
 import org.eclipse.smarthome.core.events.Event
 import org.eclipse.smarthome.core.events.EventPublisher
 import org.eclipse.smarthome.core.events.EventSubscriber
@@ -34,10 +36,9 @@ import com.google.common.collect.Sets
  */
 class ItemUpdaterOSGiTest extends OSGiTest {
 
-
     EventPublisher eventPublisher
     ItemRegistry itemRegistry
-    Event lastReceivedEvent
+    ConcurrentLinkedQueue<Event> receivedEvents
 
     @Before
     void setUp() {
@@ -45,12 +46,13 @@ class ItemUpdaterOSGiTest extends OSGiTest {
         eventPublisher = getService(EventPublisher)
         itemRegistry = getService(ItemRegistry)
         itemRegistry.add(new SwitchItem("switch"))
+        receivedEvents = new ConcurrentLinkedQueue<Event>()
         def eventSubscriber = [
             getSubscribedEventTypes: {
                 Sets.newHashSet(ItemStateChangedEvent.TYPE)
             },
             getEventFilter: { null },
-            receive: { event -> lastReceivedEvent = event }
+            receive: { event -> receivedEvents.add(event) }
         ] as EventSubscriber
         registerService(eventSubscriber)
     }
@@ -58,25 +60,48 @@ class ItemUpdaterOSGiTest extends OSGiTest {
     @Test
     void 'assert ItemUpdater sets item state'() {
         eventPublisher.post(ItemEventFactory.createStateEvent("switch", OnOffType.ON))
-
         SwitchItem switchItem = itemRegistry.get("switch")
-        waitForAssert { assertThat switchItem.state, is(OnOffType.ON) }
+        waitForAssert {
+            assertThat switchItem.state, is(OnOffType.ON)
+        }
     }
 
     @Test
     void 'assert ItemUpdater sends state changed event'() {
+        ItemStateChangedEvent changedEvent
+
         eventPublisher.post(ItemEventFactory.createStateEvent("switch", OnOffType.ON))
 
         SwitchItem switchItem = itemRegistry.get("switch")
-        waitForAssert { assertThat switchItem.state, is(OnOffType.ON) }
+        waitForAssert {
+            assertThat switchItem.state, is(OnOffType.ON)
+        }
 
         // change state
         eventPublisher.post(ItemEventFactory.createStateEvent("switch", OnOffType.OFF))
-        waitFor { lastReceivedEvent != null }
-        assertThat lastReceivedEvent.itemState, is(OnOffType.OFF)
-        assertThat lastReceivedEvent.oldItemState, is(OnOffType.ON)
 
-        lastReceivedEvent = null
+        // wait for an event that change the state from OFF to ON
+        // there could be one remaining event from the 'ItemUpdater sets item state' test
+        waitFor ({
+            if (receivedEvents.isEmpty()) {
+                return false;
+            }
+
+            changedEvent = (ItemStateChangedEvent)receivedEvents.poll();
+            if (changedEvent == null) {
+                return false;
+            }
+
+            if (changedEvent.oldItemState != OnOffType.ON) {
+                return false;
+            }
+
+            if (changedEvent.itemState != OnOffType.OFF) {
+                return false;
+            }
+
+            return true;
+        }, 10000)
 
         // send update for same state
         eventPublisher.post(ItemEventFactory.createStateEvent("switch", OnOffType.OFF))
@@ -85,6 +110,6 @@ class ItemUpdaterOSGiTest extends OSGiTest {
         Thread.sleep(100)
 
         // make sure no state changed event has been sent
-        assertThat lastReceivedEvent, is(null)
+        assertTrue(receivedEvents.isEmpty())
     }
 }


### PR DESCRIPTION
There are currently two tests in the ItemUpdateOSGiTest.
* ItemUpdater sets item state
* ItemUpdater sends state changed event

The "sets item state" test triggers a changed event
* UnDefType.NULL => OnOffType.ON

The "sends state changed event" test triggers a changed event
* OnOffType.ON => OnOffType.OFF

The first test does not check / reset the event.
The second test checks for the ON => OFF event.
If the first event is stored to "last event" but the second on is not
yet received, the check for "ON => OFF" will fail.

The receiving of the event is done asynchron, so we have to use correct
sync mechanism, too.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>