### PR TITLE
material icons: use woff format only

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -59,7 +59,7 @@ var paths = {
     ],
     FontLibs: [
         './node_modules/roboto-fontface/fonts/*.woff',
-        './node_modules/material-design-icons/iconfont/MaterialIcons-Regular.*'
+        './node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff'
     ]
 };
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/material-icons.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/material-icons.css
@@ -2,11 +2,8 @@
 	font-family: 'Material Icons';
 	font-style: normal;
 	font-weight: 400;
-	src: url(../fonts/MaterialIcons-Regular.eot); /* For IE6-8 */
 	src: local('Material Icons'), local('MaterialIcons-Regular'),
-		url(../fonts/MaterialIcons-Regular.woff2) format('woff2'),
-		url(../fonts/MaterialIcons-Regular.woff) format('woff'),
-		url(../fonts/MaterialIcons-Regular.ttf) format('truetype')
+		url(../fonts/MaterialIcons-Regular.woff) format('woff');
 }
 
 .material-icons {


### PR DESCRIPTION
This will reduce the bundle size (about 268K).

```
120K	MaterialIcons-Regular.eot
108K	MaterialIcons-Regular.ttf
64K	    MaterialIcons-Regular.woff
40K     MaterialIcons-Regular.woff2
```