### PR TITLE
Angular material version update

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
@@ -6,7 +6,7 @@
     "angular": "1.3.15",
     "angular-animate": "^1.4.9",
     "angular-aria": "^1.4.9",
-    "angular-material": "0.10.0",
+    "angular-material": "0.10.1",
     "angular-messages": "1.3.13",
     "angular-resource": "1.3.13",
     "angular-route": "1.3.13",


### PR DESCRIPTION
Angular material version updated to 0.10.1. Version 0.10.0 is not compatible with PaperUI.