### PR TITLE
fixed InboxOSGiTest timing issues

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/InboxOSGITest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/InboxOSGITest.groovy
@@ -632,11 +632,6 @@ class InboxOSGITest extends OSGiTest {
 
     @Test
     void 'assert that remove removes associated DiscoveryResults from Inbox when Bridge is removed'() {
-        inbox.add(BRIDGE)
-        inbox.add(THING1_WITH_BRIDGE)
-        inbox.add(THING2_WITH_BRIDGE)
-        inbox.add(THING_WITHOUT_BRIDGE)
-        inbox.add(THING_WITH_OTHER_BRIDGE)
         def receivedEvents = new ArrayList()
         def inboxEventSubscriber = [
             receive: { event -> receivedEvents.add(event) },
@@ -644,6 +639,16 @@ class InboxOSGITest extends OSGiTest {
             getEventFilter: { null },
         ] as EventSubscriber
         registerService inboxEventSubscriber
+        inbox.add(BRIDGE)
+        inbox.add(THING1_WITH_BRIDGE)
+        inbox.add(THING2_WITH_BRIDGE)
+        inbox.add(THING_WITHOUT_BRIDGE)
+        inbox.add(THING_WITH_OTHER_BRIDGE)
+        waitForAssert {
+            assertThat receivedEvents.size(), is(5)
+        }
+        receivedEvents.clear()
+
         assertTrue inbox.remove(BRIDGE.thingUID)
         assertTrue inbox.get(new InboxFilterCriteria(BRIDGE.thingUID, DiscoveryResultFlag.NEW)).isEmpty()
         assertTrue inbox.get(new InboxFilterCriteria(THING1_WITH_BRIDGE.thingUID, DiscoveryResultFlag.NEW)).isEmpty()
@@ -659,10 +664,6 @@ class InboxOSGITest extends OSGiTest {
 
     @Test
     void 'assert that remove leaves associated DiscoveryResults in Inbox when Bridge is added to ThingRegistry'() {
-        inbox.add(BRIDGE)
-        inbox.add(THING1_WITH_BRIDGE)
-        inbox.add(THING2_WITH_BRIDGE)
-        inbox.add(THING_WITHOUT_BRIDGE)
         def receivedEvents = new ArrayList()
         def inboxEventSubscriber = [
             receive: { event -> receivedEvents.add(event) },
@@ -670,6 +671,15 @@ class InboxOSGITest extends OSGiTest {
             getEventFilter: { null },
         ] as EventSubscriber
         registerService inboxEventSubscriber
+        inbox.add(BRIDGE)
+        inbox.add(THING1_WITH_BRIDGE)
+        inbox.add(THING2_WITH_BRIDGE)
+        inbox.add(THING_WITHOUT_BRIDGE)
+        waitForAssert {
+            assertThat receivedEvents.size(), is(4)
+        }
+        receivedEvents.clear()
+
         registry.add(BridgeBuilder.create(BRIDGE.thingUID).build())
         assertTrue inbox.get(new InboxFilterCriteria(BRIDGE.thingUID, DiscoveryResultFlag.NEW)).isEmpty()
         assertThat inbox.get(new InboxFilterCriteria(DiscoveryResultFlag.NEW)), hasItems(THING1_WITH_BRIDGE,THING2_WITH_BRIDGE,THING_WITHOUT_BRIDGE)


### PR DESCRIPTION
as sometimes the (asynchronously delivered) events of the test setup were captured by the assertions, leading to false positives.