### PR TITLE
add m2e stuff

### DIFF
--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -2385,6 +2385,12 @@
         excludedTriggers="STARTUP"
         predecessor="antlr-generator-3.2.0-patch"
         launcher="Generate All Models"/>
+    <setupTask
+        xsi:type="setup:ResourceCreationTask"
+        id="lifecycle-mapping"
+        content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;lifecycleMappingMetadata>&#xA;  &lt;pluginExecutions>&#xA;    &lt;pluginExecution>&#xA;      &lt;pluginExecutionFilter>&#xA;        &lt;groupId>org.codehaus.mojo&lt;/groupId>&#xA;        &lt;artifactId>build-helper-maven-plugin&lt;/artifactId>&#xA;        &lt;versionRange>1.8&lt;/versionRange>&#xA;        &lt;goals>&#xA;          &lt;goal>add-source&lt;/goal>&#xA;          &lt;goal>add-test-source&lt;/goal>&#xA;        &lt;/goals>&#xA;      &lt;/pluginExecutionFilter>&#xA;      &lt;action>&#xA;        &lt;ignore />&#xA;      &lt;/action>&#xA;    &lt;/pluginExecution>&#xA;  &lt;/pluginExecutions>&#xA;&lt;/lifecycleMappingMetadata>&#xA;"
+        targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml"
+        encoding="UTF-8"/>
     <stream
         name="master"/>
   </project>

--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -2313,6 +2313,8 @@
           name="org.eclipse.wst.jsdt.feature.feature.group"/>
       <requirement
           name="org.eclipse.wst.web_ui.feature.feature.group"/>
+      <requirement
+          name="org.jboss.tools.m2e.jdt.feature.feature.group"/>
       <repository
           url="http://repo1.maven.org/maven2/.m2e/connectors/m2eclipse-tycho/0.7.0/N/0.7.0.201309291400/"/>
       <repository


### PR DESCRIPTION
If you open "org.eclipse.smarthome.io.console.karaf" in the Eclipse SmartHome IDE, the IDE shows three errors caused by missing lifecycle mappings.
Two of them have to be disabled in the IDE settings, for the maven-compiler-plugin a m2e connector should be installed.
The search for connectors identify four connectors as usable (in combination of other features) to be installed:
* m2e-wtp - Maven Integration for WTP
* M2E connector for the Eclipse JDT Compiler
* Maven Integration for Eclipse JDT APT
* Groovy-Eclipse M2E integration
