### PR TITLE
Allow thing label to be changed

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -350,6 +350,9 @@ public class ThingResource implements RESTResource {
         thing.setBridgeUID(bridgeUID);
         updateConfiguration(thing, getConfiguration(thingBean));
 
+        // Update the label
+        thing.setLabel(thingBean.label);
+
         // update, returns null in case Thing cannot be found
         Thing oldthing = managedThingProvider.update(thing);
         if (null == oldthing) {


### PR DESCRIPTION
There's currently no way to update the thing label - I assume that this should be allowed and this is just an oversight...
Signed-off-by: Chris Jackson <chris@cd-jackson.com>