### PR TITLE
add no-arg constructor

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/RuleStatusInfo.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/RuleStatusInfo.java
@@ -21,6 +21,12 @@ public class RuleStatusInfo {
     private String description;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected RuleStatusInfo() {
+    }
+
+    /**
      * Constructs a status info.
      *
      * @param status the status (must not be null)
@@ -111,22 +117,29 @@ public class RuleStatusInfo {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         RuleStatusInfo other = (RuleStatusInfo) obj;
         if (description == null) {
-            if (other.description != null)
+            if (other.description != null) {
                 return false;
-        } else if (!description.equals(other.description))
+            }
+        } else if (!description.equals(other.description)) {
             return false;
-        if (status != other.status)
+        }
+        if (status != other.status) {
             return false;
-        if (statusDetail != other.statusDetail)
+        }
+        if (statusDetail != other.statusDetail) {
             return false;
+        }
         return true;
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusInfo.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusInfo.java
@@ -16,7 +16,7 @@ import org.apache.commons.lang.StringUtils;
  * <li>detail of the status</il>
  * <li>and a description of the status</il>
  * </ul>
- * 
+ *
  * @author Stefan Bußweiler - Initial contribution
  * @author Dennis Nobel - Added null checks
  */
@@ -29,12 +29,18 @@ public class ThingStatusInfo {
     private String description;
 
     /**
+     * Default constructor for deserialization e.g. by Gson.
+     */
+    protected ThingStatusInfo() {
+    }
+
+    /**
      * Constructs a status info.
-     * 
+     *
      * @param status the status (must not be null)
      * @param statusDetail the detail of the status (must not be null)
      * @param description the description of the status
-     * 
+     *
      * @throws IllegalArgumentException if thing status or thing status detail is null
      */
     public ThingStatusInfo(ThingStatus status, ThingStatusDetail statusDetail, String description)
@@ -52,7 +58,7 @@ public class ThingStatusInfo {
 
     /**
      * Gets the status itself.
-     * 
+     *
      * @return the status (not null)
      */
     public ThingStatus getStatus() {
@@ -61,7 +67,7 @@ public class ThingStatusInfo {
 
     /**
      * Gets the detail of the status.
-     * 
+     *
      * @return the status detail (not null)
      */
     public ThingStatusDetail getStatusDetail() {
@@ -70,7 +76,7 @@ public class ThingStatusInfo {
 
     /**
      * Gets the description of the status.
-     * 
+     *
      * @return the description
      */
     public String getDescription() {
@@ -79,8 +85,7 @@ public class ThingStatusInfo {
 
     @Override
     public String toString() {
-        return getStatus() 
-                + (getStatusDetail()==ThingStatusDetail.NONE ? "" : " (" + getStatusDetail() + ")") 
+        return getStatus() + (getStatusDetail() == ThingStatusDetail.NONE ? "" : " (" + getStatusDetail() + ")")
                 + (StringUtils.isBlank(getDescription()) ? "" : ": " + getDescription());
     }
 
@@ -96,22 +101,29 @@ public class ThingStatusInfo {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         ThingStatusInfo other = (ThingStatusInfo) obj;
         if (description == null) {
-            if (other.description != null)
+            if (other.description != null) {
                 return false;
-        } else if (!description.equals(other.description))
+            }
+        } else if (!description.equals(other.description)) {
             return false;
-        if (status != other.status)
+        }
+        if (status != other.status) {
             return false;
-        if (statusDetail != other.statusDetail)
+        }
+        if (statusDetail != other.statusDetail) {
             return false;
+        }
         return true;
     }
 


### PR DESCRIPTION
This adds an easy support for deserialization without using the
sun.misc.Unsafe class.

Bug: https://github.com/eclipse/smarthome/issues/876
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>