### PR TITLE
sonos: handle every case in switch

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
@@ -114,7 +114,7 @@ public class SonosXMLParser {
     /**
      * Returns the meta data which is needed to play Pandora
      * (and others?) favorites
-     * 
+     *
      * @param xml
      * @return The value of the desc xml tag
      * @throws SAXException
@@ -311,6 +311,9 @@ public class SonosXMLParser {
                 case RESMD:
                     desc.append(ch, start, length);
                     break;
+                case DESC:
+                    desc.append(ch, start, length);
+                    break;
                 // no default
             }
         }
@@ -399,7 +402,6 @@ public class SonosXMLParser {
                     break;
                 case DESC:
                     desc.append(ch, start, length);
-                    ;
                     break;
                 default:
                     break;
@@ -736,6 +738,9 @@ public class SonosXMLParser {
                     case albumArtist:
                         albumArtist.append(ch, start, length);
                         break;
+                    case desc:
+                        break;
+                    // no default
                 }
             }
         }


### PR DESCRIPTION
I don't know why it has been decided to not add a default case to the
switch statement. But we should at least handle every value of the
enum(s).

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>