### PR TITLE
Roboto font: fix css

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -55,7 +55,6 @@ var paths = {
     CSSLibs: [
         './node_modules/bootstrap/dist/css/bootstrap.min.css',
         './node_modules/angular-material/angular-material.min.css',
-        './node_modules/roboto-fontface/css/roboto-fontface.css'
     ],
     FontLibs: [
         './node_modules/roboto-fontface/fonts/*.woff',

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/roboto-fontface.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/roboto-fontface.css
@@ -1,0 +1,263 @@
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-Thin.eot');
+  src:  url('../fonts/Roboto-Thin.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Thin.woff2') format('woff2'),
+        url('../fonts/Roboto-Thin.woff') format('woff'),
+        url('../fonts/Roboto-Thin.ttf') format('truetype'),
+        url('../fonts/Roboto-Thin.svg#Roboto') format('svg');
+  font-weight: 100;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Roboto-Thin';
+  src:  url('../fonts/Roboto-Thin.eot');
+  src:  url('../fonts/Roboto-Thin.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Thin.woff2') format('woff2'),
+        url('../fonts/Roboto-Thin.woff') format('woff'),
+        url('../fonts/Roboto-Thin.ttf') format('truetype'),
+        url('../fonts/Roboto-Thin.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-ThinItalic.eot');
+  src:  url('../fonts/Roboto-ThinItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-ThinItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-ThinItalic.woff') format('woff'),
+        url('../fonts/Roboto-ThinItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-ThinItalic.svg#Roboto') format('svg');
+  font-weight: 100;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'Roboto-ThinItalic';
+  src:  url('../fonts/Roboto-ThinItalic.eot');
+  src:  url('../fonts/Roboto-ThinItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-ThinItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-ThinItalic.woff') format('woff'),
+        url('../fonts/Roboto-ThinItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-ThinItalic.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-Light.eot');
+  src:  url('../fonts/Roboto-Light.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Light.woff2') format('woff2'),
+        url('../fonts/Roboto-Light.woff') format('woff'),
+        url('../fonts/Roboto-Light.ttf') format('truetype'),
+        url('../fonts/Roboto-Light.svg#Roboto') format('svg');
+  font-weight: 300;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Roboto-Light';
+  src:  url('../fonts/Roboto-Light.eot');
+  src:  url('../fonts/Roboto-Light.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Light.woff2') format('woff2'),
+        url('../fonts/Roboto-Light.woff') format('woff'),
+        url('../fonts/Roboto-Light.ttf') format('truetype'),
+        url('../fonts/Roboto-Light.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-LightItalic.eot');
+  src:  url('../fonts/Roboto-LightItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-LightItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-LightItalic.woff') format('woff'),
+        url('../fonts/Roboto-LightItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-LightItalic.svg#Roboto') format('svg');
+  font-weight: 300;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'Roboto-LightItalic';
+  src:  url('../fonts/Roboto-LightItalic.eot');
+  src:  url('../fonts/Roboto-LightItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-LightItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-LightItalic.woff') format('woff'),
+        url('../fonts/Roboto-LightItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-LightItalic.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-Regular.eot');
+  src:  url('../fonts/Roboto-Regular.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Regular.woff2') format('woff2'),
+        url('../fonts/Roboto-Regular.woff') format('woff'),
+        url('../fonts/Roboto-Regular.ttf') format('truetype'),
+        url('../fonts/Roboto-Regular.svg#Roboto') format('svg');
+  font-weight: 400;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Roboto-Regular';
+  src:  url('../fonts/Roboto-Regular.eot');
+  src:  url('../fonts/Roboto-Regular.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Regular.woff2') format('woff2'),
+        url('../fonts/Roboto-Regular.woff') format('woff'),
+        url('../fonts/Roboto-Regular.ttf') format('truetype'),
+        url('../fonts/Roboto-Regular.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-RegularItalic.eot');
+  src:  url('../fonts/Roboto-RegularItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-RegularItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-RegularItalic.woff') format('woff'),
+        url('../fonts/Roboto-RegularItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-RegularItalic.svg#Roboto') format('svg');
+  font-weight: 400;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'Roboto-RegularItalic';
+  src:  url('../fonts/Roboto-RegularItalic.eot');
+  src:  url('../fonts/Roboto-RegularItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-RegularItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-RegularItalic.woff') format('woff'),
+        url('../fonts/Roboto-RegularItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-RegularItalic.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-Medium.eot');
+  src:  url('../fonts/Roboto-Medium.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Medium.woff2') format('woff2'),
+        url('../fonts/Roboto-Medium.woff') format('woff'),
+        url('../fonts/Roboto-Medium.ttf') format('truetype'),
+        url('../fonts/Roboto-Medium.svg#Roboto') format('svg');
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Roboto-Medium';
+  src:  url('../fonts/Roboto-Medium.eot');
+  src:  url('../fonts/Roboto-Medium.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Medium.woff2') format('woff2'),
+        url('../fonts/Roboto-Medium.woff') format('woff'),
+        url('../fonts/Roboto-Medium.ttf') format('truetype'),
+        url('../fonts/Roboto-Medium.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-MediumItalic.eot');
+  src:  url('../fonts/Roboto-MediumItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-MediumItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-MediumItalic.woff') format('woff'),
+        url('../fonts/Roboto-MediumItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-MediumItalic.svg#Roboto') format('svg');
+  font-weight: 500;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'Roboto-MediumItalic';
+  src:  url('../fonts/Roboto-MediumItalic.eot');
+  src:  url('../fonts/Roboto-MediumItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-MediumItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-MediumItalic.woff') format('woff'),
+        url('../fonts/Roboto-MediumItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-MediumItalic.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-Bold.eot');
+  src:  url('../fonts/Roboto-Bold.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Bold.woff2') format('woff2'),
+        url('../fonts/Roboto-Bold.woff') format('woff'),
+        url('../fonts/Roboto-Bold.ttf') format('truetype'),
+        url('../fonts/Roboto-Bold.svg#Roboto') format('svg');
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Roboto-Bold';
+  src:  url('../fonts/Roboto-Bold.eot');
+  src:  url('../fonts/Roboto-Bold.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Bold.woff2') format('woff2'),
+        url('../fonts/Roboto-Bold.woff') format('woff'),
+        url('../fonts/Roboto-Bold.ttf') format('truetype'),
+        url('../fonts/Roboto-Bold.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-BoldItalic.eot');
+  src:  url('../fonts/Roboto-BoldItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-BoldItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-BoldItalic.woff') format('woff'),
+        url('../fonts/Roboto-BoldItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-BoldItalic.svg#Roboto') format('svg');
+  font-weight: 700;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'Roboto-BoldItalic';
+  src:  url('../fonts/Roboto-BoldItalic.eot');
+  src:  url('../fonts/Roboto-BoldItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-BoldItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-BoldItalic.woff') format('woff'),
+        url('../fonts/Roboto-BoldItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-BoldItalic.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-Black.eot');
+  src:  url('../fonts/Roboto-Black.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Black.woff2') format('woff2'),
+        url('../fonts/Roboto-Black.woff') format('woff'),
+        url('../fonts/Roboto-Black.ttf') format('truetype'),
+        url('../fonts/Roboto-Black.svg#Roboto') format('svg');
+  font-weight: 900;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'Roboto-Black';
+  src:  url('../fonts/Roboto-Black.eot');
+  src:  url('../fonts/Roboto-Black.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-Black.woff2') format('woff2'),
+        url('../fonts/Roboto-Black.woff') format('woff'),
+        url('../fonts/Roboto-Black.ttf') format('truetype'),
+        url('../fonts/Roboto-Black.svg#Roboto') format('svg');
+}
+
+@font-face {
+  font-family: 'Roboto';
+  src:  url('../fonts/Roboto-BlackItalic.eot');
+  src:  url('../fonts/Roboto-BlackItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-BlackItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-BlackItalic.woff') format('woff'),
+        url('../fonts/Roboto-BlackItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-BlackItalic.svg#Roboto') format('svg');
+  font-weight: 900;
+  font-style: italic;
+}
+
+@font-face {
+  font-family: 'Roboto-BlackItalic';
+  src:  url('../fonts/Roboto-BlackItalic.eot');
+  src:  url('../fonts/Roboto-BlackItalic.eot?#iefix') format('embedded-opentype'),
+        url('../fonts/Roboto-BlackItalic.woff2') format('woff2'),
+        url('../fonts/Roboto-BlackItalic.woff') format('woff'),
+        url('../fonts/Roboto-BlackItalic.ttf') format('truetype'),
+        url('../fonts/Roboto-BlackItalic.svg#Roboto') format('svg');
+}

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/roboto-fontface.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/roboto-fontface.css
@@ -1,263 +1,143 @@
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-Thin.eot');
-  src:  url('../fonts/Roboto-Thin.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Thin.woff2') format('woff2'),
-        url('../fonts/Roboto-Thin.woff') format('woff'),
-        url('../fonts/Roboto-Thin.ttf') format('truetype'),
-        url('../fonts/Roboto-Thin.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Thin.woff') format('woff');
   font-weight: 100;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Roboto-Thin';
-  src:  url('../fonts/Roboto-Thin.eot');
-  src:  url('../fonts/Roboto-Thin.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Thin.woff2') format('woff2'),
-        url('../fonts/Roboto-Thin.woff') format('woff'),
-        url('../fonts/Roboto-Thin.ttf') format('truetype'),
-        url('../fonts/Roboto-Thin.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Thin.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-ThinItalic.eot');
-  src:  url('../fonts/Roboto-ThinItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-ThinItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-ThinItalic.woff') format('woff'),
-        url('../fonts/Roboto-ThinItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-ThinItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-ThinItalic.woff') format('woff');
   font-weight: 100;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Roboto-ThinItalic';
-  src:  url('../fonts/Roboto-ThinItalic.eot');
-  src:  url('../fonts/Roboto-ThinItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-ThinItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-ThinItalic.woff') format('woff'),
-        url('../fonts/Roboto-ThinItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-ThinItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-ThinItalic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-Light.eot');
-  src:  url('../fonts/Roboto-Light.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Light.woff2') format('woff2'),
-        url('../fonts/Roboto-Light.woff') format('woff'),
-        url('../fonts/Roboto-Light.ttf') format('truetype'),
-        url('../fonts/Roboto-Light.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Light.woff') format('woff');
   font-weight: 300;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Roboto-Light';
-  src:  url('../fonts/Roboto-Light.eot');
-  src:  url('../fonts/Roboto-Light.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Light.woff2') format('woff2'),
-        url('../fonts/Roboto-Light.woff') format('woff'),
-        url('../fonts/Roboto-Light.ttf') format('truetype'),
-        url('../fonts/Roboto-Light.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Light.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-LightItalic.eot');
-  src:  url('../fonts/Roboto-LightItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-LightItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-LightItalic.woff') format('woff'),
-        url('../fonts/Roboto-LightItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-LightItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-LightItalic.woff') format('woff');
   font-weight: 300;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Roboto-LightItalic';
-  src:  url('../fonts/Roboto-LightItalic.eot');
-  src:  url('../fonts/Roboto-LightItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-LightItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-LightItalic.woff') format('woff'),
-        url('../fonts/Roboto-LightItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-LightItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-LightItalic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-Regular.eot');
-  src:  url('../fonts/Roboto-Regular.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Regular.woff2') format('woff2'),
-        url('../fonts/Roboto-Regular.woff') format('woff'),
-        url('../fonts/Roboto-Regular.ttf') format('truetype'),
-        url('../fonts/Roboto-Regular.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Regular.woff') format('woff');
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Roboto-Regular';
-  src:  url('../fonts/Roboto-Regular.eot');
-  src:  url('../fonts/Roboto-Regular.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Regular.woff2') format('woff2'),
-        url('../fonts/Roboto-Regular.woff') format('woff'),
-        url('../fonts/Roboto-Regular.ttf') format('truetype'),
-        url('../fonts/Roboto-Regular.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Regular.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-RegularItalic.eot');
-  src:  url('../fonts/Roboto-RegularItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-RegularItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-RegularItalic.woff') format('woff'),
-        url('../fonts/Roboto-RegularItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-RegularItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-RegularItalic.woff') format('woff');
   font-weight: 400;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Roboto-RegularItalic';
-  src:  url('../fonts/Roboto-RegularItalic.eot');
-  src:  url('../fonts/Roboto-RegularItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-RegularItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-RegularItalic.woff') format('woff'),
-        url('../fonts/Roboto-RegularItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-RegularItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-RegularItalic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-Medium.eot');
-  src:  url('../fonts/Roboto-Medium.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Medium.woff2') format('woff2'),
-        url('../fonts/Roboto-Medium.woff') format('woff'),
-        url('../fonts/Roboto-Medium.ttf') format('truetype'),
-        url('../fonts/Roboto-Medium.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Medium.woff') format('woff');
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Roboto-Medium';
-  src:  url('../fonts/Roboto-Medium.eot');
-  src:  url('../fonts/Roboto-Medium.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Medium.woff2') format('woff2'),
-        url('../fonts/Roboto-Medium.woff') format('woff'),
-        url('../fonts/Roboto-Medium.ttf') format('truetype'),
-        url('../fonts/Roboto-Medium.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Medium.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-MediumItalic.eot');
-  src:  url('../fonts/Roboto-MediumItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-MediumItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-MediumItalic.woff') format('woff'),
-        url('../fonts/Roboto-MediumItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-MediumItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-MediumItalic.woff') format('woff');
   font-weight: 500;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Roboto-MediumItalic';
-  src:  url('../fonts/Roboto-MediumItalic.eot');
-  src:  url('../fonts/Roboto-MediumItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-MediumItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-MediumItalic.woff') format('woff'),
-        url('../fonts/Roboto-MediumItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-MediumItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-MediumItalic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-Bold.eot');
-  src:  url('../fonts/Roboto-Bold.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Bold.woff2') format('woff2'),
-        url('../fonts/Roboto-Bold.woff') format('woff'),
-        url('../fonts/Roboto-Bold.ttf') format('truetype'),
-        url('../fonts/Roboto-Bold.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Roboto-Bold';
-  src:  url('../fonts/Roboto-Bold.eot');
-  src:  url('../fonts/Roboto-Bold.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Bold.woff2') format('woff2'),
-        url('../fonts/Roboto-Bold.woff') format('woff'),
-        url('../fonts/Roboto-Bold.ttf') format('truetype'),
-        url('../fonts/Roboto-Bold.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Bold.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-BoldItalic.eot');
-  src:  url('../fonts/Roboto-BoldItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-BoldItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-BoldItalic.woff') format('woff'),
-        url('../fonts/Roboto-BoldItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-BoldItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-BoldItalic.woff') format('woff');
   font-weight: 700;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Roboto-BoldItalic';
-  src:  url('../fonts/Roboto-BoldItalic.eot');
-  src:  url('../fonts/Roboto-BoldItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-BoldItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-BoldItalic.woff') format('woff'),
-        url('../fonts/Roboto-BoldItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-BoldItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-BoldItalic.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-Black.eot');
-  src:  url('../fonts/Roboto-Black.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Black.woff2') format('woff2'),
-        url('../fonts/Roboto-Black.woff') format('woff'),
-        url('../fonts/Roboto-Black.ttf') format('truetype'),
-        url('../fonts/Roboto-Black.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Black.woff') format('woff');
   font-weight: 900;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'Roboto-Black';
-  src:  url('../fonts/Roboto-Black.eot');
-  src:  url('../fonts/Roboto-Black.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-Black.woff2') format('woff2'),
-        url('../fonts/Roboto-Black.woff') format('woff'),
-        url('../fonts/Roboto-Black.ttf') format('truetype'),
-        url('../fonts/Roboto-Black.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-Black.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Roboto';
-  src:  url('../fonts/Roboto-BlackItalic.eot');
-  src:  url('../fonts/Roboto-BlackItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-BlackItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-BlackItalic.woff') format('woff'),
-        url('../fonts/Roboto-BlackItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-BlackItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-BlackItalic.woff') format('woff');
   font-weight: 900;
   font-style: italic;
 }
 
 @font-face {
   font-family: 'Roboto-BlackItalic';
-  src:  url('../fonts/Roboto-BlackItalic.eot');
-  src:  url('../fonts/Roboto-BlackItalic.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/Roboto-BlackItalic.woff2') format('woff2'),
-        url('../fonts/Roboto-BlackItalic.woff') format('woff'),
-        url('../fonts/Roboto-BlackItalic.ttf') format('truetype'),
-        url('../fonts/Roboto-BlackItalic.svg#Roboto') format('svg');
+  src:  url('../fonts/Roboto-BlackItalic.woff') format('woff');
 }


### PR DESCRIPTION
At the moment the roboto fontface css and web font is downloaded by npm.
With gulp we add the font format woff and the css to the bundle.
The css refer the whole collection of formats:
* eot
* woff2
* woff
* ttf
* svg

If we have a look at your browser console, you will see errors (at least with firefox) because files should be loaded that are not available. At least the recent Firefox tries to load the woff2 file.

If we bundle only the woff file, we should not use the unmodified upstream css file that refers to all the other files.

This PR is split into two commits.
The first one adds the unmodified css file and remove it from gulp.
The second one cleans the css file to refer only available files / the woff file.