### PR TITLE
fix bundle names

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Automation Modules
+Bundle-Name: Eclipse SmartHome Automation Module Core
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.core
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.automation.module.core.internal.Activator

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Script Automation Modules
+Bundle-Name: Eclipse SmartHome Automation Module Script
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.automation.module.script.internal.ScriptModuleActivator

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Timer Automation Modules
+Bundle-Name: Eclipse SmartHome Automation Module Timer
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer
 Bundle-Version: 0.8.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.automation.module.timer.internal.Activator


### PR DESCRIPTION
There are some bundles that name does not fit to the scheme the other bundles are using.

Before:
```text
   81|Active     |    4|Eclipse SmartHome Automation API (0.8.0.qualifier)
   82|Active     |    4|Eclipse SmartHome Automation commands (0.8.0.qualifier)
   83|Active     |    4|Eclipse SmartHome Automation Core (0.8.0.qualifier)
   84|Active     |    4|Automation Modules (0.8.0.qualifier)
   85|Active     |    4|Script Automation Modules (0.8.0.qualifier)
   86|Active     |    4|Eclipse SmartHome Automation Script Globals (0.8.0.qualifier)
   87|Starting   |    4|Timer Automation Modules (0.8.0.qualifier)
   88|Active     |    4|Eclipse SmartHome Automation GSON Parser (0.8.0.qualifier)
   89|Active     |    4|Eclipse SmartHome Automation Providers (0.8.0.qualifier)
   90|Active     |    4|Eclipse SmartHome Automation REST API (0.8.0.qualifier)
   91|Active     |    4|Eclipse SmartHome Config Core (0.8.0.qualifier)
   92|Active     |    4|Eclipse SmartHome Configuration Discovery (0.8.0.qualifier)
   93|Active     |    4|Eclipse SmartHome Config Dispatcher (0.8.0.qualifier)
   94|Active     |    4|Eclipse SmartHome Config XML (0.8.0.qualifier)
   95|Active     |    4|Eclipse SmartHome Core (0.8.0.qualifier)
   96|Active     |    4|Eclipse SmartHome AutoUpdate Binding (0.8.0.qualifier)
   97|Active     |    4|Eclipse SmartHome Core Binding XML (0.8.0.qualifier)
   98|Active     |    4|Eclipse SmartHome Core Persistence (0.8.0.qualifier)
   99|Active     |    4|Eclipse SmartHome Scheduler Service (0.8.0.qualifier)
  100|Active     |    4|Eclipse SmartHome Core Thing (0.8.0.qualifier)
  101|Active     |    4|Eclipse SmartHome Core Thing XML (0.8.0.qualifier)
  102|Active     |    4|Eclipse SmartHome Transformation Service (0.8.0.qualifier)
  103|Active     |    4|Eclipse SmartHome Console (0.8.0.qualifier)
  104|Active     |    4|Eclipse SmartHome Console for OSGi framework Eclipse Equinox (0.8.0.qualifier)
  105|Active     |    4|Eclipse SmartHome Monitor (0.8.0.qualifier)
  106|Active     |    4|Eclipse SmartHome Multimedia I/O Bundle (0.8.0.qualifier)
  107|Active     |    4|Eclipse SmartHome Net I/O Bundle (0.8.0.qualifier)
  108|Active     |    4|Eclipse SmartHome REST Interface Bundle (0.8.0.qualifier)
  109|Active     |    4|Eclipse SmartHome Core REST API (0.8.0.qualifier)
  110|Active     |    4|Eclipse SmartHome Sitemap REST API (0.8.0.qualifier)
  111|Active     |    4|Eclipse SmartHome SSE REST API (0.8.0.qualifier)
  112|Active     |    5|Eclipse SmartHome Model Core (0.8.0.qualifier)
  113|Active     |    3|Eclipse SmartHome Item Model (0.8.0.qualifier)
  114|Active     |    3|Eclipse SmartHome Item Model Runtime (0.8.0.qualifier)
  115|Active     |    3|Eclipse SmartHome Persistence Model (0.8.0.qualifier)
  116|Active     |    3|Eclipse SmartHome Persistence Runtime (0.8.0.qualifier)
  117|Active     |    3|Eclipse SmartHome Rule Model (0.8.0.qualifier)
  118|Active     |    3|Eclipse SmartHome Rule Runtime (0.8.0.qualifier)
  119|Active     |    3|Eclipse SmartHome Script (0.8.0.qualifier)
  120|Active     |    3|Eclipse SmartHome Script Runtime (0.8.0.qualifier)
  121|Active     |    3|Eclipse SmartHome Sitemap Model (0.8.0.qualifier)
  122|Active     |    3|Eclipse SmartHome Sitemap Runtime (0.8.0.qualifier)
  123|Active     |    3|Eclipse SmartHome Thing Model (0.8.0.qualifier)
  124|Active     |    3|Eclipse SmartHome Thing Model Runtime (0.8.0.qualifier)
  125|Active     |    4|Eclipse SmartHome MapDB Storage Service (0.8.0.qualifier)
  126|Active     |    4|Eclipse SmartHome UI (0.8.0.qualifier)
  127|Active     |    4|Eclipse SmartHome Basic UI (0.8.0.qualifier)
  128|Active     |    4|Eclipse SmartHome WebApp UI (0.8.0.qualifier)
  129|Active     |    4|Eclipse SmartHome UI Icons (0.8.0.qualifier)
  130|Active     |    4|Eclipse SmartHome Classic IconSet (0.8.0.qualifier)
  131|Active     |    4|Eclipse SmartHome Paper UI (0.8.0.qualifier)
```

After:
```text
   81|Active     |    4|Eclipse SmartHome Automation API (0.8.0.qualifier)
   82|Active     |    4|Eclipse SmartHome Automation commands (0.8.0.qualifier)
   83|Active     |    4|Eclipse SmartHome Automation Core (0.8.0.qualifier)
   84|Active     |    4|Eclipse SmartHome Automation Module Core (0.8.0.qualifier)
   85|Active     |    4|Eclipse SmartHome Automation Module Script (0.8.0.qualifier)
   86|Active     |    4|Eclipse SmartHome Automation Script Globals (0.8.0.qualifier)
   87|Starting   |    4|Eclipse SmartHome Automation Module Timer (0.8.0.qualifier)
   88|Active     |    4|Eclipse SmartHome Automation GSON Parser (0.8.0.qualifier)
   89|Active     |    4|Eclipse SmartHome Automation Providers (0.8.0.qualifier)
   90|Active     |    4|Eclipse SmartHome Automation REST API (0.8.0.qualifier)
   91|Active     |    4|Eclipse SmartHome Config Core (0.8.0.qualifier)
   92|Active     |    4|Eclipse SmartHome Configuration Discovery (0.8.0.qualifier)
   93|Active     |    4|Eclipse SmartHome Config Dispatcher (0.8.0.qualifier)
   94|Active     |    4|Eclipse SmartHome Config XML (0.8.0.qualifier)
   95|Active     |    4|Eclipse SmartHome Core (0.8.0.qualifier)
   96|Active     |    4|Eclipse SmartHome AutoUpdate Binding (0.8.0.qualifier)
   97|Active     |    4|Eclipse SmartHome Core Binding XML (0.8.0.qualifier)
   98|Active     |    4|Eclipse SmartHome Core Persistence (0.8.0.qualifier)
   99|Active     |    4|Eclipse SmartHome Scheduler Service (0.8.0.qualifier)
  100|Active     |    4|Eclipse SmartHome Core Thing (0.8.0.qualifier)
  101|Active     |    4|Eclipse SmartHome Core Thing XML (0.8.0.qualifier)
  102|Active     |    4|Eclipse SmartHome Transformation Service (0.8.0.qualifier)
  103|Active     |    4|Eclipse SmartHome Console (0.8.0.qualifier)
  104|Active     |    4|Eclipse SmartHome Console for OSGi framework Eclipse Equinox (0.8.0.qualifier)
  105|Active     |    4|Eclipse SmartHome Monitor (0.8.0.qualifier)
  106|Active     |    4|Eclipse SmartHome Multimedia I/O Bundle (0.8.0.qualifier)
  107|Active     |    4|Eclipse SmartHome Net I/O Bundle (0.8.0.qualifier)
  108|Active     |    4|Eclipse SmartHome REST Interface Bundle (0.8.0.qualifier)
  109|Active     |    4|Eclipse SmartHome Core REST API (0.8.0.qualifier)
  110|Active     |    4|Eclipse SmartHome Sitemap REST API (0.8.0.qualifier)
  111|Active     |    4|Eclipse SmartHome SSE REST API (0.8.0.qualifier)
  112|Active     |    5|Eclipse SmartHome Model Core (0.8.0.qualifier)
  113|Active     |    3|Eclipse SmartHome Item Model (0.8.0.qualifier)
  114|Active     |    3|Eclipse SmartHome Item Model Runtime (0.8.0.qualifier)
  115|Active     |    3|Eclipse SmartHome Persistence Model (0.8.0.qualifier)
  116|Active     |    3|Eclipse SmartHome Persistence Runtime (0.8.0.qualifier)
  117|Active     |    3|Eclipse SmartHome Rule Model (0.8.0.qualifier)
  118|Active     |    3|Eclipse SmartHome Rule Runtime (0.8.0.qualifier)
  119|Active     |    3|Eclipse SmartHome Script (0.8.0.qualifier)
  120|Active     |    3|Eclipse SmartHome Script Runtime (0.8.0.qualifier)
  121|Active     |    3|Eclipse SmartHome Sitemap Model (0.8.0.qualifier)
  122|Active     |    3|Eclipse SmartHome Sitemap Runtime (0.8.0.qualifier)
  123|Active     |    3|Eclipse SmartHome Thing Model (0.8.0.qualifier)
  124|Active     |    3|Eclipse SmartHome Thing Model Runtime (0.8.0.qualifier)
  125|Active     |    4|Eclipse SmartHome MapDB Storage Service (0.8.0.qualifier)
  126|Active     |    4|Eclipse SmartHome UI (0.8.0.qualifier)
  127|Active     |    4|Eclipse SmartHome Basic UI (0.8.0.qualifier)
  128|Active     |    4|Eclipse SmartHome WebApp UI (0.8.0.qualifier)
  129|Active     |    4|Eclipse SmartHome UI Icons (0.8.0.qualifier)
  130|Active     |    4|Eclipse SmartHome Classic IconSet (0.8.0.qualifier)
  131|Active     |    4|Eclipse SmartHome Paper UI (0.8.0.qualifier)
```