### PR TITLE
karaf console wrapper: argument list as string

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.console.karaf/src/main/java/org/eclipse/smarthome/io/console/karaf/internal/CommandWrapper.java
+++ b/bundles/io/org.eclipse.smarthome.io.console.karaf/src/main/java/org/eclipse/smarthome/io/console/karaf/internal/CommandWrapper.java
@@ -36,7 +36,16 @@ public class CommandWrapper implements Command {
     @Override
     public Object execute(Session session, List<Object> argList) throws Exception {
         final String[] args = new String[argList.size()];
-        argList.toArray(args);
+        for (int i = 0; i < args.length; ++i) {
+            final Object ele = argList.get(i);
+            final String str;
+            if (ele instanceof String) {
+                str = (String) ele;
+            } else {
+                str = ele.toString();
+            }
+            args[i] = str;
+        }
 
         ConsoleInterpreter.execute(new OSGiConsole(getScope()), command, args);
         return null;


### PR DESCRIPTION
The list of arguments does not need to be string objects.
If you are using a number on the Karaf command line the object type
could be e.g. a Long class object.

Bug: https://github.com/eclipse/smarthome/issues/984
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>