### PR TITLE
Fix #1159 Add channelLinked() to HueLightHandler

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
@@ -330,6 +330,14 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
         }
 
     }
+    
+    @Override
+    public void channelLinked(ChannelUID channelUID) {
+        HueBridgeHandler handler = getHueBridgeHandler();
+        if (handler != null) {
+            onLightStateChanged(null, handler.getLightById(lightId));
+        }
+    }
 
     @Override
     public void onLightRemoved(HueBridge bridge, FullLight light) {


### PR DESCRIPTION
This is neccessary if you have enableChannels=true. Because if you use inbox/approve, the links are made after the HueLightHandler is created and the first channel updates are not forwarded to any item - they're linked after that.

Signed-off-by: Sebastian Janzen <sebastian@janzen.it>