### PR TITLE
made HueBridgeLightHandlerOSGiTest more robust wrt timing

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueLightHandlerOSGiTest.groovy
@@ -485,7 +485,12 @@ class HueLightHandlerOSGiTest extends OSGiTest {
         // mock HttpClient
         def hueBridgeField = hueBridgeHandler.getClass().getDeclaredField("bridge")
         hueBridgeField.accessible = true
-        def hueBridgeValue = hueBridgeField.get(hueBridgeHandler)
+        def hueBridgeValue = null
+
+        waitForAssert({
+            hueBridgeValue = hueBridgeField.get(hueBridgeHandler)
+            assertThat hueBridgeValue, is(notNullValue())
+        }, 10000, 100)
 
         def httpClientField = hueBridgeValue.getClass().getDeclaredField("http")
         httpClientField.accessible = true


### PR DESCRIPTION
...in order to get rid of the occasional
      java.lang.NoSuchFieldException: http
exception.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>