### PR TITLE
add no-arg constructor

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ActionType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ActionType.java
@@ -42,6 +42,12 @@ public class ActionType extends ModuleType {
     private List<Output> outputs;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected ActionType() {
+    }
+
+    /**
      * This constructor is responsible to create an instance of {@link ActionType} with base properties - UID, a
      * {@link List} of configuration descriptions and a {@link List} of {@link Input} definitions.
      *

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/CompositeActionType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/CompositeActionType.java
@@ -31,6 +31,12 @@ public class CompositeActionType extends ActionType {
     private List<Action> children;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected CompositeActionType() {
+    }
+
+    /**
      * This constructor is responsible for creation of a {@code CompositeActionType} with ordered set of {@link Action}
      * s.
      * It initialize only base properties of the {@code CompositeActionType}.

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/CompositeConditionType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/CompositeConditionType.java
@@ -30,6 +30,12 @@ public class CompositeConditionType extends ConditionType {
     private List<Condition> children;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected CompositeConditionType() {
+    }
+
+    /**
      * This constructor is responsible for creation of a {@code CompositeConditionType} with ordered set of
      * {@link Condition}s.
      * It initialize only base properties of the {@code CompositeConditionType}.

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/CompositeTriggerType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/CompositeTriggerType.java
@@ -30,6 +30,12 @@ public class CompositeTriggerType extends TriggerType {
     private List<Trigger> children;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected CompositeTriggerType() {
+    }
+
+    /**
      * This constructor is responsible for creation of a {@code CompositeTriggerType} with ordered set of
      * {@link Trigger}s.
      * It initialize only base properties of the {@code CompositeTriggerType}.

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ConditionType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ConditionType.java
@@ -31,6 +31,12 @@ public class ConditionType extends ModuleType {
     private List<Input> inputs;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected ConditionType() {
+    }
+
+    /**
      * This constructor is responsible to create an instance of {@link ConditionType} with base properties - UID, a
      * {@link List} of configuration descriptions and a {@link List} of {@link Input} descriptions.
      *

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/Input.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/Input.java
@@ -62,6 +62,12 @@ public class Input {
     private Object defaultValue;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected Input() {
+    }
+
+    /**
      * Constructor of the {@code Input} object. Creates Input base on type of accepted data and {@code Input}'s name.
      *
      * @param type data type accepted by this Input. The accepted types are any java types defined by fully qualified
@@ -95,8 +101,9 @@ public class Input {
      */
     public Input(String name, String type, String label, String description, Set<String> tags, boolean required,
             String reference, Object defaultValue) {
-        if (name == null)
+        if (name == null) {
             throw new IllegalArgumentException("The name of the input must not be NULL!");
+        }
         this.name = name;
         setType(type);
         this.label = label;

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ModuleType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ModuleType.java
@@ -62,6 +62,12 @@ public abstract class ModuleType {
     protected List<ConfigDescriptionParameter> configDescriptions;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected ModuleType() {
+    }
+
+    /**
      * This constructor is responsible to initialize common base properties of the {@link ModuleType}s.
      *
      * @param UID is an unique id of the {@link ModuleType}, used as reference from the {@link Module}s, to find their
@@ -173,18 +179,23 @@ public abstract class ModuleType {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         ModuleType other = (ModuleType) obj;
         if (uid == null) {
-            if (other.uid != null)
+            if (other.uid != null) {
                 return false;
-        } else if (!uid.equals(other.uid))
+            }
+        } else if (!uid.equals(other.uid)) {
             return false;
+        }
         return true;
     }
 

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/Output.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/Output.java
@@ -81,6 +81,12 @@ public class Output {
     private Object defaultValue;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected Output() {
+    }
+
+    /**
      * Constructor of {@code Output} objects. It is based on the type of data and {@code Output}'s name.
      *
      * @param name is an unique name of the {@code Output}.
@@ -115,8 +121,9 @@ public class Output {
      */
     public Output(String name, String type, String label, String description, Set<String> tags, String reference,
             Object defaultValue) {
-        if (name == null)
+        if (name == null) {
             throw new IllegalArgumentException("The name of the input must not be NULL!");
+        }
         this.name = name;
         setType(type);
         this.label = label;

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/TriggerType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/TriggerType.java
@@ -34,6 +34,12 @@ public class TriggerType extends ModuleType {
     private List<Output> outputs;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected TriggerType() {
+    }
+
+    /**
      * This constructor is responsible to create an instance of {@link TriggerType} with base properties - UID, a
      * {@link List} of configuration descriptions and a {@link List} of {@link Output} descriptions.
      *

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ParameterOption.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ParameterOption.java
@@ -21,6 +21,12 @@ public class ParameterOption {
     private String label;
     private String value;
 
+    /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected ParameterOption() {
+    }
+
     public ParameterOption(String value, String label) {
         this.value = value;
         this.label = label;

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/dto/AbstractLinkDTO.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/dto/AbstractLinkDTO.java
@@ -16,6 +16,12 @@ public abstract class AbstractLinkDTO {
 
     public String itemName;
 
+    /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected AbstractLinkDTO() {
+    }
+
     public AbstractLinkDTO(String itemName) {
         this.itemName = itemName;
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/dto/ItemChannelLinkDTO.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/dto/ItemChannelLinkDTO.java
@@ -16,6 +16,12 @@ public class ItemChannelLinkDTO extends AbstractLinkDTO {
 
     public String channelUID;
 
+    /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected ItemChannelLinkDTO() {
+    }
+
     public ItemChannelLinkDTO(String itemName, String channelUID) {
         super(itemName);
         this.channelUID = channelUID;

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/dto/ItemThingLinkDTO.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/dto/ItemThingLinkDTO.java
@@ -16,6 +16,12 @@ public class ItemThingLinkDTO extends AbstractLinkDTO {
 
     public String thingUID;
 
+    /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected ItemThingLinkDTO() {
+    }
+
     public ItemThingLinkDTO(String itemName, String thingUID) {
         super(itemName);
         this.thingUID = thingUID;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -127,15 +127,17 @@ public class ItemEventFactory extends AbstractEventFactory {
 
     private String getItemName(String topic) {
         String[] topicElements = getTopicElements(topic);
-        if (topicElements.length < 4)
+        if (topicElements.length < 4) {
             throw new IllegalArgumentException("Event creation failed, invalid topic: " + topic);
+        }
         return topicElements[2];
     }
 
     private String getMemberName(String topic) {
         String[] topicElements = getTopicElements(topic);
-        if (topicElements.length < 5)
+        if (topicElements.length < 5) {
             throw new IllegalArgumentException("Event creation failed, invalid topic: " + topic);
+        }
         return topicElements[3];
     }
 
@@ -361,6 +363,12 @@ public class ItemEventFactory extends AbstractEventFactory {
         private String type;
         private String value;
 
+        /**
+         * Default constructor for deserialization e.g. by Gson.
+         */
+        protected ItemEventPayloadBean() {
+        }
+
         public ItemEventPayloadBean(String type, String value) {
             this.type = type;
             this.value = value;
@@ -383,6 +391,12 @@ public class ItemEventFactory extends AbstractEventFactory {
         private String value;
         private String oldType;
         private String oldValue;
+
+        /**
+         * Default constructor for deserialization e.g. by Gson.
+         */
+        protected ItemStateChangedEventPayloadBean() {
+        }
 
         public ItemStateChangedEventPayloadBean(String type, String value, String oldType, String oldValue) {
             this.type = type;


### PR DESCRIPTION
This adds an easy support for deserialization without using the
sun.misc.Unsafe class.

Bug: https://github.com/eclipse/smarthome/issues/876
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>