### PR TITLE
add md-icons to Paper UI

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/build.properties
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/build.properties
@@ -11,8 +11,7 @@ bin.includes = META-INF/,\
                web/js/,\
                web/partials/
 source.. = src/main/java/
-bin.excludes = web/fonts/md-icons/,\
-               web/fonts/Roboto-Thin.eot,\
+bin.excludes = web/fonts/Roboto-Thin.eot,\
                web/fonts/Roboto-Thin.ttf,\
                web/fonts/Roboto-Thin.woff,\
                web/fonts/Roboto-Thin.woff2,\


### PR DESCRIPTION
CQ 10013 has been approved for check-in, we therefore can now package the material design icons directly with the Paper UI.

Signed-off-by: Kai Kreuzer <kai@openhab.org>