### PR TITLE
Add error message when auotmation's create rule REST call is faild.

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Import-Package: io.swagger.annotations;resolution:=optional,
  org.eclipse.smarthome.core.common,
  org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.io.rest,
+ org.eclipse.smarthome.io.rest.core,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/RuleResource.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/RuleResource.java
@@ -35,6 +35,7 @@ import org.eclipse.smarthome.automation.Trigger;
 import org.eclipse.smarthome.automation.rest.internal.dto.EnrichedRuleDTO;
 import org.eclipse.smarthome.io.rest.ConfigUtil;
 import org.eclipse.smarthome.io.rest.RESTResource;
+import org.eclipse.smarthome.io.rest.core.JSONResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +104,9 @@ public class RuleResource implements RESTResource {
             ruleRegistry.add(rule);
             return Response.status(Status.CREATED).build();
         } catch (IllegalArgumentException e) {
-            return Response.status(Status.CONFLICT).build();
+            String errMessage = "Creation of the rule is refused: " + e.getMessage();
+            logger.warn(errMessage);
+            return JSONResponse.createErrorResponse(Status.CONFLICT, errMessage);
         }
     }
 

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -50,7 +50,9 @@ Import-Package: com.google.common.base,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.slf4j
-Export-Package: org.eclipse.smarthome.io.rest.core.item,
+Export-Package: org.eclipse.smarthome.io.rest.core,
+ org.eclipse.smarthome.io.rest.core.internal,
+ org.eclipse.smarthome.io.rest.core.item,
  org.eclipse.smarthome.io.rest.core.thing
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/JSONResponse.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/JSONResponse.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.io.rest.core.internal;
+package org.eclipse.smarthome.io.rest.core;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -129,8 +129,9 @@ public class JSONResponse {
 
         // configure response
         ResponseBuilder rp = response(status);
-        if (null != ret)
+        if (null != ret) {
             rp = rp.entity(GSON.toJson(ret));
+        }
         return rp.build();
     }
 
@@ -140,7 +141,7 @@ public class JSONResponse {
      * @author Joerg Plewe
      */
     @Provider
-    static class ExceptionMapper implements javax.ws.rs.ext.ExceptionMapper<Exception> {
+    public static class ExceptionMapper implements javax.ws.rs.ext.ExceptionMapper<Exception> {
         /**
          * create JSON Response
          */

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/RESTCoreActivator.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/RESTCoreActivator.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.smarthome.io.rest.core.internal;
 
+import org.eclipse.smarthome.io.rest.core.JSONResponse;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
@@ -53,7 +53,7 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.eclipse.smarthome.io.rest.LocaleUtil;
 import org.eclipse.smarthome.io.rest.RESTResource;
-import org.eclipse.smarthome.io.rest.core.internal.JSONResponse;
+import org.eclipse.smarthome.io.rest.core.JSONResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -54,7 +54,7 @@ import org.eclipse.smarthome.core.thing.link.ManagedItemChannelLinkProvider;
 import org.eclipse.smarthome.io.rest.ConfigUtil;
 import org.eclipse.smarthome.io.rest.LocaleUtil;
 import org.eclipse.smarthome.io.rest.RESTResource;
-import org.eclipse.smarthome.io.rest.core.internal.JSONResponse;
+import org.eclipse.smarthome.io.rest.core.JSONResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Move the JSONResponce from org.eclipse.smarthome.io.rest.core.internal to org.eclipse.smarthome.io.rest.core package.

Signed-off-by: Yordan Mihaylov <j.mihailov@prosyst.com>