### PR TITLE
Bug fix for 'configure button in bindings not working'

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.configurebinding.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.configurebinding.html
@@ -16,6 +16,6 @@
 	</a>
 	<span flex="auto"></span>
 	<md-button ng-click="close()">Cancel</md-button>
-	<md-button ng-disabled="form.configForm.$invalid && !expertMode" " ng-click="save()">Save</md-button>
+	<md-button ng-disabled="form.configForm.$invalid && !expertMode" ng-click="save()">Save</md-button>
 </div>
 </md-dialog>


### PR DESCRIPTION
Fixed the problem with configure button in bindings as reported here: https://github.com/eclipse/smarthome/issues/1312

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>