### PR TITLE
cors preflight content type header in response fix with reference to #903

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.test/src/test/groovy/org/eclipse/smarthome/io/rest/test/filter/CorsFilterTest.groovy
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/src/test/groovy/org/eclipse/smarthome/io/rest/test/filter/CorsFilterTest.groovy
@@ -14,6 +14,7 @@ import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.container.ContainerResponseContext
 import javax.ws.rs.core.MultivaluedHashMap
 import javax.ws.rs.core.MultivaluedMap
+import javax.ws.rs.core.HttpHeaders
 
 import org.eclipse.smarthome.io.rest.internal.filter.CorsFilter
 import org.junit.Before
@@ -33,6 +34,8 @@ class CorsFilterTest {
     private static final String HTTP_POST_METHOD = "POST"
     private static final String HTTP_GET_METHOD = "GET"
     private static final String HTTP_OPTIONS_METHOD = "OPTIONS"
+
+    private static final String CONTENT_TYPE_HEADER = HttpHeaders.CONTENT_TYPE;
 
     private static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method"
     private static final String ACCESS_CONTROL_REQUEST_HEADERS = "Access-Control-Request-Headers"
@@ -100,7 +103,7 @@ class CorsFilterTest {
 
         assertTrue containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_METHODS_HEADER, ACCEPTED_HTTP_METHODS)
         assertTrue containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, ECLIPSE_ORIGIN)
-        assertFalse containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_HEADERS, null)
+        assertTrue containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_HEADERS, CONTENT_TYPE_HEADER)
         assertTrue containsHeaderWithValue(responseContext.getHeaders(), VARY_HEADER, VARY_HEADER_VALUE + "," + ORIGIN_HEADER)
     }
 
@@ -111,7 +114,7 @@ class CorsFilterTest {
 
         filter.filter(requestContext, responseContext)
 
-        // Since the requestMehod header is not present in the request, it is not a valid Preflight CORS request.
+        // Since the requestMethod header is not present in the request, it is not a valid Preflight CORS request.
         // Thus, no CORS header should be added to the response.
         assertFalse containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_METHODS_HEADER, null)
         assertFalse containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, null)
@@ -126,11 +129,11 @@ class CorsFilterTest {
 
         filter.filter(requestContext, responseContext)
 
-        // Since the requestMehod header is not present in the request, it is not a valid Preflight CORS request.
+        // Since the requestMethod header is not present in the request, it is not a valid Preflight CORS request.
         // Thus, no CORS header should be added to the response.
         assertTrue containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_METHODS_HEADER, ACCEPTED_HTTP_METHODS)
         assertTrue containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, ECLIPSE_ORIGIN)
-        assertFalse containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_HEADERS, null)
+        assertTrue containsHeaderWithValue(responseContext.getHeaders(), ACCESS_CONTROL_ALLOW_HEADERS, CONTENT_TYPE_HEADER)
         assertTrue containsHeaderWithValue(responseContext.getHeaders(), VARY_HEADER, VARY_HEADER_VALUE + "," + ORIGIN_HEADER)
     }
 

--- a/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/filter/CorsFilter.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/filter/CorsFilter.java
@@ -16,6 +16,7 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.Provider;
+import javax.ws.rs.core.HttpHeaders;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.io.rest.internal.Constants;
@@ -45,10 +46,13 @@ public class CorsFilter implements ContainerResponseFilter {
     private static final String HTTP_POST_METHOD = "POST";
     private static final String HTTP_GET_METHOD = "GET";
     private static final String HTTP_OPTIONS_METHOD = "OPTIONS";
+    
+    private static final String CONTENT_TYPE_HEADER = HttpHeaders.CONTENT_TYPE;
 
     private static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
     private static final String ACCESS_CONTROL_ALLOW_METHODS_HEADER = "Access-Control-Allow-Methods";
     private static final String ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = "Access-Control-Allow-Origin";
+    private static final String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
     private static final String ORIGIN_HEADER = "Origin";
     private static final String VARY_HEADER = "Vary";
 
@@ -118,6 +122,7 @@ public class CorsFilter implements ContainerResponseFilter {
             if (isCorsPreflight) {
                 responseContext.getHeaders().add(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, origin);
                 responseContext.getHeaders().add(ACCESS_CONTROL_ALLOW_METHODS_HEADER, ACCEPTED_HTTP_METHODS);
+                responseContext.getHeaders().add(ACCESS_CONTROL_ALLOW_HEADERS, CONTENT_TYPE_HEADER);
 
                 // Add the accepted request headers
                 appendVaryHeader(responseContext);


### PR DESCRIPTION
This is the fix regarding issue #903
Now the response to CORS preflight request also contains the header
"content-type":"application/json".
Therefore, the CORS request Rest APIs which post/put JSON data will also succeed.

Signed-off-by: shry15harsh <shry.harsh@gmail.com>