### PR TITLE
Test failure: have a workaround, need a solution

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
@@ -8,6 +8,8 @@ Fragment-Host: org.eclipse.smarthome.automation.module.script
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.collect,
  groovy.lang,
+ org.apache.commons.io,
+ org.apache.commons.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,


### PR DESCRIPTION
This PR should perhaps not be merged immediately.
The following change is necessary on my machine to get the automation script test working.
Without this lines it fails.

The test themselves does not use this packages directly (commons-io and commons-lang) and IMHO the org.eclipse.smarthome bundles that are involved and are using this packages, does have a valid import package in their manifest.

The Eclipse IDE can run the test without this changes, but maven fails (on my machine) all the time.

Could someone help me to investigate this problem.

```text
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.eclipse.smarthome.automation.module.script.ScriptRuleTest
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.87 sec <<< FAILURE! - in org.eclipse.smarthome.automation.module.script.ScriptRuleTest
testPredefinedRule(org.eclipse.smarthome.automation.module.script.ScriptRuleTest)  Time elapsed: 1.519 sec  <<< FAILURE!
java.lang.AssertionError: 
Expected: not null
     but: was null
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:865)
	at org.junit.Assert.assertThat(Assert.java:832)
	at org.junit.Assert$assertThat.callStatic(Unknown Source)
	at org.eclipse.smarthome.automation.module.script.ScriptRuleTest$_testPredefinedRule_closure12.doCall(ScriptRuleTest.groovy:130)
	at org.eclipse.smarthome.automation.module.script.ScriptRuleTest$_testPredefinedRule_closure12.doCall(ScriptRuleTest.groovy)
	at sun.reflect.GeneratedMethodAccessor5.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:324)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:278)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1016)
	at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:39)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:112)
	at org.eclipse.smarthome.test.OSGiTest.waitForAssert(OSGiTest.groovy:181)
	at org.eclipse.smarthome.test.OSGiTest.waitForAssert(OSGiTest.groovy)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:207)
	at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:56)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:49)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
	at org.eclipse.smarthome.automation.module.script.ScriptRuleTest.testPredefinedRule(ScriptRuleTest.groovy:129)


Results :

Failed tests: 
  ScriptRuleTest.testPredefinedRule:129->OSGiTest.waitForAssert:-1->OSGiTest.waitForAssert:181 
Expected: not null
     but: was null

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```