### PR TITLE
Minor gulp fixes

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -58,8 +58,7 @@ var paths = {
         './node_modules/roboto-fontface/css/roboto-fontface.css'
     ],
     FontLibs: [
-        './node_modules/roboto-fontface/fonts/*',
-        '!./node_modules/roboto-fontface/fonts/*.svg'
+        './node_modules/roboto-fontface/fonts/*.woff'
     ]
 };
 
@@ -70,10 +69,6 @@ gulp.task('uglify', function () {
     return gulp.src(paths.scripts)
         .pipe(ngAnnotate())
         .pipe(uglify())
-        .pipe(rename(function (path) {
-            path.basename += '.min';
-            return path;
-        }))
         .pipe(gulp.dest('./web/js/'));
 });
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
@@ -118,13 +118,13 @@
 	<script src="js/sprintf.min.js"></script>
 
 	<!-- custom js files -->
-	<script src="js/app.min.js"></script>
-	<script src="js/constants.min.js"></script>
+	<script src="js/app.js"></script>
+	<script src="js/constants.js"></script>
 	<script src="js/services.min.js"></script>
 	<script src="js/controllers.min.js"></script>
-	<script src="js/extensions.min.js"></script>
-	<script src="js/main.min.js"></script>
-	<script src="js/shared.properties.min.js"></script>
+	<script src="js/extensions.js"></script>
+	<script src="js/main.js"></script>
+	<script src="js/shared.properties.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Removes .min from all JS files that are copied. Does not remove .min from files that were combined with other files. #918

Also makes it so that only woff fonts are copied over. #924

Signed-off-by: Grady Duncan <gradyduncan@gmail.com>