### PR TITLE
sonos: comment unused variable as long as code is comment

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
@@ -114,7 +114,7 @@ public class SonosXMLParser {
     /**
      * Returns the meta data which is needed to play Pandora
      * (and others?) favorites
-     * 
+     *
      * @param xml
      * @return The value of the desc xml tag
      * @throws SAXException
@@ -558,7 +558,7 @@ public class SonosXMLParser {
         private final List<String> textFields = new ArrayList<String>();
         private String textField;
         private String type;
-        private String logo;
+        // private String logo;
 
         @Override
         public void startElement(String uri, String localName, String qName, Attributes attributes)


### PR DESCRIPTION
The code that sets the logo member is comment, the variable is present
but not used.
If we do not need logo at all (there is also no need to write that
member if it is never read) there is no need to keep that field.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>