### PR TITLE
add maven-bundle-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,19 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.0.1</version>
+          <extensions>true</extensions>
+          <configuration>
+            <supportedProjectTypes>
+              <supportedProjectType>jar</supportedProjectType>
+              <supportedProjectType>bundle</supportedProjectType>
+              <supportedProjectType>eclipse-plugin</supportedProjectType>
+            </supportedProjectTypes>
+          </configuration>
+        </plugin>
+        <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven.compiler.version}</version>
           <configuration>
@@ -245,7 +258,6 @@
             </dependency>
           </dependencies>
         </plugin>
-
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>


### PR DESCRIPTION
The configuration has been added, so we could trigger a manual manifest
generation. The generated manifest could be used by developers to
identify missing imports.
The manifest generation could be triggered by:
mvn bundle:manifest -DniceManifest=true
The "nice manifest" option will add line breaks after every imported
package.
Now you can have a look at the manifest that would be generated by the
bndtool using:
cat target/classes/META-INF/MANIFEST.MF

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>