### PR TITLE
Update Channel references to use ThingUID rather than ThingTypeUID

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
@@ -17,6 +17,7 @@ import java.util.List;
  * @author Oliver Libutzki - Initital contribution
  * @author Jochen Hiller - Bugfix 455434: added default constructor
  * @author Dennis Nobel - Added channel group id
+ * @author Chris Jackson - Made channel references relative to things
  */
 public class ChannelUID extends UID {
 
@@ -40,9 +41,8 @@ public class ChannelUID extends UID {
      * @param id
      *            the channel's id
      */
-    @Deprecated
     public ChannelUID(ThingUID thingUID, String id) {
-        super(getArray(thingUID.getBindingId(), thingUID.getThingTypeId(), thingUID.getId(), null, id,
+        super(getArray(thingUID.getBindingId(), thingUID.getThingId(), thingUID.getId(), null, id,
                 thingUID.getBridgeIds()));
     }
 
@@ -58,12 +58,19 @@ public class ChannelUID extends UID {
      * @param id
      *            the channel's id
      */
-    @Deprecated
     public ChannelUID(ThingUID thingUID, String groupId, String id) {
-        super(getArray(thingUID.getBindingId(), thingUID.getThingTypeId(), thingUID.getId(), groupId, id,
+        super(getArray(thingUID.getBindingId(), thingUID.getThingId(), thingUID.getId(), groupId, id,
                 thingUID.getBridgeIds()));
     }
 
+    /**
+     * @param thingUID
+     *            the unique identifier of the thing the channel belongs to
+     * @param groupId the channel's group id
+     * @param id
+     *            the channel's id
+     */
+    @Deprecated
     public ChannelUID(ThingTypeUID thingTypeUID, ThingUID thingUID, String groupId, String id) {
         super(getArray(thingTypeUID.getBindingId(), thingTypeUID.getId(), thingUID.getId(), groupId, id,
                 thingUID.getBridgeIds()));
@@ -74,6 +81,7 @@ public class ChannelUID extends UID {
      * @param thingId the id of the thing the channel belongs to
      * @param id the channel's id
      */
+    @Deprecated
     public ChannelUID(ThingTypeUID thingTypeUID, String thingId, String id) {
         this(thingTypeUID.getBindingId(), thingTypeUID.getId(), thingId, id);
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingUID.java
@@ -15,6 +15,7 @@ import java.util.List;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Jochen Hiller - Bugfix 455434: added default constructor
+ * @author Chris Jackson - Added getThingId method
  */
 public class ThingUID extends UID {
 
@@ -164,6 +165,20 @@ public class ThingUID extends UID {
             return null;
         } else {
             return new ThingTypeUID(getSegment(0), getSegment(1));
+        }
+    }
+
+    /**
+     * Returns the thing id.
+     *
+     * @return thing id
+     */
+    public String getThingId() {
+        String thingType = getSegment(1);
+        if (NO_THING_TYPE.equals(thingType)) {
+            return null;
+        } else {
+            return thingType;
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingFactoryHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingFactoryHelper.java
@@ -18,7 +18,6 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
-import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingFactory;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
@@ -39,6 +38,7 @@ import com.google.common.collect.Lists;
  * It is supposed to contain methods that are commonly shared between {@link ThingManager} and {@link ThingFactory}.
  *
  * @author Simon Kaufmann - Initial contribution and API
+ * @author Chris Jackson - Updated to use thingId for creation of channels
  *
  */
 public class ThingFactoryHelper {
@@ -59,8 +59,7 @@ public class ThingFactoryHelper {
         List<Channel> channels = Lists.newArrayList();
         List<ChannelDefinition> channelDefinitions = thingType.getChannelDefinitions();
         for (ChannelDefinition channelDefinition : channelDefinitions) {
-            Channel channel = createChannel(channelDefinition, thingUID, thingType.getUID(), null,
-                    configDescriptionRegistry);
+            Channel channel = createChannel(channelDefinition, thingUID, null, configDescriptionRegistry);
             if (channel != null) {
                 channels.add(channel);
             }
@@ -71,8 +70,8 @@ public class ThingFactoryHelper {
             if (channelGroupType != null) {
                 List<ChannelDefinition> channelGroupChannelDefinitions = channelGroupType.getChannelDefinitions();
                 for (ChannelDefinition channelDefinition : channelGroupChannelDefinitions) {
-                    Channel channel = createChannel(channelDefinition, thingUID, thingType.getUID(),
-                            channelGroupDefinition.getId(), configDescriptionRegistry);
+                    Channel channel = createChannel(channelDefinition, thingUID, channelGroupDefinition.getId(),
+                            configDescriptionRegistry);
                     if (channel != null) {
                         channels.add(channel);
                     }
@@ -86,8 +85,8 @@ public class ThingFactoryHelper {
         return channels;
     }
 
-    private static Channel createChannel(ChannelDefinition channelDefinition, ThingUID thingUID,
-            ThingTypeUID thingTypeUID, String groupId, ConfigDescriptionRegistry configDescriptionRegistry) {
+    private static Channel createChannel(ChannelDefinition channelDefinition, ThingUID thingUID, String groupId,
+            ConfigDescriptionRegistry configDescriptionRegistry) {
         ChannelType type = TypeResolver.resolve(channelDefinition.getChannelTypeUID());
         if (type == null) {
             logger.warn(
@@ -97,7 +96,7 @@ public class ThingFactoryHelper {
         }
 
         ChannelBuilder channelBuilder = ChannelBuilder
-                .create(new ChannelUID(thingTypeUID, thingUID, groupId, channelDefinition.getId()), type.getItemType())
+                .create(new ChannelUID(thingUID, groupId, channelDefinition.getId()), type.getItemType())
                 .withType(type.getUID()).withDefaultTags(type.getTags());
 
         // If we want to override the label, add it...


### PR DESCRIPTION
As discussed in #1175 creation of channels is currently using the ThingTypeUID as the reference, while other parts of the code are using the ThingID. This change uses the thingId for creation of channels.

It also reverts some of the methods that were deprecated when the changeThingType functionality was added. This is where the thingType got linked to channel creation, and since I think we agree this is wrong, I've reverted it.

It's not quite a revert since the previous methods called getThingTypeUID - since the thingTypeUID can't be got from the ThingUID now, I've added a new method that does the same thing, but called getThingId() and this is used for the creation of channels.

Any thoughts welcome....

Signed-off-by: Chris Jackson <chris@cd-jackson.com>