### PR TITLE
made control ui work without groups

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -21,16 +21,18 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
     $scope.refresh = function() {
         itemRepository.getAll(function(items) {
             $scope.tabs = [];
+            $scope.tabs.push({
+                name : 'all',
+                label : 'All'
+            });
             $scope.items['All'] = items;
             for (var int = 0; int < items.length; int++) {
                 var item = items[int];
-                if (item.type === 'GroupItem') {
-                    if (item.tags.indexOf("home-group") > -1) {
-                        $scope.tabs.push({
-                            name : item.name,
-                            label : item.label
-                        });
-                    }
+                if (item.tags.indexOf('home-group') > -1) {
+                    $scope.tabs.push({
+                        name : item.name,
+                        label : item.label
+                    });
                 }
             }
         }, true);
@@ -44,6 +46,21 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
             }
         }
         return null;
+    }
+
+    $scope.getItemsForTab = function(tabName) {
+        var items = []
+        if (tabName === 'all') {
+            for (var int = 0; int < $scope.data.items.length; int++) {
+                var item = $scope.data.items[int];
+                if (item.tags.indexOf('thing') > -1) {
+                    items.push(item);
+                }
+            }
+            return items;
+        } else {
+            return getItem(tabName).members;
+        }
     }
 
     $scope.masonry = function() {
@@ -189,8 +206,7 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
     }
 
     /**
-     * Check if the item has a configured option list. Returns true if there are
-     * options, otherwise false.
+     * Check if the item has a configured option list. Returns true if there are options, otherwise false.
      * 
      * @param item
      *            the current item

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
@@ -3,19 +3,20 @@
 		<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 	</div>
 
+<!-- right now, we always have an "All" tab; once we introduce locations/rooms, this can be added again 
 	<p class="text-center" ng-show="tabs.length == 0" style="margin-top: 20px;">
-		No groups defined yet.
-		<button class="md-button" ng-click="$location.path('configuration/groups')">Add Group</button>
+		No locations defined yet.
+		<button class="md-button" ng-click="$location.path('configuration/locations')">Add Location</button>
 	</p>
-
+ -->
 	<md-tabs md-stretch-tabs="always" class="section-tabs" md-selected="selectedIndex" ng-show="tabs.length > 0"> <md-tab ng-repeat="tab in tabs" ng-disabled="tab.disabled" label="{{tab.label}}" layout-fill> <md-tab-content layout-fill="">
 
 	<p class="text-center" ng-show="getItem(tabs[selectedIndex].name).members.length == 0">
-		Group is empty.
+		No Things available.
 		<button class="md-button" ng-click="$location.path('inbox/setup')">Add Thing</button>
 	</p>
 	<div ng-controller="ControlController" class="items row" md-swipe-left="next()" md-swipe-right="prev()" ng-if="tabs[selectedIndex] === tab" ng-attr-id="{{'items-' + tabs.indexOf(tab)}}">
-		<div class="col-lg-4 col-sm-6 col-xs-12 item-wrapper" ng-repeat="groupMemberItem in getItem(tabs[selectedIndex].name).members" on-finish-render="ngRepeatFinished">
+		<div class="col-lg-4 col-sm-6 col-xs-12 item-wrapper" ng-repeat="groupMemberItem in getItemsForTab(tabs[selectedIndex].name)" on-finish-render="ngRepeatFinished">
 			<div class="card item {{groupMemberItem.type}}" data-item-name="{{groupMemberItem.name}}">
 				<div class="ibadge">
 					<span class="icon-x">


### PR DESCRIPTION
With this PR, the control ui of the Paper UI now shows an "All" tab and lists all available Things on it.

Signed-off-by: Kai Kreuzer <kai@openhab.org>