### PR TITLE
fix ThingSetupManager removal handling

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingSetupManager.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingSetupManager.xml
@@ -20,6 +20,6 @@
    <reference bind="setItemRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
    <service>
       <provide interface="org.eclipse.smarthome.core.thing.setup.ThingSetupManager"/>
-      <provide interface="org.eclipse.smarthome.core.events.EventSubscriber"/>
    </service>
+   <reference bind="addManagedThingProvider" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ManagedThingProvider" name="ManagedThingProvider" policy="static" unbind="removeManagedThingProvider"/>
 </scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/setup/ThingSetupManager.java
@@ -16,9 +16,9 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.events.Event;
+import org.eclipse.smarthome.core.common.registry.Provider;
+import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.events.EventFilter;
-import org.eclipse.smarthome.core.events.EventSubscriber;
 import org.eclipse.smarthome.core.events.TopicEventFilter;
 import org.eclipse.smarthome.core.items.ActiveItem;
 import org.eclipse.smarthome.core.items.GenericItem;
@@ -29,6 +29,7 @@ import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -73,7 +74,7 @@ import com.google.common.collect.ImmutableSet;
  * @author Chris Jackson - Remove children when deleted bridge. Add label/description.
  */
 @Deprecated
-public class ThingSetupManager implements EventSubscriber {
+public class ThingSetupManager implements ProviderChangeListener<Thing> {
 
     public static final String TAG_CHANNEL_GROUP = "channel-group";
     public static final String TAG_HOME_GROUP = "home-group";
@@ -727,31 +728,35 @@ public class ThingSetupManager implements EventSubscriber {
         }
     }
 
-    @Override
-    public Set<String> getSubscribedEventTypes() {
-        return subscribedEventTypes;
+    protected void addManagedThingProvider(ManagedThingProvider managedThingProvider) {
+        managedThingProvider.addProviderChangeListener(this);
+    }
+
+    protected void removeManagedThingProvider(ManagedThingProvider managedThingProvider) {
+        managedThingProvider.removeProviderChangeListener(this);
     }
 
     @Override
-    public EventFilter getEventFilter() {
-        return eventFiter;
+    public void added(Provider<Thing> provider, Thing thing) {
     }
 
     @Override
-    public void receive(Event event) {
-        if (event instanceof ThingRemovedEvent) {
-            ThingRemovedEvent thingRemovedEvent = (ThingRemovedEvent) event;
-            ThingUID thingUID = new ThingUID(thingRemovedEvent.getThing().UID);
-            String itemName = toItemName(thingUID);
-            if (itemRegistry.get(itemName) != null) {
-                try {
-                    itemRegistry.remove(itemName, true);
-                    itemThingLinkRegistry.remove(AbstractLink.getIDFor(itemName, thingUID));
-                    itemChannelLinkRegistry.removeLinksForThing(thingUID);
-                } catch (Exception ex) {
-                    logger.error("Coud not remove items and links for removed thing: " + ex.getMessage(), ex);
-                }
+    public void removed(Provider<Thing> provider, Thing thing) {
+        ThingUID thingUID = thing.getUID();
+        String itemName = toItemName(thingUID);
+        if (itemRegistry.get(itemName) != null) {
+            try {
+                itemRegistry.remove(itemName, true);
+                itemThingLinkRegistry.remove(AbstractLink.getIDFor(itemName, thingUID));
+                itemChannelLinkRegistry.removeLinksForThing(thingUID);
+            } catch (Exception ex) {
+                logger.error("Coud not remove items and links for removed thing: " + ex.getMessage(), ex);
             }
         }
     }
+
+    @Override
+    public void updated(Provider<Thing> provider, Thing oldThing, Thing thing) {
+    }
+
 }


### PR DESCRIPTION
The horse is dead, long live the horse.!!!

The ThingSetupManager used to listen to ThingRemovedEvents, which are sent out not only if a Thing gets removed explicitly, but also if a ThingProvider gets removed (the ThingRegistry notifies the listeners by sending out the event). As a result, the TSM deletes will also delete Items etc. if during shutdown DS deactivates the ManagedThingProvider before the ThingRegistry, leading to data loss (i.e. room assignment and labels cannot be restored).

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>