### PR TITLE
Config status should allow situation with no message

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/status/test/ConfigStatusInfoTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/status/test/ConfigStatusInfoTest.groovy
@@ -131,6 +131,6 @@ class ConfigStatusInfoTest {
     }
 
     def static ConfigStatusMessage createMessage(String paramName, Type type, String messageKey, Integer statusCode=null) {
-        return new ConfigStatusMessage.Builder(paramName, type, messageKey).withStatusCode(statusCode).build()
+        return new ConfigStatusMessage.Builder(paramName, type).withMessageKey(messageKey).withStatusCode(statusCode).build()
     }
 }

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusMessage.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusMessage.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
  * </p>
  *
  * @author Thomas Höfer - Initial contribution
+ * @author Chris Jackson - Add withMessageKey and remove message from other methods
  */
 public final class ConfigStatusMessage {
 
@@ -120,19 +121,17 @@ public final class ConfigStatusMessage {
 
         private final Type type;
 
-        private final String messageKey;
+        private String messageKey;
 
         private Object[] arguments;
 
         private Integer statusCode;
 
-        private Builder(String parameterName, Type type, String messageKey) {
+        private Builder(String parameterName, Type type) {
             Preconditions.checkNotNull(parameterName, "Parameter name must not be null.");
             Preconditions.checkNotNull(type, "Type must not be null.");
-            Preconditions.checkNotNull(messageKey, "Message key must not be null.");
             this.parameterName = parameterName;
             this.type = type;
-            this.messageKey = messageKey;
         }
 
         /**
@@ -140,48 +139,44 @@ public final class ConfigStatusMessage {
          * {@link Type#INFORMATION}.
          *
          * @param parameterName the name of the configuration parameter (must not be null)
-         * @param messageKey the key for the message to be internationalized (must not be null)
          *
          * @return the new builder instance
          */
-        public static Builder information(String parameterName, String messageKey) {
-            return new Builder(parameterName, Type.INFORMATION, messageKey);
+        public static Builder information(String parameterName) {
+            return new Builder(parameterName, Type.INFORMATION);
         }
 
         /**
          * Creates a builder for the construction of a {@link ConfigStatusMessage} having type {@link Type#WARNING}.
          *
          * @param parameterName the name of the configuration parameter (must not be null)
-         * @param messageKey the key for the message to be internationalized (must not be null)
          *
          * @return the new builder instance
          */
-        public static Builder warning(String parameterName, String messageKey) {
-            return new Builder(parameterName, Type.WARNING, messageKey);
+        public static Builder warning(String parameterName) {
+            return new Builder(parameterName, Type.WARNING);
         }
 
         /**
          * Creates a builder for the construction of a {@link ConfigStatusMessage} having type {@link Type#ERROR}.
          *
          * @param parameterName the name of the configuration parameter (must not be null)
-         * @param messageKey the key for the message to be internationalized (must not be null)
          *
          * @return the new builder instance
          */
-        public static Builder error(String parameterName, String messageKey) {
-            return new Builder(parameterName, Type.ERROR, messageKey);
+        public static Builder error(String parameterName) {
+            return new Builder(parameterName, Type.ERROR);
         }
 
         /**
          * Creates a builder for the construction of a {@link ConfigStatusMessage} having type {@link Type#PENDING}.
          *
          * @param parameterName the name of the configuration parameter (must not be null)
-         * @param messageKey the key for the message to be internationalized (must not be null)
          *
          * @return the new builder instance
          */
-        public static Builder pending(String parameterName, String messageKey) {
-            return new Builder(parameterName, Type.PENDING, messageKey);
+        public static Builder pending(String parameterName) {
+            return new Builder(parameterName, Type.PENDING);
         }
 
         /**
@@ -205,6 +200,18 @@ public final class ConfigStatusMessage {
          */
         public Builder withStatusCode(Integer statusCode) {
             this.statusCode = statusCode;
+            return this;
+        }
+
+        /**
+         * Adds the given message to the builder.
+         *
+         * @param message the message key to be added
+         *
+         * @return the updated builder
+         */
+        public Builder withMessageKey(String messageKey) {
+            this.messageKey = messageKey;
             return this;
         }
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusService.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusService.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
  * {@link ConfigStatusProvider}.
  *
  * @author Thomas Höfer - Initial contribution
+ * @author Chris Jackson - Allow null messages
  */
 public final class ConfigStatusService implements ConfigStatusCallback {
 
@@ -105,16 +106,20 @@ public final class ConfigStatusService implements ConfigStatusCallback {
         ConfigStatusInfo info = new ConfigStatusInfo();
 
         for (ConfigStatusMessage configStatusMessage : configStatus) {
-            String message = i18nProvider.getText(bundle, configStatusMessage.messageKey, null, locale,
-                    configStatusMessage.arguments);
-            if (message == null) {
-                logger.warn(
-                        "No translation found for key {} and config status provider {}. Will ignore the config status message.",
-                        configStatusMessage.messageKey, configStatusProvider.getClass().getSimpleName());
-            } else {
-                info.add(new ConfigStatusMessage(configStatusMessage.parameterName, configStatusMessage.type, message,
-                        configStatusMessage.statusCode));
+            String message = null;
+            if (configStatusMessage.messageKey != null) {
+                message = i18nProvider.getText(bundle, configStatusMessage.messageKey, null, locale,
+                        configStatusMessage.arguments);
+                if (message == null) {
+                    logger.warn(
+                            "No translation found for key {} and config status provider {}. Will ignore the config status message.",
+                            configStatusMessage.messageKey, configStatusProvider.getClass().getSimpleName());
+                    continue;
+                }
             }
+            info.add(new ConfigStatusMessage(configStatusMessage.parameterName, configStatusMessage.type, message,
+                    configStatusMessage.statusCode));
+
         }
 
         return info;

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/src/main/java/org/eclipse/smarthome/binding/yahooweather/handler/YahooWeatherHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/src/main/java/org/eclipse/smarthome/binding/yahooweather/handler/YahooWeatherHandler.java
@@ -143,7 +143,7 @@ public class YahooWeatherHandler extends ConfigStatusThingHandler {
             String weatherData = getWeatherData();
             String result = StringUtils.substringBetween(weatherData, "<item><title>", "</title>");
             if ("City not found".equals(result)) {
-                configStatus.add(ConfigStatusMessage.Builder.error(LOCATION_PARAM, LOCATION_NOT_FOUND)
+                configStatus.add(ConfigStatusMessage.Builder.error(LOCATION_PARAM).withMessageKey(LOCATION_NOT_FOUND)
                         .withArguments(location).build());
             }
         } catch (IOException e) {


### PR DESCRIPTION
This is especially the case for states like PENDING where there might not be much to add, and no message is really needed - the user just needs to know the update is pending. This change ensures the status is provided, but without a message.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>