### PR TITLE
Return empty config instead of 404

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/service/ConfigurableServiceResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/service/ConfigurableServiceResource.java
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.io.rest.core.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -90,14 +91,14 @@ public class ConfigurableServiceResource implements RESTResource {
     @Path("/{serviceId}/config")
     @Produces({ MediaType.APPLICATION_JSON })
     @ApiOperation(value = "Get service configuration for given service ID.")
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"), @ApiResponse(code = 404, message = "Not found"),
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
             @ApiResponse(code = 500, message = "Configuration can not be read due to internal error") })
     public Response getConfiguration(
             @PathParam("serviceId") @ApiParam(value = "service ID", required = true) String serviceId) {
         try {
             Configuration configuration = configurationService.get(serviceId);
             return configuration != null ? Response.ok(configuration.getProperties()).build()
-                    : Response.status(404).build();
+                    : Response.ok(Collections.emptyMap()).build();
         } catch (IOException ex) {
             logger.error("Cannot get configuration for service {}: " + ex.getMessage(), serviceId, ex);
             return Response.status(Status.INTERNAL_SERVER_ERROR).build();


### PR DESCRIPTION
If no configuration has been set yet for a service, the REST API currently returns a 404.
If a service is present, a not set configuration should instead be considered to be an empty configuration - the web client (here the Paper UI) should not have to care about that. 

Signed-off-by: Kai Kreuzer <kai@openhab.org>