### PR TITLE
ScriptEngine: Expose ScriptEngine as OSGI-Bundle, ScriptExtension, GlobalScope optimization

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/ScriptEngineProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/ScriptEngineProvider.java
@@ -1,0 +1,271 @@
+package org.eclipse.smarthome.automation.module.script;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineFactory;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.SimpleBindings;
+
+import org.eclipse.smarthome.automation.module.script.internal.ScriptExtensionManager;
+import org.eclipse.smarthome.automation.module.script.internal.handler.AbstractScriptModuleHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Joiner;
+
+public class ScriptEngineProvider {
+    private static final Logger logger = LoggerFactory.getLogger(ScriptEngineProvider.class);
+
+    private final static ScriptEngineManager engineManager = new ScriptEngineManager();
+
+    private static Set<ScriptScopeProvider> scriptScopeProviders = new CopyOnWriteArraySet<ScriptScopeProvider>();
+
+    private static ScriptEngine nashornEngine = null;
+
+    // global binding which is used for the Nashorn-ScriptEngine
+    private static SimpleBindings nashornGlobalBinding;
+
+    public static List<String> getScriptLanguages() {
+        ArrayList<String> languages = new ArrayList<>();
+
+        for (ScriptEngineFactory f : engineManager.getEngineFactories()) {
+            languages.addAll(f.getExtensions());
+        }
+
+        return languages;
+    }
+
+    public static boolean isNashorn(ScriptEngine engine) {
+        return engine != null && engine.getFactory().getEngineName().toLowerCase().endsWith("nashorn");
+    }
+
+    /**
+     * Gets the instance of a script engine of a given type
+     *
+     * @param type the mime type of the desired script engine
+     *
+     * @return a script engine that supports scripts of the given mime type
+     */
+    public static ScriptEngine getScriptEngine(String type) {
+        ScriptEngine engine = engineManager.getEngineByMimeType(type);
+        if (engine == null) {
+            engine = engineManager.getEngineByName(type);
+        }
+
+        if (engine == null) {
+            engine = engineManager.getEngineByExtension(type);
+        }
+
+        if (engine != null) {
+            if (isNashorn(engine)) {
+                if (nashornEngine == null) {
+                    nashornEngine = engineManager.getEngineByExtension("js");
+                    nashornGlobalBinding = new SimpleBindings();
+
+                    for (ScriptScopeProvider provider : scriptScopeProviders) {
+                        initializeNashornScope(nashornEngine, provider);
+                    }
+                }
+
+                engine.setBindings(nashornGlobalBinding, ScriptContext.GLOBAL_SCOPE);
+            }
+
+            // import default presets from script extensions
+
+            boolean isNashorn = isNashorn(engine);
+            for (ScriptExtensionProvider provider : ScriptExtensionManager.getScriptExtensionProviders()) {
+                Collection<String> presets = provider.getDefaultPresets();
+                if (presets.size() > 0) {
+                    logger.debug("importing presets: {}", presets);
+
+                    for (String preset : presets) {
+                        scopeValues(engine, provider.importPreset(engine.hashCode(), preset), isNashorn);
+                    }
+                }
+            }
+
+            HashMap<String, Object> scriptExtension = new HashMap<>(1);
+            scriptExtension.put("ScriptExtension", new ScriptExtensionManager(engine));
+            scopeValues(engine, scriptExtension, isNashorn);
+
+        } else {
+            logger.error("unknown script language: {}", type);
+        }
+
+        return engine;
+    }
+
+    public static void removeEngine(ScriptEngine engine) {
+        try {
+            ScriptExtensionManager.dispose(engine.hashCode());
+        } catch (Exception ex) {
+            logger.error("error removing engine", ex);
+        }
+    }
+
+    /**
+     * initializes Globals for Oracle Nashorn in conjunction with Java 8
+     *
+     * To prevent Class loading Problems use this directive: -Dorg.osgi.framework.bundle.parent=ext
+     * further information:
+     * http://apache-felix.18485.x6.nabble.com/org-osgi-framework-bootdelegation-and-org-osgi-framework-system-packages-
+     * extra-td4946354.html
+     * https://bugs.eclipse.org/bugs/show_bug.cgi?id=466683
+     * http://spring.io/blog/2009/01/19/exposing-the-boot-classpath-in-osgi/
+     * http://osdir.com/ml/users-felix-apache/2015-02/msg00067.html
+     * http://stackoverflow.com/questions/30225398/java-8-scriptengine-across-classloaders
+     *
+     * later we will get auto imports for Classes in Nashorn:
+     * further information:
+     * http://nashorn.36665.n7.nabble.com/8u60-8085937-add-autoimports-sample-script-to-easily-explore-Java-classes-in-
+     * interactive-mode-td4705.html
+     *
+     * Later in a pure Java 8/9 environment:
+     * http://mail.openjdk.java.net/pipermail/nashorn-dev/2015-February/004177.html
+     * Using Nashorn with interfaces loaded from custom classloaders, "script function" as a Java lambda:
+     *
+     * engine.put("JavaClass", (Function<String, Class>)
+     * s -> {
+     * try {
+     * // replace this whatever Class finding logic here
+     * // say, using your own class loader(s) based search
+     * Class<?> c = Class.forName(s);
+     * logger.error("Class " + c.getName());
+     * logger.error("s " + s);
+     * return Class.forName(s);
+     * } catch (ClassNotFoundException cnfe) {
+     * throw new RuntimeException(cnfe);
+     * }
+     * });
+     * engine.eval("var System = JavaClass('java.lang.System').static");
+     * engine.eval("System.out.println('hello world')");
+     *
+     *
+     * functionality:
+     *
+     * As we already have the classes loaded into the global scope even for the Nashorn engine, we can simply convert
+     * them to Java types by adding ".static",
+     * otherwise we could get OSGI classloader issues.
+     *
+     * So we use a dedicated ScriptEngine instance to generate our Nashorn global scope. This will replace each class
+     * instance in the context by java type instances.
+     * This context will be assigned to each Nashorn GLOBAL SCOPE.
+     *
+     * @param engine the script engine to initialize
+     * @param provider the provider holding the elements that should be added to the scope
+     */
+    private static void initializeNashornScope(ScriptEngine engine, ScriptScopeProvider provider) {
+        if (!AbstractScriptModuleHandler.class.getClassLoader().getParent().toString().contains("ExtClassLoader")) {
+            logger.warn(
+                    "Found wrong classloader: To prevent class loading problems use this directive: -Dorg.osgi.framework.bundle.parent=ext");
+        }
+        logger.debug("initializing script scope from '{}' for engine '{}'.", provider.getClass().getSimpleName(),
+                engine.getFactory().getEngineName());
+
+        nashornScopeValues(engine, provider.getScopeElements());
+
+        Bindings bindings = nashornEngine.getBindings(ScriptContext.ENGINE_SCOPE);
+        logger.debug("new nashorn object keyset: " + bindings.keySet());
+
+        for (String key : bindings.keySet()) {
+            nashornGlobalBinding.put(key, bindings.get(key));
+        }
+
+        logger.debug("nashorn global keyset: " + nashornGlobalBinding.keySet());
+    }
+
+    public static void scopeValues(ScriptEngine engine, Map<String, Object> entries) {
+        scopeValues(engine, entries, isNashorn(engine));
+    }
+
+    public static void scopeValues(ScriptEngine engine, Map<String, Object> entries, boolean isNashorn) {
+        if (isNashorn) {
+            nashornScopeValues(engine, entries);
+        } else {
+            generalScopeValues(engine, entries);
+        }
+    }
+
+    public static void generalScopeValues(ScriptEngine engine, Map<String, Object> entries) {
+        for (Entry<String, Object> entry : entries.entrySet()) {
+            engine.put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public static void nashornScopeValues(ScriptEngine engine, Map<String, Object> entries) {
+        Set<String> expressions = new HashSet<String>();
+
+        for (Entry<String, Object> entry : entries.entrySet()) {
+            engine.put(entry.getKey(), entry.getValue());
+
+            if (entry.getValue() instanceof Class) {
+                @SuppressWarnings("unchecked")
+                Class<Object> c = (Class<Object>) entry.getValue();
+                expressions.add(String.format("%s = %s.static;", entry.getKey(), entry.getKey()));
+            }
+        }
+        String scriptToEval = Joiner.on("\n").join(expressions);
+        try {
+            engine.eval(scriptToEval);
+        } catch (ScriptException e) {
+            logger.error("ScriptException while importing scope: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Code for any other scriptengine than Nashorn
+     *
+     * @param engine the script engine to initialize
+     * @param provider the provider holding the elements that should be added to the scope
+     */
+    private static void initializeGeneralScope(ScriptScopeProvider provider) {
+        logger.debug("initializing script scope from '{}'.", new Object[] { provider.getClass().getSimpleName() });
+
+        Bindings bindings = engineManager.getBindings();
+
+        for (Entry<String, Object> entry : provider.getScopeElements().entrySet()) {
+            bindings.put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public static void addScopeProvider(ScriptScopeProvider provider) {
+        scriptScopeProviders.add(provider);
+        initializeGeneralScope(provider);
+
+        // we only need to execute nashorn specific scope generation if there already exist a Nashorn-ScriptEngine,
+        // otherwise the scope will be generated on first ScriptEngine request
+        if (nashornEngine != null) {
+            initializeNashornScope(nashornEngine, provider);
+        }
+    }
+
+    public static void removeScopeProvider(ScriptScopeProvider provider) {
+        scriptScopeProviders.remove(provider);
+
+        Bindings bindings = engineManager.getBindings();
+
+        for (String key : provider.getScopeElements().keySet()) {
+            bindings.remove(key);
+
+            if (nashornGlobalBinding != null) {
+                nashornGlobalBinding.remove(key);
+            }
+        }
+    }
+
+    public static void clearProviders() {
+        scriptScopeProviders.clear();
+    }
+}

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/ScriptExtensionProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/ScriptExtensionProvider.java
@@ -1,0 +1,62 @@
+package org.eclipse.smarthome.automation.module.script;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * A {@link ScriptExtensionProvider} can provide variable and types on ScriptEngine instance basis.
+ *
+ * @author Simon Merschjohann- Initial contribution
+ *
+ */
+public interface ScriptExtensionProvider {
+
+    /**
+     * These presets will always get injected into the ScriptEngine on instance creation.
+     *
+     * @return collection of presets
+     */
+    public Collection<String> getDefaultPresets();
+
+    /**
+     * Returns the provided Presets which are supported by this ScriptExtensionProvider.
+     * Presets define imports which will be injected into the ScriptEngine if called by "importPreset".
+     *
+     * @return provided presets
+     */
+    public Collection<String> getPresets();
+
+    /**
+     * Returns the supported types which can be received by the given ScriptExtensionProvider
+     *
+     * @return provided types
+     */
+    public Collection<String> getTypes();
+
+    /**
+     * This method should return an Object of the given type. Note: get can be called multiple times in the scripts use
+     * caching where appropriate.
+     *
+     * @param scriptEngine the script engine instance requesting the given type
+     * @param type
+     * @return
+     */
+    public Object get(int scriptEngineId, String type);
+
+    /**
+     * This method should return variables and types of the concrete type which will be injected into the ScriptEngines
+     * scope.
+     *
+     * @param scriptEngineId - the script engine which will receive the preset
+     */
+    public Map<String, Object> importPreset(int scriptEngineId, String preset);
+
+    /**
+     * This will be called when the ScriptEngine will be unloaded (e.g. if the Script is deleted or updated).
+     * Every Context information stored in the ScriptExtensionProvider should be removed.
+     *
+     * @param scriptEngineId
+     */
+    public void unLoad(int scriptEngineId);
+
+}

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/ScriptExtensionManager.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/ScriptExtensionManager.java
@@ -1,0 +1,86 @@
+package org.eclipse.smarthome.automation.module.script.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import javax.script.ScriptEngine;
+
+import org.eclipse.smarthome.automation.module.script.ScriptEngineProvider;
+import org.eclipse.smarthome.automation.module.script.ScriptExtensionProvider;
+
+public class ScriptExtensionManager {
+    private ScriptEngine scriptEngine;
+
+    private static Set<ScriptExtensionProvider> scriptExtensionProviders = new CopyOnWriteArraySet<ScriptExtensionProvider>();
+
+    public static Set<ScriptExtensionProvider> getScriptExtensionProviders() {
+        return scriptExtensionProviders;
+    }
+
+    public static void addScriptExtensionProvider(ScriptExtensionProvider provider) {
+        scriptExtensionProviders.add(provider);
+    }
+
+    public static void removeScriptExtensionProvider(ScriptExtensionProvider provider) {
+        scriptExtensionProviders.remove(provider);
+    }
+
+    public ScriptExtensionManager(ScriptEngine engine) {
+        this.scriptEngine = engine;
+    }
+
+    @Override
+    public void finalize() {
+        dispose(scriptEngine.hashCode());
+    }
+
+    public List<String> getTypes() {
+        ArrayList<String> types = new ArrayList<>();
+
+        for (ScriptExtensionProvider provider : scriptExtensionProviders) {
+            types.addAll(provider.getTypes());
+        }
+
+        return types;
+    }
+
+    public List<String> getPresets() {
+        ArrayList<String> presets = new ArrayList<>();
+
+        for (ScriptExtensionProvider provider : scriptExtensionProviders) {
+            presets.addAll(provider.getPresets());
+        }
+
+        return presets;
+    }
+
+    public Object get(String type) {
+        for (ScriptExtensionProvider provider : scriptExtensionProviders) {
+            if (provider.getTypes().contains(type)) {
+                return provider.get(scriptEngine.hashCode(), type);
+            }
+        }
+
+        return null;
+    }
+
+    public void importPreset(String preset) {
+        for (ScriptExtensionProvider provider : scriptExtensionProviders) {
+            if (provider.getPresets().contains(preset)) {
+                Map<String, Object> scopeValues = provider.importPreset(scriptEngine.hashCode(), preset);
+
+                ScriptEngineProvider.scopeValues(scriptEngine, scopeValues);
+            }
+        }
+    }
+
+    public static void dispose(int scriptEngineId) {
+        for (ScriptExtensionProvider provider : scriptExtensionProviders) {
+            provider.unLoad(scriptEngineId);
+        }
+    }
+
+}

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/ScriptModuleActivator.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/ScriptModuleActivator.java
@@ -7,32 +7,20 @@
  */
 package org.eclipse.smarthome.automation.module.script.internal;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
-import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
-import javax.script.ScriptException;
-
 import org.eclipse.smarthome.automation.handler.ModuleHandlerFactory;
+import org.eclipse.smarthome.automation.module.script.ScriptEngineProvider;
+import org.eclipse.smarthome.automation.module.script.ScriptExtensionProvider;
 import org.eclipse.smarthome.automation.module.script.ScriptScopeProvider;
 import org.eclipse.smarthome.automation.module.script.internal.factory.ScriptModuleHandlerFactory;
-import org.eclipse.smarthome.automation.module.script.internal.handler.AbstractScriptModuleHandler;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.Filter;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.ServiceTracker;
 import org.osgi.util.tracker.ServiceTrackerCustomizer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.Joiner;
 
 /**
  * ScriptModuleActivator class for script automation modules
@@ -49,11 +37,6 @@ public class ScriptModuleActivator implements BundleActivator {
     private ServiceRegistration factoryRegistration;
     @SuppressWarnings("rawtypes")
     private ServiceTracker scriptScopeProviderServiceTracker;
-    static private Set<ScriptScopeProvider> scriptScopeProviders;
-
-    private final static ScriptEngineManager engineManager = new ScriptEngineManager();
-
-    protected final static Map<String, ScriptEngine> engines = new HashMap<>();
 
     public BundleContext getContext() {
         return context;
@@ -73,42 +56,47 @@ public class ScriptModuleActivator implements BundleActivator {
         moduleHandlerFactory.activate();
         this.factoryRegistration = bundleContext.registerService(ModuleHandlerFactory.class.getName(),
                 this.moduleHandlerFactory, null);
-        scriptScopeProviders = new CopyOnWriteArraySet<ScriptScopeProvider>();
-        scriptScopeProviderServiceTracker = new ServiceTracker(bundleContext, ScriptScopeProvider.class.getName(),
-                new ServiceTrackerCustomizer() {
 
-                    @Override
-                    public Object addingService(ServiceReference reference) {
-                        Object service = bundleContext.getService(reference);
-                        if (service instanceof ScriptScopeProvider) {
-                            ScriptScopeProvider provider = (ScriptScopeProvider) service;
-                            scriptScopeProviders.add(provider);
-                            for (ScriptEngine engine : engines.values()) {
-                                initializeGeneralScope(engine, provider);
-                            }
-                            return service;
-                        } else {
-                            return null;
-                        }
-                    }
+        Filter filter = bundleContext.createFilter("(|(objectClass=" + ScriptScopeProvider.class.getName()
+                + ")(objectClass=" + ScriptExtensionProvider.class.getName() + "))");
 
-                    @Override
-                    public void modifiedService(ServiceReference reference, Object service) {
-                    }
+        scriptScopeProviderServiceTracker = new ServiceTracker(bundleContext, filter, new ServiceTrackerCustomizer() {
 
-                    @Override
-                    public void removedService(ServiceReference reference, Object service) {
-                        if (service instanceof ScriptScopeProvider) {
-                            ScriptScopeProvider provider = (ScriptScopeProvider) service;
-                            scriptScopeProviders.remove(provider);
-                            for (ScriptEngine engine : engines.values()) {
-                                for (String key : provider.getScopeElements().keySet()) {
-                                    engine.getBindings(ScriptContext.ENGINE_SCOPE).remove(key);
-                                }
-                            }
-                        }
-                    }
-                });
+            @Override
+            public Object addingService(ServiceReference reference) {
+                Object service = bundleContext.getService(reference);
+                if (service instanceof ScriptScopeProvider) {
+                    ScriptScopeProvider provider = (ScriptScopeProvider) service;
+
+                    ScriptEngineProvider.addScopeProvider(provider);
+                    return service;
+                } else if (service instanceof ScriptExtensionProvider) {
+                    ScriptExtensionProvider provider = (ScriptExtensionProvider) service;
+
+                    ScriptExtensionManager.addScriptExtensionProvider(provider);
+                    return service;
+                } else {
+                    return null;
+                }
+            }
+
+            @Override
+            public void modifiedService(ServiceReference reference, Object service) {
+            }
+
+            @Override
+            public void removedService(ServiceReference reference, Object service) {
+                if (service instanceof ScriptScopeProvider) {
+                    ScriptScopeProvider provider = (ScriptScopeProvider) service;
+                    ScriptEngineProvider.removeScopeProvider(provider);
+                } else if (service instanceof ScriptExtensionProvider) {
+                    ScriptExtensionProvider provider = (ScriptExtensionProvider) service;
+
+                    ScriptExtensionManager.removeScriptExtensionProvider(provider);
+                }
+            }
+        });
+
         scriptScopeProviderServiceTracker.open();
 
         logger.debug("Started script automation support");
@@ -129,123 +117,7 @@ public class ScriptModuleActivator implements BundleActivator {
         }
         this.moduleHandlerFactory = null;
         this.scriptScopeProviderServiceTracker.close();
-        ScriptModuleActivator.scriptScopeProviders.clear();
-        ScriptModuleActivator.scriptScopeProviders = null;
-
-    }
-
-    /**
-     * Gets the instance of a script engine of a given type
-     *
-     * @param type the mime type of the desired script engine
-     *
-     * @return a script engine that supports scripts of the given mime type
-     */
-    public static synchronized ScriptEngine getScriptEngine(String type) {
-        ScriptEngine engine = engines.get(type);
-        if (engine == null) {
-            engine = engineManager.getEngineByMimeType(type);
-            for (ScriptScopeProvider provider : scriptScopeProviders) {
-                initializeScope(engine, provider);
-            }
-            engines.put(type, engine);
-        }
-        return engine;
-    }
-
-    /**
-     * Adds elements from a provider to the engine scope
-     *
-     * @param engine the script engine to initialize
-     * @param provider the provider holding the elements that should be added to the scope
-     */
-    private static void initializeScope(ScriptEngine engine, ScriptScopeProvider provider) {
-        if (engine.getFactory().getEngineName().toLowerCase().endsWith("nashorn")) {
-            initializeNashornScope(engine, provider);
-        } else {
-            initializeGeneralScope(engine, provider);
-        }
-    }
-
-    /**
-     * initializes Globals for Oracle Nashorn in conjunction with Java 8
-     *
-     * To prevent Class loading Problems use this directive: -Dorg.osgi.framework.bundle.parent=ext
-     * further information:
-     * http://apache-felix.18485.x6.nabble.com/org-osgi-framework-bootdelegation-and-org-osgi-framework-system-packages-
-     * extra-td4946354.html
-     * https://bugs.eclipse.org/bugs/show_bug.cgi?id=466683
-     * http://spring.io/blog/2009/01/19/exposing-the-boot-classpath-in-osgi/
-     * http://osdir.com/ml/users-felix-apache/2015-02/msg00067.html
-     * http://stackoverflow.com/questions/30225398/java-8-scriptengine-across-classloaders
-     *
-     * later we will get auto imports for Classes in Nashorn:
-     * further information:
-     * http://nashorn.36665.n7.nabble.com/8u60-8085937-add-autoimports-sample-script-to-easily-explore-Java-classes-in-
-     * interactive-mode-td4705.html
-     *
-     * Later in a pure Java 8/9 environment:
-     * http://mail.openjdk.java.net/pipermail/nashorn-dev/2015-February/004177.html
-     * Using Nashorn with interfaces loaded from custom classloaders, "script function" as a Java lambda:
-     *
-     * engine.put("JavaClass", (Function<String, Class>)
-     * s -> {
-     * try {
-     * // replace this whatever Class finding logic here
-     * // say, using your own class loader(s) based search
-     * Class<?> c = Class.forName(s);
-     * logger.error("Class " + c.getName());
-     * logger.error("s " + s);
-     * return Class.forName(s);
-     * } catch (ClassNotFoundException cnfe) {
-     * throw new RuntimeException(cnfe);
-     * }
-     * });
-     * engine.eval("var System = JavaClass('java.lang.System').static");
-     * engine.eval("System.out.println('hello world')");
-     *
-     * @param engine the script engine to initialize
-     * @param provider the provider holding the elements that should be added to the scope
-     */
-    private static void initializeNashornScope(ScriptEngine engine, ScriptScopeProvider provider) {
-        if (!AbstractScriptModuleHandler.class.getClassLoader().getParent().toString().contains("ExtClassLoader")) {
-            logger.warn(
-                    "Found wrong classloader: To prevent class loading problems use this directive: -Dorg.osgi.framework.bundle.parent=ext");
-        }
-        logger.debug("initializing script scope from '{}' for engine '{}'.",
-                new Object[] { provider.getClass().getSimpleName(), engine.getFactory().getEngineName() });
-
-        Set<String> expressions = new HashSet<String>();
-        for (Entry<String, Object> entry : provider.getScopeElements().entrySet()) {
-            if (entry.getValue() instanceof Class) {
-                @SuppressWarnings("unchecked")
-                Class<Object> c = (Class<Object>) entry.getValue();
-                expressions.add(entry.getKey() + " = Java.type('" + c.getCanonicalName() + "')");
-            } else {
-                engine.put(entry.getKey(), entry.getValue());
-            }
-        }
-        String scriptToEval = Joiner.on(",\n").join(expressions);
-        try {
-            engine.eval(scriptToEval);
-        } catch (ScriptException e) {
-            logger.error("ScriptException while importing scope: {}", e.getMessage());
-        }
-    }
-
-    /**
-     * Code for any other scriptengine than Nashorn
-     *
-     * @param engine the script engine to initialize
-     * @param provider the provider holding the elements that should be added to the scope
-     */
-    private static void initializeGeneralScope(ScriptEngine engine, ScriptScopeProvider provider) {
-        logger.debug("initializing script scope from '{}' for engine '{}'.",
-                new Object[] { provider.getClass().getSimpleName(), engine.getFactory().getEngineName() });
-
-        for (Entry<String, Object> entry : provider.getScopeElements().entrySet()) {
-            engine.put(entry.getKey(), entry.getValue());
-        }
+        ScriptEngineProvider.clearProviders();
     }
 
 }

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/handler/ScriptActionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/handler/ScriptActionHandler.java
@@ -16,7 +16,7 @@ import javax.script.ScriptException;
 
 import org.eclipse.smarthome.automation.Action;
 import org.eclipse.smarthome.automation.handler.ActionHandler;
-import org.eclipse.smarthome.automation.module.script.internal.ScriptModuleActivator;
+import org.eclipse.smarthome.automation.module.script.ScriptEngineProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +42,8 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action>impl
     }
 
     @Override
-    public void dispose() {}
+    public void dispose() {
+    }
 
     @Override
     public Map<String, Object> execute(Map<String, ?> context) {
@@ -50,7 +51,7 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action>impl
         Object script = module.getConfiguration().get(SCRIPT);
         if (type instanceof String) {
             if (script instanceof String) {
-                ScriptEngine engine = ScriptModuleActivator.getScriptEngine((String) type);
+                ScriptEngine engine = ScriptEngineProvider.getScriptEngine((String) type);
                 if (engine != null) {
                     ScriptContext executionContext = getExecutionContext(engine, context);
                     try {
@@ -61,6 +62,8 @@ public class ScriptActionHandler extends AbstractScriptModuleHandler<Action>impl
                     } catch (ScriptException e) {
                         logger.error("Script execution failed: {}", e.getMessage());
                     }
+
+                    ScriptEngineProvider.removeEngine(engine);
                 } else {
                     logger.debug("No engine available for script type '{}' in action '{}'.",
                             new Object[] { type, module.getId() });

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/handler/ScriptConditionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/handler/ScriptConditionHandler.java
@@ -15,7 +15,7 @@ import javax.script.ScriptException;
 
 import org.eclipse.smarthome.automation.Condition;
 import org.eclipse.smarthome.automation.handler.ConditionHandler;
-import org.eclipse.smarthome.automation.module.script.internal.ScriptModuleActivator;
+import org.eclipse.smarthome.automation.module.script.ScriptEngineProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +41,7 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
         Object script = module.getConfiguration().get(SCRIPT);
         if (type instanceof String) {
             if (script instanceof String) {
-                ScriptEngine engine = ScriptModuleActivator.getScriptEngine((String) type);
+                ScriptEngine engine = ScriptEngineProvider.getScriptEngine((String) type);
                 if (engine != null) {
                     ScriptContext executionContext = getExecutionContext(engine, context);
                     try {
@@ -54,6 +54,8 @@ public class ScriptConditionHandler extends AbstractScriptModuleHandler<Conditio
                     } catch (ScriptException e) {
                         logger.error("Script execution failed: {}", e.getMessage());
                     }
+
+                    ScriptEngineProvider.removeEngine(engine);
                 } else {
                     logger.debug("No engine available for script type '{}' in condition '{}'.",
                             new Object[] { type, module.getId() });


### PR DESCRIPTION
This PR will allow other bundles to use and instantiate ScriptEngines.

It also contains a GlobalScope optimization, which is required to circumvent some OSGI related issues concerning the current implementation of class loading for the Nashorn-based solution. It will use "variable = variable.static" instead of "variable = Java.type(...)". In addition the Scope will be initialized only one time and injected as GLOBAL_SCOPE instead of ENGINE_SCOPE.

Futhermore this PR introduces a ScriptExtensionProvider. This allows OSGI-Bundles to provide functionality which is not needed at all times. The given features can be requested from a script and are not imported in all ScriptEngine instances. It furthermore allows to keep track of the loaded instances based on a ScriptEngineId. If the ScriptEngine gets unloaded, the ScriptExtensionProvider will be notified about this and can unload or undo changes it has done to the runtime.