### PR TITLE
declared ConfigValidationException as RuntimeException in order to av…

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/ConfigDescriptionValidator.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/ConfigDescriptionValidator.java
@@ -61,8 +61,7 @@ public final class ConfigDescriptionValidator {
      * @throws NullPointerException if given config description URI or configuration parameters are null
      */
     @SuppressWarnings("unchecked")
-    public static void validate(Map<String, Object> configurationParameters, URI configDescriptionURI)
-            throws ConfigValidationException {
+    public static void validate(Map<String, Object> configurationParameters, URI configDescriptionURI) {
         Preconditions.checkNotNull(configurationParameters, "Configuration parameters must not be null");
         Preconditions.checkNotNull(configDescriptionURI, "Config description URI must not be null");
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/ConfigValidationException.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/ConfigValidationException.java
@@ -22,12 +22,12 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Exception to be thrown if given {@link Configuration} parameters do not match their declaration in the
+ * A runtime exception to be thrown if given {@link Configuration} parameters do not match their declaration in the
  * {@link ConfigDescription}.
  *
  * @author Thomas Höfer - Initial contribution
  */
-public final class ConfigValidationException extends Exception {
+public final class ConfigValidationException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingRegistry.java
@@ -53,8 +53,7 @@ public interface ThingRegistry extends Registry<Thing, ThingUID> {
      * @throws ConfigValidationException if one or more of the given configuration parameters do not match
      *             their declarations in the configuration description
      */
-    void updateConfiguration(ThingUID thingUID, Map<String, Object> configurationParameters)
-            throws ConfigValidationException;
+    void updateConfiguration(ThingUID thingUID, Map<String, Object> configurationParameters);
 
     /**
      * Initiates the removal process for the {@link Thing} specified by the given {@link ThingUID}.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -110,8 +110,7 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<String, Object> configurationParameters)
-            throws ConfigValidationException {
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
         validateConfigurationParameters(configurationParameters);
 
         // can be overridden by subclasses
@@ -187,8 +186,7 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @throws ConfigValidationException if one or more of the given configuration parameters do not match
      *             their declarations in the configuration description
      */
-    protected void validateConfigurationParameters(Map<String, Object> configurationParameters)
-            throws ConfigValidationException {
+    protected void validateConfigurationParameters(Map<String, Object> configurationParameters) {
         ThingType thingType = TypeResolver.resolve(getThing().getThingTypeUID());
         if (thingType != null && thingType.getConfigDescriptionURI() != null) {
             ConfigDescriptionValidator.validate(configurationParameters, thingType.getConfigDescriptionURI());

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ConfigStatusThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ConfigStatusThingHandler.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.status.ConfigStatusCallback;
 import org.eclipse.smarthome.config.core.status.ConfigStatusProvider;
-import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
 import org.eclipse.smarthome.core.thing.Thing;
 
 /**
@@ -53,8 +52,7 @@ public abstract class ConfigStatusThingHandler extends BaseThingHandler implemen
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<String, Object> configurationParameters)
-            throws ConfigValidationException {
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
         super.handleConfigurationUpdate(configurationParameters);
         if (configStatusCallback != null) {
             configStatusCallback.configUpdated(new ThingConfigStatusSource(getThing().getUID().getAsString()));

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
@@ -95,7 +95,7 @@ public interface ThingHandler {
      * @throws ConfigValidationException if one or more of the given configuration parameters do not match
      *             their declarations in the configuration description
      */
-    void handleConfigurationUpdate(Map<String, Object> configurationParameters) throws ConfigValidationException;
+    void handleConfigurationUpdate(Map<String, Object> configurationParameters);
 
     /**
      * This method is called, before the handler is shut down.
@@ -161,7 +161,7 @@ public interface ThingHandler {
      * This method is called, when the status of the bridge has been changed to
      * {@link ThingStatus#ONLINE} or {@link ThingStatus#OFFLINE}. If the thing
      * of this handler does not have a bridge, this method is never called.
-     * 
+     *
      * @param thingStatusInfo the status info of the bridge
      */
     void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
@@ -83,8 +82,7 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID>implemen
     }
 
     @Override
-    public void updateConfiguration(ThingUID thingUID, Map<String, Object> configurationParameters)
-            throws ConfigValidationException {
+    public void updateConfiguration(ThingUID thingUID, Map<String, Object> configurationParameters) {
         Thing thing = get(thingUID);
         if (thing != null) {
             ThingHandler thingHandler = thing.getHandler();


### PR DESCRIPTION
…oid indirect dependency on org.eclipse.smarthome.config.core.validation for bindings (as discussed in #1149)

Signed-off-by: Thomas Höfer <t.hoefer@telekom.de>