### PR TITLE
Allow specifying thing ID during manual creation

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -559,6 +559,7 @@ angular.module('PaperUI.controllers.configuration', []).controller('Configuratio
     $scope.thing;
     $scope.groups = [];
     $scope.thingType;
+    $scope.isEditing = true;
     var originalThing = {};
 
     $scope.update = function(thing) {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
@@ -188,9 +188,11 @@ angular.module('PaperUI.controllers.setup', []).controller('SetupPageController'
             label : null,
             groupNames : []
         }
-    }
+    };
+    $scope.thingID = null;
 
     $scope.addThing = function(thing) {
+        thing.UID = thingTypeUID + ':' + thing.ID;
         thingSetupService.add({
             'enableChannels' : !$scope.advancedMode
         }, thing, function() {
@@ -223,7 +225,7 @@ angular.module('PaperUI.controllers.setup', []).controller('SetupPageController'
         $scope.setHeaderText(thingType.description);
         $scope.thingType = thingType;
         $scope.parameters = configService.getRenderingModel(thingType.configParameters, thingType.parameterGroups);
-        $scope.thing.UID = thingType.UID + ':' + generateUUID();
+        $scope.thing.ID = generateUUID();
         $scope.thing.item.label = thingType.label;
         $scope.thing.label = thingType.label;
         $scope.needsBridge = $scope.thingType.supportedBridgeTypeUIDs && $scope.thingType.supportedBridgeTypeUIDs.length > 0;

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.thingconfig.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.thingconfig.html
@@ -1,12 +1,20 @@
-<div class="container" ng-if="thing.item">
-	<div class="thingName">
-		<md-input-container> <label>Name</label> <input ng-model="thing.label"> </md-input-container>
+<form name="form.thingform">
+	<div class="container" ng-if="thing.item">
+		<div class="thingName">
+			<md-input-container> <label>Name</label> <input ng-model="thing.label"> </md-input-container>
+
+			<md-input-container ng-if="!isEditing"> <label>Thing ID</label> <input ng-model="thing.ID" required>
+			<div ng-messages="form.thingform.uid.$error">
+				<div ng-message="pattern">ID is required</div>
+			</div>
+			</md-input-container>
+		</div>
 	</div>
-</div>
-<div class="container" ng-if="needsBridge">
-	<h3>Bridge Selection</h3>
-	<div class="form-group">
-		<md-select placeholder="Select a Bridge" ng-model="thing.bridgeUID" ng-readonly="true"> <md-option ng-value="bridge.UID" ng-repeat="bridge in bridges">{{bridge.label + ' - '}}{{bridge.UID}}</md-option> </md-select>
+	<div class="container" ng-if="needsBridge">
+		<h3>Bridge Selection</h3>
+		<div class="form-group">
+			<md-select placeholder="Select a Bridge" ng-model="thing.bridgeUID" ng-readonly="true"> <md-option ng-value="bridge.UID" ng-repeat="bridge in bridges">{{bridge.label + ' - '}}{{bridge.UID}}</md-option> </md-select>
+		</div>
+		<hr />
 	</div>
-	<hr />
-</div>
+</form>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/setup.html
@@ -153,16 +153,16 @@
 		<div class="section-header">
 			<div class="container">
 				<div class="toolbar">
-					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid" class="md-fab" aria-label="Add"> <i class="material-icons">check</i></md-button>
+					<md-button title="Add" ng-click="addThing(thing)" ng-disabled="form.configForm.$invalid || form.thingform.$invalid" class="md-fab" aria-label="Add"> <i class="material-icons">check</i></md-button>
 				</div>
 			</div>
 		</div>
+		<div ng-init="form={}">
+			<div ng-include="'partials/include.thingconfig.html'"></div>
+			<div class="container">
+				<h3>Configuration Parameters</h3>
+				<p>Configure parameters for the thing.</p>
 
-		<div ng-include="'partials/include.thingconfig.html'"></div>
-		<div class="container">
-			<h3>Configuration Parameters</h3>
-			<p>Configure parameters for the thing.</p>
-			<div ng-init="form={}">
 				<div ng-include="'partials/include.config.html'" onload="configuration=thing.configuration"></div>
 			</div>
 		</div>


### PR DESCRIPTION
Allow user to specify thing id while manually creating a thing. Related issue is: https://github.com/eclipse/smarthome/issues/762.

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>