### PR TITLE
use DS for model.*.runtime

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Import-Package: org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.item
-Bundle-Activator: org.eclipse.smarthome.model.item.runtime.internal.ItemRuntimeActivator
+Service-Component: OSGI-INF/runtime.xml

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/OSGI-INF/runtime.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/OSGI-INF/runtime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.model.item.runtime">
+   <implementation class="org.eclipse.smarthome.model.item.runtime.internal.ItemRuntimeActivator"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.model.item.runtime.internal.ItemRuntimeActivator"/>
+   </service>
+</scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/build.properties
@@ -1,5 +1,6 @@
-source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               about.html
+               about.html,\
+               OSGI-INF/
+source.. = src/

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/src/org/eclipse/smarthome/model/item/runtime/internal/ItemRuntimeActivator.java
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/src/org/eclipse/smarthome/model/item/runtime/internal/ItemRuntimeActivator.java
@@ -8,23 +8,19 @@
 package org.eclipse.smarthome.model.item.runtime.internal;
 
 import org.eclipse.smarthome.model.ItemsStandaloneSetup;
-import org.osgi.framework.BundleActivator;
-import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ItemRuntimeActivator implements BundleActivator {
+public class ItemRuntimeActivator {
 
     private final Logger logger = LoggerFactory.getLogger(ItemRuntimeActivator.class);
 
-    @Override
-    public void start(BundleContext context) throws Exception {
+    public void activate() throws Exception {
         ItemsStandaloneSetup.doSetup();
         logger.debug("Registered 'item' configuration parser");
     }
 
-    @Override
-    public void stop(BundleContext context) throws Exception {
+    public void deactivate() throws Exception {
     }
 
 }

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/.project
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.persistence
-Bundle-Activator: org.eclipse.smarthome.model.persistence.runtime.internal.PersistenceRuntimeActivator
+Service-Component: OSGI-INF/runtime.xml

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/OSGI-INF/runtime.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/OSGI-INF/runtime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.model.persistence.runtime">
+   <implementation class="org.eclipse.smarthome.model.persistence.runtime.internal.PersistenceRuntimeActivator"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.model.persistence.runtime.internal.PersistenceRuntimeActivator"/>
+   </service>
+</scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/build.properties
@@ -1,5 +1,6 @@
-source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               about.html
+               about.html,\
+               OSGI-INF/
+source.. = src/

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/src/org/eclipse/smarthome/model/persistence/runtime/internal/PersistenceRuntimeActivator.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/src/org/eclipse/smarthome/model/persistence/runtime/internal/PersistenceRuntimeActivator.java
@@ -8,23 +8,19 @@
 package org.eclipse.smarthome.model.persistence.runtime.internal;
 
 import org.eclipse.smarthome.model.persistence.PersistenceStandaloneSetup;
-import org.osgi.framework.BundleActivator;
-import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PersistenceRuntimeActivator implements BundleActivator {
+public class PersistenceRuntimeActivator {
 
     private final Logger logger = LoggerFactory.getLogger(PersistenceRuntimeActivator.class);
 
-    @Override
-    public void start(BundleContext context) throws Exception {
+    public void activate() throws Exception {
         PersistenceStandaloneSetup.doSetup();
         logger.debug("Registered 'persistence' configuration parser");
     }
 
-    @Override
-    public void stop(BundleContext context) throws Exception {
+    public void deactivate() throws Exception {
     }
 
 }

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,8 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Service-Component: OSGI-INF/ruleengine.xml
+Service-Component: OSGI-INF/ruleengine.xml,
+ OSGI-INF/runtime.xml
 Import-Package: org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.items,
@@ -26,5 +27,4 @@ Import-Package: org.eclipse.smarthome.core.common.registry,
  org.quartz.utils,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.rule
-Bundle-Activator: org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator
 Export-Package: org.eclipse.smarthome.model.rule.runtime

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/runtime.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/runtime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.model.rule.runtime">
+   <implementation class="org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator"/>
+   </service>
+</scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/build.properties
@@ -1,6 +1,6 @@
-source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               OSGI-INF/,\
-               about.html
+               about.html,\
+               OSGI-INF/
+source.. = src/

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/RuleRuntimeActivator.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/RuleRuntimeActivator.java
@@ -10,7 +10,6 @@ package org.eclipse.smarthome.model.rule.runtime.internal;
 import org.eclipse.smarthome.model.core.ModelRepository;
 import org.eclipse.smarthome.model.rule.RulesStandaloneSetup;
 import org.eclipse.smarthome.model.script.engine.ScriptEngine;
-import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.Logger;
@@ -21,15 +20,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution and API
  */
-public class RuleRuntimeActivator implements BundleActivator {
+public class RuleRuntimeActivator {
 
     private final Logger logger = LoggerFactory.getLogger(RuleRuntimeActivator.class);
 
     public static ServiceTracker<ModelRepository, ModelRepository> modelRepositoryTracker;
     public static ServiceTracker<ScriptEngine, ScriptEngine> scriptEngineTracker;
 
-    @Override
-    public void start(BundleContext bc) throws Exception {
+    public void activate(BundleContext bc) throws Exception {
 
         RulesStandaloneSetup.doSetup();
         logger.debug("Registered 'rule' configuration parser");
@@ -41,8 +39,7 @@ public class RuleRuntimeActivator implements BundleActivator {
 
     }
 
-    @Override
-    public void stop(BundleContext context) throws Exception {
+    public void deactivate() throws Exception {
         modelRepositoryTracker.close();
         scriptEngineTracker.close();
     }

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
@@ -5,8 +5,8 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.script.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Service-Component: OSGI-INF/scriptengine.xml
+Service-Component: OSGI-INF/scriptengine.xml,
+ OSGI-INF/runtime.xml
 Import-Package: org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.script
-Bundle-Activator: org.eclipse.smarthome.model.script.runtime.internal.ScriptRuntimeActivator

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/OSGI-INF/runtime.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/OSGI-INF/runtime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.model.script.runtime">
+   <implementation class="org.eclipse.smarthome.model.script.runtime.internal.ScriptRuntimeActivator"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.model.script.runtime.internal.ScriptRuntimeActivator"/>
+   </service>
+</scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/build.properties
@@ -1,6 +1,7 @@
-source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
-               about.html
+               about.html,\
+               OSGI-INF/runtime.xml
+source.. = src/

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/ScriptRuntimeActivator.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/ScriptRuntimeActivator.java
@@ -7,23 +7,19 @@
  */
 package org.eclipse.smarthome.model.script.runtime.internal;
 
-import org.osgi.framework.BundleActivator;
-import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ScriptRuntimeActivator implements BundleActivator {
+public class ScriptRuntimeActivator {
 
     private final Logger logger = LoggerFactory.getLogger(ScriptRuntimeActivator.class);
 
-    @Override
-    public void start(BundleContext context) throws Exception {
+    public void activate() throws Exception {
         ScriptRuntimeStandaloneSetup.doSetup();
         logger.debug("Registered 'script' configuration parser");
     }
 
-    @Override
-    public void stop(BundleContext context) throws Exception {
+    public void deactivate() throws Exception {
     }
 
 }

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/.project
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
@@ -8,4 +8,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.sitemap
-Bundle-Activator: org.eclipse.smarthome.model.sitemap.runtime.internal.SitemapRuntimeActivator
+Service-Component: OSGI-INF/runtime.xml

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/OSGI-INF/runtime.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/OSGI-INF/runtime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.model.sitemap.runtime">
+   <implementation class="org.eclipse.smarthome.model.sitemap.runtime.internal.SitemapRuntimeActivator"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.model.sitemap.runtime.internal.SitemapRuntimeActivator"/>
+   </service>
+</scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/build.properties
@@ -1,5 +1,6 @@
-source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               about.html
+               about.html,\
+               OSGI-INF/
+source.. = src/

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/src/org/eclipse/smarthome/model/sitemap/runtime/internal/SitemapRuntimeActivator.java
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/src/org/eclipse/smarthome/model/sitemap/runtime/internal/SitemapRuntimeActivator.java
@@ -8,23 +8,19 @@
 package org.eclipse.smarthome.model.sitemap.runtime.internal;
 
 import org.eclipse.smarthome.model.SitemapStandaloneSetup;
-import org.osgi.framework.BundleActivator;
-import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SitemapRuntimeActivator implements BundleActivator {
+public class SitemapRuntimeActivator {
 
     private final Logger logger = LoggerFactory.getLogger(SitemapRuntimeActivator.class);
 
-    @Override
-    public void start(BundleContext context) throws Exception {
+    public void activate() throws Exception {
         SitemapStandaloneSetup.doSetup();
         logger.debug("Registered 'sitemap' configuration parser");
     }
 
-    @Override
-    public void stop(BundleContext context) throws Exception {
+    public void deactivate() throws Exception {
     }
 
 }

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/.project
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
@@ -8,5 +8,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.thing
-Bundle-Activator: org.eclipse.smarthome.model.thing.runtime.internal.ThingRuntimeActivator
+Service-Component: OSGI-INF/runtime.xml
 

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/OSGI-INF/runtime.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/OSGI-INF/runtime.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.model.thing.runtime">
+   <implementation class="org.eclipse.smarthome.model.thing.runtime.internal.ThingRuntimeActivator"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.model.thing.runtime.internal.ThingRuntimeActivator"/>
+   </service>
+</scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/build.properties
@@ -1,5 +1,6 @@
-source.. = src/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               about.html
+               about.html,\
+               OSGI-INF/
+source.. = src/

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/src/org/eclipse/smarthome/model/thing/runtime/internal/ThingRuntimeActivator.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/src/org/eclipse/smarthome/model/thing/runtime/internal/ThingRuntimeActivator.java
@@ -8,23 +8,19 @@
 package org.eclipse.smarthome.model.thing.runtime.internal;
 
 import org.eclipse.smarthome.model.thing.ThingStandaloneSetup;
-import org.osgi.framework.BundleActivator;
-import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ThingRuntimeActivator implements BundleActivator {
+public class ThingRuntimeActivator {
 
     private final Logger logger = LoggerFactory.getLogger(ThingRuntimeActivator.class);
 
-    @Override
-    public void start(BundleContext context) throws Exception {
+    public void activate() throws Exception {
         ThingStandaloneSetup.doSetup();
         logger.debug("Registered 'thing' configuration parser");
     }
 
-    @Override
-    public void stop(BundleContext context) throws Exception {
+    public void deactivate() throws Exception {
     }
 
 }


### PR DESCRIPTION
This is a proof of concept to have services to check if the model runtime has been started (other services could depend on them on so they are started after...).

I have a short test using openHAB 2 demo and all seems to be working.
Perhaps someone could give it a try.

Do you think this could help us?