### PR TITLE
automation timer test stabilization

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/src/test/groovy/org/eclipse/smarthome/automation/module/timer/internal/RuntimeRuleTest.groovy
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/src/test/groovy/org/eclipse/smarthome/automation/module/timer/internal/RuntimeRuleTest.groovy
@@ -19,39 +19,23 @@ import org.eclipse.smarthome.automation.Condition
 import org.eclipse.smarthome.automation.Rule
 import org.eclipse.smarthome.automation.RuleRegistry
 import org.eclipse.smarthome.automation.RuleStatus
-import org.eclipse.smarthome.automation.RuleStatusInfo
 import org.eclipse.smarthome.automation.Trigger
-import org.eclipse.smarthome.automation.type.ModuleTypeRegistry
-import org.eclipse.smarthome.automation.events.RuleStatusInfoEvent
-import org.eclipse.smarthome.automation.module.core.handler.CompareConditionHandler;
 import org.eclipse.smarthome.automation.module.timer.handler.TimerTriggerHandler
-import org.eclipse.smarthome.core.events.Event
-import org.eclipse.smarthome.core.events.EventPublisher
-import org.eclipse.smarthome.core.events.EventSubscriber
+import org.eclipse.smarthome.automation.type.ModuleTypeRegistry
 import org.eclipse.smarthome.core.items.ItemProvider
 import org.eclipse.smarthome.core.items.ItemRegistry
-import org.eclipse.smarthome.core.items.events.ItemCommandEvent
-import org.eclipse.smarthome.core.items.events.ItemEventFactory
-import org.eclipse.smarthome.core.items.events.ItemStateEvent
-import org.eclipse.smarthome.core.items.events.ItemUpdatedEvent
 import org.eclipse.smarthome.core.library.items.SwitchItem
 import org.eclipse.smarthome.core.library.types.OnOffType
-import org.eclipse.smarthome.core.types.Command
-import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.TypeParser
 import org.eclipse.smarthome.test.OSGiTest
 import org.eclipse.smarthome.test.storage.VolatileStorageService
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-import com.google.common.collect.Sets
-
 /**
  * this tests the Timer Trigger
- * 
+ *
  * @author Christoph Knauf - initial contribution
  *
  */
@@ -94,13 +78,19 @@ class RuntimeRuleTest extends OSGiTest{
         def testItemName = "myLampItem"
 
         def triggerConfig = [cronExpression:testExpression]
-        def triggers = [new Trigger("MyTimerTrigger", "TimerTrigger", triggerConfig)]
+        def triggers = [
+            new Trigger("MyTimerTrigger", "TimerTrigger", triggerConfig)
+        ]
 
         def actionConfig = [itemName:testItemName, command:"ON"]
-        def actions = [new Action("MyItemPostCommandAction", "ItemPostCommandAction", actionConfig, null)]
+        def actions = [
+            new Action("MyItemPostCommandAction", "ItemPostCommandAction", actionConfig, null)
+        ]
 
         def conditionConfig = [operator:"=", itemName:testItemName, state:"OFF"]
-        def conditions = [new Condition("MyItemStateCondition", "ItemStateCondition", conditionConfig, null)]
+        def conditions = [
+            new Condition("MyItemStateCondition", "ItemStateCondition", conditionConfig, null)
+        ]
 
         def rule = new Rule("MyRule"+new Random().nextInt(),triggers, conditions, actions, null, null)
         rule.name="MyTimerTriggerTestRule"
@@ -112,7 +102,7 @@ class RuntimeRuleTest extends OSGiTest{
         waitForAssert({
             assertThat lampItem.state,is(OnOffType.OFF)
         })
-        
+
         ruleRegistry.add(rule)
         ruleRegistry.setEnabled(rule.UID, true)
         waitForAssert({
@@ -122,10 +112,12 @@ class RuntimeRuleTest extends OSGiTest{
 
         def numberOfTests = 3
         for (int i=0; i < numberOfTests;i++){
+            ruleRegistry.setEnabled(rule.UID, false)
             lampItem.send(OnOffType.OFF);
             waitForAssert({
                 assertThat lampItem.state,is(OnOffType.OFF)
             })
+            ruleRegistry.setEnabled(rule.UID, true)
             waitForAssert({
                 assertThat lampItem.state,is(OnOffType.ON)
             })


### PR DESCRIPTION
The current test sets an item, check if the state of the item is the set
one and then checks if the state has been changed to another one. The
state change is triggered by a timer triggered rule.
The timer activates the rule every second (using wildcard for the cron
expression statements).
If the rule is triggered between the set state and the assertion that
expects the state is the set one, the test fails.
This commit changes the logic that it disables the rule to check if the
value has been set and then enables it again afterwards before checking
if the rule has been applied.

Most stuff are changes that has been done by the formatter.
The real change is this one:
```diff
         def numberOfTests = 3
         for (int i=0; i < numberOfTests;i++){
+            ruleRegistry.setEnabled(rule.UID, false)
             lampItem.send(OnOffType.OFF);
             waitForAssert({
                 assertThat lampItem.state,is(OnOffType.OFF)
             })
+            ruleRegistry.setEnabled(rule.UID, true)
             waitForAssert({
                 assertThat lampItem.state,is(OnOffType.ON)
             })
         }
```