### PR TITLE
Unlink channel after confirmation

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -359,13 +359,22 @@ angular.module('PaperUI.controllers.configuration', []).controller('Configuratio
 
     $scope.unlinkChannel = function(channelID) {
         var channel = $scope.getChannelById(channelID);
-        var linkedItem = channel.linkedItems[0];
-        linkService.unlink({
-            itemName : linkedItem,
-            channelUID : $scope.thing.UID + ':' + channelID
-        }, function() {
-            $scope.getThing(true);
-            toastService.showDefaultToast('Channel unlinked');
+        $mdDialog.show({
+            controller : 'UnlinkChannelDialogController',
+            templateUrl : 'partials/dialog.unlinkchannel.html',
+            targetEvent : event,
+            hasBackdrop : true,
+            locals : {
+                itemName : channel.linkedItems[0]
+            }
+        }).then(function(itemName) {
+            linkService.unlink({
+                itemName : channel.linkedItems[0],
+                channelUID : $scope.thing.UID + ':' + channelID
+            }, function() {
+                $scope.getThing(true);
+                toastService.showDefaultToast('Channel unlinked');
+            });
         });
     }
 
@@ -548,6 +557,14 @@ angular.module('PaperUI.controllers.configuration', []).controller('Configuratio
     }
     $scope.link = function(itemName) {
         $mdDialog.hide(itemName);
+    }
+}).controller('UnlinkChannelDialogController', function($scope, $mdDialog, toastService, linkService, itemName) {
+    $scope.itemName = itemName;
+    $scope.close = function() {
+        $mdDialog.cancel();
+    }
+    $scope.unlink = function() {
+        $mdDialog.hide();
     }
 }).controller('EditThingController', function($scope, $mdDialog, toastService, thingTypeRepository, thingRepository, thingSetupService, configService, thingService) {
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.unlinkchannel.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.unlinkchannel.html
@@ -1,0 +1,8 @@
+<md-dialog aria-label="Remove thing"> <md-dialog-content>
+<h2>Remove item '{{itemName}}'?</h2>
+</md-dialog-content>
+<div class="md-actions" layout="row">
+    <md-button ng-click="close()">Cancel</md-button>
+    <md-button class="md-primary" ng-click="unlink(channel.UID)">Remove</md-button>
+</div>
+</md-dialog>


### PR DESCRIPTION
Allows confirmation before a channel is unlinked as described here: https://github.com/eclipse/smarthome/issues/1105.

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>