### PR TITLE
Bug fix: Missing discovery results label

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
@@ -3,11 +3,21 @@ angular.module('PaperUI.controllers.setup', []).controller('SetupPageController'
         $location.path('inbox/' + path);
     }
     $scope.thingTypes = [];
-    thingTypeRepository.getAll(function(thingTypes) {
-        $.each(thingTypes, function(i, thingType) {
-            $scope.thingTypes[thingType.UID] = thingType;
+    function getThingTypes() {
+        thingTypeRepository.getAll(function(thingTypes) {
+            $.each(thingTypes, function(i, thingType) {
+                $scope.thingTypes[thingType.UID] = thingType;
+            });
         });
-    });
+    }
+    $scope.getThingTypeLabel = function(key) {
+        if ($scope.thingTypes && Object.keys($scope.thingTypes).length != 0) {
+            return $scope.thingTypes[key].label;
+        } else {
+            getThingTypes();
+        }
+    };
+    getThingTypes();
 }).controller('InboxController', function($scope, $timeout, $mdDialog, $q, inboxService, discoveryResultRepository, thingTypeRepository, thingSetupService, toastService) {
     $scope.setHeaderText('Shows a list of found things in your home.')
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.inbox.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.inbox.html
@@ -2,7 +2,7 @@
 	<md-button title="Add" class="md-fab green" ng-click="approve(discoveryResult.thingUID,discoveryResult.thingTypeUID, $event)" aria-label="Approve"> <i class="material-icons">done</i></md-button>
 	<div class="item-content">
 		<h3>
-			{{thingTypes[discoveryResult.thingTypeUID].label}} <small ng-show="discoveryResult.flag === 'IGNORED'" class="badge">IGNORED</small>
+			{{getThingTypeLabel(discoveryResult.thingTypeUID)}} <small ng-show="discoveryResult.flag === 'IGNORED'" class="badge">IGNORED</small>
 		</h3>
 		<p>{{discoveryResult.label}}</p>
 		<p>{{discoveryResult.thingUID}}</p>


### PR DESCRIPTION
Fixed the missing label bug in discovery results(inbox) as reported here: https://github.com/eclipse/smarthome/issues/1276.

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>