### PR TITLE
ExecUtil: Sync ESH with OH 1.8.1

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
@@ -104,7 +104,7 @@ public class ExecUtil {
         ByteArrayOutputStream stdout = new ByteArrayOutputStream();
         PumpStreamHandler streamHandler = new PumpStreamHandler(stdout);
 
-        executor.setExitValue(1);
+        executor.setExitValues(null);
         executor.setStreamHandler(streamHandler);
         executor.setWatchdog(watchdog);
 
@@ -113,9 +113,9 @@ public class ExecUtil {
             executor.execute(cmdLine, resultHandler);
             logger.debug("executed commandLine '{}'", commandLine);
         } catch (ExecuteException e) {
-            logger.error("couldn't execute commandLine '" + commandLine + "'", e);
+            logger.warn("couldn't execute commandLine '" + commandLine + "'", e);
         } catch (IOException e) {
-            logger.error("couldn't execute commandLine '" + commandLine + "'", e);
+            logger.warn("couldn't execute commandLine '" + commandLine + "'", e);
         }
 
         // some time later the result handler callback was invoked so we
@@ -130,7 +130,7 @@ public class ExecUtil {
                 logger.debug("exit code '{}', result '{}'", exitCode, retval);
             }
         } catch (InterruptedException e) {
-            logger.error("Timeout occured when executing commandLine '" + commandLine + "'", e);
+            logger.warn("Timeout occured when executing commandLine '" + commandLine + "'", e);
         }
 
         return retval;


### PR DESCRIPTION
 PR https://github.com/openhab/openhab/pull/3825.

`executor.setExitValue(1)` means "for any non-1 exit code, raise an exception" which then gets logged as WARN.  `executor.setExitValues(null)` [means](https://commons.apache.org/proper/commons-exec/apidocs/org/apache/commons/exec/DefaultExecutor.html#setExitValues(int[])) "skip checking of exit codes".  Otherwise the log is spammed with WARNs about non-1 exit codes.

Also, unlike OH1, other exceptions should be logged as WARN, not ERROR, since they don't effect the stability of the runtime.

Signed-off-by: John Cocula <john@cocula.com>