### PR TITLE
Change REST ItemResource and ClassicUI response content-type to text/plain

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
@@ -281,7 +282,9 @@ public class ItemResource implements RESTResource {
             if (command != null) {
                 logger.debug("Received HTTP POST request at '{}' with value '{}'.", uriInfo.getPath(), value);
                 eventPublisher.post(ItemEventFactory.createCommandEvent(itemname, command));
-                return Response.ok().build();
+                ResponseBuilder resbuilder = Response.ok();
+                resbuilder.type(MediaType.TEXT_PLAIN);
+                return resbuilder.build();
             } else {
                 logger.warn("Received HTTP POST request at '{}' with an invalid status value '{}'.", uriInfo.getPath(),
                         value);

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/CmdServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/CmdServlet.java
@@ -74,6 +74,8 @@ public class CmdServlet extends BaseServlet {
      */
     @Override
     public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
+        res.setContentType("text/plain");
+
         for (Object key : req.getParameterMap().keySet()) {
             String itemName = key.toString();
 


### PR DESCRIPTION
By default, Firefox tries to parse XMLHTTPRequest responses as `text/xml`. When the response is empty, it shows a warning in the console (`no element found` meaning that there is no document root element). This message is shown when items are changed through BasicUI or ClassicUI. This commit fixes it.

This is a combination of 2 commits.

* REST: Change ItemResource response content-type to text/plain
* ClassicUI: Set command servlet response content-type to text/plain

Signed-off-by: Vlad Ivanov <vlad-mbx@ya.ru>