### PR TITLE
moved thing handler initialization into a separate thread

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
@@ -253,7 +253,9 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
 
         // ThingHandler.initialize() has been called; thing with status ONLINE.NONE
         statusInfo = ThingStatusInfoBuilder.create(ThingStatus.ONLINE).build()
+        waitForAssert({
         assertThat thing.getStatusInfo(), is(statusInfo)
+        }, 4000)
     }
 
     class ConfigStatusProviderThingHandlerFactory extends BaseThingHandlerFactory {
@@ -385,8 +387,11 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
             def thing = ThingBuilder.create(new ThingUID("bindingId:type:thingId")).build()
             assertThat thing.channels.size(), is(0)
             managedThingProvider.add(thing)
+
+            waitForAssert({
             assertThat thingUpdated, is(true)
             assertThat updatedThing.channels.size(), is(1)
+            }, 4000)
 
             updatedThing.getHandler().updateConfig()
             assertThat updatedThing.getConfiguration().get("key"), is("value")

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
@@ -702,8 +702,10 @@ class ThingManagerOSGiTest extends OSGiTest {
         callback.statusUpdated(thing, statusInfo)
 
         // ThingHandler.initialize() called, thing status is ONLINE.NONE
+        waitForAssert({
         assertThat initializedCalled, is(true)
         assertThat thing.getStatusInfo(), is(statusInfo)
+        }, 4000)
     }
 
     @Test
@@ -739,7 +741,9 @@ class ThingManagerOSGiTest extends OSGiTest {
         managedThingProvider.add(bridge)
         managedThingProvider.add(thing)
 
-        waitForAssert({assertThat bridgeInitCalled, is(true)})
+        waitForAssert({
+            waitForAssert({assertThat bridgeInitCalled, is(true)})
+        }, 4000)
     }
     
     class SomeThingHandlerFactory extends BaseThingHandlerFactory {


### PR DESCRIPTION
...in order to break up the long call-stack which prevents service registration callbacks to get fired when adding/removing services within handler initialization.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>