### PR TITLE
Toggle ignored results and removed buttons shadow

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/app.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/app.js
@@ -12,7 +12,7 @@ angular.module('PaperUI', [ 'PaperUI.controllers', 'PaperUI.controllers.control'
         redirectTo : '/inbox/setup/bindings'
     }).when('/inbox/search', {
         templateUrl : 'partials/setup.html',
-        controller : 'InboxController',
+        controller : 'SetupWizardController',
         title : 'Inbox'
     }).when('/inbox/manual-setup/choose', {
         templateUrl : 'partials/setup.html',

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -86,8 +86,8 @@
 							<p>{{thingTypes[thing.thingTypeUID].label}}</p>
 							<p>{{thing.UID}}</p>
 							<div class="actions">
-								<md-button class="md-raised" ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit"> <i class="material-icons">edit</i></md-button>
-								<md-button class="md-raised" ng-click="remove(thing, $event)" aria-label="Delete"> <i class="material-icons">delete</i></md-button>
+								<md-button ng-click="navigateTo('things/edit/' + thing.UID)" aria-label="Edit"> <i class="material-icons">edit</i></md-button>
+								<md-button ng-click="remove(thing, $event)" aria-label="Delete"> <i class="material-icons">delete</i></md-button>
 							</div>
 						</div>
 						<hr class="border-line" ng-show="!$last" />

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/extensions.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/extensions.html
@@ -16,8 +16,8 @@
 				<h3>{{extension.label}}</h3>
 				<p>{{extension.id}} - {{extension.version}}</p>
 				<div class="actions">
-					<md-button class="md-raised" aria-label="Install" ng-show="!extension.installed && !extension.inProgress" ng-click="install(extension.id)">Install</md-button>
-					<md-button class="md-raised" aria-label="Uninstall" ng-show="extension.installed && !extension.inProgress" ng-click="uninstall(extension.id)">Uninstall</md-button>
+					<md-button aria-label="Install" ng-show="!extension.installed && !extension.inProgress" ng-click="install(extension.id)">Install</md-button>
+					<md-button aria-label="Uninstall" ng-show="extension.installed && !extension.inProgress" ng-click="uninstall(extension.id)">Uninstall</md-button>
 					<md-progress-circular md-mode="indeterminate" ng-show="extension.inProgress" style="margin-right: 25px;"></md-progress-circular>
 				</div>
 			</div>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/rules.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/rules.html
@@ -20,9 +20,9 @@
 							<h3>{{rule.name}}</h3>
 							<p>{{rule.uid}}</p>
 							<div class="actions">
-								<md-button class="md-raised" ng-click="toggleEnabled(rule, $event)" aria-label="Toggle Enable"> <i class="material-icons">{{rule.enabled ? "alarm_on" : "alarm_off"}}</i></md-button>
-								<md-button class="md-raised" ng-click="configure(rule, $event)" aria-label="Configure"> <i class="material-icons">settings</i></md-button>
-								<md-button class="md-raised" ng-click="remove(rule, $event)" aria-label="Remove"> <i class="material-icons">delete</i></md-button>
+								<md-button ng-click="toggleEnabled(rule, $event)" aria-label="Toggle Enable"> <i class="material-icons">{{rule.enabled ? "alarm_on" : "alarm_off"}}</i></md-button>
+								<md-button ng-click="configure(rule, $event)" aria-label="Configure"> <i class="material-icons">settings</i></md-button>
+								<md-button ng-click="remove(rule, $event)" aria-label="Remove"> <i class="material-icons">delete</i></md-button>
 							</div>
 						</div>
 						<hr class="border-line" ng-show="!$last" />


### PR DESCRIPTION
1) Ignored results were always showed in Inbox due to a bug as reported here: https://github.com/eclipse/smarthome/issues/1190
2) Removed default shadow of buttons.
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>