### PR TITLE
change visibility to public of RuleEngine.hasRule() method

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleEngine.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleEngine.java
@@ -820,7 +820,7 @@ public class RuleEngine
      * @param rUID unique id of the {@link Rule}
      * @return true when such rule exists, false otherwise.
      */
-    protected boolean hasRule(String rUID) {
+    public boolean hasRule(String rUID) {
         return rules.get(rUID) != null;
     }
 


### PR DESCRIPTION
Signed-off-by: Yordan Mihaylov <j.mihailov@prosyst.com>

This change will permit to call the method from different packages. The method is optimize version of getRule(UID) != null, because it does not create a copy of the rule, which is not needed for this check. 