### PR TITLE
fix display of label with pattern without label text

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -337,7 +337,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         int indexOpenBracket = label.indexOf("[");
         int indexCloseBracket = label.endsWith("]") ? label.length() - 1 : -1;
 
-        if ((indexOpenBracket > 0) && (indexCloseBracket > indexOpenBracket)) {
+        if ((indexOpenBracket >= 0) && (indexCloseBracket > indexOpenBracket)) {
             return label.substring(indexOpenBracket + 1, indexCloseBracket);
         } else {
             return null;


### PR DESCRIPTION
Label with only pattern shows up as the literal pattern on right side where value is supposed to be

Bug: https://github.com/eclipse/smarthome/issues/810
Signed-off-by: Dennis Drapeau <doubled-ca@hotmail.com>