### PR TITLE
Add getInboxEntry method to AbstractDiscoveryService

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Refactored API
  * @author Dennis Nobel - Added background discovery configuration through Configuration Admin
  * @author Andre Fuechsel - Added removeOlderResults
+ * @author Chris Jackson - Added getInboxEntry
  */
 public abstract class AbstractDiscoveryService implements DiscoveryService {
 
@@ -43,7 +44,8 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
 
     private final Logger logger = LoggerFactory.getLogger(AbstractDiscoveryService.class);
 
-    static protected final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(DISCOVERY_THREADPOOL_NAME);
+    static protected final ScheduledExecutorService scheduler = ThreadPoolManager
+            .getScheduledPool(DISCOVERY_THREADPOOL_NAME);
 
     private Set<DiscoveryListener> discoveryListeners = new CopyOnWriteArraySet<>();
     protected ScanListener scanListener = null;
@@ -292,6 +294,17 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      */
     protected void removeOlderResults(long timestamp) {
         removeOlderResults(timestamp, null);
+    }
+
+    /**
+     * Call to get an existing cached inbox entry if it exists.
+     *
+     * @param thingUID
+     *            The UID of the removed thing. null if no entry exists.
+     * @return
+     */
+    protected DiscoveryResult getInboxEntry(ThingUID thingUID) {
+        return cachedResults.get(thingUID);
     }
 
     /**


### PR DESCRIPTION
In Z-Wave, when I first discover a device, I add it immediately to the inbox so that users have the visibility that it has been discovered. Later, when I know more about it, I would like to update the inbox entry - mainly to update the label.

Currently, the only way to do this is to remove the entry, and add it again. This results in notifications even if there is no change.  This PR adds a getInboxEntry method to return the existing discovery result so that it can be checked to see if it has been updated. If it has changed, then we can remove it and add it again.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>