### PR TITLE
Link added to OH1 binding that lists further compatible radios.

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/README.md
@@ -10,7 +10,7 @@ This binding integrates internet radios based on the [Frontier Silicon chipset](
 
 ## Supported Things
 
-Successfully tested are internet radios [Hama IR100](https://de.hama.com/00054823/hama-internetradio-ir110), [Medion MD87180](http://internetradio.medion.com/), and [MEDION MD86988](http://internetradio.medion.com/).
+Successfully tested are internet radios [Hama IR100](https://de.hama.com/00054823/hama-internetradio-ir110), [Medion MD87180](http://internetradio.medion.com/), and [MEDION MD86988](http://internetradio.medion.com/). Further radios have been successfully tested with the [frontiersiliconradio binding for openhab 1.x](https://github.com/openhab/openhab/wiki/Frontier-Silicon-Radio-Binding).
 
 But in principle, all internet radios based on the [Frontier Silicon chipset](http://www.frontier-silicon.com/) should be supported because they share the same API.
 


### PR DESCRIPTION
In the meantime, further compatible radios have been tested with the OH1 binding, so they should also be compatible with the ESH FS internet radio binding. I added a note and a link to the wiki page that the radios listed there are most likely also compatible.