### PR TITLE
added baseItem to group item REST response.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/events/ItemEventFactoryTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/events/ItemEventFactoryTest.groovy
@@ -15,7 +15,7 @@ import org.eclipse.smarthome.core.events.Event
 import org.eclipse.smarthome.core.items.GroupItem
 import org.eclipse.smarthome.core.items.dto.ItemDTOMapper
 import org.eclipse.smarthome.core.items.events.ItemEventFactory.ItemEventPayloadBean
-import org.eclipse.smarthome.core.items.events.ItemEventFactory.ItemStateChangedEventPayloadBean;
+import org.eclipse.smarthome.core.items.events.ItemEventFactory.ItemStateChangedEventPayloadBean
 import org.eclipse.smarthome.core.library.items.SwitchItem
 import org.eclipse.smarthome.core.library.types.OnOffType
 import org.eclipse.smarthome.core.types.RefreshType
@@ -42,14 +42,14 @@ class ItemEventFactoryTest extends OSGiTest {
     def ITEM_COMMAND_EVENT_TYPE = ItemCommandEvent.TYPE
     def ITEM_STATE_EVENT_TYPE = ItemStateEvent.TYPE
     def ITEM_ADDED_EVENT_TYPE = ItemAddedEvent.TYPE
-    def GROUPITEM_CHANGED_EVENT_TYPE = GroupItemStateChangedEvent.TYPE  
+    def GROUPITEM_CHANGED_EVENT_TYPE = GroupItemStateChangedEvent.TYPE
 
     def ITEM_COMMAND_EVENT_TOPIC = ItemEventFactory.ITEM_COMAND_EVENT_TOPIC.replace("{itemName}", ITEM_NAME)
     def ITEM_STATE_EVENT_TOPIC = ItemEventFactory.ITEM_STATE_EVENT_TOPIC.replace("{itemName}", ITEM_NAME)
     def ITEM_ADDED_EVENT_TOPIC = ItemEventFactory.ITEM_ADDED_EVENT_TOPIC.replace("{itemName}", ITEM_NAME)
     def GROUPITEM_STATE_CHANGED_EVENT_TOPIC = ItemEventFactory.GROUPITEM_STATE_CHANGED_EVENT_TOPIC.replace("{itemName}", GROUP_NAME).replace("{memberName}", ITEM_NAME)
-    
-    
+
+
     def ITEM_COMMAND = OnOffType.ON
     def ITEM_COMMAND_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(ITEM_COMMAND.getClass().getSimpleName(), ITEM_COMMAND.toString()))
     def ITEM_REFRESH_COMMAND_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(RefreshType.REFRESH.getClass().getSimpleName(), RefreshType.REFRESH.toString()))
@@ -57,8 +57,8 @@ class ItemEventFactoryTest extends OSGiTest {
     def ITEM_STATE = OnOffType.OFF
     def NEW_ITEM_STATE = OnOffType.ON
     def ITEM_STATE_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(ITEM_STATE.getClass().getSimpleName(), ITEM_STATE.toString()))
-    def ITEM_ADDED_EVENT_PAYLOAD = new Gson().toJson(ItemDTOMapper.map(ITEM, false))
-    def ITEM_STATE_CHANGED_EVENT_PAYLOAD = new Gson().toJson(new ItemStateChangedEventPayloadBean(NEW_ITEM_STATE.getClass().getSimpleName(),NEW_ITEM_STATE.toString(),ITEM_STATE.getClass().getSimpleName(),ITEM_STATE.toString())) 
+    def ITEM_ADDED_EVENT_PAYLOAD = new Gson().toJson(ItemDTOMapper.map(ITEM))
+    def ITEM_STATE_CHANGED_EVENT_PAYLOAD = new Gson().toJson(new ItemStateChangedEventPayloadBean(NEW_ITEM_STATE.getClass().getSimpleName(),NEW_ITEM_STATE.toString(),ITEM_STATE.getClass().getSimpleName(),ITEM_STATE.toString()))
 
     @Test
     void 'ItemEventFactory creates Event as ItemCommandEvent OnOffType correctly'() {
@@ -116,7 +116,7 @@ class ItemEventFactoryTest extends OSGiTest {
         assertThat itemStateEvent.getSource(), is(SOURCE)
         assertThat itemStateEvent.getItemState(), is(UnDefType.UNDEF)
     }
-    
+
     @Test
     void 'ItemEventFactory creates GroupItemStateChangedEvent correctly'() {
         Event event = factory.createEvent(GROUPITEM_CHANGED_EVENT_TYPE, GROUPITEM_STATE_CHANGED_EVENT_TOPIC, ITEM_STATE_CHANGED_EVENT_PAYLOAD, SOURCE)
@@ -132,7 +132,6 @@ class ItemEventFactoryTest extends OSGiTest {
         assertThat groupItemStateChangedEvent.getSource(), is(null)
         assertThat groupItemStateChangedEvent.getItemState(), is(NEW_ITEM_STATE)
         assertThat groupItemStateChangedEvent.getOldItemState(), is(ITEM_STATE)
-        
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/GroupItemDTO.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/GroupItemDTO.java
@@ -15,7 +15,6 @@ package org.eclipse.smarthome.core.items.dto;
  */
 public class GroupItemDTO extends ItemDTO {
 
-    public ItemDTO[] members;
     public String groupType;
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/GroupItemDTO.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/GroupItemDTO.java
@@ -9,12 +9,13 @@ package org.eclipse.smarthome.core.items.dto;
 
 /**
  * This is a data transfer object that is used to serialize group items.
- * 
+ *
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
 public class GroupItemDTO extends ItemDTO {
 
     public ItemDTO[] members;
+    public String groupType;
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
@@ -76,13 +76,19 @@ public class ItemDTOMapper {
     }
 
     private static void fillProperties(ItemDTO itemDTO, Item item, boolean drillDown) {
-        if (item instanceof GroupItem && drillDown) {
+        if (item instanceof GroupItem) {
             GroupItem groupItem = (GroupItem) item;
-            Collection<ItemDTO> memberDTOs = new LinkedHashSet<ItemDTO>();
-            for (Item member : groupItem.getMembers()) {
-                memberDTOs.add(map(member, drillDown));
+            GroupItemDTO groupItemDTO = (GroupItemDTO) itemDTO;
+            if (groupItem.getBaseItem() != null) {
+                groupItemDTO.groupType = groupItem.getBaseItem().getType();
             }
-            ((GroupItemDTO) itemDTO).members = memberDTOs.toArray(new ItemDTO[memberDTOs.size()]);
+            if (drillDown) {
+                Collection<ItemDTO> memberDTOs = new LinkedHashSet<ItemDTO>();
+                for (Item member : groupItem.getMembers()) {
+                    memberDTOs.add(map(member, drillDown));
+                }
+                groupItemDTO.members = memberDTOs.toArray(new ItemDTO[memberDTOs.size()]);
+            }
         }
         itemDTO.name = item.getName();
         itemDTO.type = item.getClass().getSimpleName();

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
@@ -7,8 +7,6 @@
  */
 package org.eclipse.smarthome.core.items.dto;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.eclipse.smarthome.core.items.GenericItem;
@@ -69,25 +67,18 @@ public class ItemDTOMapper {
      * @param uri the uri
      * @return item DTO object
      */
-    public static ItemDTO map(Item item, boolean drillDown) {
+    public static ItemDTO map(Item item) {
         ItemDTO itemDTO = item instanceof GroupItem ? new GroupItemDTO() : new ItemDTO();
-        fillProperties(itemDTO, item, drillDown);
+        fillProperties(itemDTO, item);
         return itemDTO;
     }
 
-    private static void fillProperties(ItemDTO itemDTO, Item item, boolean drillDown) {
+    private static void fillProperties(ItemDTO itemDTO, Item item) {
         if (item instanceof GroupItem) {
             GroupItem groupItem = (GroupItem) item;
             GroupItemDTO groupItemDTO = (GroupItemDTO) itemDTO;
             if (groupItem.getBaseItem() != null) {
                 groupItemDTO.groupType = groupItem.getBaseItem().getType();
-            }
-            if (drillDown) {
-                Collection<ItemDTO> memberDTOs = new LinkedHashSet<ItemDTO>();
-                for (Item member : groupItem.getMembers()) {
-                    memberDTOs.add(map(member, drillDown));
-                }
-                groupItemDTO.members = memberDTOs.toArray(new ItemDTO[memberDTOs.size()]);
             }
         }
         itemDTO.name = item.getName();

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -335,7 +335,7 @@ public class ItemEventFactory extends AbstractEventFactory {
     }
 
     private static ItemDTO map(Item item) {
-        return ItemDTOMapper.map(item, false);
+        return ItemDTOMapper.map(item);
     }
 
     private static void assertValidArguments(String itemName, Type type, String typeArgumentName) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedGroupItemDTO.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedGroupItemDTO.java
@@ -18,12 +18,14 @@ import org.eclipse.smarthome.core.types.StateDescription;
  */
 public class EnrichedGroupItemDTO extends EnrichedItemDTO {
 
-    public EnrichedGroupItemDTO(ItemDTO itemDTO, EnrichedItemDTO[] members, String link, String state,
+    public EnrichedGroupItemDTO(ItemDTO itemDTO, String groupType, EnrichedItemDTO[] members, String link, String state,
             StateDescription stateDescription) {
         super(itemDTO, link, state, stateDescription);
         this.members = members;
+        this.groupType = groupType;
     }
 
     public EnrichedItemDTO[] members;
+    public String groupType;
 
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -37,7 +37,7 @@ public class EnrichedItemDTOMapper {
      * @return item DTO object
      */
     public static EnrichedItemDTO map(Item item, boolean drillDown, URI uri, Locale locale) {
-        ItemDTO itemDTO = ItemDTOMapper.map(item, drillDown);
+        ItemDTO itemDTO = ItemDTOMapper.map(item);
         return map(item, itemDTO, uri, drillDown, locale);
     }
 

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -51,6 +51,10 @@ public class EnrichedItemDTOMapper {
 
         if (item instanceof GroupItem) {
             GroupItem groupItem = (GroupItem) item;
+            String groupType = null;
+            if (groupItem.getBaseItem() != null) {
+                groupType = groupItem.getBaseItem().getType();
+            }
             EnrichedItemDTO[] memberDTOs;
             if (drillDown) {
                 Collection<EnrichedItemDTO> members = new LinkedHashSet<>();
@@ -61,7 +65,7 @@ public class EnrichedItemDTOMapper {
             } else {
                 memberDTOs = new EnrichedItemDTO[0];
             }
-            enrichedItemDTO = new EnrichedGroupItemDTO(itemDTO, memberDTOs, link, state, stateDescription);
+            enrichedItemDTO = new EnrichedGroupItemDTO(itemDTO, groupType, memberDTOs, link, state, stateDescription);
         } else {
             enrichedItemDTO = new EnrichedItemDTO(itemDTO, link, state, stateDescription);
         }


### PR DESCRIPTION
This will allow to distinguish between switch and rollershutter item on a client to display proper control widget for a group.

Bug: https://github.com/eclipse/smarthome/issues/1252
Signed-off-by: Robert Michalak <rbrt.michalak@gmail.com>