### PR TITLE
Frontend log bundle

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.log/.classpath
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/.project
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.io.rest.log</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.7

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/META-INF/MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome UI Logging Handler
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.log;singleton:=true
+Bundle-Vendor: Eclipse.org
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Import-Package: io.swagger.annotations;resolution:=optional,
+ javax.ws.rs,
+ javax.ws.rs.core,
+ org.eclipse.smarthome.io.rest,
+ org.slf4j
+Service-Component: OSGI-INF/loghandler.xml

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/OSGI-INF/loghandler.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/OSGI-INF/loghandler.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.smarthome.io.rest.log.internal.LogHandler">
+   <implementation class="org.eclipse.smarthome.io.rest.log.internal.LogHandler"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.io.rest.RESTResource"/>
+   </service>
+</scr:component>

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/README.md
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/README.md
@@ -1,0 +1,122 @@
+FORMAT: 1A
+
+# Eclipse SmartHome UI Logging Bundle
+
+This Bundle provides a resource at the REST API to enable a consumer to fetch the set log levels.
+It also receives log messages which will be logged to the server's log.
+The last logged messages by this API can be requested to be displayed in UIs.
+
+Meta: This document is in normal markdown format,
+but also compatible to [Apiary](apiary.com) for automatic doc generation and API testing.
+
+## Log levels [/rest/log/levels]
+
+### Get enabled log levels [GET]
+
+ This depends on the current log settings at the backend.
+
+
++ Response 200 (application/json)
+
+        {
+            "warn": true,
+            "error": true,
+            "debug": true,
+            "info": true
+        }
+
+
+## Log [/rest/log]
+
+### Send log message [POST]
+
++ Request (application/json)
+
+    + Attributes
+        + severity (enum[string], required) - The severity of the log message
+            + Members
+                + `error`
+                + `warn`
+                + `info`
+                + `debug`
+
+        + url (string, optional) - The URL where the log event ocurred.
+        + message (string, optional) - The message to log.
+
+    + Body
+
+            {
+                "severity" : "error",
+                "url" : "http://exmple.org/",
+                "message" : "A test message"
+            }
+
++ Response 200
+
++ Response 403 (application/json)
+
+    + Attributes
+        + error (string)
+        + severity (string)
+
+    + Body
+
+            {
+                 "error": "Your log severity is not supported.",
+                 "severity": "info"
+            }
+
+
+## Log [/rest/log/{limit}]    
+
+### Get last log messages [GET]
+
+Return the last log entries received by `/rest/log/`.
+
+
++ Parameters
+    + limit (number, optional) - Limit the amount of messages.
+
+        On invalid input, limit is set to it's default.
+
+        + Default: 500
+
++ Response 200 (application/json)
+
+    + Attributes
+        + timestamp (number) - UTC milliseconds from the epoch.
+
+            In JavaScript, you can use this value for constructing a `Date`.
+
+        + severity (enum[string])
+            + Members
+                + `error`
+                + `warn`
+                + `info`
+                + `debug`
+
+        + url (string)
+        + message (string)
+
+    + Body
+
+            [
+              {
+                "timestamp": 1450531459479,
+                "severity": "error",
+                "url": "http://example.com/page1",
+                "message": "test 5"
+              },
+              {
+                "timestamp": 1450531459655,
+                "severity": "error",
+                "url": "http://example.com/page1",
+                "message": "test 6"
+              },
+              {
+                "timestamp": 1450531460038,
+                "severity": "error",
+                "url": "http://example.com/page2",
+                "message": "test 7"
+              }
+            ]        

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/about.html
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 5, 2006</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+        
+</body>
+</html>

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/build.properties
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/build.properties
@@ -1,0 +1,7 @@
+source.. = src/main/java/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               about.html
+

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.smarthome.bundles</groupId>
+		<artifactId>io</artifactId>
+		<version>0.9.0-SNAPSHOT</version>
+	</parent>
+
+	<properties>
+		<bundle.symbolicName>org.eclipse.smarthome.io.rest.log</bundle.symbolicName>
+		<bundle.namespace>org.eclipse.smarthome.io.rest.log</bundle.namespace>
+	</properties>
+
+	<artifactId>org.eclipse.smarthome.io.rest.log</artifactId>
+	<groupId>org.eclipse.smarthome.io</groupId>
+
+	<name>Eclipse SmartHome Core REST UI Logging Module</name>
+
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/LogConstants.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/LogConstants.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.rest.log;
+
+/**
+ * The {@link LogConstants} class defines common constants, which are
+ * used across the whole module.
+ *
+ * @author Sebastian Janzen - Initial contribution
+ */
+public class LogConstants {
+
+    // Log and response message to express, that the log severity addressed is not handled.
+    public static final String LOG_SEVERITY_IS_NOT_SUPPORTED = "Your log severity is not supported.";
+    public static final String LOG_HANDLE_ERROR = "Internal logging error.";
+
+    // slf4j log pattern to format received log messages, params are URL and message
+    public static final String FRONTEND_LOG_PATTERN = "Frontend Log ({}): {}";
+
+    public static final int LOG_BUFFER_LIMIT = 500;
+
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.rest.log.internal;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.smarthome.io.rest.RESTResource;
+import org.eclipse.smarthome.io.rest.log.LogConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+@Path("/log")
+@Api(value = LogHandler.PATH_LOG)
+@Produces(MediaType.APPLICATION_JSON)
+public class LogHandler implements RESTResource {
+
+    private final Logger logger = LoggerFactory.getLogger(LogHandler.class);
+    public static final String PATH_LOG = "log";
+
+    private final static String TEMPLATE_INTERNAL_ERROR = "{\"error\":\"%s\",\"severity\":\"%s\"}";
+
+    /**
+     * Rolling array to store the last LOG_BUFFER_LIMIT messages. Those can be fetched e.g. by a
+     * diagnostic UI to display errors of other clients, where e.g. the logs are not easily accessible.
+     */
+    private final ConcurrentLinkedDeque<LogMessage> LOG_BUFFER = new ConcurrentLinkedDeque<>();
+
+    /**
+     * Container for a log message
+     */
+    public class LogMessage {
+        public long timestamp;
+        public String severity;
+        public URL url;
+        public String message;
+    }
+
+    @GET
+    @Path("/levels")
+    @ApiOperation(value = "Get log severities, which are logged by the current logger settings.", code = 200, notes = "This depends on the current log settings at the backend.")
+    public Response getLogLevels() {
+        return Response.ok(createLogLevelsMap()).build();
+    }
+
+    @GET
+    @ApiOperation(value = "Returns the last logged frontend messages. The amount is limited to the "
+            + LogConstants.LOG_BUFFER_LIMIT + " last entries.")
+    @ApiParam(name = "limit", allowableValues = "range[1, " + LogConstants.LOG_BUFFER_LIMIT + "]")
+    public Response getLastLogs(@DefaultValue(LogConstants.LOG_BUFFER_LIMIT + "") @QueryParam("limit") Integer limit) {
+        if (LOG_BUFFER.size() <= 0) {
+            return Response.ok("[]").build();
+        }
+
+        if (limit == null || limit <= 0 || limit > LogConstants.LOG_BUFFER_LIMIT) {
+            limit = LOG_BUFFER.size();
+        }
+
+        if (limit >= LOG_BUFFER.size()) {
+            return Response.ok(LOG_BUFFER.toArray()).build();
+        } else {
+            final List<LogMessage> result = new ArrayList<>();
+            Iterator<LogMessage> iter = LOG_BUFFER.descendingIterator();
+            do {
+                result.add(iter.next());
+            } while (iter.hasNext() && result.size() < limit);
+            Collections.reverse(result);
+            return Response.ok(result).build();
+        }
+
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Log a frontend log message to the backend.")
+    @ApiParam(name = "logMessage", value = "Severity is required and can be one of error, warn, info or debug, depending on activated severities which you can GET at /logLevels.", example = "{\"severity\": \"error\", \"url\": \"http://example.org\", \"message\": \"Error message\"}")
+    @ApiResponses({ @ApiResponse(code = 200, message = "OK"),
+            @ApiResponse(code = 403, message = LogConstants.LOG_SEVERITY_IS_NOT_SUPPORTED) })
+    public Response log(final LogMessage logMessage) {
+        if (logMessage == null) {
+            logger.debug("Received null log message model!");
+            return Response.status(500).entity(String.format(TEMPLATE_INTERNAL_ERROR, LogConstants.LOG_HANDLE_ERROR))
+                    .build();
+        }
+        logMessage.timestamp = Calendar.getInstance().getTimeInMillis();
+
+        if (!doLog(logMessage)) {
+            return Response.status(403).entity(String.format(TEMPLATE_INTERNAL_ERROR,
+                    LogConstants.LOG_SEVERITY_IS_NOT_SUPPORTED, logMessage.severity)).build();
+        }
+
+        LOG_BUFFER.add(logMessage);
+        if (LOG_BUFFER.size() > LogConstants.LOG_BUFFER_LIMIT) {
+            LOG_BUFFER.pollLast(); // Remove last element of Deque
+        }
+
+        return Response.ok().build();
+    }
+
+    /**
+     * Executes the logging call.
+     *
+     * @param logMessage
+     * @return Falls if severity is not supported, true if successfully logged.
+     */
+    private boolean doLog(LogMessage logMessage) {
+        switch (logMessage.severity.toLowerCase()) {
+            case "error":
+                logger.error(LogConstants.FRONTEND_LOG_PATTERN, logMessage.url, logMessage.message);
+                break;
+            case "warn":
+                logger.warn(LogConstants.FRONTEND_LOG_PATTERN, logMessage.url, logMessage.message);
+                break;
+            case "info":
+                logger.info(LogConstants.FRONTEND_LOG_PATTERN, logMessage.url, logMessage.message);
+                break;
+            case "debug":
+                logger.debug(LogConstants.FRONTEND_LOG_PATTERN, logMessage.url, logMessage.message);
+                break;
+            default:
+                return false;
+        }
+        return true;
+    }
+
+    /**
+     * Return map of currently logged messages. They can change at runtime.
+     */
+    private Map<String, Boolean> createLogLevelsMap() {
+        Map<String, Boolean> result = new HashMap<>();
+        result.put("error", logger.isErrorEnabled());
+        result.put("warn", logger.isWarnEnabled());
+        result.put("info", logger.isInfoEnabled());
+        result.put("debug", logger.isDebugEnabled());
+        return result;
+    }
+
+}

--- a/bundles/io/pom.xml
+++ b/bundles/io/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="MACROMAN"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
@@ -31,6 +31,7 @@
     <module>org.eclipse.smarthome.io.rest.sse</module>
     <module>org.eclipse.smarthome.io.rest.sse.test</module>
     <module>org.eclipse.smarthome.io.rest.sitemap</module>
+    <module>org.eclipse.smarthome.io.rest.log</module>
     <module>org.eclipse.smarthome.io.rest.voice</module>
     <module>org.eclipse.smarthome.io.transport.dbus</module>
     <module>org.eclipse.smarthome.io.transport.mdns</module>

--- a/features/org.eclipse.smarthome.feature.runtime.rest/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.rest/feature.xml
@@ -59,7 +59,7 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-		 
+
    <plugin
          id="org.eclipse.smarthome.io.rest.sse"
          download-size="0"
@@ -69,6 +69,13 @@
 
    <plugin
          id="org.eclipse.smarthome.io.rest.voice"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.smarthome.io.rest.log"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
As announced at [Eclipse Forum](https://www.eclipse.org/forums/index.php?t=msg&th=1072176&goto=1714706&#msg_1714706), I've implemented a UI-Log receiver.

I added a README which is normal Markdown but also a valid [API Blueprint](https://apiblueprint.org/) document, which can be used in e.g. [Apiary](https://apiary.io).

The PR for PaperUI will come later on.

Signed-off-by: Sebastian Janzen sebastian.janzen@innoq.com
