### PR TITLE
ignore thing types without config descriptions

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -189,7 +189,7 @@ public abstract class BaseThingHandler implements ThingHandler {
     protected void validateConfigurationParameters(Map<String, Object> configurationParameters)
             throws ConfigValidationException {
         ThingType thingType = TypeResolver.resolve(getThing().getThingTypeUID());
-        if (thingType != null) {
+        if (thingType != null && thingType.getConfigDescriptionURI() != null) {
             ConfigDescriptionValidator.validate(configurationParameters, thingType.getConfigDescriptionURI());
         }
     }
@@ -515,13 +515,13 @@ public abstract class BaseThingHandler implements ThingHandler {
 
     /**
      * Returns whether the thing has already been initialized.
-     * 
+     *
      * @return true if thing is initialized, false otherwise
      */
     protected boolean thingIsInitialized() {
         return getThing().getStatus() == ThingStatus.ONLINE || getThing().getStatus() == ThingStatus.OFFLINE;
     }
-    
+
     @Override
     public void bridgeHandlerInitialized(ThingHandler thingHandler, Bridge bridge) {
         // do nothing by default, can be overridden by subclasses


### PR DESCRIPTION
Bug fix for the problem that it was not possible to update a Thing configuration where the thing type does not include any config description.

Signed-off-by: Kai Kreuzer kai@openhab.org
