### PR TITLE
Wait for running handler registration to complete

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ChangeThingTypeOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ChangeThingTypeOSGiTest.groovy
@@ -200,7 +200,6 @@ class ChangeThingTypeOSGiTest extends OSGiTest {
         @Override
         public void initialize() {
             println "[ChangeThingTypeOSGiTest] GenericThingHandler.initialize"
-            new RuntimeException().printStackTrace()
             super.initialize()
             genericInits++;
             if (selfChanging) {


### PR DESCRIPTION
...in order to prevent a race condition when changing thing types
during initialization (see #1131).

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>