### PR TITLE
Fix exception in EnrichedThingDTO where no label exists

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/EnrichedThingDTO.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/EnrichedThingDTO.java
@@ -25,7 +25,11 @@ public class EnrichedThingDTO extends ThingDTO {
 
     public EnrichedThingDTO(ThingDTO thingDTO, ThingStatusInfo statusInfo, EnrichedGroupItemDTO item, String link) {
         this.UID = thingDTO.UID;
-        this.label = thingDTO.label != null ? thingDTO.label : item.label;
+        if (thingDTO.label != null) {
+            this.label = thingDTO.label;
+        } else if (item != null) {
+            this.label = item.label;
+        }
         this.thingTypeUID = thingDTO.thingTypeUID;
         this.bridgeUID = thingDTO.bridgeUID;
         this.channels = thingDTO.channels;


### PR DESCRIPTION
This guards against the case where there is no label set for a thing, but there's also no linked item.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>