### PR TITLE
Update thing resource to save channel configuration

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableSet;
  * @author Benedikt Niehues - fix for Bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=445137 considering default
  *         values
  * @author Chris Jackson - Added properties, label, description
+ * @author Chris Jackson - Added configuration update methods
  */
 public class Channel {
 
@@ -221,5 +222,25 @@ public class Channel {
     @Deprecated
     public boolean isLinked() {
         return !getLinkedItems().isEmpty();
+    }
+
+    /**
+     * Returns a copy of the configuration, that can be modified. The method
+     * {@link Channel#updateConfiguration(Configuration)} must be called to persist the configuration.
+     *
+     * @return copy of the thing configuration (not null)
+     */
+    public Configuration editConfiguration() {
+        Map<String, Object> properties = this.configuration.getProperties();
+        return new Configuration(new HashMap<>(properties));
+    }
+
+    /**
+     * Update the configuration properties after the configuration is changed
+     *
+     * @param newConfiguration an update confifguration
+     */
+    public void updateConfiguration(Configuration newConfiguration) {
+        configuration.setProperties(newConfiguration.getProperties());
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -48,6 +48,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.dto.ChannelDTO;
 import org.eclipse.smarthome.core.thing.dto.ThingDTO;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
@@ -74,6 +75,7 @@ import io.swagger.annotations.ApiResponses;
  * @author Thomas Höfer - added validation of configuration
  * @author Yordan Zhelev - Added Swagger annotations
  * @author Jörg Plewe - refactoring, error handling
+ * @author Chris Jackson - added channel configuration updates
  */
 @Path(ThingResource.PATH_THINGS)
 @Api(value = ThingResource.PATH_THINGS)
@@ -352,6 +354,17 @@ public class ThingResource implements RESTResource {
 
         // Update the label
         thing.setLabel(thingBean.label);
+
+        // Update the configuration in the channels
+        for (Channel channel : thing.getChannels()) {
+            for (ChannelDTO newChannel : thingBean.channels) {
+                if (newChannel.uid.equals(channel.getUID().getAsString())) {
+                    Configuration configuration = channel.editConfiguration();
+                    configuration.setProperties(newChannel.configuration);
+                    channel.updateConfiguration(configuration);
+                }
+            }
+        }
 
         // update, returns null in case Thing cannot be found
         Thing oldthing = managedThingProvider.update(thing);


### PR DESCRIPTION
This updates the thing resource to save the channel configuration, and adds two methods to the Channel class to edit and update the channel configuration.

I guess validation probably should be run on the configuration update as well - I've not added this at the moment. I know others are working on a fix for this issue as well, but as it's been a month, and this is causing ZWave users in the US a lot of problems, I thought I'd propose something to get started...

fixes https://github.com/eclipse/smarthome/issues/1103

FYI: @xsnrg

Signed-off-by: Chris Jackson <chris@cd-jackson.com>