### PR TITLE
fixes #774: Guard GenericItem#addGroupName 

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GenericItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GenericItemTest.groovy
@@ -10,35 +10,19 @@ package org.eclipse.smarthome.core.items
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 
-import java.util.List
-import java.util.Set
-import javax.management.InstanceOfQueryExp
 import org.eclipse.smarthome.core.events.Event
 import org.eclipse.smarthome.core.events.EventPublisher
-import org.eclipse.smarthome.core.events.EventSubscriber
-import org.eclipse.smarthome.core.items.events.GroupItemStateChangedEvent
 import org.eclipse.smarthome.core.items.events.ItemEventFactory
 import org.eclipse.smarthome.core.items.events.ItemStateChangedEvent
 import org.eclipse.smarthome.core.items.events.ItemStateEvent
-import org.eclipse.smarthome.core.library.items.NumberItem
-import org.eclipse.smarthome.core.library.items.SwitchItem
 import org.eclipse.smarthome.core.library.types.RawType
-import org.eclipse.smarthome.core.types.Command
-import org.eclipse.smarthome.core.types.RefreshType
-import org.eclipse.smarthome.core.types.State
-import org.eclipse.smarthome.core.types.UnDefType
-import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import org.eclipse.smarthome.core.events.Event
-import org.eclipse.smarthome.core.items.TestItem
-import org.eclipse.smarthome.core.events.EventPublisher
-import org.junit.Before
 
 /**
  * The GenericItemTest tests functionality of the GenericItem.
  *
- * @author Christoph Knauf - Initial contribution, event tests 
+ * @author Christoph Knauf - Initial contribution, event tests
  */
 class GenericItemTest {
 
@@ -86,6 +70,21 @@ class GenericItemTest {
         assertThat events.size(), is(0)
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    void 'assert that null as group name is not allowed for addGroupName'() {
+        def item = new TestItem("member1")
+        item.addGroupName(null)
+    }
 
+    @Test(expected = IllegalArgumentException.class)
+    void 'assert that null as group name is not allowed for addGroupNames'() {
+        def item = new TestItem("member1")
+        item.addGroupNames(["group-a", null, "group-b"])
+    }
 
+    @Test(expected = IllegalArgumentException.class)
+    void 'assert that null as group name is not allowed for removeGroupName'() {
+        def item = new TestItem("member1")
+        item.removeGroupName(null)
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -35,7 +35,7 @@ import com.google.common.collect.ImmutableSet;
  * The abstract base class for all items. It provides all relevant logic
  * for the infrastructure, such as publishing updates to the event bus
  * or notifying listeners.
- * 
+ *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Andre Fuechsel - Added tags
  * @author Stefan Bußweiler - Migration to new ESH event concept
@@ -125,9 +125,14 @@ abstract public class GenericItem implements ActiveItem {
      *
      * @param groupItemName
      *            group item name to add
+     *
+     * @throws IllegalArgumentException if groupItemName is {@code null}
      */
     @Override
     public void addGroupName(String groupItemName) {
+        if (groupItemName == null) {
+            throw new IllegalArgumentException("Group item name must not be null!");
+        }
         if (!groupNames.contains(groupItemName)) {
             groupNames.add(groupItemName);
         }
@@ -152,9 +157,14 @@ abstract public class GenericItem implements ActiveItem {
      *
      * @param groupItemName
      *            group item name to remove
+     *
+     * @throws IllegalArgumentException if groupItemName is {@code null}
      */
     @Override
     public void removeGroupName(String groupItemName) {
+        if (groupItemName == null) {
+            throw new IllegalArgumentException("Group item name must not be null!");
+        }
         groupNames.remove(groupItemName);
     }
 


### PR DESCRIPTION
GenericItem#addGroupName and #addGroupNames do not allow null as parameter. An InvalidArgumentException is thrown.

Signed-off-by: Andre Fuechsel <a.fuechsel@telekom.de>