### PR TITLE
Thing's configurations now posting to '/things/{UID}/config'

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -476,7 +476,7 @@ angular.module('PaperUI.controllers.configuration',
         $mdDialog.hide(itemName);
     }
 }).controller('EditThingController', function($scope, $mdDialog, toastService, 
-		thingTypeRepository, thingRepository, thingSetupService, homeGroupRepository, configService) {
+		thingTypeRepository, thingRepository, thingSetupService, homeGroupRepository, configService, thingService) {
 	
 	$scope.setHeaderText('Click the \'Save\' button to apply the changes.');
 	
@@ -505,8 +505,10 @@ angular.module('PaperUI.controllers.configuration',
 		} else {
 		    thing.item = {};
         }
-		thingSetupService.update(thing, function() {
-	        thingRepository.update(thing);
+		thingService.updateConfig({
+			thingUID : thing.UID
+		}, thing.configuration, function() {
+			thingRepository.update(thing);
 			toastService.showDefaultToast('Thing updated');
 			$scope.navigateTo('things/view/' + thing.UID);
 		});

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.rest.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.rest.js
@@ -245,6 +245,16 @@ angular.module('PaperUI.services.rest', ['PaperUI.constants'])
                 'Content-Type' : 'application/json'
             }
         },
+        updateConfig : {
+            method : 'PUT',
+            params : {
+                thingUID : '@thingUID'
+            },
+            url : restConfig.restPath + '/things/:thingUID/config',
+            headers : {
+                'Content-Type' : 'application/json'
+            }
+        },
         link : {
             method : 'POST',
             params : {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -196,11 +196,11 @@
 				</div>
 			</div>
 		</div>
-		<div class="container">
-			<h3>Configuration Parameters</h3>
-			<p>Configure parameters for the thing.</p>
-			<div ng-init="counter=0;form={}">
-				<div ng-include="'partials/include.thingconfig.html'" onload="counter=counter+1;"></div>
+		<div ng-init="counter=0;form={}">
+			<div ng-include="'partials/include.thingconfig.html'" onload="counter=counter+1;"></div>
+			<div class="container">
+				<h3>Configuration Parameters</h3>
+				<p>Configure parameters for the thing.</p>
 				<div ng-if="counter==1" ng-include="'partials/include.config.html'" onload="configuration=thing.configuration"></div>
 			</div>
 		</div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
@@ -186,5 +186,12 @@
 		</div>
 
 		<div ng-include="'partials/include.thingconfig.html'"></div>
+		<div class="container">
+            <h3>Configuration Parameters</h3>
+            <p>Configure parameters for the thing.</p>
+            <div ng-init="form={}">
+                <div ng-include="'partials/include.config.html'" onload="configuration=thing.configuration"></div>
+            </div>
+        </div>
 	</div>
 </section>


### PR DESCRIPTION
1) Things configurations are now updated through /things/{UID}/config rest endpoint as described here https://github.com/eclipse/smarthome/issues/771
2) Also fixes the issue https://github.com/eclipse/smarthome/issues/960

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>