### PR TITLE
add option to change 'check build' Maven arguments

### DIFF
--- a/tools/ref-tag/create.sh
+++ b/tools/ref-tag/create.sh
@@ -140,7 +140,10 @@ log "change hardcoded version string in files"
 sed 's:\("version"\: *"\).*\(".*\):\1'"${VERSION_NEW}"'\2:g' -i extensions/ui/org.eclipse.smarthome.ui.paper/bower.json
 
 # Check if maven could build
-mvn clean install || die "mvn clean install failed"
+if [ -z "${REF_TAG_MVN_ARGS_CHECK_BUILD}" ]; then
+  REF_TAG_MVN_ARGS_CHECK_BUILD="clean install"
+fi
+mvn ${REF_TAG_MVN_ARGS_CHECK_BUILD} || die "Check build using 'mvn ${REF_TAG_MVN_ARGS_CHECK_BUILD}' failed"
 
 # Commit changes done in the working copy
 git add . || die "git add failed"


### PR DESCRIPTION
As long as #1131 is not resolved I am not able to build a tagged / versioned reference.

So only workaround I see here is that I use "clean install -DskipTests" for my ref-tag/create.sh call.
