### PR TITLE
Make last swagger dependency optional.

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.base,
  com.google.common.collect,
  com.google.gson,
- io.swagger.annotations,
+ io.swagger.annotations;resolution:=optional,
  javax.servlet,
  javax.servlet.http,
  javax.ws.rs,


### PR DESCRIPTION
This fixes a build problem in openhab-core.

Signed-off-by: Davy Vanherbergen <davy.vanherbergen@gmail.com>