### PR TITLE
Update Sonos binding

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Connector CONNECT Thing Type -->
+	<thing-type id="CONNECT" listed="false">
+		<label>CONNECT</label>
+		<description>Represents SONOS CONNECT connector</description>
+
+		<channels>
+			<channel id="add" typeId="add" />
+			<channel id="alarm" typeId="alarm" />
+			<channel id="alarmproperties" typeId="alarmproperties" />
+			<channel id="alarmrunning" typeId="alarmrunning" />
+			<channel id="control" typeId="control" />
+			<channel id="currentalbum" typeId="currentalbum" />
+			<channel id="currentartist" typeId="currentartist" />
+			<channel id="currenttitle" typeId="currenttitle" />
+			<channel id="currenttrack" typeId="currenttrack" />
+			<channel id="favorite" typeId="favorite" />
+			<channel id="led" typeId="led" />
+			<channel id="localcoordinator" typeId="localcoordinator" />
+			<channel id="mute" typeId="mute" />
+			<channel id="notificationsound" typeId="notificationsound" />
+			<channel id="notificationvolume" typeId="notificationvolume" />
+			<channel id="playlist" typeId="playlist" />
+			<channel id="playqueue" typeId="playqueue" />			
+			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playuri" typeId="playuri" />
+			<channel id="publicaddress" typeId="publicaddress" />
+			<channel id="radio" typeId="radio" />
+			<channel id="remove" typeId="remove" />
+			<channel id="restore" typeId="restore" />
+			<channel id="restoreall" typeId="restoreall" />
+			<channel id="save" typeId="save" />
+			<channel id="saveall" typeId="saveall" />
+			<channel id="snooze" typeId="snooze" />
+			<channel id="standalone" typeId="standalone" />
+			<channel id="state" typeId="state" />
+			<channel id="stop" typeId="stop" />
+			<channel id="volume" typeId="volume" />
+			<channel id="zonegroup" typeId="zonegroup" />
+			<channel id="zonegroupid" typeId="zonegroupid" />
+			<channel id="zonename" typeId="zonename" />
+			<channel id="coordinator" typeId="coordinator" />
+			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
+			<channel id="linein" typeId="linein" />
+	        <channel id="playlinein" typeId="playlinein" />
+		</channels>
+		
+		<properties>
+        	<property name="vendor">SONOS</property>
+        	<property name="modelId"></property>
+        </properties>
+
+		<config-description>
+			<parameter name="udn" type="text">
+				<label>Unique Device Name</label>
+				<description>The UDN identifies the Zone Player.</description>
+				<required>true</required>
+			</parameter>
+
+			<parameter name="refresh" type="integer">
+				<label>Refresh interval</label>
+				<description>Specifies the refresh interval in seconds</description>
+				<default>60</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Amplifier CONNECT:AMP Thing Type -->
+	<thing-type id="CONNECTAMP" listed="false">
+		<!-- Label without column (:) because of device pairing name restrictions -->
+		<label>CONNECT AMP</label>
+		<description>Represents SONOS CONNECT:AMP amplifier</description>
+
+		<channels>
+			<channel id="add" typeId="add" />
+			<channel id="alarm" typeId="alarm" />
+			<channel id="alarmproperties" typeId="alarmproperties" />
+			<channel id="alarmrunning" typeId="alarmrunning" />
+			<channel id="control" typeId="control" />
+			<channel id="currentalbum" typeId="currentalbum" />
+			<channel id="currentartist" typeId="currentartist" />
+			<channel id="currenttitle" typeId="currenttitle" />
+			<channel id="currenttrack" typeId="currenttrack" />
+			<channel id="favorite" typeId="favorite" />
+			<channel id="led" typeId="led" />
+			<channel id="localcoordinator" typeId="localcoordinator" />
+			<channel id="mute" typeId="mute" />
+			<channel id="notificationsound" typeId="notificationsound" />
+			<channel id="notificationvolume" typeId="notificationvolume" />
+			<channel id="playlist" typeId="playlist" />
+			<channel id="playqueue" typeId="playqueue" />			
+			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playuri" typeId="playuri" />
+			<channel id="publicaddress" typeId="publicaddress" />
+			<channel id="radio" typeId="radio" />
+			<channel id="remove" typeId="remove" />
+			<channel id="restore" typeId="restore" />
+			<channel id="restoreall" typeId="restoreall" />
+			<channel id="save" typeId="save" />
+			<channel id="saveall" typeId="saveall" />
+			<channel id="snooze" typeId="snooze" />
+			<channel id="standalone" typeId="standalone" />
+			<channel id="state" typeId="state" />
+			<channel id="stop" typeId="stop" />
+			<channel id="volume" typeId="volume" />
+			<channel id="zonegroup" typeId="zonegroup" />
+			<channel id="zonegroupid" typeId="zonegroupid" />
+			<channel id="zonename" typeId="zonename" />
+			<channel id="coordinator" typeId="coordinator" />
+			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
+			<channel id="linein" typeId="linein" />
+	        <channel id="playlinein" typeId="playlinein" />
+		</channels>
+		
+		<properties>
+        	<property name="vendor">SONOS</property>
+        	<property name="modelId">CONNECT:AMP</property>
+        </properties>
+
+		<config-description>
+			<parameter name="udn" type="text">
+				<label>Unique Device Name</label>
+				<description>The UDN identifies the Zone Player.</description>
+				<required>true</required>
+			</parameter>
+
+			<parameter name="refresh" type="integer">
+				<label>Refresh interval</label>
+				<description>Specifies the refresh interval in seconds</description>
+				<default>60</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Player PLAY:1 Thing Type -->
+	<thing-type id="PLAY1" listed="false">
+		<!-- Label without column (:) because of device pairing name restrictions -->
+		<label>PLAY 1</label>
+		<description>Represents SONOS PLAY:1 Zone Player</description>
+
+		<channels>
+			<channel id="add" typeId="add" />
+			<channel id="alarm" typeId="alarm" />
+			<channel id="alarmproperties" typeId="alarmproperties" />
+			<channel id="alarmrunning" typeId="alarmrunning" />
+			<channel id="control" typeId="control" />
+			<channel id="currentalbum" typeId="currentalbum" />
+			<channel id="currentartist" typeId="currentartist" />
+			<channel id="currenttitle" typeId="currenttitle" />
+			<channel id="currenttrack" typeId="currenttrack" />
+			<channel id="favorite" typeId="favorite" />
+			<channel id="led" typeId="led" />
+			<channel id="localcoordinator" typeId="localcoordinator" />
+			<channel id="mute" typeId="mute" />
+			<channel id="notificationsound" typeId="notificationsound" />
+			<channel id="notificationvolume" typeId="notificationvolume" />
+			<channel id="playlist" typeId="playlist" />
+			<channel id="playqueue" typeId="playqueue" />			
+			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playuri" typeId="playuri" />
+			<channel id="publicaddress" typeId="publicaddress" />
+			<channel id="radio" typeId="radio" />
+			<channel id="remove" typeId="remove" />
+			<channel id="restore" typeId="restore" />
+			<channel id="restoreall" typeId="restoreall" />
+			<channel id="save" typeId="save" />
+			<channel id="saveall" typeId="saveall" />
+			<channel id="snooze" typeId="snooze" />
+			<channel id="standalone" typeId="standalone" />
+			<channel id="state" typeId="state" />
+			<channel id="stop" typeId="stop" />
+			<channel id="volume" typeId="volume" />
+			<channel id="zonegroup" typeId="zonegroup" />
+			<channel id="zonegroupid" typeId="zonegroupid" />
+			<channel id="zonename" typeId="zonename" />
+			<channel id="coordinator" typeId="coordinator" />
+		</channels>
+		
+		<properties>
+        	<property name="vendor">SONOS</property>
+        	<property name="modelId">PLAY:1</property>
+        </properties>
+
+		<config-description>
+			<parameter name="udn" type="text">
+				<label>Unique Device Name</label>
+				<description>The UDN identifies the Zone Player.</description>
+				<required>true</required>
+			</parameter>
+
+			<parameter name="refresh" type="integer">
+				<label>Refresh interval</label>
+				<description>Specifies the refresh interval in seconds</description>
+				<default>60</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Player PLAY:3 Thing Type -->
+	<thing-type id="PLAY3" listed="false">
+		<!-- Label without column (:) because of device pairing name restrictions -->
+		<label>PLAY 3</label>
+		<description>Represents SONOS PLAY:3 Zone Player</description>
+
+		<channels>
+			<channel id="add" typeId="add" />
+			<channel id="alarm" typeId="alarm" />
+			<channel id="alarmproperties" typeId="alarmproperties" />
+			<channel id="alarmrunning" typeId="alarmrunning" />
+			<channel id="control" typeId="control" />
+			<channel id="currentalbum" typeId="currentalbum" />
+			<channel id="currentartist" typeId="currentartist" />
+			<channel id="currenttitle" typeId="currenttitle" />
+			<channel id="currenttrack" typeId="currenttrack" />
+			<channel id="favorite" typeId="favorite" />
+			<channel id="led" typeId="led" />
+			<channel id="localcoordinator" typeId="localcoordinator" />
+			<channel id="mute" typeId="mute" />
+			<channel id="notificationsound" typeId="notificationsound" />
+			<channel id="notificationvolume" typeId="notificationvolume" />
+			<channel id="playlist" typeId="playlist" />
+			<channel id="playqueue" typeId="playqueue" />			
+			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playuri" typeId="playuri" />
+			<channel id="publicaddress" typeId="publicaddress" />
+			<channel id="radio" typeId="radio" />
+			<channel id="remove" typeId="remove" />
+			<channel id="restore" typeId="restore" />
+			<channel id="restoreall" typeId="restoreall" />
+			<channel id="save" typeId="save" />
+			<channel id="saveall" typeId="saveall" />
+			<channel id="snooze" typeId="snooze" />
+			<channel id="standalone" typeId="standalone" />
+			<channel id="state" typeId="state" />
+			<channel id="stop" typeId="stop" />
+			<channel id="volume" typeId="volume" />
+			<channel id="zonegroup" typeId="zonegroup" />
+			<channel id="zonegroupid" typeId="zonegroupid" />
+			<channel id="zonename" typeId="zonename" />
+			<channel id="coordinator" typeId="coordinator" />
+		</channels>
+		
+		<properties>
+        	<property name="vendor">SONOS</property>
+        	<property name="modelId">PLAY:3</property>
+        </properties>
+
+		<config-description>
+			<parameter name="udn" type="text">
+				<label>Unique Device Name</label>
+				<description>The UDN identifies the Zone Player.</description>
+				<required>true</required>
+			</parameter>
+
+			<parameter name="refresh" type="integer">
+				<label>Refresh interval</label>
+				<description>Specifies the refresh interval in seconds</description>
+				<default>60</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Player PLAY:5 Thing Type -->
+	<thing-type id="PLAY5" listed="false">
+		<!-- Label without column (:) because of device pairing name restrictions -->
+		<label>PLAY 5</label>
+		<description>Represents SONOS PLAY:5 Zone Player</description>
+
+		<channels>
+			<channel id="add" typeId="add" />
+			<channel id="alarm" typeId="alarm" />
+			<channel id="alarmproperties" typeId="alarmproperties" />
+			<channel id="alarmrunning" typeId="alarmrunning" />
+			<channel id="control" typeId="control" />
+			<channel id="currentalbum" typeId="currentalbum" />
+			<channel id="currentartist" typeId="currentartist" />
+			<channel id="currenttitle" typeId="currenttitle" />
+			<channel id="currenttrack" typeId="currenttrack" />
+			<channel id="favorite" typeId="favorite" />
+			<channel id="led" typeId="led" />
+			<channel id="localcoordinator" typeId="localcoordinator" />
+			<channel id="mute" typeId="mute" />
+			<channel id="notificationsound" typeId="notificationsound" />
+			<channel id="notificationvolume" typeId="notificationvolume" />
+			<channel id="playlist" typeId="playlist" />
+			<channel id="playqueue" typeId="playqueue" />			
+			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playuri" typeId="playuri" />
+			<channel id="publicaddress" typeId="publicaddress" />
+			<channel id="radio" typeId="radio" />
+			<channel id="remove" typeId="remove" />
+			<channel id="restore" typeId="restore" />
+			<channel id="restoreall" typeId="restoreall" />
+			<channel id="save" typeId="save" />
+			<channel id="saveall" typeId="saveall" />
+			<channel id="snooze" typeId="snooze" />
+			<channel id="standalone" typeId="standalone" />
+			<channel id="state" typeId="state" />
+			<channel id="stop" typeId="stop" />
+			<channel id="volume" typeId="volume" />
+			<channel id="zonegroup" typeId="zonegroup" />
+			<channel id="zonegroupid" typeId="zonegroupid" />
+			<channel id="zonename" typeId="zonename" />
+			<channel id="coordinator" typeId="coordinator" />
+			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
+			<channel id="linein" typeId="linein" />
+	        <channel id="playlinein" typeId="playlinein" />
+		</channels>
+		
+		<properties>
+        	<property name="vendor">SONOS</property>
+        	<property name="modelId">PLAY:5</property>
+        </properties>
+
+		<config-description>
+			<parameter name="udn" type="text">
+				<label>Unique Device Name</label>
+				<description>The UDN identifies the Zone Player.</description>
+				<required>true</required>
+			</parameter>
+
+			<parameter name="refresh" type="integer">
+				<label>Refresh interval</label>
+				<description>Specifies the refresh interval in seconds</description>
+				<default>60</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Soundbar PLAYBAR Thing Type -->
+	<thing-type id="PLAYBAR" listed="false">
+		<label>PLAYBAR</label>
+		<description>Represents SONOS PLAYBAR soundbar</description>
+
+	    <channels>
+			<channel id="add" typeId="add" />
+			<channel id="alarm" typeId="alarm" />
+			<channel id="alarmproperties" typeId="alarmproperties" />
+			<channel id="alarmrunning" typeId="alarmrunning" />
+			<channel id="control" typeId="control" />
+			<channel id="currentalbum" typeId="currentalbum" />
+			<channel id="currentartist" typeId="currentartist" />
+			<channel id="currenttitle" typeId="currenttitle" />
+			<channel id="currenttrack" typeId="currenttrack" />
+			<channel id="favorite" typeId="favorite" />
+			<channel id="led" typeId="led" />
+			<channel id="localcoordinator" typeId="localcoordinator" />
+			<channel id="mute" typeId="mute" />
+			<channel id="notificationsound" typeId="notificationsound" />
+			<channel id="notificationvolume" typeId="notificationvolume" />
+			<channel id="playlist" typeId="playlist" />
+			<channel id="playqueue" typeId="playqueue" />			
+			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playuri" typeId="playuri" />
+			<channel id="publicaddress" typeId="publicaddress" />
+			<channel id="radio" typeId="radio" />
+			<channel id="remove" typeId="remove" />
+			<channel id="restore" typeId="restore" />
+			<channel id="restoreall" typeId="restoreall" />
+			<channel id="save" typeId="save" />
+			<channel id="saveall" typeId="saveall" />
+			<channel id="snooze" typeId="snooze" />
+			<channel id="standalone" typeId="standalone" />
+			<channel id="state" typeId="state" />
+			<channel id="stop" typeId="stop" />
+			<channel id="volume" typeId="volume" />
+			<channel id="zonegroup" typeId="zonegroup" />
+			<channel id="zonegroupid" typeId="zonegroupid" />
+			<channel id="zonename" typeId="zonename" />
+			<channel id="coordinator" typeId="coordinator" />
+		</channels>
+		
+		<properties>
+        	<property name="vendor">SONOS</property>
+        	<property name="modelId">PLAYBAR</property>
+        </properties>
+
+		<config-description>
+			<parameter name="udn" type="text">
+				<label>Unique Device Name</label>
+				<description>The UDN identifies the Zone Player.</description>
+				<required>true</required>
+			</parameter>
+
+			<parameter name="refresh" type="integer">
+				<label>Refresh interval</label>
+				<description>Specifies the refresh interval in seconds</description>
+				<default>60</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Generic Unknown Player Thing Type -->
+	<thing-type id="zoneplayer">
+		<!-- Label without column (:) because of device pairing name restrictions -->
+		<label>Zone Player</label>
+		<description>The Zone Player represents a Sonos Zone Player which is not known to this binding</description>
+
+		<channels>
+			<channel id="add" typeId="add" />
+			<channel id="alarm" typeId="alarm" />
+			<channel id="alarmproperties" typeId="alarmproperties" />
+			<channel id="alarmrunning" typeId="alarmrunning" />
+			<channel id="control" typeId="control" />
+			<channel id="currentalbum" typeId="currentalbum" />
+			<channel id="currentartist" typeId="currentartist" />
+			<channel id="currenttitle" typeId="currenttitle" />
+			<channel id="currenttrack" typeId="currenttrack" />
+			<channel id="favorite" typeId="favorite" />
+			<channel id="led" typeId="led" />
+			<channel id="localcoordinator" typeId="localcoordinator" />
+			<channel id="mute" typeId="mute" />
+			<channel id="notificationsound" typeId="notificationsound" />
+			<channel id="notificationvolume" typeId="notificationvolume" />
+			<channel id="playlist" typeId="playlist" />
+			<channel id="playqueue" typeId="playqueue" />			
+			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playuri" typeId="playuri" />
+			<channel id="publicaddress" typeId="publicaddress" />
+			<channel id="radio" typeId="radio" />
+			<channel id="remove" typeId="remove" />
+			<channel id="restore" typeId="restore" />
+			<channel id="restoreall" typeId="restoreall" />
+			<channel id="save" typeId="save" />
+			<channel id="saveall" typeId="saveall" />
+			<channel id="snooze" typeId="snooze" />
+			<channel id="standalone" typeId="standalone" />
+			<channel id="state" typeId="state" />
+			<channel id="stop" typeId="stop" />
+			<channel id="volume" typeId="volume" />
+			<channel id="zonegroup" typeId="zonegroup" />
+			<channel id="zonegroupid" typeId="zonegroupid" />
+			<channel id="zonename" typeId="zonename" />
+			<channel id="coordinator" typeId="coordinator" />
+		</channels>
+		
+		<properties>
+        	<property name="vendor">SONOS</property>
+        	<property name="modelId">ZonePlayer</property>
+        </properties>
+
+		<config-description>
+			<parameter name="udn" type="text">
+				<label>Unique Device Name</label>
+				<description>The UDN identifies the Zone Player.</description>
+				<required>true</required>
+			</parameter>
+
+			<parameter name="refresh" type="integer">
+				<label>Refresh interval</label>
+				<description>Specifies the refresh interval in seconds</description>
+				<default>60</default>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="sonos"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<!-- Channels common for all SONOS devices -->
+	<channel-type id="add" advanced="true">
+		<item-type>String</item-type>
+		<label>Add</label>
+		<description>Add a Zone Player to the group of the given Zone Player</description>
+	</channel-type>
+
+	<channel-type id="alarm" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Set Alarm</label>
+		<description>Set the first occurring alarm either ON or OFF. Alarms have first have to be defined through the Sonos Controller app</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="alarmproperties" advanced="true">
+		<item-type>String</item-type>
+		<label>Alarm Properties</label>
+		<description>Properties of the alarm currently running</description>
+	</channel-type>
+
+	<channel-type id="alarmrunning" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Alarm is running</label>
+		<description>Set to ON if the alarm was triggered</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="control">
+		<item-type>Player</item-type>
+		<label>Control</label>
+		<description>Control the Zone Player, e.g. start/stop/next/previous/ffward/rewind</description>
+		<category>Player</category>
+	</channel-type>
+	
+	<channel-type id="currentalbum">
+		<item-type>String</item-type>
+		<label>Current Album</label>
+		<description>Name of the album currently playing</description>
+	</channel-type>
+
+	<channel-type id="currentartist">
+		<item-type>String</item-type>
+		<label>Current Artist</label>
+		<description>Name of the artist currently playing</description>
+	</channel-type>
+
+	<channel-type id="currenttitle">
+		<item-type>String</item-type>
+		<label>Current Title</label>
+		<description>Title of the song currently playing</description>
+	</channel-type>
+
+	<channel-type id="currenttrack" advanced="true">
+		<item-type>String</item-type>
+		<label>Current Track</label>
+		<description>Name of the current track or radio station currently playing</description>
+	</channel-type>
+
+	<channel-type id="favorite" advanced="true">
+		<item-type>String</item-type>
+		<label>Favorite</label>
+		<description>Play the given favorite entry. The favorite entry has to be predefined in the Sonos Controller app</description>
+	</channel-type>
+	
+	<channel-type id="led" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Led</label>
+		<description>Set or get the status of the white led on the front of the Zone Player </description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="localcoordinator" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Local Coordinator</label>
+		<description>Indicator set to ON if the this Zone Player is the Zone Group Coordinator</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="mute" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Mute</label>
+		<description>Set or get the mute state of the master volume of the Zone Player</description>
+		<category>Switch</category>
+	</channel-type>
+	
+	<channel-type id="notificationsound" advanced="true">
+		<item-type>String</item-type>
+		<label>Notification Sound</label>
+		<description>Play a notification sound by a given URI</description>
+	</channel-type>
+	
+	<channel-type id="notificationvolume" advanced="true">
+		<item-type>Dimmer</item-type>
+		<label>Notification Sound Volume</label>
+		<description>Set the volume applied to a notification sound</description>
+		<category>SoundVolume</category>
+	</channel-type>
+
+	<channel-type id="playlist" advanced="true">
+		<item-type>String</item-type>
+		<label>Play Playlist</label>
+		<description>Play the given playlist. The playlist has to predefined in the Sonos Controller app</description>
+	</channel-type>
+
+	<channel-type id="playqueue" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Play Queue</label>
+		<description>Play the songs from the current queue</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="playtrack" advanced="true">
+		<item-type>Number</item-type>
+		<label>Play Track</label>
+		<description>Play the given track number from the current queue</description>
+	</channel-type>	
+	
+	<channel-type id="playuri" advanced="true">
+		<item-type>String</item-type>
+		<label>Play URI</label>
+		<description>Play the given URI</description>
+	</channel-type>
+
+	<channel-type id="publicaddress" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Public Address</label>
+		<description>Put all Zone Players in one group, and stream audio from the line-in from the Zone Player that triggered the command</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="radio" advanced="true">
+		<item-type>String</item-type>
+		<label>Radio</label>
+		<description>Play the given radio station. The radio station has to be predefined in the Sonos Controller app</description>
+	</channel-type>
+
+	<channel-type id="remove" advanced="true">
+		<item-type>String</item-type>
+		<label>Remove</label>
+		<description>Remove the given Zone Player to the group of this Zone Player</description>
+	</channel-type>
+
+	<channel-type id="restore" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Restore</label>
+		<description>Restore the state of the Zone Player</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="restoreall" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Restore All</label>
+		<description>Restore the state of all the Zone Players</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="save" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Save</label>
+		<description>Save the state of the Zone Player</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="saveall" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Save All</label>
+		<description>Save the state of all the Zone Players</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="snooze" advanced="true">
+		<item-type>Number</item-type>
+		<label>Snooze</label>
+		<description>Snooze the running alarm, if any, with the given number of minutes</description>
+	</channel-type>
+
+	<channel-type id="standalone" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Stand Alone</label>
+		<description>Make the Zone Player leave its Group and become a standalone Zone Player</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<!-- The Sonos State Type -->
+	<channel-type id="state" advanced="true">
+		<item-type>String</item-type>
+		<label>State</label>
+		<description>The State channel contains state of the Zone Player, e.g. PLAYING, STOPPED,...</description>
+	</channel-type>
+
+	<channel-type id="stop" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Stop</label>
+		<description>Stop the Zone Player</description>
+		<category>Switch</category>
+	</channel-type>
+
+	<channel-type id="volume">
+		<item-type>Dimmer</item-type>
+		<label>Volume</label>
+		<description>Set or get the master volume</description>
+		<category>SoundVolume</category>
+	</channel-type>
+
+	<channel-type id="zonegroup" advanced="true">
+		<item-type>String</item-type>
+		<label>Zone Group</label>
+		<description>XML formatted string with the current zonegroup configuration</description>
+	</channel-type>
+
+	<channel-type id="zonegroupid"  advanced="true">
+		<item-type>String</item-type>
+		<label>Zone Group ID</label>
+		<description>Id of the Zone Group the Zone Player belongs to</description>
+	</channel-type>
+
+	<channel-type id="zonename">
+		<item-type>String</item-type>
+		<label>Zone Name</label>
+		<description>Name of the Zone Group the Zone Player belongs to</description>
+	</channel-type>
+	
+	<channel-type id="coordinator" advanced="true">
+		<item-type>String</item-type>
+		<label>Coordinator</label>
+		<description>UDN of the coordinator for the current group</description>
+	</channel-type>	
+	
+	<!-- Extended channels (for SONOS PLAY5, CONNECT & CONNECT:AMP only) -->
+	<channel-type id="linein" advanced="true">
+		<item-type>Switch</item-type>
+		<label>Line-in connected</label>
+		<description>Indicator set to ON when the line-in of the Zone Player is connected</description>
+		<category>Switch</category>
+	</channel-type>
+	
+	<channel-type id="playlinein" advanced="true">
+		<item-type>String</item-type>
+		<label>Play Line-in</label>
+		<description>Play the Line-in of the the Zone Player corresponding to the given UIN</description>
+	</channel-type>
+
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
@@ -8,6 +8,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,
  org.apache.commons.lang,
+ org.eclipse.smarthome.binding.sonos,
+ org.eclipse.smarthome.binding.sonos.handler,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.common.registry,
@@ -28,3 +30,4 @@ Import-Package: com.google.common.collect,
 Service-Component: OSGI-INF/*
 Export-Package: org.eclipse.smarthome.binding.sonos,
  org.eclipse.smarthome.binding.sonos.handler
+Bundle-ActivationPolicy: lazy

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/SonosBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/SonosBindingConstants.java
@@ -8,10 +8,15 @@
  */
 package org.eclipse.smarthome.binding.sonos;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
+import com.google.common.collect.Sets;
+
 /**
- * The {@link SonosBinding} class defines common constants, which are 
+ * The {@link SonosBinding} class defines common constants, which are
  * used across the whole binding.
  * 
  * @author Karel Goderis - Initial contribution
@@ -19,16 +24,36 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 public class SonosBindingConstants {
 
     public static final String BINDING_ID = "sonos";
-    
+    public static final String ESH_PREFIX = "openHAB-";
+
     // List of all Thing Type UIDs
+    // Column (:) is not used for PLAY:1, PLAY:3, PLAY:5 and CONNECT:AMP because of
+    // ThingTypeUID and device pairing name restrictions
+    public final static ThingTypeUID PLAY1_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "PLAY1");
+    public final static ThingTypeUID PLAY3_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "PLAY3");
+    public final static ThingTypeUID PLAY5_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "PLAY5");
+    public final static ThingTypeUID PLAYBAR_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "PLAYBAR");
+    public final static ThingTypeUID CONNECT_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "CONNECT");
+    public final static ThingTypeUID CONNECTAMP_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "CONNECTAMP");
     public final static ThingTypeUID ZONEPLAYER_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "zoneplayer");
+
+    public static final Set<ThingTypeUID> SUPPORTED_KNOWN_THING_TYPES_UIDS = Sets.newHashSet(PLAY1_THING_TYPE_UID,
+            PLAY3_THING_TYPE_UID, PLAY5_THING_TYPE_UID, PLAYBAR_THING_TYPE_UID, CONNECT_THING_TYPE_UID,
+            CONNECTAMP_THING_TYPE_UID);
+
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<ThingTypeUID>(
+            SUPPORTED_KNOWN_THING_TYPES_UIDS) {
+        {
+            add(ZONEPLAYER_THING_TYPE_UID);
+        }
+    };
 
     // List of all Channel ids
     public final static String ADD = "add";
     public final static String ALARM = "alarm";
     public final static String ALARMPROPERTIES = "alarmproperties";
     public final static String ALARMRUNNING = "alarmrunning";
-    public final static String CONTROL ="control";
+    public final static String CONTROL = "control";
     public final static String CURRENTALBUM = "currentalbum";
     public final static String CURRENTARTIST = "currentartist";
     public final static String CURRENTTITLE = "currenttitle";
@@ -38,6 +63,8 @@ public class SonosBindingConstants {
     public final static String LINEIN = "linein";
     public final static String LOCALCOORDINATOR = "localcoordinator";
     public final static String MUTE = "mute";
+    public final static String NOTIFICATIONSOUND = "notificationsound";
+    public final static String NOTIFICATIONVOLUME = "notificationvolume";
     public final static String PLAYLINEIN = "playlinein";
     public final static String PLAYLIST = "playlist";
     public final static String PLAYQUEUE = "playqueue";
@@ -58,6 +85,7 @@ public class SonosBindingConstants {
     public final static String ZONEGROUP = "zonegroup";
     public final static String ZONEGROUPID = "zonegroupid";
     public final static String ZONENAME = "zonename";
-    
+    public final static String COORDINATOR = "coordinator";
+    public final static String MODELID = "modelId";
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/config/ZonePlayerConfiguration.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/config/ZonePlayerConfiguration.java
@@ -10,17 +10,16 @@ package org.eclipse.smarthome.binding.sonos.config;
 
 public class ZonePlayerConfiguration {
 
-	public static final String UDN = "udn";
-	public static final String FRIENDLY_NAME = "friendlyName";
-	public static final String IP_ADDRESS = "ipAddress";
-	public static final String MODEL = "model";
-	public static final String DEVICE = "device";
+    public static final String UDN = "udn";
+    public static final String FRIENDLY_NAME = "friendlyName";
+    public static final String IDENTIFICATION = "identification";
+    public static final String MODEL = "model";
+    public static final String DEVICE = "device";
 
-	
-	public String udn;
-	public String friendlyName;
-	public String ipAddress;
-	public String model;
-	public String device;
-	
+    public String udn;
+    public String friendlyName;
+    public String ipAddress;
+    public String model;
+    public String device;
+
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/discovery/ZonePlayerDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/discovery/ZonePlayerDiscoveryParticipant.java
@@ -8,19 +8,24 @@
  */
 package org.eclipse.smarthome.binding.sonos.discovery;
 
-import static org.eclipse.smarthome.binding.sonos.SonosBindingConstants.ZONEPLAYER_THING_TYPE_UID;
-import static org.eclipse.smarthome.binding.sonos.config.ZonePlayerConfiguration.*;
+import static org.eclipse.smarthome.binding.sonos.SonosBindingConstants.BINDING_ID;
+import static org.eclipse.smarthome.binding.sonos.config.ZonePlayerConfiguration.IDENTIFICATION;
+import static org.eclipse.smarthome.binding.sonos.config.ZonePlayerConfiguration.UDN;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import org.eclipse.smarthome.binding.sonos.SonosBindingConstants;
+import org.eclipse.smarthome.binding.sonos.internal.SonosXMLParser;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.jupnp.model.meta.RemoteDevice;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.eclipse.smarthome.config.discovery.*;
 
 /**
  * The {@link ZonePlayerDiscoveryParticipant} is responsible processing the
@@ -30,56 +35,67 @@ import org.eclipse.smarthome.config.discovery.*;
  */
 public class ZonePlayerDiscoveryParticipant implements UpnpDiscoveryParticipant {
 
-	private Logger logger = LoggerFactory
-			.getLogger(ZonePlayerDiscoveryParticipant.class);
+    private Logger logger = LoggerFactory.getLogger(ZonePlayerDiscoveryParticipant.class);
 
-	@Override
-	public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
-		return Collections.singleton(ZONEPLAYER_THING_TYPE_UID);
-	}
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return SonosBindingConstants.SUPPORTED_THING_TYPES_UIDS;
+    }
 
-	@Override
-	public DiscoveryResult createResult(RemoteDevice device) {
-		ThingUID uid = getThingUID(device);
-		if (uid != null) {
-			Map<String, Object> properties = new HashMap<>(3);
-			String label = "Sonos device";
-			try {
-				label = device.getDetails().getModelDetails().getModelName();
-			} catch(Exception e) {
-				// ignore and use default label
-			}
-			properties.put(UDN, device.getIdentity().getUdn()
-					.getIdentifierString());
+    @Override
+    public DiscoveryResult createResult(RemoteDevice device) {
+        ThingUID uid = getThingUID(device);
+        if (uid != null) {
+            Map<String, Object> properties = new HashMap<>(3);
+            String label = "Sonos device";
+            try {
+                label = device.getDetails().getModelDetails().getModelName();
+            } catch (Exception e) {
+                // ignore and use default label
+            }
+            properties.put(UDN, device.getIdentity().getUdn().getIdentifierString());
+            properties.put(IDENTIFICATION, getSonosRoomName(device));
 
-			DiscoveryResult result = DiscoveryResultBuilder.create(uid)
-					.withProperties(properties)
-					.withLabel(label).build();
+            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(label)
+                    .withRepresentationProperty(IDENTIFICATION).build();
 
-			logger.debug(
-					"Created a DiscoveryResult for device '{}' with UDN '{}'",
-					device.getDetails().getFriendlyName(), device.getIdentity()
-					.getUdn().getIdentifierString());
-			return result;
-		} else {
-			return null;
-		}
-	}
+            logger.debug("Created a DiscoveryResult for device '{}' with UDN '{}'",
+                    device.getDetails().getFriendlyName(), device.getIdentity().getUdn().getIdentifierString());
+            return result;
+        } else {
+            return null;
+        }
+    }
 
-	@Override
-	public ThingUID getThingUID(RemoteDevice device) {
-		if (device != null) {
-			if(device.getDetails().getManufacturerDetails().getManufacturer() != null) {
-				if (device.getDetails().getManufacturerDetails().getManufacturer()
-						.toUpperCase().contains("SONOS")) {
-					logger.debug(
-							"Discovered a Sonos Zone Player thing with UDN '{}'",
-							device.getIdentity().getUdn().getIdentifierString());
-					return new ThingUID(ZONEPLAYER_THING_TYPE_UID, device
-							.getIdentity().getUdn().getIdentifierString());
-				} 
-			}
-		}
-		return null;
-	}
+    @Override
+    public ThingUID getThingUID(RemoteDevice device) {
+        if (device != null) {
+            if (device.getDetails().getManufacturerDetails().getManufacturer() != null) {
+                if (device.getDetails().getManufacturerDetails().getManufacturer().toUpperCase().contains("SONOS")) {
+
+                    ThingTypeUID thingUID = new ThingTypeUID(BINDING_ID, getModelName(device));
+
+                    // In case a new "unknown" Sonos player is discovered a generic ThingTypeUID will be used
+                    if (!SonosBindingConstants.SUPPORTED_KNOWN_THING_TYPES_UIDS.contains(thingUID)) {
+                        thingUID = SonosBindingConstants.ZONEPLAYER_THING_TYPE_UID;
+                    }
+
+                    logger.debug("Discovered a Sonos '{}' thing with UDN '{}'", thingUID,
+                            device.getIdentity().getUdn().getIdentifierString());
+                    return new ThingUID(thingUID, device.getIdentity().getUdn().getIdentifierString());
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private String getModelName(RemoteDevice device) {
+        return SonosXMLParser.extractModelName(device.getDetails().getModelDetails().getModelName());
+    }
+
+    private String getSonosRoomName(RemoteDevice device) {
+        return SonosXMLParser.getRoomName(device.getIdentity().getDescriptorURL().toString());
+    }
+
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosAlarm.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosAlarm.java
@@ -8,15 +8,17 @@
  */
 package org.eclipse.smarthome.binding.sonos.internal;
 
+import java.util.Calendar;
+import java.util.Date;
+
 /**
  * The {@link SonosAlarm} is a datastructure to describe
  * alarms in the Sonos ecosystem
- *
+ * 
  * @author Karel Goderis - Initial contribution
  */
 public class SonosAlarm implements Cloneable {
 
-    @Override
     public Object clone() {
         try {
             return super.clone();

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosEntry.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosEntry.java
@@ -20,8 +20,8 @@ import org.apache.commons.lang.StringEscapeUtils;
  */
 public class SonosEntry implements Serializable {
 
-	private static final long serialVersionUID = -4543607156929701588L;
-	private final String id;
+    private static final long serialVersionUID = -4543607156929701588L;
+    private final String id;
     private final String title;
     private final String parentId;
     private final String upnpClass;
@@ -31,106 +31,106 @@ public class SonosEntry implements Serializable {
     private final String creator;
     private final int originalTrackNumber;
     private final SonosResourceMetaData resourceMetaData;
-    
-    public SonosEntry(String id, String title, String parentId, String album, String albumArtUri, 
-            String creator, String upnpClass, String res) {
-    	this(id, title, parentId, album, albumArtUri, creator, upnpClass, res, -1);
+
+    public SonosEntry(String id, String title, String parentId, String album, String albumArtUri, String creator,
+            String upnpClass, String res) {
+        this(id, title, parentId, album, albumArtUri, creator, upnpClass, res, -1);
     }
-    
-    public SonosEntry(String id, String title, String parentId, String album, String albumArtUri, 
-        String creator, String upnpClass, String res, int originalTrackNumber) {
-    	this(id, title, parentId, album, albumArtUri, creator, upnpClass, res, originalTrackNumber,null);
+
+    public SonosEntry(String id, String title, String parentId, String album, String albumArtUri, String creator,
+            String upnpClass, String res, int originalTrackNumber) {
+        this(id, title, parentId, album, albumArtUri, creator, upnpClass, res, originalTrackNumber, null);
     }
-    
-    public SonosEntry(String id, String title, String parentId, String album, String albumArtUri, 
-            String creator, String upnpClass, String res, int originalTrackNumber, SonosResourceMetaData resourceMetaData) {
-      this.id = id;
-      this.title=title;
-      this.parentId = parentId;
-      this.album = album;
-      this.albumArtUri = albumArtUri;
-      this.creator = creator;
-      this.upnpClass = upnpClass;
-      this.res = res;
-      this.originalTrackNumber = originalTrackNumber;
-      this.resourceMetaData = resourceMetaData;
+
+    public SonosEntry(String id, String title, String parentId, String album, String albumArtUri, String creator,
+            String upnpClass, String res, int originalTrackNumber, SonosResourceMetaData resourceMetaData) {
+        this.id = id;
+        this.title = title;
+        this.parentId = parentId;
+        this.album = album;
+        this.albumArtUri = albumArtUri;
+        this.creator = creator;
+        this.upnpClass = upnpClass;
+        this.res = res;
+        this.originalTrackNumber = originalTrackNumber;
+        this.resourceMetaData = resourceMetaData;
     }
-    
+
     /**
      * @return the title of the entry.
      */
     @Override
     public String toString() {
-      return title;
+        return title;
     }
-    
+
     /**
      * @return the unique identifier of this entry.
      */
     public String getId() {
-      return id;
+        return id;
     }
-    
+
     /**
      * @return the title of the entry.
      */
     public String getTitle() {
-      return title;
+        return title;
     }
-    
+
     /**
      * @return the unique identifier of the parent of this entry.
      */
     public String getParentId() {
-      return parentId;
+        return parentId;
     }
 
     /**
      * @return a URI of this entry.
      */
     public String getRes() {
-      return res;
+        return res;
     }
 
     /**
      * @return the UPnP classname for this entry.
      */
     public String getUpnpClass() {
-      return upnpClass;
+        return upnpClass;
     }
 
     /**
      * @return the name of the album.
      */
     public String getAlbum() {
-      return album;
+        return album;
     }
 
     /**
      * @return the URI for the album art.
      */
     public String getAlbumArtUri() {
-      return StringEscapeUtils.unescapeXml(albumArtUri);
+        return StringEscapeUtils.unescapeXml(albumArtUri);
     }
 
     /**
      * @return the name of the artist who created the entry.
      */
     public String getCreator() {
-      return creator;
+        return creator;
     }
-    
+
     public int getOriginalTrackNumber() {
-    	return originalTrackNumber;
+        return originalTrackNumber;
     }
-    
+
     /**
-     * The resourceMetaData field from the ResMD parent, this will be login info for 
+     * The resourceMetaData field from the ResMD parent, this will be login info for
      * streaming accounts to use in favorites
+     * 
      * @return
      */
-    public SonosResourceMetaData getResourceMetaData(){
-    	return resourceMetaData;
+    public SonosResourceMetaData getResourceMetaData() {
+        return resourceMetaData;
     }
 }
-

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosHandlerFactory.java
@@ -29,47 +29,44 @@ import org.eclipse.smarthome.io.transport.upnp.UpnpIOService;
 
 import com.google.common.collect.Lists;
 
-
 /**
- * The {@link SonosHandlerFactory} is responsible for creating things and thing 
+ * The {@link SonosHandlerFactory} is responsible for creating things and thing
  * handlers.
  * 
  * @author Karel Goderis - Initial contribution
  */
 public class SonosHandlerFactory extends BaseThingHandlerFactory {
-	
-	private Logger logger = LoggerFactory.getLogger(SonosHandlerFactory.class);
-    
-	private UpnpIOService upnpIOService;
-	private DiscoveryServiceRegistry discoveryServiceRegistry;
 
-	// optional OPML URL that can be configured through configuration admin 
-	private String opmlUrl = null;
-	
-    private final static Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists.newArrayList(ZONEPLAYER_THING_TYPE_UID);
-    
+    private Logger logger = LoggerFactory.getLogger(SonosHandlerFactory.class);
+
+    private UpnpIOService upnpIOService;
+    private DiscoveryServiceRegistry discoveryServiceRegistry;
+
+    // optional OPML URL that can be configured through configuration admin
+    private String opmlUrl = null;
+
     protected void activate(ComponentContext componentContext) {
-    	super.activate(componentContext);
-    	Dictionary<String, Object> properties = componentContext.getProperties();
-		opmlUrl = (String) properties.get("opmlUrl");
+        super.activate(componentContext);
+        Dictionary<String, Object> properties = componentContext.getProperties();
+        opmlUrl = (String) properties.get("opmlUrl");
     };
-    
-    @Override
-    public Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration,
-            ThingUID thingUID, ThingUID bridgeUID) {
 
-        if (ZONEPLAYER_THING_TYPE_UID.equals(thingTypeUID)) {
-            ThingUID sonosPlayerUID = getPlayerUID(thingTypeUID, thingUID, configuration);
-            logger.debug("Creating a sonos zone player thing with ID '{}'",sonosPlayerUID);
-            return super.createThing(thingTypeUID, configuration, sonosPlayerUID,null);
+    @Override
+    public Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration, ThingUID thingUID,
+            ThingUID bridgeUID) {
+
+        if (SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID)) {
+            ThingUID sonosDeviceUID = getPlayerUID(thingTypeUID, thingUID, configuration);
+            logger.debug("Creating a sonos thing with ID '{}'", sonosDeviceUID);
+            return super.createThing(thingTypeUID, configuration, sonosDeviceUID, null);
         }
-        throw new IllegalArgumentException("The thing type " + thingTypeUID
-                + " is not supported by the sonos binding.");
+        throw new IllegalArgumentException(
+                "The thing type " + thingTypeUID + " is not supported by the sonos binding.");
     }
-    
-    
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
     }
 
@@ -78,43 +75,40 @@ public class SonosHandlerFactory extends BaseThingHandlerFactory {
 
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(ZONEPLAYER_THING_TYPE_UID)) {
-        	logger.debug("Creating a ZonePlayerHandler for thing '{}' with UDN '{}'",thing.getUID(),thing.getConfiguration().get(UDN));
+        if (SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID)) {
+            logger.debug("Creating a ZonePlayerHandler for thing '{}' with UDN '{}'", thing.getUID(),
+                    thing.getConfiguration().get(UDN));
             return new ZonePlayerHandler(thing, upnpIOService, discoveryServiceRegistry, opmlUrl);
         }
 
         return null;
     }
-    
-    
-    private ThingUID getPlayerUID(ThingTypeUID thingTypeUID, ThingUID thingUID,
-            Configuration configuration) {
-    	
+
+    private ThingUID getPlayerUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration) {
+
         String udn = (String) configuration.get(UDN);
 
         if (thingUID == null) {
             thingUID = new ThingUID(thingTypeUID, udn);
         }
-        
+
         return thingUID;
     }
-    
-	protected void setUpnpIOService(UpnpIOService upnpIOService) {
-		this.upnpIOService = upnpIOService;
-	}
 
-	protected void unsetUpnpIOService(UpnpIOService upnpIOService) {
-		this.upnpIOService = null;
-	}
-    
+    protected void setUpnpIOService(UpnpIOService upnpIOService) {
+        this.upnpIOService = upnpIOService;
+    }
+
+    protected void unsetUpnpIOService(UpnpIOService upnpIOService) {
+        this.upnpIOService = null;
+    }
+
     protected void setDiscoveryServiceRegistry(DiscoveryServiceRegistry discoveryServiceRegistry) {
         this.discoveryServiceRegistry = discoveryServiceRegistry;
     }
-    
+
     protected void unsetDiscoveryServiceRegistry(DiscoveryServiceRegistry discoveryServiceRegistry) {
-    	this.discoveryServiceRegistry = null;
+        this.discoveryServiceRegistry = null;
     }
 
-
 }
-

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosMetaData.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosMetaData.java
@@ -16,76 +16,75 @@ package org.eclipse.smarthome.binding.sonos.internal;
  */
 public class SonosMetaData {
 
-	  private final String id;
-	  private final String parentId;
-	  private final String resource;
-	  private final String streamContent;
-	  private final String albumArtUri;
-	  private final String title;
-	  private final String upnpClass;
-	  private final String creator;
-	  private final String album;
-	  private final String albumArtist;
-	  
-	  public SonosMetaData(String id, String parentId, String res, String streamContent, 
-	      String albumArtUri, String title, String upnpClass, String creator, String album, 
-	      String albumArtist) {
-	    this.id = id;
-	    this.parentId = parentId;
-	    this.resource = res;
-	    this.streamContent = streamContent;
-	    this.albumArtUri = albumArtUri;
-	    this.title = title;
-	    this.upnpClass = upnpClass;
-	    this.creator = creator;
-	    this.album = album;
-	    this.albumArtist = albumArtist;
-	  }
-	  
-	  @Override
-	  public String toString() {
-		  return "SonosMetaData [id=" + id + ", parentID=" + parentId + ", resource="+resource+" ,streamContent="+
-	  streamContent+", arturi="+albumArtUri+", title="+title+", upnpclass="+upnpClass+", creator="+creator+
-	  ", album="+album+", albumtartist="+albumArtist+"]";
-	  }
+    private final String id;
+    private final String parentId;
+    private final String resource;
+    private final String streamContent;
+    private final String albumArtUri;
+    private final String title;
+    private final String upnpClass;
+    private final String creator;
+    private final String album;
+    private final String albumArtist;
 
-	  public String getAlbum() {
-	    return album;
-	  }
+    public SonosMetaData(String id, String parentId, String res, String streamContent, String albumArtUri, String title,
+            String upnpClass, String creator, String album, String albumArtist) {
+        this.id = id;
+        this.parentId = parentId;
+        this.resource = res;
+        this.streamContent = streamContent;
+        this.albumArtUri = albumArtUri;
+        this.title = title;
+        this.upnpClass = upnpClass;
+        this.creator = creator;
+        this.album = album;
+        this.albumArtist = albumArtist;
+    }
 
-	  public String getAlbumArtist() {
-	    return albumArtist;
-	  }
+    @Override
+    public String toString() {
+        return "SonosMetaData [id=" + id + ", parentID=" + parentId + ", resource=" + resource + " ,streamContent="
+                + streamContent + ", arturi=" + albumArtUri + ", title=" + title + ", upnpclass=" + upnpClass
+                + ", creator=" + creator + ", album=" + album + ", albumtartist=" + albumArtist + "]";
+    }
 
-	  public String getAlbumArtUri() {
-	    return albumArtUri;
-	  }
+    public String getAlbum() {
+        return album;
+    }
 
-	  public String getCreator() {
-	    return creator;
-	  }
+    public String getAlbumArtist() {
+        return albumArtist;
+    }
 
-	  public String getResource() {
-	    return resource;
-	  }
+    public String getAlbumArtUri() {
+        return albumArtUri;
+    }
 
-	  public String getStreamContent() {
-	    return streamContent;
-	  }
+    public String getCreator() {
+        return creator;
+    }
 
-	  public String getTitle() {
-	    return title;
-	  }
+    public String getResource() {
+        return resource;
+    }
 
-	  public String getUpnpClass() {
-	    return upnpClass;
-	  }
+    public String getStreamContent() {
+        return streamContent;
+    }
 
-	  public String getId() {
-	    return id;
-	  }
+    public String getTitle() {
+        return title;
+    }
 
-	  public String getParentId() {
-	    return parentId;
-	  }	
+    public String getUpnpClass() {
+        return upnpClass;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getParentId() {
+        return parentId;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosResourceMetaData.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosResourceMetaData.java
@@ -3,69 +3,76 @@ package org.eclipse.smarthome.binding.sonos.internal;
 import java.io.Serializable;
 
 /**
- * Contains the resource meta data within a browse response result 
- * "<r:resMD>..</r:resMD>".  This is used for SONOS favorites.
+ * Contains the resource meta data within a browse response result
+ * "<r:resMD>..</r:resMD>". This is used for SONOS favorites.
+ * 
  * @author Dan Cunningham
  *
  */
 public class SonosResourceMetaData implements Serializable {
-	
-	private static final long serialVersionUID = 7438424501599637712L;
-	String id;
-	String parentId;
-	String title;
-	String upnpClass;
-	String desc;
-	
-	public SonosResourceMetaData(String id, String parentId, String title, String upnpClass, String desc) {
-		super();
-		this.id = id;
-		this.parentId = parentId;
-		this.title = title;
-		this.upnpClass = upnpClass;
-		this.desc = desc;
-	}
 
-	/**
-	 * The parent id for the resource meta data
-	 * @return
-	 */
-	public String getId() {
-		return id;
-	}
+    private static final long serialVersionUID = 7438424501599637712L;
+    String id;
+    String parentId;
+    String title;
+    String upnpClass;
+    String desc;
 
-	/**
-	 * The parent id for the resource meta data
-	 * @return
-	 */
-	public String getParentId() {
-		return parentId;
-	}
+    public SonosResourceMetaData(String id, String parentId, String title, String upnpClass, String desc) {
+        super();
+        this.id = id;
+        this.parentId = parentId;
+        this.title = title;
+        this.upnpClass = upnpClass;
+        this.desc = desc;
+    }
 
-	/**
-	 * title from the resource meta data
-	 * @return
-	 */
-	public String getTitle() {
-		return title;
-	}
-	/**
-	 * The upnp class for the resource meta data.  This can be different from the
-	 * parent meta data class and should be used to match the play type over the
-	 * parent value.
-	 * @return
-	 */
-	public String getUpnpClass() {
-		return upnpClass;
-	}
-	
-	/**
-	 * The desc text for the resource meta data.  This contains the service login
-	 * id for streaming accounts (pandora, spotify, etc..)
-	 * @return
-	 */
-	public String getDesc() {
-		return desc;
-	}
+    /**
+     * The parent id for the resource meta data
+     * 
+     * @return
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * The parent id for the resource meta data
+     * 
+     * @return
+     */
+    public String getParentId() {
+        return parentId;
+    }
+
+    /**
+     * title from the resource meta data
+     * 
+     * @return
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * The upnp class for the resource meta data. This can be different from the
+     * parent meta data class and should be used to match the play type over the
+     * parent value.
+     * 
+     * @return
+     */
+    public String getUpnpClass() {
+        return upnpClass;
+    }
+
+    /**
+     * The desc text for the resource meta data. This contains the service login
+     * id for streaming accounts (pandora, spotify, etc..)
+     * 
+     * @return
+     */
+    public String getDesc() {
+        return desc;
+    }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosZoneGroup.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosZoneGroup.java
@@ -20,54 +20,70 @@ import java.util.List;
  */
 public class SonosZoneGroup implements Cloneable {
 
-	private final List<String> members;
-	private final String coordinator;
-	private final String id;
+    private final List<String> members;
+    private List<String> memberZoneNames;
+    private final String coordinator;
+    private final String id;
 
-	public Object clone() {
-		try
-		{
-			return super.clone();
-		}
-		catch(Exception e){ return null; }
-	}
+    public Object clone() {
+        try {
+            return super.clone();
+        } catch (Exception e) {
+            return null;
+        }
+    }
 
-	public SonosZoneGroup(String id, String coordinator, Collection<String> members) {
-		this.members= new ArrayList<String>(members);
-		if (!this.members.contains(coordinator)) {
-			this.members.add(coordinator);
-		}
-		this.coordinator = coordinator;
-		this.id = id;
-	}
+    public SonosZoneGroup(String id, String coordinator, Collection<String> members,
+            Collection<String> memberZoneNames) {
+        this.members = new ArrayList<String>(members);
+        if (!this.members.contains(coordinator)) {
+            this.members.add(coordinator);
+        }
+        this.memberZoneNames = new ArrayList<String>(memberZoneNames);
+        this.coordinator = coordinator;
+        this.id = id;
+    }
 
-	public List<String> getMembers() {
-		return members;
-	}
+    public SonosZoneGroup(String id, String coordinator, Collection<String> members) {
+        this.members = new ArrayList<String>(members);
+        if (!this.members.contains(coordinator)) {
+            this.members.add(coordinator);
+        }
+        this.coordinator = coordinator;
+        this.id = id;
+    }
 
-	public String getCoordinator() {
-		return coordinator;
-	}
+    public List<String> getMembers() {
+        return members;
+    }
 
-	public String getId() {
-		return id;
-	}
+    public List<String> getMemberZoneNames() {
+        return memberZoneNames;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == null) {
-			return false;
-		}
-		if (obj instanceof SonosZoneGroup) {
-			SonosZoneGroup group = (SonosZoneGroup) obj;
-			return group.getId().equals(getId());
-		}
-		return false;
-	}
-	
-	@Override
-	public int hashCode() {
-	  return id.hashCode();
-	}
-	
-}	
+    public String getCoordinator() {
+        return coordinator;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj instanceof SonosZoneGroup) {
+            SonosZoneGroup group = (SonosZoneGroup) obj;
+            return group.getId().equals(getId());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosZonePlayerState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosZonePlayerState.java
@@ -10,16 +10,16 @@ package org.eclipse.smarthome.binding.sonos.internal;
 
 /**
  * The {@link SonosZoneGroup} is data structure to describe
- * state of a Zone Player 
+ * state of a Zone Player
  * 
  * @author Karel Goderis - Initial contribution
  */
 public class SonosZonePlayerState {
 
-	public String transportState;
-	public String volume;
-	public String relTime;
-	public SonosEntry entry;
-	public long track;
-	
+    public String transportState;
+    public String volume;
+    public String relTime;
+    public SonosEntry entry;
+    public long track;
+
 }


### PR DESCRIPTION
- Added notification sound functionality
- Added slave->coordinator delegation for all relevant channels
- Delegate all relevant item state events to all group members
- Use seperate ThingTypes for each Sonos player
- Remove deadlock during GEMA subscription
- Reduce unnecessary item state updates
- Clear track metadata channels (album, artist, track) when clear playlist in the Sonos-App
- Add Sonos room name to discovery result
- Cache coordinator ThingHandler and update it during change in Sonos grouping 
