### PR TITLE
Parse string to integer and boolean values

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -81,8 +81,8 @@ angular.module('PaperUI.controllers.configuration', []).controller('Configuratio
         bindingService.getConfigById({
             id : bindingId
         }).$promise.then(function(config) {
-            $scope.configuration = config;
-            $scope.configArray = configService.getConfigAsArray(config);
+            $scope.configuration = configService.convertValues(config);
+            $scope.configArray = configService.getConfigAsArray($scope.configuration);
         }, function(failed) {
             $scope.configuration = {};
             $scope.configArray = configService.getConfigAsArray($scope.configuration);
@@ -198,8 +198,8 @@ angular.module('PaperUI.controllers.configuration', []).controller('Configuratio
             id : serviceId
         }).$promise.then(function(config) {
             if (config) {
-                $scope.configuration = config;
-                $scope.configArray = configService.getConfigAsArray(config);
+                $scope.configuration = configService.convertValues(config);
+                $scope.configArray = configService.getConfigAsArray($scope.configuration);
                 if ($scope.parameters && $scope.parameters.length > 0) {
                     $scope.configuration = configService.setConfigDefaults($scope.configuration, $scope.parameters);
                 }

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.module.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.module.js
@@ -27,7 +27,7 @@ angular.module('PaperUI.controllers.rules').controller('addModuleDialogControlle
 
         var index = sharedProperties.searchArray(sharedProperties.getModuleArray(type), $scope.id);
         if (index != -1) {
-            $scope.configuration = sharedProperties.getModuleArray(type)[index].configuration;
+            $scope.configuration = configService.convertValues(sharedProperties.getModuleArray(type)[index].configuration);
             $scope.configArray = configService.getConfigAsArray($scope.configuration);
         }
     }

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
@@ -192,7 +192,9 @@ angular.module('PaperUI.services', [ 'PaperUI.constants' ]).config(function($htt
                             if (parameter.type === 'TEXT') {
                                 configuration[parameter.name] = parameter.defaultValue
                             } else if (parameter.type === 'BOOLEAN') {
-                                configuration[parameter.name] = new Boolean(parameter.defaultValue);
+                                if (typeof (configuration[parameter.name]) !== 'boolean') {
+                                    configuration[parameter.name] = new Boolean(parameter.defaultValue);
+                                }
                             } else if (parameter.type === 'INTEGER' || parameter.type === 'DECIMAL') {
                                 configuration[parameter.name] = parseInt(parameter.defaultValue);
                             } else {
@@ -205,6 +207,26 @@ angular.module('PaperUI.services', [ 'PaperUI.constants' ]).config(function($htt
                 });
             }
             return configuration;
+        },
+        convertValues : function(configurations) {
+            angular.forEach(configurations, function(value, name) {
+                if (typeof (value) !== "boolean") {
+                    var parsedValue = Number(value);
+                    if (isNaN(parsedValue)) {
+                        if (value.toUpperCase() == 'TRUE') {
+                            configurations[name] = true;
+                        } else if (value.toUpperCase() == 'FALSE') {
+                            configurations[name] = false;
+                        } else {
+                            configurations[name] = value;
+                        }
+
+                    } else {
+                        configurations[name] = parsedValue;
+                    }
+                }
+            });
+            return configurations;
         }
     };
 });


### PR DESCRIPTION
Parse integer and boolean values returned as strings in configurations. 
fixes https://github.com/eclipse/smarthome/issues/1313

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>