### PR TITLE
Force http download for node & npm

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
@@ -39,6 +39,8 @@
                         <configuration>
                             <nodeVersion>v5.4.0</nodeVersion>
                             <npmVersion>3.3.12</npmVersion>
+                            <nodeDownloadRoot>http://nodejs.org/dist/</nodeDownloadRoot>
+                            <npmDownloadRoot>http://registry.npmjs.org/npm/-/</npmDownloadRoot>
                             <!-- optional: where to download node and npm from. Defaults to http://nodejs.org/dist/ -->
                             <!--<downloadRoot>https://nodejs.org:80/dist/</downloadRoot>-->
                         </configuration>


### PR DESCRIPTION
This fixes a minor bug #844 introduced in PR https://github.com/eclipse/smarthome/pull/829

Signed-off-by: Grady Duncan <gradyduncan@gmail.com>