### PR TITLE
Add null checks to REST interface when creating item

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
@@ -485,8 +485,12 @@ public class ItemResource implements RESTResource {
         // Update the label
         newItem.setLabel(item.label);
         newItem.setCategory(item.category);
-        newItem.addGroupNames(item.groupNames);
-        newItem.addTags(item.tags);
+        if (item.groupNames != null) {
+            newItem.addGroupNames(item.groupNames);
+        }
+        if (item.tags != null) {
+            newItem.addTags(item.tags);
+        }
 
         // Save the item
         if (existingItem == null) {


### PR DESCRIPTION
Currently when creating a new item, it tags or groups is null, the call fails with error 500 and it's not so easy to know what's wrong. It seems that it should be allowable to create items that don't have tags or groups, so this adds a null check which creates empty arrays for tags and groups when the item is created.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>