### PR TITLE
drop lazy activation

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
@@ -17,7 +17,6 @@ Import-Package: com.google.common.collect,
  org.quartz.impl,
  org.quartz.utils,
  org.slf4j;version="1.7.2"
-Bundle-ActivationPolicy: lazy
 Automation-ResourceType: json
 Export-Package: org.eclipse.smarthome.automation.module.timer.factory,
  org.eclipse.smarthome.automation.module.timer.handler


### PR DESCRIPTION
The automation module 'timer' should be activated if present and not if
a class is used first. The lazy activation conflicts with the intention
of a module that extents some functionality.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>