### PR TITLE
Bugfix: Unwrap the double quotes

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -431,6 +431,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         // if an icon is defined for the widget, use it
         if (w.getIcon() != null) {
             category = w.getIcon();
+            // Unwrap quotes
+            category = category.replaceAll("^\"(.*)\"$", "$1");
         } else {
             // otherwise check if any item ui provider provides an icon for this item
             String itemName = w.getItem();


### PR DESCRIPTION
Every time a sitemap explicitely defines an icon, it results in `""category""` which is escaped and result in an wrong icon-path. See demo sitemap with classicui to reproduce.

I wondered, is this is really a bug and this is the correct fix. Should be reviewed really carefully! (That one line)

Signed-off-by: Sebastian Janzen <sebastian@janzen.it>