### PR TITLE
ClassicUI: Incorrect format for viewport <META> tag

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.classic/snippets/main.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/snippets/main.html
@@ -3,7 +3,7 @@
 	<head>
 		<title>%label%</title>
        	<META HTTP-EQUIV="Content-type" CONTENT="text/html; charset=utf-8">
-   		<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;" />
+   		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 		<meta name="apple-mobile-web-app-status-bar-style" content="black" />
 		


### PR DESCRIPTION
`content` must be separated with commas, not semicolons; `user-scalable=0` is undocumented and should be `user-scalable=no`.

Give me a :star: for the world's most inconsequential pull request!

Signed-off-by: John Cocula <john@cocula.com>