### PR TITLE
Allow options to be outside of min/max in validator

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/MinMaxValidator.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/MinMaxValidator.java
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.config.core.validation.internal;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
+import org.eclipse.smarthome.config.core.ParameterOption;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationMessage;
 import org.eclipse.smarthome.config.core.validation.internal.TypeIntrospections.TypeIntrospection;
 
@@ -17,6 +18,7 @@ import org.eclipse.smarthome.config.core.validation.internal.TypeIntrospections.
  * {@link ConfigDescriptionParameter}.
  *
  * @author Thomas Höfer - Initial contribution
+ * @authod Chris Jackson - Allow options to be outside of min/max value
  * @param <T>
  */
 final class MinMaxValidator implements ConfigDescriptionParameterValidator {
@@ -32,6 +34,14 @@ final class MinMaxValidator implements ConfigDescriptionParameterValidator {
     public ConfigValidationMessage validate(ConfigDescriptionParameter parameter, Object value) {
         if (value == null || parameter.getType() == Type.BOOLEAN) {
             return null;
+        }
+
+        // Allow specified options to be outside of the min/max value
+        for (ParameterOption option : parameter.getOptions()) {
+            // Option values are a string, so we can do a simple compare
+            if (option.getValue().equals(value.toString())) {
+                return null;
+            }
         }
 
         TypeIntrospection typeIntrospection = TypeIntrospections.get(parameter.getType());


### PR DESCRIPTION
Min/max validation should allows values outside of min/max if they are in the defined options. As an example, in Zwave we have lots of parameters that have a range of (say) 0 to 100, but have an option of setting 255 to disable. With the current implementation, I would need to set min/max to 0/255, which allows any value. It seems better to me to allow values to be outside of the range to cover this case.

This was discussed a long time ago when I added the 'limit to options' configuration in the parameter for exactly this purpose.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>