### PR TITLE
removed reference to non-existent OSGI-INF

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.audio/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.audio/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: org.slf4j
-Service-Component: OSGI-INF/*.xml,
 Export-Package: org.eclipse.smarthome.io.audio
 Bundle-ActivationPolicy: lazy
 


### PR DESCRIPTION
Fixes https://community.openhab.org/t/oh2-startup-error-in-latest-build/9082

Signed-off-by: Kai Kreuzer <kai@openhab.org>