### PR TITLE
'Setup Wizard' name change

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
@@ -48,9 +48,9 @@
 				<a href="#control">
 					<span class="icon md-icon-dashboard"></span> Control</a>
 			</li>
-			<li ng-class="{active: isActive('setup')}">
-				<a href="#setup/wizard" class="clickable">
-					<span class="icon md-icon-add-circle-outline"></span> Setup Wizard
+			<li ng-class="{active: isActive('inbox')}">
+				<a href="#inbox" class="clickable">
+					<span class="icon md-icon-add-circle-outline"></span> Inbox
 					<span ng-show="getNumberOfNewDiscoveryResults() > 0" class="badge">{{getNumberOfNewDiscoveryResults()}}</span>
 				</a>
 			</li>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/app.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/app.js
@@ -16,15 +16,16 @@ angular.module('PaperUI', [
 ]).config(['$routeProvider', '$httpProvider', 'globalConfig', function($routeProvider, httpProvider, globalConfig) {
   $routeProvider.
 	when('/control', {templateUrl: 'partials/control.html', controller: 'ControlPageController', title: 'Control', simpleHeader: true}).
-	when('/setup', {redirectTo: '/setup/search'}).
-	when('/setup/search', {templateUrl: 'partials/setup.html', controller: 'InboxController', title: 'Setup Wizard'}).
-	when('/setup/manual-setup/choose', {templateUrl: 'partials/setup.html', controller: 'ManualSetupChooseController', title: 'Setup Wizard'}).
-	when('/setup/manual-setup/configure/:thingTypeUID', {templateUrl: 'partials/setup.html', controller: 'ManualSetupConfigureController', title: 'Setup Wizard'}).
-	when('/setup/wizard', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Setup Wizard'}).
-	when('/setup/wizard/bindings', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Setup Wizard'}).
-	when('/setup/wizard/search/:bindingId', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Setup Wizard'}).
-	when('/setup/wizard/thing-types/:bindingId', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Setup Wizard'}).
-	when('/setup/wizard/add/:thingTypeUID', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Setup Wizard'}).
+	when('/setup', {redirectTo: '/inbox/search'}).
+	when('/inbox', {redirectTo: '/inbox/search'}).
+	when('/inbox/search', {templateUrl: 'partials/setup.html', controller: 'InboxController', title: 'Inbox'}).
+	when('/inbox/manual-setup/choose', {templateUrl: 'partials/setup.html', controller: 'ManualSetupChooseController', title: 'Inbox'}).
+	when('/inbox/manual-setup/configure/:thingTypeUID', {templateUrl: 'partials/setup.html', controller: 'ManualSetupConfigureController', title: 'Inbox'}).
+	when('/inbox/setup', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Inbox'}).
+	when('/inbox/setup/bindings', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Inbox'}).
+	when('/inbox/setup/search/:bindingId', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Inbox'}).
+	when('/inbox/setup/thing-types/:bindingId', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Inbox'}).
+	when('/inbox/setup/add/:thingTypeUID', {templateUrl: 'partials/setup.html', controller: 'SetupWizardController', title: 'Inbox'}).
 	when('/configuration', {redirectTo: '/configuration/bindings'}).
 	when('/configuration/bindings', {templateUrl: 'partials/configuration.html', controller: 'ConfigurationPageController', title: 'Configuration'}).
 	when('/configuration/services', {templateUrl: 'partials/configuration.html', controller: 'ConfigurationPageController', title: 'Configuration'}).

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
@@ -38,7 +38,7 @@ angular.module('PaperUI.controllers', ['PaperUI.constants']).controller('BodyCon
 
     var numberOfInboxEntries = -1;
     eventService.onEvent('smarthome/inbox/*/added', function(topic, discoveryResult) {
-    	toastService.showDefaultToast('New Inbox Entry: ' + discoveryResult.label, 'Show Inbox', 'setup/wizard');
+    	toastService.showDefaultToast('New Inbox Entry: ' + discoveryResult.label, 'Show Inbox', 'inbox/setup');
 	});
     eventService.onEvent('smarthome/items/*/state', function(topic, stateObject) {
     	

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
@@ -6,7 +6,7 @@ function getThingTypeUID(thingUID) {
 angular.module('PaperUI.controllers.setup', 
 []).controller('SetupPageController', function($scope, $location, thingTypeRepository, bindingRepository) {
     $scope.navigateTo = function(path) {
-        $location.path('setup/' + path);
+        $location.path('inbox/' + path);
     }
     $scope.getThingTypeUID = function(thingUID) {
         return getThingTypeUID(thingUID);
@@ -55,7 +55,7 @@ angular.module('PaperUI.controllers.setup',
                 });
                 
                 if(thingType && thingType.bridge) {
-                    $scope.navigateTo('wizard/search/' + thingUID.split(':')[0]);
+                    $scope.navigateTo('setup/search/' + thingUID.split(':')[0]);
                 } else {
                 	discoveryResultRepository.getAll(true);
                 }
@@ -222,7 +222,7 @@ angular.module('PaperUI.controllers.setup',
 		thingSetupService.add({'enableChannels': !$scope.advancedMode}, thing, function() {
 		    homeGroupRepository.setDirty(true);
 			toastService.showDefaultToast('Thing added');
-			$scope.navigateTo('wizard/search/' + $scope.thingType.UID.split(':')[0]);
+			$scope.navigateTo('setup/search/' + $scope.thingType.UID.split(':')[0]);
 		});
 	};
 	
@@ -275,7 +275,7 @@ angular.module('PaperUI.controllers.setup',
     $scope.setHeaderText('Choose a Binding for which you want to add new things.');
     bindingRepository.getAll();
     $scope.selectBinding = function(bindingId) {
-        $scope.navigateTo('wizard/search/' + bindingId);
+        $scope.navigateTo('setup/search/' + bindingId);
     }
 }).controller('SetupWizardSearchBindingController', function($scope, discoveryResultRepository, discoveryService, 
         thingTypeRepository, bindingRepository) {
@@ -330,7 +330,7 @@ angular.module('PaperUI.controllers.setup',
     $scope.setHeaderText('Choose a Thing from the ' + (binding ? binding.name : '') + ' which you want to add.');
     
     $scope.selectThingType = function(thingTypeUID) {
-        $scope.navigateTo('wizard/add/' + thingTypeUID);
+        $scope.navigateTo('setup/add/' + thingTypeUID);
     }
     $scope.filter = function(thingType) {
         return thingType.UID.split(':')[0] === $scope.bindingId;

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -99,14 +99,14 @@
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab md-icon-add" ng-click="$location.path('setup/wizard')" aria-label="Add"></md-button>
+					<md-button class="md-fab md-icon-add" ng-click="$location.path('inbox/setup')" aria-label="Add"></md-button>
 				</div>
 			</div>
 		</div>
 		<div class="container">
 			<p class="text-center" ng-show="data.things.length == 0">
 				No things configured yet.
-				<button class="md-button" ng-click="$location.path('setup/wizard')">Add Things</button>
+				<button class="md-button" ng-click="$location.path('inbox/setup')">Add Things</button>
 			</p>
 			<div class="things">
 				<div class="clickable" ng-repeat="thing in data.things | filter:search">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
@@ -14,7 +14,7 @@
 
 	<p class="text-center" ng-show="getItem(tabs[selectedIndex].name).members.length == 0">
 		Group is empty.
-		<button class="md-button" ng-click="$location.path('setup/wizard')">Add Thing</button>
+		<button class="md-button" ng-click="$location.path('inbox/setup')">Add Thing</button>
 	</p>
 	<div ng-controller="ControlController" class="items row" md-swipe-left="next()" md-swipe-right="prev()"
 		ng-if="tabs[selectedIndex] === tab" ng-attr-id="{{'items-' + tabs.indexOf(tab)}}">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
@@ -41,16 +41,23 @@
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button title="Add" ng-click="addThing(thing)"
+					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid"
 						class="md-fab md-icon-check" aria-label="Add Thing">
 				</div>
 			</div>
 		</div>
 
 		<div ng-include="'partials/include.thingconfig.html'"></div>
+		<div class="container">
+			<h3>Configuration Parameters</h3>
+			<p>Configure parameters for the thing.</p>
+			<div ng-init="form={}">
+				<div ng-include="'partials/include.config.html'" onload="configuration=thing.configuration"></div>
+			</div>
+		</div>
 	</div>
 	<div ng-controller="InboxController" class="thing-add white-bg"
-		ng-if="page === 'wizard' && !path[3]">
+		ng-if="page === 'search' && !path[3]">
 		<div class="header-toolbar">
 			<md-button title="Scan" class="md-icon-settings-input-antenna"
 				ng-click="showScanDialog($event)" aria-label="Scan"></md-button>
@@ -61,7 +68,7 @@
 			<div class="container">
 				<div class="toolbar">
 					<md-button class="md-fab md-icon-add"
-						ng-click="navigateTo('wizard/bindings')" aria-label="Add Thing"></md-button>
+						ng-click="navigateTo('setup/bindings')" aria-label="Add Thing"></md-button>
 				</div>
 			</div>
 		</div>
@@ -74,13 +81,13 @@
 			<p class="text-center">
 				<span>Thing not listed?</span>
 				<md-button title="Add Manually" class="md-button"
-					ng-click="navigateTo('wizard/bindings')">Search For
+					ng-click="navigateTo('setup/bindings')">Search For
 				Things</md-button>
 			</p>
 		</div>
 	</div>
 	<div ng-controller="SetupWizardBindingsController" class="white-bg"
-		ng-if="page === 'wizard' && path[3] === 'bindings'">
+		ng-if="page === 'setup' && path[3] === 'bindings'">
 		<div class="section-header"></div>
 		<div class="container selection-list">
 			<div ng-repeat="binding in data.bindings"
@@ -101,7 +108,7 @@
 	</div>
 	<div ng-controller="SetupWizardSearchBindingController"
 		class="white-bg"
-		ng-if="page === 'wizard' && path[3] === 'search' && path[4]">
+		ng-if="page === 'setup' && path[3] === 'search' && path[4]">
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
@@ -126,7 +133,7 @@
 				<div>
 					<span>Thing not found?
 						<button class="md-button"
-							ng-click="navigateTo('wizard/thing-types/' + bindingId)">Manually
+							ng-click="navigateTo('setup/thing-types/' + bindingId)">Manually
 							Add Thing</button>
 					</span>
 				</div>
@@ -135,7 +142,7 @@
 				<p class="text-center">
 					Binding does not support discovery.
 					<button class="md-button"
-						ng-click="navigateTo('wizard/thing-types/' + bindingId)">Manually
+						ng-click="navigateTo('setup/thing-types/' + bindingId)">Manually
 						Add Thing</button>
 				</p>
 			</div>
@@ -144,13 +151,13 @@
 			<p class="text-center">
 				<span>Thing not listed?</span>
 				<button class="md-button"
-					ng-click="navigateTo('wizard/thing-types/' + bindingId)">Add
+					ng-click="navigateTo('setup/thing-types/' + bindingId)">Add
 					Manually</button>
 			</p>
 		</div>
 	</div>
 	<div ng-controller="SetupWizardThingTypesController" class="white-bg"
-		ng-if="page === 'wizard' && path[3] === 'thing-types'">
+		ng-if="page === 'setup' && path[3] === 'thing-types'">
 		<div class="section-header"></div>
 		<div class="container selection-list">
 			<div
@@ -172,9 +179,9 @@
 	</div>
 	<div ng-controller="ManualSetupConfigureController"
 		class="thing-configure white-bg"
-		ng-if="page === 'wizard' && path[3] === 'add'">
+		ng-if="page === 'setup' && path[3] === 'add'">
 		<div class="header-toolbar">
-			<md-button class="md-icon-close" ng-click="navigateTo('wizard')" aria-label="Close"></md-button>
+			<md-button class="md-icon-close" ng-click="navigateTo('setup')" aria-label="Close"></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">


### PR DESCRIPTION
Setup Wizard's name changed to 'Inbox' as discussed here https://github.com/eclipse/smarthome/issues/890.

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>