### PR TITLE
Paper UI: apply the formatter to all js and html files

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
@@ -13,25 +13,25 @@
 
 <head>
 
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
-	<title>Paper UI</title>
+<title>Paper UI</title>
 
-	<link type="text/css" href="css/bootstrap.min.css" rel="stylesheet">
-	<link type="text/css" href="css/angular-material.min.css" rel="stylesheet">
+<link type="text/css" href="css/bootstrap.min.css" rel="stylesheet">
+<link type="text/css" href="css/angular-material.min.css" rel="stylesheet">
 
-	<!-- custom css files -->
-	<link type="text/css" href="css/components.css" rel="stylesheet">
-	<link type="text/css" href="css/layout.css" rel="stylesheet">
-	<link type="text/css" href="css/views.css" rel="stylesheet">
-	<link type="text/css" href="css/theme.css" rel="stylesheet">
+<!-- custom css files -->
+<link type="text/css" href="css/components.css" rel="stylesheet">
+<link type="text/css" href="css/layout.css" rel="stylesheet">
+<link type="text/css" href="css/views.css" rel="stylesheet">
+<link type="text/css" href="css/theme.css" rel="stylesheet">
 
-	<!-- Icons/Fonts -->
-	<link type="text/css" href="css/roboto-fontface.css" rel="stylesheet" media="all">
-	<link type="text/css" href="css/material-icons.css" rel="stylesheet" media="all">
+<!-- Icons/Fonts -->
+<link type="text/css" href="css/roboto-fontface.css" rel="stylesheet" media="all">
+<link type="text/css" href="css/material-icons.css" rel="stylesheet" media="all">
 
-	<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
 
 </head>
 
@@ -46,37 +46,51 @@
 		<ul>
 			<li ng-class="{active: isActive('control'), hidden: isHidden('control')}">
 				<a href="#control">
-					<span class="icon material-icons">dashboard</span> Control</a>
+					<span class="icon material-icons">dashboard</span>
+					Control
+				</a>
 			</li>
 			<li ng-class="{active: isActive('inbox')}">
 				<a href="#inbox" class="clickable">
-					<span class="icon material-icons">add_circle_outline</span> Inbox
+					<span class="icon material-icons">add_circle_outline</span>
+					Inbox
 					<span ng-show="getNumberOfNewDiscoveryResults() > 0" class="badge">{{getNumberOfNewDiscoveryResults()}}</span>
 				</a>
 			</li>
 			<li ng-class="{active: isActive('configuration'), hidden: isHidden('configuration')}">
 				<a ng-click="open('configuration')" class="clickable">
-					<span class="icon material-icons">settings</span> Configuration</a>
+					<span class="icon material-icons">settings</span>
+					Configuration
+				</a>
 				<ul ng-show="isActive('configuration')">
-					<li ng-class="{active: isSubActive('bindings')}"><a href="#configuration/bindings">Bindings</a></li>
-					<li ng-class="{active: isSubActive('services')}"><a href="#configuration/services">Services</a></li>
-					<li ng-class="{active: isSubActive('things')}"><a href="#configuration/things">Things</a></li>
+					<li ng-class="{active: isSubActive('bindings')}">
+						<a href="#configuration/bindings">Bindings</a>
+					</li>
+					<li ng-class="{active: isSubActive('services')}">
+						<a href="#configuration/services">Services</a>
+					</li>
+					<li ng-class="{active: isSubActive('things')}">
+						<a href="#configuration/things">Things</a>
+					</li>
 				</ul>
 			</li>
 			<li ng-class="{active: isActive('extensions'), hidden: isHidden('extensions')}">
 				<a href="#extensions">
 					<span class="icon material-icons">extension</span>
-					Extensions</a>
+					Extensions
+				</a>
 			</li>
 			<li ng-class="{active: isActive('rules'), hidden: isHidden('rules')}">
 				<a href="#rules">
 					<span class="icon material-icons">movie_creation</span>
-					Rules</a>
+					Rules
+				</a>
 			</li>
 			<li ng-class="{active: isActive('preferences'), hidden: isHidden('preferences')}">
 				<a href="#preferences">
 					<span class="icon material-icons">brightness_medium</span>
-					Preferences</a>
+					Preferences
+				</a>
 			</li>
 		</ul>
 		<div class="bottom">
@@ -91,7 +105,9 @@
 				<h1>
 					{{title}}
 					<span ng-repeat="subtitle in subtitles" class="subtitle">
-						<span class="chevron material-icons">chevron_right</span> {{subtitle}}</span>
+						<span class="chevron material-icons">chevron_right</span>
+						{{subtitle}}
+					</span>
 				</h1>
 			</div>
 		</header>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/app.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/app.js
@@ -123,7 +123,11 @@ angular.module('PaperUI', [ 'PaperUI.controllers', 'PaperUI.controllers.control'
 
             element[0].addEventListener('click', function() {
                 scope.$watch(attrs.ngModel, function(value) {
-                    if ((value === undefined || value == "") && attrs.isrequired){element.addClass('border-invalid');} else {element.removeClass('border-invalid');}
+                    if ((value === undefined || value == "") && attrs.isrequired) {
+                        element.addClass('border-invalid');
+                    } else {
+                        element.removeClass('border-invalid');
+                    }
                 });
             });
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -1,8 +1,7 @@
 <section id="main">
 	<div class="bindings tab-panel content" ng-if="page === 'bindings'" ng-controller="BindingController">
 		<div class="header-toolbar">
-			<md-button ng-click="refresh()" aria-label="Refresh">
-			<i class="material-icons">refresh</i></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header"></div>
 		<div class="container">
@@ -27,14 +26,12 @@
 	</div>
 	<div class="services tab-panel content" ng-if="page === 'services'" ng-controller="ServicesController">
 		<div class="header-toolbar">
-			<md-button ng-click="refresh()" aria-label="Refresh">
-			<i class="material-icons">refresh</i></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab" ng-click="add()" aria-label="Add Configuration">
-					<i class="material-icons">add</i></md-button>
+					<md-button class="md-fab" ng-click="add()" aria-label="Add Configuration"> <i class="material-icons">add</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -64,14 +61,12 @@
 	</div>
 	<div class="things white-bg" ng-if="page === 'things' && !path[3]" ng-controller="ThingController">
 		<div class="header-toolbar">
-			<md-button ng-click="refresh()" aria-label="Refresh">
-			<i class="material-icons">refresh</i></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab" ng-click="$location.path('inbox/setup')" aria-label="Add">
-					<i class="material-icons">add</i></md-button>
+					<md-button class="md-fab" ng-click="$location.path('inbox/setup')" aria-label="Add"> <i class="material-icons">add</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -91,10 +86,8 @@
 							<p>{{thingTypes[thing.thingTypeUID].label}}</p>
 							<p>{{thing.UID}}</p>
 							<div class="actions">
-								<md-button class="md-raised" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit">
-								<i class="material-icons">edit</i></md-button>
-								<md-button class="md-raised" ng-click="remove(thing, $event)" aria-label="Delete">
-								<i class="material-icons">delete</i></md-button>
+								<md-button class="md-raised" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit"> <i class="material-icons">edit</i></md-button>
+								<md-button class="md-raised" ng-click="remove(thing, $event)" aria-label="Delete"> <i class="material-icons">delete</i></md-button>
 							</div>
 						</div>
 						<hr class="border-line" ng-show="!$last" />
@@ -105,16 +98,13 @@
 	</div>
 	<div class="thing-view white-bg" ng-if="page === 'things' && path[3] === 'view'" ng-controller="ViewThingController">
 		<div class="header-toolbar">
-			<md-button ng-click="remove(thing, $event)" aria-label="Delete">
-			<i class="material-icons">delete</i></md-button>
-			<md-button ng-click="navigateTo('things')" aria-label="Close">
-			<i class="material-icons">close</i></md-button>
+			<md-button ng-click="remove(thing, $event)" aria-label="Delete"> <i class="material-icons">delete</i></md-button>
+			<md-button ng-click="navigateTo('things')" aria-label="Close"> <i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit">
-					<i class="material-icons">edit</i></md-button>
+					<md-button class="md-fab" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit"> <i class="material-icons">edit</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -142,10 +132,8 @@
 						</div>
 						<div class="channel fab-item" ng-repeat="channel in group.channels">
 							<div ng-show="!collapsed">
-								<md-button ng-if="channel.linkedItems.length == 0" class="md-fab" ng-click="enableChannel(thing.UID, channel.id, $event)" aria-label="Off">
-								<i class="material-icons">radio_button_unchecked</i></md-button>
-								<md-button ng-if="channel.linkedItems.length > 0" class="md-fab" ng-click="disableChannel(thing.UID, channel.id, $event)" aria-label="On">
-								<i class="material-icons">radio_button_checked</i></md-button>
+								<md-button ng-if="channel.linkedItems.length == 0" class="md-fab" ng-click="enableChannel(thing.UID, channel.id, $event)" aria-label="Off"> <i class="material-icons">radio_button_unchecked</i></md-button>
+								<md-button ng-if="channel.linkedItems.length > 0" class="md-fab" ng-click="disableChannel(thing.UID, channel.id, $event)" aria-label="On"> <i class="material-icons">radio_button_checked</i></md-button>
 								<div class="item-content">
 									<h3>{{getChannelTypeById(channel.id).label}}</h3>
 									<p>{{thing.UID + ':' + channel.id}}</p>
@@ -161,14 +149,12 @@
 	</div>
 	<div class="thing-edit white-bg" ng-if="page === 'things' && path[3] === 'edit'" ng-controller="EditThingController">
 		<div class="header-toolbar">
-			<md-button ng-click="navigateTo('things/view/' + thing.UID)" aria-label="Close">
-			<i class="material-icons">close</i></md-button>
+			<md-button ng-click="navigateTo('things/view/' + thing.UID)" aria-label="Close"> <i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button title="Save" ng-click="update(thing)" ng-disabled="form.configForm.$invalid" class="md-fab" aria-label="Save">
-					<i class="material-icons">check</i></md-button>
+					<md-button title="Save" ng-click="update(thing)" ng-disabled="form.configForm.$invalid" class="md-fab" aria-label="Save"> <i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
@@ -1,7 +1,6 @@
 <section id="main" class="control header-tabs">
 	<div class="header-toolbar">
-		<md-button ng-click="refresh()" aria-label="Refresh">
-		<i class="material-icons">refresh</i></md-button>
+		<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 	</div>
 
 	<p class="text-center" ng-show="tabs.length == 0" style="margin-top: 20px;">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.scan.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.scan.html
@@ -3,8 +3,7 @@
 <p>Click on the "Scan" button to scan for new things for a binding.</p>
 <br />
 <div class="fab-item" ng-repeat="binding in supportedBindings">
-	<md-button ng-show="activeScans.indexOf(binding) < 0" title="Refresh" class="md-fab" ng-click="scan(binding)" aria-label="Refresh">
-	<i class="material-icons">settings_input_antenna</i></md-button>
+	<md-button ng-show="activeScans.indexOf(binding) < 0" title="Refresh" class="md-fab" ng-click="scan(binding)" aria-label="Refresh"> <i class="material-icons">settings_input_antenna</i></md-button>
 	<md-progress-circular ng-show="activeScans.indexOf(binding) >= 0" md-mode="indeterminate"></md-progress-circular>
 	<div class="item-content">
 		<h3>{{getBindingById(binding).name}}</h3>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/extensions.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/extensions.html
@@ -1,7 +1,6 @@
 <section id="main" class="white-bg extensions header-tabs">
 	<div class="header-toolbar">
-		<md-button ng-click="refresh()" aria-label="Refresh">
-		<i class="material-icons">refresh</i></md-button>
+		<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 	</div>
 	<md-tabs md-stretch-tabs="always" class="section-tabs" md-selected="selectedIndex"> <md-tab ng-repeat="extensionType in extensionTypes" ng-disabled="tab.disabled" label="{{extensionType.label}}" layout-fill> <md-tab-content layout-fill="">
 	<div class="search" layout="row" layout-align="center center">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.inbox.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.inbox.html
@@ -1,6 +1,5 @@
 <div class="fab-item" ng-repeat="discoveryResult in data.discoveryResults | filter:filter | orderBy:flag" ng-controller="InboxEntryController">
-	<md-button title="Add" class="md-fab green" ng-click="approve(discoveryResult.thingUID,discoveryResult.thingTypeUID, $event)" aria-label="Approve">
-	<i class="material-icons">done</i></md-button>
+	<md-button title="Add" class="md-fab green" ng-click="approve(discoveryResult.thingUID,discoveryResult.thingTypeUID, $event)" aria-label="Approve"> <i class="material-icons">done</i></md-button>
 	<div class="item-content">
 		<h3>
 			{{thingTypes[discoveryResult.thingTypeUID].label}} <small ng-show="discoveryResult.flag === 'IGNORED'" class="badge">IGNORED</small>
@@ -8,12 +7,9 @@
 		<p>{{discoveryResult.label}}</p>
 		<p>{{discoveryResult.thingUID}}</p>
 		<div class="actions">
-			<md-button ng-show="discoveryResult.flag === 'IGNORED'" ng-click="unignore(discoveryResult.thingUID)" aria-label="Unignore">
-			<i class="material-icons">visibility</i></md-button>
-			<md-button ng-show="discoveryResult.flag !== 'IGNORED'" ng-click="ignore(discoveryResult.thingUID)" aria-label="Ignore">
-			<i class="material-icons">visibility_off</i></md-button>
-			<md-button ng-click="remove(discoveryResult.thingUID, $event)" aria-label="Delete">
-			<i class="material-icons">delete</i></md-button>
+			<md-button ng-show="discoveryResult.flag === 'IGNORED'" ng-click="unignore(discoveryResult.thingUID)" aria-label="Unignore"> <i class="material-icons">visibility</i></md-button>
+			<md-button ng-show="discoveryResult.flag !== 'IGNORED'" ng-click="ignore(discoveryResult.thingUID)" aria-label="Ignore"> <i class="material-icons">visibility_off</i></md-button>
+			<md-button ng-click="remove(discoveryResult.thingUID, $event)" aria-label="Delete"> <i class="material-icons">delete</i></md-button>
 		</div>
 	</div>
 	<hr class="border-line" ng-show="!$last" />

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.thingconfig.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.thingconfig.html
@@ -1,8 +1,6 @@
 <div class="container" ng-if="thing.item">
 	<div class="thingName">
-		<md-input-container>
-            <label>Name</label> <input ng-model="thing.label"> 
-        </md-input-container>
+		<md-input-container> <label>Name</label> <input ng-model="thing.label"> </md-input-container>
 	</div>
 </div>
 <div class="container" ng-if="needsBridge">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/preferences.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/preferences.html
@@ -1,14 +1,12 @@
 <section id="main" class="white-bg">
 	<div class="content">
 		<div class="header-toolbar">
-			<md-button ng-click="navigateToRoot()" aria-label="Close">
-			<i class="material-icons">close</i></md-button>
+			<md-button ng-click="navigateToRoot()" aria-label="Close"> <i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button title="Save" ng-click="save()" class="md-fab" aria-label="Save">
-					<i class="material-icons">check</i></md-button>
+					<md-button title="Save" ng-click="save()" class="md-fab" aria-label="Save"> <i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/rules.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/rules.html
@@ -1,14 +1,12 @@
 <section id="main" class="white-bg">
 	<div class="rules white-bg" ng-if="!page" ng-controller="RulesController">
 		<div class="header-toolbar">
-			<md-button ng-click="refresh()" aria-label="Refresh">
-			<i class="material-icons">refresh</i></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-menu md-offset="60 -25"> <md-button class="md-fab" ng-click="$mdOpenMenu(ev);" aria-label="Add">
-					<i class="material-icons">add</i></md-button> <md-menu-content width="2" ng-init="ruleOptions=['New rule','Rule from template']"> <md-menu-item ng-repeat="item in ruleOptions"> <md-button ng-click="ruleOptionSelected($event,$index)"> {{item}} </md-button> </md-menu-item> </md-menu-content> </md-menu>
+					<md-menu md-offset="60 -25"> <md-button class="md-fab" ng-click="$mdOpenMenu(ev);" aria-label="Add"> <i class="material-icons">add</i></md-button> <md-menu-content width="2" ng-init="ruleOptions=['New rule','Rule from template']"> <md-menu-item ng-repeat="item in ruleOptions"> <md-button ng-click="ruleOptionSelected($event,$index)"> {{item}} </md-button> </md-menu-item> </md-menu-content> </md-menu>
 				</div>
 			</div>
 		</div>
@@ -22,12 +20,9 @@
 							<h3>{{rule.name}}</h3>
 							<p>{{rule.uid}}</p>
 							<div class="actions">
-								<md-button class="md-raised" ng-click="toggleEnabled(rule, $event)" aria-label="Toggle Enable">
-								<i class="material-icons">{{rule.enabled ? "alarm_on" : "alarm_off"}}</i></md-button>
-								<md-button class="md-raised" ng-click="configure(rule, $event)" aria-label="Configure">
-								<i class="material-icons">settings</i></md-button>
-								<md-button class="md-raised" ng-click="remove(rule, $event)" aria-label="Remove">
-								<i class="material-icons">delete</i></md-button>
+								<md-button class="md-raised" ng-click="toggleEnabled(rule, $event)" aria-label="Toggle Enable"> <i class="material-icons">{{rule.enabled ? "alarm_on" : "alarm_off"}}</i></md-button>
+								<md-button class="md-raised" ng-click="configure(rule, $event)" aria-label="Configure"> <i class="material-icons">settings</i></md-button>
+								<md-button class="md-raised" ng-click="remove(rule, $event)" aria-label="Remove"> <i class="material-icons">delete</i></md-button>
 							</div>
 						</div>
 						<hr class="border-line" ng-show="!$last" />
@@ -38,14 +33,12 @@
 	</div>
 	<div class="rules white-bg" ng-if="page === 'view'" ng-controller="ViewRuleController">
 		<div class="header-toolbar">
-			<md-button ng-click="navigateTo('')" aria-label="Refresh">
-			<i class="material-icons">close</i></md-button>
+			<md-button ng-click="navigateTo('')" aria-label="Refresh"> <i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab" ng-click="navigateTo('')" aria-label="Back">
-					<i class="material-icons">chevron_left</i></md-button>
+					<md-button class="md-fab" ng-click="navigateTo('')" aria-label="Back"> <i class="material-icons">chevron_left</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -57,16 +50,13 @@
 	<!-- Config block -->
 	<div class="rules white-bg" ng-if="page === 'configure' || page ==='new' " ng-controller="NewRuleController">
 		<div class="header-toolbar">
-			<md-button ng-click="navigateTo('')" aria-label="Refresh">
-			<i class="material-icons">close</i></md-button>
+			<md-button ng-click="navigateTo('')" aria-label="Refresh"> <i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button ng-show="editing" title="Save" ng-click="updateUserRule()" class="md-fab" aria-label="Save">
-					<i class="material-icons">check</i></md-button>
-					<md-button ng-show="!editing" title="Save" ng-click="saveUserRule()" class="md-fab" aria-label="Save">
-					<i class="material-icons">check</i></md-button>
+					<md-button ng-show="editing" title="Save" ng-click="updateUserRule()" class="md-fab" aria-label="Save"> <i class="material-icons">check</i></md-button>
+					<md-button ng-show="!editing" title="Save" ng-click="saveUserRule()" class="md-fab" aria-label="Save"> <i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -74,8 +64,7 @@
 			<div class="bindings row">
 				<div class="row">
 					<md-input-container style="padding-bottom:12px; margin-right:3%;"> <label>Name</label> <input ng-model="name" /> </md-input-container>
-					<md-input-container style=" margin-right:3%;">
-					<label>Description</label> <textarea rows="1" ng-model="description"></textarea> </md-input-container>
+					<md-input-container style=" margin-right:3%;"> <label>Description</label> <textarea rows="1" ng-model="description"></textarea> </md-input-container>
 					<input type="hidden" ng-value="id" />
 				</div>
 
@@ -91,8 +80,7 @@
 								<h5 class="col-md-10">{{val.label?val.label:'Trigger '+($index+1)}}</h5>
 								<div class="col-md-2">
 
-									<md-button ng-click="openUpdateModuleDialog($event,'trigger',val)" class="md-raised">
-									<i class="material-icons">settings</i></md-button>
+									<md-button ng-click="openUpdateModuleDialog($event,'trigger',val)" class="md-raised"> <i class="material-icons">settings</i></md-button>
 								</div>
 							</div>
 							<p>{{val.description}}</p>
@@ -114,8 +102,7 @@
 							<div class="row">
 								<h5 class="col-md-10">{{val.label?val.label:'Action '+($index+1)}}</h5>
 								<div class="col-md-2">
-									<md-button ng-click="openUpdateModuleDialog($event,'action',val)" class="md-raised">
-									<i class="material-icons">settings</i></md-button>
+									<md-button ng-click="openUpdateModuleDialog($event,'action',val)" class="md-raised"> <i class="material-icons">settings</i></md-button>
 								</div>
 							</div>
 							<p>{{val.description}}</p>
@@ -141,8 +128,7 @@
 							<div class="row">
 								<h5 class="col-md-10">{{val.label?val.label:'Condition '+($index+1)}}</h5>
 								<div class="col-md-1">
-									<md-button ng-click="openUpdateModuleDialog($event,'condition',val)" class="md-raised">
-									<i class="material-icons">settings</i></md-button>
+									<md-button ng-click="openUpdateModuleDialog($event,'condition',val)" class="md-raised"> <i class="material-icons">settings</i></md-button>
 
 								</div>
 							</div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
@@ -27,14 +27,12 @@
 	</div>
 	<div ng-controller="ManualSetupConfigureController" class="thing-configure white-bg" ng-if="page === 'manual-setup' && path[3] === 'configure'">
 		<div class="header-toolbar">
-			<md-button ng-click="navigateTo('manual-setup/choose')" aria-label="Close">
-			<i class="material-icons">close</i></md-button>
+			<md-button ng-click="navigateTo('manual-setup/choose')" aria-label="Close"> <i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid" class="md-fab" aria-label="Add Thing">
-					<i class="material-icons">check</i></md-button>
+					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid" class="md-fab" aria-label="Add Thing"> <i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -50,16 +48,13 @@
 	</div>
 	<div ng-controller="InboxController" class="thing-add white-bg" ng-if="page === 'search' && !path[3]">
 		<div class="header-toolbar">
-			<md-button title="Scan" ng-click="showScanDialog($event)" aria-label="Scan">
-			<i class="material-icons">settings_input_antenna</i></md-button>
-			<md-button ng-click="refresh()" aria-label="Refresh">
-			<i class="material-icons">refresh</i></md-button>
+			<md-button title="Scan" ng-click="showScanDialog($event)" aria-label="Scan"> <i class="material-icons">settings_input_antenna</i></md-button>
+			<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab" ng-click="navigateTo('setup/bindings')" aria-label="Add Thing">
-					<i class="material-icons">add</i></md-button>
+					<md-button class="md-fab" ng-click="navigateTo('setup/bindings')" aria-label="Add Thing"> <i class="material-icons">add</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -97,8 +92,7 @@
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button class="md-fab" ng-click="scan(bindingId)" aria-label="Refresh" title="Refresh">
-					<i class="material-icons">refresh</i></md-button>
+					<md-button class="md-fab" ng-click="scan(bindingId)" aria-label="Refresh" title="Refresh"> <i class="material-icons">refresh</i></md-button>
 				</div>
 			</div>
 		</div>
@@ -154,14 +148,12 @@
 	</div>
 	<div ng-controller="ManualSetupConfigureController" class="thing-configure white-bg" ng-if="page === 'setup' && path[3] === 'add'">
 		<div class="header-toolbar">
-			<md-button ng-click="navigateTo('setup')" aria-label="Close">
-			<i class="material-icons">close</i></md-button>
+			<md-button ng-click="navigateTo('setup')" aria-label="Close"> <i class="material-icons">close</i></md-button>
 		</div>
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid" class="md-fab" aria-label="Add">
-					<i class="material-icons">check</i></md-button>
+					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid" class="md-fab" aria-label="Add"> <i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
The about.html has not been reformatted, as it is no part of the web
stuff.

Related to: https://github.com/eclipse/smarthome/pull/1161
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>