### PR TITLE
Always return parsable stuff.

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/CmdServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/CmdServlet.java
@@ -101,6 +101,9 @@ public class CmdServlet extends BaseServlet {
                 }
             }
         }
+        res.setContentType("application/xml;charset=UTF-8");
+        res.getWriter().write("<root></root>");
+
     }
 
 }

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/WebAppServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/WebAppServlet.java
@@ -160,6 +160,9 @@ public class WebAppServlet extends BaseServlet {
                     result.append(renderer.processPage(renderer.getItemUIRegistry().getWidgetId(w), sitemapName, label,
                             children, async));
                 }
+            } else if (widgetId.equals("Colorpicker")) {
+                result.append("<root></root>");
+
             }
         } catch (RenderException e) {
             throw new ServletException(e.getMessage(), e);
@@ -179,7 +182,7 @@ public class WebAppServlet extends BaseServlet {
      * @return the response of the servlet on a polling timeout
      */
     private String getTimeoutResponse() {
-        return "<root><part><destination mode=\"replace\" zone=\"timeout\" create=\"false\"/><data/></part></root>";
+        return "<root></root>";
     }
 
     /**


### PR DESCRIPTION
Remove JS console error messages because of unparsable empty responses and in case of an timeout, just return an empty root node instead of an un-executable render-request to a fake-zone named 'timeout'.

Signed-off-by: Sebastian Janzen <sebastian@janzen.it>