### PR TITLE
Making MapTransformationServiceTest more robust

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
@@ -146,6 +146,7 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
             Path transformFilePath = Paths.get(watchedDirectory);
             try {
                 transformFilePath.register(watchService, ENTRY_DELETE, ENTRY_MODIFY);
+                logger.debug("Watching directory {}", transformFilePath);
                 watchedDirectories.add(subDirectory);
             } catch (IOException e) {
                 logger.warn("Unable to watch transformation directory : {}", watchedDirectory);
@@ -217,7 +218,7 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
     /**
      * Returns the path to the root of the transformation folder
      */
-    private String getSourcePath() {
+    protected String getSourcePath() {
         return ConfigConstants.getConfigFolder() + File.separator + TransformationService.TRANSFORM_FOLDER_NAME
                 + File.separator;
     }

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/src/test/java/org/eclipse/smarthome/transform/map/internal/MapTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/src/test/java/org/eclipse/smarthome/transform/map/internal/MapTransformationServiceTest.java
@@ -9,12 +9,14 @@ package org.eclipse.smarthome.transform.map.internal;
 
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.concurrent.Callable;
 
-import org.eclipse.smarthome.core.transform.TransformationException;
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,44 +26,65 @@ import org.junit.Test;
  */
 public class MapTransformationServiceTest {
 
+    private static final String SOURCE_CLOSED = "CLOSED";
+    private static final String SOURCE_UNKNOWN = "UNKNOWN";
+    private static final String EXISTING_FILENAME_DE = "map/doorstatus_de.map";
+    private static final String SHOULD_BE_LOCALIZED_FILENAME = "map/doorstatus.map";
+    private static final String INEXISTING_FILENAME = "map/de.map";
+    private static final String BASE_FOLDER = "target";
+    private static final String SRC_FOLDER = "conf";
+    private static final String CONFIG_FOLDER = BASE_FOLDER + File.separator + SRC_FOLDER;
+    private static final String USED_FILENAME = CONFIG_FOLDER + File.separator + "transform/" + EXISTING_FILENAME_DE;
+
     private MapTransformationService processor;
 
     @Before
-    public void init() {
-        processor = new MapTransformationService();
+    public void init() throws IOException {
+        processor = new MapTransformationService() {
+            @Override
+            protected String getSourcePath() {
+                return BASE_FOLDER + File.separator + super.getSourcePath();
+            }
+        };
+        FileUtils.deleteDirectory(new File(CONFIG_FOLDER));
+        FileUtils.copyDirectory(new File(SRC_FOLDER), new File(CONFIG_FOLDER));
     }
 
     @Test
-    public void testTransformByMap() throws TransformationException {
-
-        String existingGermanFilename = "map/doorstatus_de.map";
-        String shouldBeLocalizedFilename = "map/doorstatus.map";
-        String inexistingFilename = "map/de.map";
+    public void testTransformByMap() throws Exception {
 
         // Test that we find a translation in an existing file
-        String source = "CLOSED";
-        String transformedResponse = processor.transform(existingGermanFilename, source);
+        String transformedResponse = processor.transform(EXISTING_FILENAME_DE, SOURCE_CLOSED);
         Assert.assertEquals("zu", transformedResponse);
-
-        String usedfile = "conf/transform/" + existingGermanFilename;
 
         Properties properties = new Properties();
         try {
-            properties.load(new FileReader(usedfile));
-            properties.setProperty(source, "changevalue");
-            properties.store(new FileWriter(usedfile), "");
+            properties.load(new FileReader(USED_FILENAME));
+            properties.setProperty(SOURCE_CLOSED, "changevalue");
+            properties.store(new FileWriter(USED_FILENAME), "");
 
             // This tests that the requested transformation file has been removed from
             // the cache
-            transformedResponse = processor.transform(existingGermanFilename, source);
-            Assert.assertEquals("changevalue", transformedResponse);
+            waitForAssert(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    final String transformedResponse = processor.transform(EXISTING_FILENAME_DE, SOURCE_CLOSED);
+                    Assert.assertEquals("changevalue", transformedResponse);
+                    return null;
+                }
+            }, 10000, 100);
 
-            properties.setProperty(source, "zu");
-            properties.store(new FileWriter(usedfile), "");
+            properties.setProperty(SOURCE_CLOSED, "zu");
+            properties.store(new FileWriter(USED_FILENAME), "");
 
-            transformedResponse = processor.transform(existingGermanFilename, source);
-            Assert.assertEquals("zu", transformedResponse);
-
+            waitForAssert(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    final String transformedResponse = processor.transform(EXISTING_FILENAME_DE, SOURCE_CLOSED);
+                    Assert.assertEquals("zu", transformedResponse);
+                    return null;
+                }
+            }, 10000, 100);
         } catch (IOException e1) {
             // TODO Auto-generated catch block
             e1.printStackTrace();
@@ -69,27 +92,42 @@ public class MapTransformationServiceTest {
 
         // Checks that an unknown input in an existing file give the expected
         // transformed response that shall be empty string (Issue #1107) if not found in the file
-        source = "UNKNOWN";
-        transformedResponse = processor.transform(existingGermanFilename, source);
+        transformedResponse = processor.transform(EXISTING_FILENAME_DE, SOURCE_UNKNOWN);
         Assert.assertEquals("", transformedResponse);
 
         // Test that an inexisting file raises correct exception as expected
-        source = "CLOSED";
         try {
-            transformedResponse = processor.transform(inexistingFilename, source);
+            transformedResponse = processor.transform(INEXISTING_FILENAME, SOURCE_CLOSED);
             fail();
         } catch (Exception e) {
             // That's what we expect.
         }
 
         // Test that we find a localized version of desired file
-        source = "CLOSED";
-        transformedResponse = processor.transform(shouldBeLocalizedFilename, source);
+        transformedResponse = processor.transform(SHOULD_BE_LOCALIZED_FILENAME, SOURCE_CLOSED);
         // as we don't know the real locale at the moment the
         // test is run, we test that the string has actually been transformed
-        Assert.assertNotEquals(source, transformedResponse);
-        transformedResponse = processor.transform(shouldBeLocalizedFilename, source);
-        Assert.assertNotEquals(source, transformedResponse);
+        Assert.assertNotEquals(SOURCE_CLOSED, transformedResponse);
+        transformedResponse = processor.transform(SHOULD_BE_LOCALIZED_FILENAME, SOURCE_CLOSED);
+        Assert.assertNotEquals(SOURCE_CLOSED, transformedResponse);
+    }
+
+    protected void waitForAssert(Callable<Void> assertion, int timeout, int sleepTime) throws Exception {
+        int waitingTime = 0;
+        while (waitingTime < timeout) {
+            try {
+                assertion.call();
+                return;
+            } catch (AssertionError error) {
+                waitingTime += sleepTime;
+                try {
+                    Thread.sleep(sleepTime);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        assertion.call();
     }
 
 }


### PR DESCRIPTION
As it seems, the events take some time to arrive on some OS/file systems...
(see #1131)

Therefore, in this change
* The test waits up to 10 seconds in order to verify the assertions
* The test first copies the property files to another place, so no versioned files get touched

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>