### PR TITLE
Fixed broken and incorrect markdown syntax

### DIFF
--- a/docs/documentation/features/internationalization.md
+++ b/docs/documentation/features/internationalization.md
@@ -33,11 +33,13 @@ ESH-INF/i18n
 ```
 
 Example files:
+
 ```
-ESH-INF/i18n
-    yahooweather_de.properties
-    yahooweather_de_DE.properties
-    yahooweather_fr.properties
+|- ESH-INF
+|---- i18n
+|------- yahooweather_de.properties
+|------- yahooweather_de_DE.properties
+|------- yahooweather_fr.properties
 ```
 
 ## Internationalize Binding XML files

--- a/docs/documentation/features/rules.md
+++ b/docs/documentation/features/rules.md
@@ -47,7 +47,7 @@ There are system module types which are provided by the system and there could b
     input variables - list of meta data for the supported input objects
     output variables - list of meta data for the supported output objects
 
-** configDescriptions** has the following metadata defined for each property
+**configDescriptions** has the following metadata defined for each property
 
     name
     type - one of the following "text", "integer", "decimal", "boolean"


### PR DESCRIPTION
Fixes include:
- File documentation/features/**rules.md** - unnecessary space was removed which caused breaking of the bold tag.
- File documentation/features/**internationalization.md** -  structure layout from documentation/develoment/bindings/**how-to.md**  was applied (so that the files listed in ESH-INF/i18n folder are visually rendered in the same way as in the Binding How-To). This correction actually fixes a rendering bug - all _.properties_ files were displayed on the same line, together with the "ESH-INF/i18n" text.

Signed-off-by: Alexander Kostadinov <alexander.g.kostadinov@gmail.com>