### PR TITLE
Add override of updateConfiguration for status updates

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusMessage.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusMessage.java
@@ -204,7 +204,7 @@ public final class ConfigStatusMessage {
         }
 
         /**
-         * Adds the given message to the builder.
+         * Adds the given message key to the builder.
          *
          * @param message the message key to be added
          *

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ConfigStatusThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ConfigStatusThingHandler.java
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.core.thing.binding;
 
 import java.util.Map;
 
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.status.ConfigStatusCallback;
 import org.eclipse.smarthome.config.core.status.ConfigStatusProvider;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
@@ -26,6 +27,7 @@ import org.eclipse.smarthome.core.thing.Thing;
  * {@link ConfigStatusProvider#getConfigStatus()}.
  *
  * @author Thomas Höfer - Initial contribution
+ * @author Chris Jackson - Add updateConfiguration override to handle status updates
  */
 public abstract class ConfigStatusThingHandler extends BaseThingHandler implements ConfigStatusProvider {
 
@@ -54,6 +56,14 @@ public abstract class ConfigStatusThingHandler extends BaseThingHandler implemen
     public void handleConfigurationUpdate(Map<String, Object> configurationParameters)
             throws ConfigValidationException {
         super.handleConfigurationUpdate(configurationParameters);
+        if (configStatusCallback != null) {
+            configStatusCallback.configUpdated(new ThingConfigStatusSource(getThing().getUID().getAsString()));
+        }
+    }
+
+    @Override
+    protected void updateConfiguration(Configuration configuration) {
+        super.updateConfiguration(configuration);
         if (configStatusCallback != null) {
             configStatusCallback.configUpdated(new ThingConfigStatusSource(getThing().getUID().getAsString()));
         }


### PR DESCRIPTION
Adds processing of config updates when the binding calls updateConfiguration.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>