### PR TITLE
Added export packages for xstream

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
@@ -29,8 +29,10 @@ Bundle-Activator: org.eclipse.smarthome.config.xml.internal.Activator
 Export-Package: com.thoughtworks.xstream,
  com.thoughtworks.xstream.annotations,
  com.thoughtworks.xstream.converters,
+ com.thoughtworks.xstream.converters.basic,
  com.thoughtworks.xstream.io,
  com.thoughtworks.xstream.io.xml,
+ com.thoughtworks.xstream.io.naming,
  org.eclipse.smarthome.config.xml,
  org.eclipse.smarthome.config.xml.osgi,
  org.eclipse.smarthome.config.xml.util


### PR DESCRIPTION
* Should export **converters.basic** because this package provides a DateConverter.
See: https://x-stream.github.io/javadoc/com/thoughtworks/xstream/converters/basic/DateConverter.html

* Should export **io.naming** if somebody want to modify the XML-Tag naming behaviour. For example see:
https://x-stream.github.io/javadoc/index.html?com/thoughtworks/xstream/io/naming/NoNameCoder.html


