### PR TITLE
use non-static logger members if not necessary

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DefaultScriptScopeProvider implements ScriptScopeProvider {
 
-    private final static Logger logger = LoggerFactory.getLogger(DefaultScriptScopeProvider.class);
+    private final Logger logger = LoggerFactory.getLogger(DefaultScriptScopeProvider.class);
 
     private Map<String, Object> elements;
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -37,7 +37,7 @@ public class Configuration {
 
     final private Map<String, Object> properties;
 
-    private static transient final Logger logger = LoggerFactory.getLogger(Configuration.class);
+    private transient final Logger logger = LoggerFactory.getLogger(Configuration.class);
 
     public Configuration() {
         this(new HashMap<String, Object>());
@@ -166,10 +166,12 @@ public class Configuration {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (!(obj instanceof Configuration))
+        }
+        if (!(obj instanceof Configuration)) {
             return false;
+        }
         return this.hashCode() == obj.hashCode();
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/internal/SseActivator.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/src/main/java/org/eclipse/smarthome/io/rest/sse/internal/SseActivator.java
@@ -18,13 +18,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Bundle activator for Eclipse Smarthome SSE bundle.
- * 
+ *
  * @author Ivan Iliev - Initial Contribution and API
- * 
+ *
  */
 public class SseActivator implements BundleActivator {
 
-    private static final Logger logger = LoggerFactory.getLogger(SseActivator.class);
+    private final Logger logger = LoggerFactory.getLogger(SseActivator.class);
 
     private static BundleContext context;
 
@@ -77,7 +77,7 @@ public class SseActivator implements BundleActivator {
 
     /**
      * Returns the bundle context of this bundle
-     * 
+     *
      * @return the bundle context
      */
     public static BundleContext getContext() {

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/src/main/java/org/eclipse/smarthome/binding/fsinternetradio/internal/radio/FrontierSiliconRadioApiResult.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/src/main/java/org/eclipse/smarthome/binding/fsinternetradio/internal/radio/FrontierSiliconRadioApiResult.java
@@ -48,7 +48,7 @@ public class FrontierSiliconRadioApiResult {
      */
     final Document xmlDoc;
 
-    private static final Logger logger = LoggerFactory.getLogger(FrontierSiliconRadioApiResult.class);
+    private final Logger logger = LoggerFactory.getLogger(FrontierSiliconRadioApiResult.class);
 
     /**
      * Create result object from XML that was received from the radio.
@@ -65,8 +65,9 @@ public class FrontierSiliconRadioApiResult {
             logger.trace("converting to XML failed: '" + requestResultString + "' with " + e.getClass().getName() + ": "
                     + e.getMessage());
             logger.debug("converting to XML failed with " + e.getClass().getName() + ": " + e.getMessage());
-            if (e instanceof IOException)
+            if (e instanceof IOException) {
                 throw (IOException) e;
+            }
             throw new IOException(e);
         }
         xmlDoc = xml;

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/src/main/java/org/eclipse/smarthome/binding/fsinternetradio/internal/radio/FrontierSiliconRadioConnection.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/src/main/java/org/eclipse/smarthome/binding/fsinternetradio/internal/radio/FrontierSiliconRadioConnection.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public class FrontierSiliconRadioConnection {
 
-    private static final Logger logger = LoggerFactory.getLogger(FrontierSiliconRadioConnection.class);
+    private final Logger logger = LoggerFactory.getLogger(FrontierSiliconRadioConnection.class);
 
     /** Timeout for HTTP requests. */
     private final static int SOCKET_TIMEOUT = 5000; // ms
@@ -180,8 +180,9 @@ public class FrontierSiliconRadioConnection {
                 }
 
                 final FrontierSiliconRadioApiResult result = new FrontierSiliconRadioApiResult(responseBody);
-                if (result.isStatusOk())
+                if (result.isStatusOk()) {
                     return result;
+                }
 
                 isLoggedIn = false;
                 method.releaseConnection();

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- */ 
+ */
 package org.eclipse.smarthome.transform.jsonpath.internal;
 
 import org.eclipse.smarthome.core.transform.TransformationException;
@@ -12,50 +12,50 @@ import org.eclipse.smarthome.core.transform.TransformationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
- 
- /**
-  * <p>
-  * The implementation of {@link TransformationService} which transforms the input by JSonPath Expressions.
-  * </p>
-  * 
-  * @author Gaël L'hopital
-  * @author Sebastian Janzen
-  * 
-  */
- public class JSonPathTransformationService implements TransformationService {
 
- 	static final Logger logger = LoggerFactory.getLogger(JSonPathTransformationService.class);
+/**
+ * <p>
+ * The implementation of {@link TransformationService} which transforms the input by JSonPath Expressions.
+ * </p>
+ *
+ * @author Gaël L'hopital
+ * @author Sebastian Janzen
+ *
+ */
+public class JSonPathTransformationService implements TransformationService {
+
+    private final Logger logger = LoggerFactory.getLogger(JSonPathTransformationService.class);
 
     /**
-     * Transforms the input <code>source</code> by JSonPath expression. 
-     * 
+     * Transforms the input <code>source</code> by JSonPath expression.
+     *
      * @param function JsonPath expression
      * @param source String which contains JSON
-     * @throws TransformationException If the JsonPath expression is invalid, a {@link InvalidPathException} is thrown, 
-     * which is encapsulated in a {@link TransformationException}. 
+     * @throws TransformationException If the JsonPath expression is invalid, a {@link InvalidPathException} is thrown,
+     *             which is encapsulated in a {@link TransformationException}.
      */
- 	public String transform(String jsonPathExpression, String source) throws TransformationException {
+    @Override
+    public String transform(String jsonPathExpression, String source) throws TransformationException {
 
- 		if (jsonPathExpression == null || source == null) {
- 			throw new TransformationException("the given parameters 'JSonPath' and 'source' must not be null");
- 		}
+        if (jsonPathExpression == null || source == null) {
+            throw new TransformationException("the given parameters 'JSonPath' and 'source' must not be null");
+        }
 
- 		logger.debug("about to transform '{}' by the function '{}'", source, jsonPathExpression);
+        logger.debug("about to transform '{}' by the function '{}'", source, jsonPathExpression);
 
- 		try {
- 			Object transformationResult = JsonPath.read(source, jsonPathExpression);
- 			logger.debug("transformation resulted in '{}'", transformationResult);
- 			return (transformationResult != null) ? transformationResult.toString() : null;
- 		} catch (PathNotFoundException e) {
- 		    return null;
- 		} catch(InvalidPathException e) {
- 			throw new TransformationException("An error occured while transforming JSON expression.", e);
- 		} 
+        try {
+            Object transformationResult = JsonPath.read(source, jsonPathExpression);
+            logger.debug("transformation resulted in '{}'", transformationResult);
+            return (transformationResult != null) ? transformationResult.toString() : null;
+        } catch (PathNotFoundException e) {
+            return null;
+        } catch (InvalidPathException e) {
+            throw new TransformationException("An error occured while transforming JSON expression.", e);
+        }
 
- 	}
+    }
 
- }
- 
+}

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
@@ -27,12 +27,12 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The implementation of {@link TransformationService} which transforms the input by XSLT.
  * </p>
- * 
+ *
  * @author Thomas.Eichstaedt-Engelen
  */
 public class XsltTransformationService implements TransformationService {
 
-    static final Logger logger = LoggerFactory.getLogger(XsltTransformationService.class);
+    private final Logger logger = LoggerFactory.getLogger(XsltTransformationService.class);
 
     /**
      * <p>
@@ -40,15 +40,15 @@ public class XsltTransformationService implements TransformationService {
      * is stored under the 'configurations/transform' folder. To organize the various transformations one should use
      * subfolders.
      * </p>
-     * 
+     *
      * @param filename
      *            the name of the file which contains the XSLT transformation rule. The name may contain subfoldernames
      *            as well
      * @param source
      *            the input to transform
-     * 
+     *
      * @{inheritDoc
-     * 
+     *
      */
     @Override
     public String transform(String filename, String source) throws TransformationException {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/src/main/java/org/eclipse/smarthome/ui/paper/internal/PaperUIApp.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/src/main/java/org/eclipse/smarthome/ui/paper/internal/PaperUIApp.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 public class PaperUIApp {
 
     public static final String WEBAPP_ALIAS = "/ui";
-    private static final Logger logger = LoggerFactory.getLogger(PaperUIApp.class);
+    private final Logger logger = LoggerFactory.getLogger(PaperUIApp.class);
 
     protected HttpService httpService;
 


### PR DESCRIPTION
This is related to #1006 and will process the (simple) cases where a static logger is used but is not necessary.