### PR TITLE
allow parsing of config descriptions of fragment bundles 

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/ESH-INF/config/config.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/ESH-INF/config/config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description/v1.0.0">
+
+	<!-- test dummy -->
+	<config-description uri="config:fragmentConfig">
+	    
+		<parameter name="testParam" type="text">
+			<label>Test</label>
+			<description>Test Parameter.</description>
+		</parameter>
+
+
+	</config-description>
+
+</config-description:config-descriptions>

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Synthetic Test Bundle
+Bundle-SymbolicName: ConfigDescriptionsFragmentTest.fragment;singleton:=true
+Bundle-Version: 0.0.1.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Fragment-Host: ConfigDescriptionsFragmentTest.host
+Import-Package: com.google.common.collect,
+ org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/ESH-INF/thing/MyThingType.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/ESH-INF/thing/MyThingType.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="hue"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+    xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <thing-type id="MyThingType">
+        <label>My Thing Type</label>
+        <description>My Thing Type</description>
+
+        <config-description>
+            <parameter name="myID" type="text">
+                <label>My ID</label>
+                <description>My ID.</description>
+            </parameter>
+        </config-description>
+    </thing-type>
+</thing:thing-descriptions>

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Synthetic Test Bundle
+Bundle-SymbolicName: ConfigDescriptionsFragmentTest.host;singleton:=true
+Bundle-Version: 0.0.1.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/osgi/AbstractAsyncBundleProcessor.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/osgi/AbstractAsyncBundleProcessor.java
@@ -107,16 +107,18 @@ public abstract class AbstractAsyncBundleProcessor {
     }
 
     /**
-     * Checks for the existence of a given directors inside the bundle.
+     * Checks for the existence of a given resource inside the bundle and its attached fragments.
+     * The bundle must be in ACTIVE state, otherwise this call might change the bundle's state
+     * to ACTIVE.
      *
      * Helper method which can be used in {@link #isBundleRelevant(Bundle)}.
      * 
      * @param bundle
      * @param path the directory name to look for
-     * @return <code>true</code> id the bundle contains the given directory
+     * @return <code>true</code> if the bundle or one of its attached fragments contain the given directory
      */
-    protected final boolean isDirectoryPresent(Bundle bundle, String path) {
-        return bundle.getEntry(path) != null;
+    protected final boolean isResourcePresent(Bundle bundle, String path) {
+        return bundle.getResource(path) != null;
     }
 
     /**

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/osgi/XmlDocumentBundleTracker.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/osgi/XmlDocumentBundleTracker.java
@@ -99,7 +99,7 @@ public class XmlDocumentBundleTracker<T> extends BundleTracker<Bundle> {
 
             @Override
             protected boolean isBundleRelevant(Bundle bundle) {
-                return isDirectoryPresent(bundle, XmlDocumentBundleTracker.this.xmlDirectory);
+                return isResourcePresent(bundle, XmlDocumentBundleTracker.this.xmlDirectory);
             }
 
             @Override

--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/SyntheticBundleInstaller.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/SyntheticBundleInstaller.java
@@ -42,6 +42,16 @@ public class SyntheticBundleInstaller {
         return syntheticBundle;
     }
 
+    public static Bundle installFragment(BundleContext bundleContext, String testBundleName) throws Exception {
+        String bundlePath = bundlePoolPath + "/" + testBundleName + "/";
+        byte[] syntheticBundleBytes = createSyntheticBundle(bundleContext.getBundle(), bundlePath, testBundleName);
+
+        Bundle syntheticBundle = bundleContext.installBundle(testBundleName,
+                new ByteArrayInputStream(syntheticBundleBytes));
+        waitUntilLoadingFinished(syntheticBundle);
+        return syntheticBundle;
+    }
+
     public static void waitUntilLoadingFinished(Bundle bundle) {
         while (!AbstractAsyncBundleProcessor.isBundleFinishedLoading(bundle)) {
             try {


### PR DESCRIPTION
AbstractAsyncBundleProcessor#isDirectoryPresent should also check attached fragments of a bundle

Signed-off-by: Andre Fuechsel <a.fuechsel@telekom.de>