### PR TITLE
use material icons

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -58,7 +58,8 @@ var paths = {
         './node_modules/roboto-fontface/css/roboto-fontface.css'
     ],
     FontLibs: [
-        './node_modules/roboto-fontface/fonts/*.woff'
+        './node_modules/roboto-fontface/fonts/*.woff',
+        './node_modules/material-design-icons/iconfont/MaterialIcons-Regular.*'
     ]
 };
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
@@ -22,6 +22,7 @@
     "http-proxy-middleware": "^0.9.0",
     "jquery": "2.1.3",
     "masonry-layout": "3.3.1",
+    "material-design-icons": "2.0.0",
     "roboto-fontface": "0.4.2",
     "sprintf-js": "1.0.3",
     "tinycolor2": "1.1.2"

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -2,22 +2,30 @@
  * Material Angular Overrides 
  */
 
+.material-icons {
+	width: auto!important;
+}
+
+.md-button .material-icons {
+	line-height: inherit;
+}
+
 /* Button */
 
-.md-button[class*="md-icon-"]:before {
+.md-button[class*="material-icons"]:before {
 	font-size: 24px;	
 }
 
-.md-button[class*="md-icon-"] {
+.md-button[class*="material-icons"] {
 	margin: 0px;
     min-width: 0px;
 }
 
-.md-button[class*="md-icon-"]:before, .md-button[class*="md-icon-"] * {
+.md-button[class*="material-icons"]:before, .md-button[class*="material-icons"] * {
 	vertical-align: middle;
 }
 
-.md-button span[class*="md-icon-"] {
+.md-button span[class*="material-icons"] {
 	margin-right: 5px;
 }
 
@@ -146,7 +154,7 @@ md-radio-button.md-default-theme.md-checked .md-ink-ripple, md-switch.md-default
 
 /* Checkbox */
 
-md-checkbox.md-default-theme.md-checked .md-icon {
+md-checkbox.md-default-theme.md-checked .material-icons {
 	background-color: #4CAF50;
 }
 
@@ -415,7 +423,7 @@ select.form-control {
 	margin: 5px 0px 10px;
 }
 
-md-input-container:not(.md-input-invalid).md-input-focused md-icon {
+md-input-container:not(.md-input-invalid).md-input-focused material-icons {
 	color: #4CAF50;
 }
 
@@ -458,7 +466,7 @@ md-progress-circular.md-default-theme .md-inner .md-left .md-half-circle {
 	margin: 10px 0px;
 }
 
-.selection-list .md-icon-chevron-right {
+.selection-list .material-icons {
 	font-size: 30px;
 	color: #999;
 }

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/material-icons.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/material-icons.css
@@ -1,0 +1,38 @@
+@font-face {
+  font-family: 'Material Icons';
+  font-style: normal;
+  font-weight: 400;
+  src: url(../fonts/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: local('Material Icons'),
+       local('MaterialIcons-Regular'),
+       url(../fonts/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../fonts/MaterialIcons-Regular.woff) format('woff'),
+       url(../fonts/MaterialIcons-Regular.ttf) format('truetype')
+}
+
+.material-icons {
+  font-family: 'Material Icons';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;  /* Preferred icon size */
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  line-height: 1;
+  text-transform: none;
+  letter-spacing: normal;
+  word-wrap: normal;
+  white-space: nowrap;
+  direction: ltr;
+
+  /* Support for all WebKit browsers. */
+  -webkit-font-smoothing: antialiased;
+  /* Support for Safari and Chrome. */
+  text-rendering: optimizeLegibility;
+
+  /* Support for Firefox. */
+  -moz-osx-font-smoothing: grayscale;
+
+  /* Support for IE. */
+  font-feature-settings: 'liga';
+}

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/views.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/views.css
@@ -96,7 +96,8 @@ section#main.header-tabs {
 }
 
 .items .item p[class^="icon-"]:before, .items .item p[class*=" icon-"]:before,
-.items .item p[class^="md-icon-"]:before, .items .item p[class*=" md-icon-"]:before,
+.items .item p[class^="material-icons"], .items .item p[class*=" material-icons"],
+.items .item i[class^="material-icons"], .items .item i[class*=" material-icons"],
 .items .item p[class^="home-icon-"]:before, .items .item p[class*=" home-icon-"]:before {
 	margin-right: 10px;
 	border-radius: 50%;
@@ -108,22 +109,8 @@ section#main.header-tabs {
 	font-size: 16px;
 	line-height: 32px;
 	padding: 10px;
-	font-family: 'md-icons';
+	display: inline;
 }
-
-.items .item [class^="md-icon-"], .items .item [class*=" md-icon-"] {
-	font-family: inherit;
-	font-weight: inherit;
-	color: inherit;
-	font-size: inherit;
-	-webkit-font-smoothing: inherit;
-  	-moz-osx-font-smoothing: inherit;
-}
-
-.items .item button[class*=" md-icon-"] {
-	font-family: 'md-icons';
-}
-
 
 .items .item md-input-container input {
 	text-align: right;

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
@@ -28,8 +28,8 @@
 	<link type="text/css" href="css/theme.css" rel="stylesheet">
 
 	<!-- Icons/Fonts -->
-	<link type="text/css" href="fonts/md-icons/md-icons.css" rel="stylesheet" media="all">
 	<link type="text/css" href="css/roboto-fontface.css" rel="stylesheet" media="all">
+	<link type="text/css" href="css/material-icons.css" rel="stylesheet" media="all">
 
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 
@@ -46,17 +46,17 @@
 		<ul>
 			<li ng-class="{active: isActive('control'), hidden: isHidden('control')}">
 				<a href="#control">
-					<span class="icon md-icon-dashboard"></span> Control</a>
+					<span class="icon material-icons">dashboard</span> Control</a>
 			</li>
 			<li ng-class="{active: isActive('inbox')}">
 				<a href="#inbox" class="clickable">
-					<span class="icon md-icon-add-circle-outline"></span> Inbox
+					<span class="icon material-icons">add_circle_outline</span> Inbox
 					<span ng-show="getNumberOfNewDiscoveryResults() > 0" class="badge">{{getNumberOfNewDiscoveryResults()}}</span>
 				</a>
 			</li>
 			<li ng-class="{active: isActive('configuration'), hidden: isHidden('configuration')}">
 				<a ng-click="open('configuration')" class="clickable">
-					<span class="icon md-icon-settings"></span> Configuration</a>
+					<span class="icon material-icons">settings</span> Configuration</a>
 				<ul ng-show="isActive('configuration')">
 					<li ng-class="{active: isSubActive('bindings')}"><a href="#configuration/bindings">Bindings</a></li>
 					<li ng-class="{active: isSubActive('services')}"><a href="#configuration/services">Services</a></li>
@@ -66,17 +66,17 @@
 			</li>
 			<li ng-class="{active: isActive('extensions'), hidden: isHidden('extensions')}">
 				<a href="#extensions">
-					<span class="icon md-icon-extension"></span>
+					<span class="icon material-icons">extension</span>
 					Extensions</a>
 			</li>
 			<li ng-class="{active: isActive('rules'), hidden: isHidden('rules')}">
 				<a href="#rules">
-					<span class="icon md-icon-movie-creation"></span>
+					<span class="icon material-icons">movie_creation</span>
 					Rules</a>
 			</li>
 			<li ng-class="{active: isActive('preferences'), hidden: isHidden('preferences')}">
 				<a href="#preferences">
-					<span class="icon md-icon-brightness-medium"></span>
+					<span class="icon material-icons">brightness_medium</span>
 					Preferences</a>
 			</li>
 		</ul>
@@ -92,7 +92,7 @@
 				<h1>
 					{{title}}
 					<span ng-repeat="subtitle in subtitles" class="subtitle">
-						<span class="chevron md-icon-chevron-right"></span> {{subtitle}}</span>
+						<span class="chevron material-icons">chevron_right</span> {{subtitle}}</span>
 				</h1>
 			</div>
 		</header>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -99,12 +99,12 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
 		'Blinds' : {},
 		'ColorLight' : {
 			label: 'Color',
-			icon: 'md-icon-wb-incandescent'
+			icon: 'wb_incandescent'
 		},
 		'Contact' : {},
 		'DimmableLight' : {
 			label: 'Brightness',
-			icon: 'md-icon-wb-incandescent'
+			icon: 'wb_incandescent'
 		},
 		'CarbonDioxide' : {
 			label: 'CO2'
@@ -130,7 +130,7 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
 		'Smoke' : {},
 		'SoundVolume' : {
 			label: 'Volume',
-			icon: 'md-icon-volume-up',
+			icon: 'volume_up',
 			hideSwitch: true
 		},
 		'Switch' : {},
@@ -160,7 +160,7 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
 		}
     }
     $scope.getIcon = function (itemCategory, fallbackIcon) {
-    	var defaultIcon = fallbackIcon ? fallbackIcon : 'md-icon-radio-button-off';
+    	var defaultIcon = fallbackIcon ? fallbackIcon : 'radio_button_unchecked';
     	if(itemCategory) {
     		var category = categories[itemCategory];
     		if(category) {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -1,7 +1,7 @@
 <section id="main">
 	<div class="bindings tab-panel content" ng-if="page === 'bindings'" ng-controller="BindingController">
 		<div class="header-toolbar">
-			<md-button class="md-icon-refresh" ng-click="refresh()" aria-label="Refresh"></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"><i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header"></div>
 		<div class="container">
@@ -27,12 +27,12 @@
 	</div>
 	<div class="services tab-panel content" ng-if="page === 'services'" ng-controller="ServicesController">
 		<div class="header-toolbar">
-			<md-button class="md-icon-refresh" ng-click="refresh()" aria-label="Refresh"></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"><i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab md-icon-add" ng-click="add()" aria-label="Add Configuration"></md-button>
+					<md-button class="md-fab" ng-click="add()" aria-label="Add Configuration"><i class="material-icons">add</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -62,12 +62,12 @@
 	</div>
 	<div class="groups white-bg" ng-if="page === 'groups'" ng-controller="GroupController">
 		<div class="header-toolbar">
-			<md-button class="md-icon-refresh" ng-click="refresh()" aria-label="Refresh"></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"><i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab md-icon-add" ng-click="add($event)" aria-label="Add"></md-button>
+					<md-button class="md-fab" ng-click="add($event)" aria-label="Add"><i class="material-icons">add</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -83,7 +83,7 @@
 						<div class="item-content">
 							<h3>{{homeGroup.label}}</h3>
 							<div class="actions">
-								<md-button class="md-raised md-icon-delete" ng-click="remove(homeGroup, $event)" aria-label="Remove"></md-button>
+								<md-button class="md-raised" ng-click="remove(homeGroup, $event)" aria-label="Remove"><i class="material-icons">delete</i></md-button>
 							</div>
 						</div>
 						<hr class="border-line" ng-show="!$last" />
@@ -94,12 +94,12 @@
 	</div>
 	<div class="things white-bg" ng-if="page === 'things' && !path[3]" ng-controller="ThingController">
 		<div class="header-toolbar">
-			<md-button class="md-icon-refresh" ng-click="refresh()" aria-label="Refresh"></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"><i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab md-icon-add" ng-click="$location.path('inbox/setup')" aria-label="Add"></md-button>
+					<md-button class="md-fab" ng-click="$location.path('inbox/setup')" aria-label="Add"><i class="material-icons">add</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -120,8 +120,8 @@
 							<p>{{thingTypes[thing.thingTypeUID].label}}</p>
 							<p>{{thing.UID}}</p>
 							<div class="actions">
-								<md-button class="md-raised md-icon-edit" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit"></md-button>
-								<md-button class="md-raised md-icon-delete" ng-click="remove(thing, $event)" aria-label="Delete"></md-button>
+								<md-button class="md-raised" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit"><i class="material-icons">edit</i></md-button>
+								<md-button class="md-raised" ng-click="remove(thing, $event)" aria-label="Delete"><i class="material-icons">delete</i></md-button>
 							</div>
 						</div>
 						<hr class="border-line" ng-show="!$last" />
@@ -132,13 +132,13 @@
 	</div>
 	<div class="thing-view white-bg" ng-if="page === 'things' && path[3] === 'view'" ng-controller="ViewThingController">
 		<div class="header-toolbar">
-			<md-button class="md-icon-delete" ng-click="remove(thing, $event)" aria-label="Delete"></md-button>
-			<md-button class="md-icon-close" ng-click="navigateTo('things')" aria-label="Close"></md-button>
+			<md-button ng-click="remove(thing, $event)" aria-label="Delete"><i class="material-icons">delete</i></md-button>
+			<md-button ng-click="navigateTo('things')" aria-label="Close"><i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab md-icon-edit" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit"></md-button>
+					<md-button class="md-fab" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit"><i class="material-icons">edit</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -159,18 +159,18 @@
 					<div ng-init="collapsed=false">
 						<div ng-show="!angular.isUndefined(group.name) && group.name.length > 0">
 							<span class="md-title">{{group.name}}</span>
-							<md-icon ng-show="!collapsed" ng-click="collapsed=!collapsed" style="font-size: 22px;float:right;"
-								class="md-raised md-icon-unfold-less"></md-icon>
-							<md-icon ng-show="collapsed" ng-click="collapsed=!collapsed" style="color:grey;font-size: 22px;float:right;"
-								class="md-raised md-icon-unfold-more"></md-icon>
+							<i ng-show="!collapsed" ng-click="collapsed=!collapsed" style="font-size: 22px;float:right;"
+								class="md-raised material-icons">unfold_less</i>
+							<i ng-show="collapsed" ng-click="collapsed=!collapsed" style="color:grey;font-size: 22px;float:right;"
+								class="md-raised material-icons">unfold_more</i>
 							<div>{{group.description}}</div>
 						</div>
 						<div class="channel fab-item" ng-repeat="channel in group.channels">
 							<div ng-show="!collapsed">
-								<md-button ng-if="channel.linkedItems.length == 0" class="md-fab md-icon-radio-button-off"
-									ng-click="enableChannel(thing.UID, channel.id, $event)" aria-label="Off"></md-button>
-								<md-button ng-if="channel.linkedItems.length > 0" class="md-fab md-icon-radio-button-on"
-									ng-click="disableChannel(thing.UID, channel.id, $event)" aria-label="On"></md-button>
+								<md-button ng-if="channel.linkedItems.length == 0" class="md-fab"
+									ng-click="enableChannel(thing.UID, channel.id, $event)" aria-label="Off"><i class="material-icons">radio_button_unchecked</i></md-button>
+								<md-button ng-if="channel.linkedItems.length > 0" class="md-fab"
+									ng-click="disableChannel(thing.UID, channel.id, $event)" aria-label="On"><i class="material-icons">radio_button_checked</i></md-button>
 								<div class="item-content">
 									<h3>{{getChannelTypeById(channel.id).label}}</h3>
 									<p>{{thing.UID + ':' + channel.id}}</p>
@@ -186,13 +186,13 @@
 	</div>
 	<div class="thing-edit white-bg" ng-if="page === 'things' && path[3] === 'edit'" ng-controller="EditThingController">
 		<div class="header-toolbar">
-			<md-button class="md-icon-close" ng-click="navigateTo('things/view/' + thing.UID)" aria-label="Close"></md-button>
+			<md-button ng-click="navigateTo('things/view/' + thing.UID)" aria-label="Close"><i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
 					<md-button title="Save" ng-click="update(thing)" ng-disabled="form.configForm.$invalid"
-						class="md-fab md-icon-check" aria-label="Save"></md-button>
+						class="md-fab" aria-label="Save"><i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
@@ -1,6 +1,6 @@
 <section id="main" class="control header-tabs">
 	<div class="header-toolbar">
-		<md-button class="md-icon-refresh" ng-click="refresh()" aria-label="Refresh"></md-button>
+		<md-button ng-click="refresh()" aria-label="Refresh"><i class="material-icons">refresh</i></md-button>
 	</div>
 
 	<p class="text-center" ng-show="tabs.length == 0" style="margin-top: 20px;">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.scan.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.scan.html
@@ -3,9 +3,7 @@
 <p>Click on the "Scan" button to scan for new things for a binding.</p>
 <br />
 <div class="fab-item" ng-repeat="binding in supportedBindings">
-	<md-button ng-show="activeScans.indexOf(binding) < 0" title="Refresh"
-		class="md-fab md-icon-settings-input-antenna" ng-click="scan(binding)"
-		aria-label="Refresh"></md-button>
+	<md-button ng-show="activeScans.indexOf(binding) < 0" title="Refresh" class="md-fab" ng-click="scan(binding)" aria-label="Refresh"><i class="material-icons">settings_input_antenna</i></md-button>
 	<md-progress-circular ng-show="activeScans.indexOf(binding) >= 0"
 		md-mode="indeterminate"></md-progress-circular>
 	<div class="item-content">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/extensions.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/extensions.html
@@ -1,7 +1,6 @@
 <section id="main" class="white-bg extensions header-tabs">
 	<div class="header-toolbar">
-		<md-button class="md-icon-refresh" ng-click="refresh()"
-			aria-label="Refresh"></md-button>
+		<md-button ng-click="refresh()" aria-label="Refresh"><i class="material-icons">refresh</i></md-button>
 	</div>
 	<md-tabs md-stretch-tabs="always" class="section-tabs"
 		md-selected="selectedIndex"> <md-tab
@@ -9,13 +8,11 @@
 		label="{{extensionType.label}}" layout-fill>
 	<md-tab-content layout-fill="">
 	<div class="search" layout="row" layout-align="center center">
-		<md-icon ng-style="{'font-size': '24px'}" class="md-icon-search"></md-icon>
+		<i ng-style="{'font-size': '24px'}" class="material-icons">search</i>
 		<md-input-container flex="auto" md-no-float class="md-block">
 		<input ng-model="searchText" type="text" placeholder="Search">
 		</md-input-container>
-		<md-icon ng-click="searchText = undefined"
-			ng-class="{'vhidden': !searchText}" ng-style="{'font-size': '24px'}"
-			class="md-icon-close"></md-icon>
+		<i ng-click="searchText = undefined" ng-class="{'vhidden': !searchText}" ng-style="{'font-size': '24px'}" class="material-icons">close</i>
 	</div>
 	<div class="container">
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.inbox.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.inbox.html
@@ -1,8 +1,8 @@
 <div class="fab-item"
 	ng-repeat="discoveryResult in data.discoveryResults | filter:filter | orderBy:flag"
 	ng-controller="InboxEntryController">
-	<md-button title="Add" class="md-fab md-icon-done green"
-		ng-click="approve(discoveryResult.thingUID,discoveryResult.thingTypeUID, $event)" aria-label="Approve"></md-button>
+	<md-button title="Add" class="md-fab green"
+		ng-click="approve(discoveryResult.thingUID,discoveryResult.thingTypeUID, $event)" aria-label="Approve"><i class="material-icons">done</i></md-button>
 	<div class="item-content">
 		<h3>
 			{{thingTypes[discoveryResult.thingTypeUID].label}} <small
@@ -12,13 +12,11 @@
 		<p>{{discoveryResult.thingUID}}</p>
 		<div class="actions">
 			<md-button ng-show="discoveryResult.flag === 'IGNORED'"
-				class="md-icon-visibility"
-				ng-click="unignore(discoveryResult.thingUID)" aria-label="Unignore"></md-button>
+				ng-click="unignore(discoveryResult.thingUID)" aria-label="Unignore"><i class="material-icons">visibility</i></md-button>
 			<md-button ng-show="discoveryResult.flag !== 'IGNORED'"
-				class="md-icon-visibility-off"
-				ng-click="ignore(discoveryResult.thingUID)" aria-label="Ignore"></md-button>
-			<md-button class="md-icon-delete"
-				ng-click="remove(discoveryResult.thingUID, $event)" aria-label="Delete"></md-button>
+				ng-click="ignore(discoveryResult.thingUID)" aria-label="Ignore"><i class="material-icons">visibility_off</i></md-button>
+			<md-button
+				ng-click="remove(discoveryResult.thingUID, $event)" aria-label="Delete"><i class="material-icons">delete</i></md-button>
 		</div>
 	</div>
 	<hr class="border-line" ng-show="!$last" />

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.itemcontrol.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.itemcontrol.html
@@ -3,8 +3,7 @@
 	<div ng-switch-when="SwitchItem" ng-controller="SwitchItemController">
 		<div layout="row" layout-align="start center" class="dimmer-widget">
 			<div flex="40">
-				<p ng-class="getIcon(item.category)">{{getLabel(item.category,
-					item.label, 'Switch')}}</p>
+				<p><i class="material-icons">{{getIcon(item.category)}}</i>{{getLabel(item.category, item.label, 'Switch')}}</p>
 			</div>
 			<div flex="60" layout="row" layout-align="end center"
 				class="switch-widget">
@@ -17,8 +16,7 @@
 	<div ng-switch-when="DimmerItem" ng-controller="DimmerItemController">
 		<div layout="row" layout-align="start center" class="dimmer-widget">
 			<div flex="40">
-				<p ng-class="getIcon(item.category, 'md-icon-brightness-medium')">{{getLabel(item.category,
-					item.label, 'Dimmer')}}</p>
+				<p><i class="material-icons">{{getIcon(item.category, 'brightness_medium')}}</i>{{getLabel(item.category, item.label, 'Dimmer')}}</p>
 			</div>
 			<div flex="60" layout="row" layout-align="end center"
 				class="dimmer-widget">
@@ -43,8 +41,7 @@
 	<div ng-switch-when="ColorItem" ng-controller="ColorItemController">
 		<div layout="row" layout-align="start center" class="dimmer-widget">
 			<div flex="40">
-				<p class="md-icon-wb-incandescent">{{getLabel(item.category,
-					null, 'Color')}}</p>
+				<p><i class="material-icons">wb_incandescent</i>{{getLabel(item.category, null, 'Color')}}</p>
 			</div>
 			<div flex="60" layout="row" layout-align="end center"
 				class="dimmer-widget">
@@ -78,8 +75,7 @@
 	<div ng-switch-when="NumberItem" ng-controller="NumberItemController">
 		<div layout="row" layout-align="start center">
 			<div flex="40" layout="row" layout-align="start center">
-				<p ng-class="getIcon(item.category, 'md-icon-trending-up')">{{getLabel(item.category,
-					item.label, 'Value')}}</p>
+				<p><i class="material-icons">{{getIcon(item.category, 'trending_up')}}</i>{{getLabel(item.category, item.label, 'Value')}}</p>
 			</div>
 			<div flex="60">
 				<div ng-show="isReadOnly(item)" layout="row"
@@ -91,8 +87,7 @@
 					<h2 class="state edit" ng-if="!editMode" ng-click="editState()">{{getStateText(item)}}</h2>
 					<md-input-container ng-show="editMode"> <input
 						ng-model="item.state" aria-label={{item.label}}></input> </md-input-container>
-					<button class="md-button md-icon-check" ng-show="editMode"
-						ng-click="updateState()"></button>
+					<button class="md-button" ng-show="editMode" ng-click="updateState()"><i class="material-icons">check</i></button>
 				</div>
 			</div>
 		</div>
@@ -111,8 +106,7 @@
 		ng-controller="RollershutterItemController">
 		<div layout="row" layout-align="start center">
 			<div flex="40" layout="row" layout-align="start center">
-				<p ng-class="getIcon(item.category, 'md-icon-format-align-justify')">{{getLabel(item.category,
-					item.label, 'Position')}}</p>
+				<p><i class="material-icons">{{getIcon(item.category, 'format_align_justify')}}</i>{{getLabel(item.category, item.label, 'Position')}}</p>
 			</div>
 			<div flex="60" layout="row" layout-align="end center">
 				<h2 class="state editable text-center" ng-if="!editMode"
@@ -120,8 +114,7 @@
 				<md-input-container ng-show="editMode" flex
 					aria-label={{item.label}}> <input
 					ng-model="item.state" aria-label={{item.label}}></input> </md-input-container>
-				<button class="md-button md-icon-check" ng-show="editMode"
-					ng-click="updateState()"></button>
+				<button class="md-button" ng-show="editMode" ng-click="updateState()"><i class="material-icons">check</i></button>
 			</div>
 		</div>
 		<div layout="row" layout-align="end center">
@@ -129,40 +122,29 @@
 				<p>Control</p>
 			</div>
 			<div flex="60" layout="row" layout-align="end center">
-				<button class="md-button md-icon-vertical-align-bottom"
-					ng-click="sendCommand('DOWN')"></button>
-				<button class="md-button md-icon-stop"
-					ng-click="sendCommand('STOP')"></button>
-				<button class="md-button md-icon-vertical-align-top"
-					ng-click="sendCommand('UP')"></button>
+				<button class="md-button" ng-click="sendCommand('DOWN')"><i class="material-icons">vertical_align_bottom</i></button>
+				<button class="md-button" ng-click="sendCommand('STOP')"><i class="material-icons">stop</i></button>
+				<button class="md-button" ng-click="sendCommand('UP')"><i class="material-icons">vertical_align_top</i></button>
 			</div>
 		</div>
 	</div>
 	<div ng-switch-when="PlayerItem" ng-controller="PlayerItemController">
 		<div layout="row" layout-align="end center">
 			<div flex="40" layout="row" layout-align="start center">
-				<p ng-class="getIcon(item.category, 'md-icon-play-arrow')">{{getLabel(null,
-					item.label, 'Control')}}</p>
+				<p><i class="material-icons">{{getIcon(item.category, 'play_arrow')}}</i>{{getLabel(null, item.label, 'Control')}}</p>
 			</div>
 			<div flex="60" layout="row" layout-align="end center">
-				<button class="md-button md-icon-skip-previous"
-					ng-click="sendCommand('PREVIOUS')"></button>
-				<button ng-show="item.state !== 'PLAY'"
-					class="md-button md-icon-play-arrow"
-					ng-click="sendCommand('PLAY', true)"></button>
-				<button ng-show="item.state === 'PLAY'"
-					class="md-button md-icon-pause"
-					ng-click="sendCommand('PAUSE', true)"></button>
-				<button class="md-button md-icon-skip-next"
-					ng-click="sendCommand('NEXT')"></button>
+				<button class="md-button" ng-click="sendCommand('PREVIOUS')"><i class="material-icons">skip_previous</i></button>
+				<button ng-show="item.state !== 'PLAY'" class="md-button" ng-click="sendCommand('PLAY', true)"><i class="material-icons">play_arrow</i></button>
+				<button ng-show="item.state === 'PLAY'" class="md-button" ng-click="sendCommand('PAUSE', true)"><i class="material-icons">pause</i></button>
+				<button class="md-button" ng-click="sendCommand('NEXT')"><i class="material-icons">skip_next</i></button>
 			</div>
 		</div>
 	</div>
 	<div ng-switch-when="ContactItem" ng-controller="DefaultItemController">
 		<div layout="row" layout-align="end center">
 			<div flex="40" layout="row" layout-align="start center">
-				<p ng-class="getIcon(item.category)">{{getLabel(item.category,
-					item.label, 'Contact')}}</p>
+				<p><i class="material-icons">{{getIcon(item.category)}}</i>{{getLabel(item.category, item.label, 'Contact')}}</p>
 			</div>
 			<div flex="60" layout="row" layout-align="end center">
 				<h2 class="state">{{getStateText(item)}}</h2>
@@ -172,8 +154,7 @@
 	<div ng-switch-when="LocationItem"
 		ng-controller="LocationItemController">
 		<div layout="row" layout-align="start center">
-			<p class="md-icon-place">{{getLabel(item.category, item.label,
-				'Location')}}</p>
+			<p><i class="material-icons">place</i>{{getLabel(item.category, item.label, 'Location')}}</p>
 		</div>
 		<div layout="row" layout-align="start center" class="map-container">
 			<div layout="row" layout-align="start center" flex>
@@ -190,19 +171,17 @@
 				<h2 class="state edit" ng-if="!editMode" ng-click="editState()">{{formattedState}}</h2>
 				<md-input-container ng-show="editMode"> <input
 					ng-model="item.state" aria-label={{item.label}}></input> </md-input-container>
-				<button class="md-button md-icon-check" ng-show="editMode"
-					ng-click="updateState()"></button>
+				<button class="md-button" ng-show="editMode" ng-click="updateState()"><i class="material-icons">check</i></button>
 			</div>
 		</div>
 	</div>
 	<div ng-switch-when="ImageItem" ng-controller="ImageItemController">
 		<div layout-align="start center" layout="row">
 			<div flex="60">
-				<p class="ng-binding md-icon-camera-alt">Camera image</p>
+				<p class="ng-binding"><i class="material-icons">camera_alt</i>Camera image</p>
 			</div>
 			<div layout="row" layout-align="end center" flex="40">
-				<button ng-click="refreshCameraImage()"
-					class="md-default-theme md-raised ng-binding md-button md-icon-autorenew"></button>
+				<button ng-click="refreshCameraImage()" class="md-default-theme md-raised ng-binding md-button"><i class="material-icons">autorenew</i></button>
 			</div>
 		</div>
 		<div class="image-widget" layout-align="center center" layout="row">
@@ -218,8 +197,7 @@
 	</div>
 	<div ng-switch-default ng-controller="DefaultItemController">
 		<div layout="row" layout-align="start center">
-			<p ng-class="getIcon(item.category)">{{getLabel(item.category,
-				item.label, 'Value')}}</p>
+			<p><i class="material-icons">{{getIcon(item.category)}}</i>{{getLabel(item.category, item.label, 'Value')}}</p>
 		</div>
 
 		<!-- default text output -->
@@ -235,8 +213,7 @@
 					ng-click="editState()" flex>{{getStateText(item)}}</h2>
 				<md-input-container ng-show="editMode" flex> <input
 					ng-model="item.state" aria-label={{item.label}}></input> </md-input-container>
-				<button class="md-button md-icon-check" ng-show="editMode"
-					ng-click="updateState()"></button>
+				<button class="md-button" ng-show="editMode" ng-click="updateState()"><i class="material-icons">check</i></button>
 			</div>
 		</div>
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/preferences.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/preferences.html
@@ -1,14 +1,12 @@
 <section id="main" class="white-bg">
 	<div class="content">
 		<div class="header-toolbar">
-			<md-button class="md-icon-close" ng-click="navigateToRoot()"
-				aria-label="Close"></md-button>
+			<md-button ng-click="navigateToRoot()" aria-label="Close"><i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button title="Save" ng-click="save()"
-						class="md-fab md-icon-check" aria-label="Save"></md-button>
+					<md-button title="Save" ng-click="save()" class="md-fab" aria-label="Save"><i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/rules.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/rules.html
@@ -2,14 +2,13 @@
 	<div class="rules white-bg" ng-if="!page"
 		ng-controller="RulesController">
 		<div class="header-toolbar">
-			<md-button class="md-icon-refresh" ng-click="refresh()"
-				aria-label="Refresh"></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"><i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-menu md-offset="60 -25"> <md-button class="md-fab md-icon-add" ng-click="$mdOpenMenu(ev);"
-						aria-label="Add"></md-button> <md-menu-content width="2" ng-init="ruleOptions=['New rule','Rule from template']">
+					<md-menu md-offset="60 -25"> <md-button class="md-fab" ng-click="$mdOpenMenu(ev);"
+						aria-label="Add"><i class="material-icons">add</i></md-button> <md-menu-content width="2" ng-init="ruleOptions=['New rule','Rule from template']">
 					<md-menu-item ng-repeat="item in ruleOptions"> <md-button
 						ng-click="ruleOptionSelected($event,$index)"> {{item}} </md-button> </md-menu-item> </md-menu-content> </md-menu>
 				</div>
@@ -28,14 +27,13 @@
 							<h3>{{rule.name}}</h3>
 							<p>{{rule.uid}}</p>
 							<div class="actions">
-							<md-button class="md-raised md-icon-alarm-off"
+							<md-button class="md-raised"
                                     ng-click="toggleEnabled(rule, $event)"
-                                    ng-class="{'md-icon-alarm-off': !rule.enabled, 'md-icon-alarm-on': rule.enabled}"
-                                    aria-label="Toggle Enable"></md-button>
-								<md-button class="md-raised md-icon-settings"
-									ng-click="configure(rule, $event)" aria-label="Configure"></md-button>
-								<md-button class="md-raised md-icon-delete"
-									ng-click="remove(rule, $event)" aria-label="Remove"></md-button>
+                                    aria-label="Toggle Enable"><i class="material-icons">{{rule.enabled ? "alarm_on" : "alarm_off"}}</i></md-button>
+								<md-button class="md-raised"
+									ng-click="configure(rule, $event)" aria-label="Configure"><i class="material-icons">settings</i></md-button>
+								<md-button class="md-raised"
+									ng-click="remove(rule, $event)" aria-label="Remove"><i class="material-icons">delete</i></md-button>
 							</div>
 						</div>
 						<hr class="border-line" ng-show="!$last" />
@@ -47,14 +45,12 @@
 	<div class="rules white-bg" ng-if="page === 'view'"
 		ng-controller="ViewRuleController">
 		<div class="header-toolbar">
-			<md-button class="md-icon-close" ng-click="navigateTo('')"
-				aria-label="Refresh"></md-button>
+			<md-button ng-click="navigateTo('')" aria-label="Refresh"><i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab md-icon-chevron-left"
-						ng-click="navigateTo('')" aria-label="Back"></md-button>
+					<md-button class="md-fab" ng-click="navigateTo('')" aria-label="Back"><i class="material-icons">chevron_left</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -67,16 +63,15 @@
 	   <div class="rules white-bg" ng-if="page === 'configure' || page ==='new' "
           ng-controller="NewRuleController">
         <div class="header-toolbar">
-            <md-button class="md-icon-close" ng-click="navigateTo('')"
-                aria-label="Refresh"></md-button>
+            <md-button ng-click="navigateTo('')" aria-label="Refresh"><i class="material-icons">close</i></md-button>
         </div>
         <div class="section-header">
             <div class="container">
                 <div class="toolbar">
                     <md-button ng-show="editing" title="Save" ng-click="updateUserRule()"
-                        class="md-fab md-icon-check" aria-label="Save"></md-button>
+                        class="md-fab" aria-label="Save"><i class="material-icons">check</i></md-button>
                      <md-button ng-show="!editing" title="Save" ng-click="saveUserRule()"
-                        class="md-fab md-icon-check" aria-label="Save"></md-button>
+                        class="md-fab" aria-label="Save"><i class="material-icons">check</i></md-button>
                 </div>
             </div>
         </div>
@@ -103,7 +98,7 @@
                                 <h5 class="col-md-10">{{val.label?val.label:'Trigger '+($index+1)}}</h5>
                                 <div class="col-md-2">
                                 
-                                 <md-button ng-click="openUpdateModuleDialog($event,'trigger',val)" class="md-raised md-icon-settings"></md-button>
+                                 <md-button ng-click="openUpdateModuleDialog($event,'trigger',val)" class="md-raised"><i class="material-icons">settings</i></md-button>
                                 </div>
                             </div>
                             <p>{{val.description}}</p>
@@ -125,7 +120,7 @@
                          <div class="row">
                         <h5 class="col-md-10">{{val.label?val.label:'Action '+($index+1)}}</h5>
                             <div class="col-md-2">
-                            <md-button ng-click="openUpdateModuleDialog($event,'action',val)" class="md-raised md-icon-settings"></md-button>
+                            <md-button ng-click="openUpdateModuleDialog($event,'action',val)" class="md-raised"><i class="material-icons">settings</i></md-button>
                             </div>
                          </div>
                        <p>{{val.description}}</p>
@@ -151,7 +146,7 @@
                              <div class="row">
                                 <h5 class="col-md-10">{{val.label?val.label:'Condition '+($index+1)}}</h5>
                                 <div class="col-md-1">
-                                <md-button ng-click="openUpdateModuleDialog($event,'condition',val)" class="md-raised md-icon-settings"></md-button>
+                                <md-button ng-click="openUpdateModuleDialog($event,'condition',val)" class="md-raised"><i class="material-icons">settings</i></md-button>
                              
                                 </div>
                             </div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
@@ -35,14 +35,13 @@
 		class="thing-configure white-bg"
 		ng-if="page === 'manual-setup' && path[3] === 'configure'">
 		<div class="header-toolbar">
-			<md-button class="md-icon-close"
-				ng-click="navigateTo('manual-setup/choose')" aria-label="Close"></md-button>
+			<md-button ng-click="navigateTo('manual-setup/choose')" aria-label="Close"><i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
 					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid"
-						class="md-fab md-icon-check" aria-label="Add Thing">
+						class="md-fab" aria-label="Add Thing"><i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -59,16 +58,15 @@
 	<div ng-controller="InboxController" class="thing-add white-bg"
 		ng-if="page === 'search' && !path[3]">
 		<div class="header-toolbar">
-			<md-button title="Scan" class="md-icon-settings-input-antenna"
-				ng-click="showScanDialog($event)" aria-label="Scan"></md-button>
-			<md-button class="md-icon-refresh" ng-click="refresh()"
-				aria-label="Refresh"></md-button>
+			<md-button title="Scan"
+				ng-click="showScanDialog($event)" aria-label="Scan"><i class="material-icons">settings_input_antenna</i></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"><i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab md-icon-add"
-						ng-click="navigateTo('setup/bindings')" aria-label="Add Thing"></md-button>
+					<md-button class="md-fab"
+						ng-click="navigateTo('setup/bindings')" aria-label="Add Thing"><i class="material-icons">add</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -99,7 +97,7 @@
 					</div>
 
 					<div flex="10" layout="row" layout-align="end center">
-						<span class="md-icon-chevron-right"></span>
+						<i class="material-icons">chevron_right</i>
 					</div>
 				</div>
 				<hr ng-show="!$last" />
@@ -112,8 +110,8 @@
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab md-icon-refresh"
-						ng-click="scan(bindingId)" aria-label="Refresh" title="Refresh"></md-button>
+					<md-button class="md-fab"
+						ng-click="scan(bindingId)" aria-label="Refresh" title="Refresh"><i class="material-icons">refresh</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -170,7 +168,7 @@
 					</div>
 
 					<div flex="10" layout="row" layout-align="end center">
-						<span class="md-icon-chevron-right"></span>
+						<i class="material-icons">chevron_right</span>
 					</div>
 				</div>
 				<hr ng-show="!$last" />
@@ -181,13 +179,13 @@
 		class="thing-configure white-bg"
 		ng-if="page === 'setup' && path[3] === 'add'">
 		<div class="header-toolbar">
-			<md-button class="md-icon-close" ng-click="navigateTo('setup')" aria-label="Close"></md-button>
+			<md-button ng-click="navigateTo('setup')" aria-label="Close"><i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
 					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid"
-						class="md-fab md-icon-check" aria-label="Add">
+						class="md-fab" aria-label="Add"><i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
At the moment all fonts of https://github.com/google/material-design-icons/tree/2.0.0/iconfont are included.
Need to check if in the bundle e.g. woff only is enough.

For the Roboto font only woff is used ATM but there are errors in the Web console that there are tries to load the woff2...

Please have a look if there is something critical missing or it could be merged and pimped later