### PR TITLE
Show only module types with visibility 'visible'

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.module.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.module.js
@@ -3,9 +3,14 @@
 angular.module('PaperUI.controllers.rules').controller('addModuleDialogController', function($rootScope, $scope, $mdDialog, moduleTypeService, sharedProperties, $filter, configService, module, ruleID, type) {
 
     var objectFilter = $filter('filter');
-
-    $scope.moduleData = moduleTypeService.getByType({
+    $scope.moduleData;
+    moduleTypeService.getByType({
         mtype : type
+    }).$promise.then(function(data) {
+        $scope.moduleData = objectFilter(data, {
+            visibility : 'VISIBLE'
+        });
+        setConfigurations();
     });
     $scope.id = module.id;
     $scope.type = type;
@@ -16,19 +21,18 @@ angular.module('PaperUI.controllers.rules').controller('addModuleDialogControlle
     $scope.configuration = {};
 
     function setConfigurations() {
-
-        $scope.moduleData.$promise.then(function(data) {
-            var params = filterByUid(data, $scope.module);
+        if ($scope.moduleData) {
+            var params = filterByUid($scope.moduleData, $scope.module);
             var res = configService.getRenderingModel(params[0].configDescriptions);
             angular.forEach(res, function(value) {
                 sharedProperties.updateParams(value);
             });
-        });
 
-        var index = sharedProperties.searchArray(sharedProperties.getModuleArray(type), $scope.id);
-        if (index != -1) {
-            $scope.configuration = configService.convertValues(sharedProperties.getModuleArray(type)[index].configuration);
-            $scope.configArray = configService.getConfigAsArray($scope.configuration);
+            var index = sharedProperties.searchArray(sharedProperties.getModuleArray(type), $scope.id);
+            if (index != -1) {
+                $scope.configuration = configService.convertValues(sharedProperties.getModuleArray(type)[index].configuration);
+                $scope.configArray = configService.getConfigAsArray($scope.configuration);
+            }
         }
     }
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.rules.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.rules.js
@@ -89,7 +89,7 @@ angular.module('PaperUI.controllers.rules', []).controller('RulesPageController'
         $scope.setSubtitle([ rule.name ]);
         $scope.rule = rule;
     });
-}).controller('NewRuleController', function($scope, itemRepository, ruleService, toastService, $mdDialog, sharedProperties) {
+}).controller('NewRuleController', function($scope, itemRepository, ruleService, toastService, $mdDialog, sharedProperties, moduleTypeService) {
     $scope.setSubtitle([ 'New Rule' ]);
     itemRepository.getAll();
     sharedProperties.reset();
@@ -113,9 +113,14 @@ angular.module('PaperUI.controllers.rules', []).controller('RulesPageController'
     }
 
     function setModuleArrays(data) {
-        sharedProperties.addArray('trigger', data.triggers);
-        sharedProperties.addArray('action', data.actions);
-        sharedProperties.addArray('condition', data.conditions);
+        moduleTypeService.getByType({
+            mtype : 'trigger'
+        }).$promise.then(function(moduleData) {
+            sharedProperties.setModuleTypes(moduleData);
+            sharedProperties.addArray('trigger', data.triggers);
+            sharedProperties.addArray('action', data.actions);
+            sharedProperties.addArray('condition', data.conditions);
+        });
     }
 
     $scope.saveUserRule = function() {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/shared.properties.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/shared.properties.js
@@ -6,6 +6,7 @@ angular.module('PaperUI.controllers.rules').service('sharedProperties', function
     var conditionsArray = [];
     var tId = 1, aId = 1, cId = 1;
     var params = [];
+    var moduleTypes = [];
     return {
         updateParams : function(elem) {
             params.push(elem);
@@ -20,7 +21,9 @@ angular.module('PaperUI.controllers.rules').service('sharedProperties', function
             arr.type = type;
             var self = this;
             angular.forEach(arr, function(value) {
-                self.updateModule(arr.type, value);
+                if (self.searchVisibleType(arr, value.type) == -1) {
+                    self.updateModule(arr.type, value);
+                }
             });
         },
         updateModule : function(type, value) {
@@ -104,6 +107,18 @@ angular.module('PaperUI.controllers.rules').service('sharedProperties', function
 
         },
 
+        searchVisibleType : function(arr, type) {
+
+            var k;
+            for (k = 0; arr != null && k < arr.length; k = k + 1) {
+                if (arr[k].uid === type && arr[k].visibility.toUpperCase() === 'VISIBLE') {
+                    return k;
+                }
+            }
+            return -1;
+
+        },
+
         getModuleArray : function(type) {
             if (type == 'trigger') {
                 return triggersArray;
@@ -113,6 +128,10 @@ angular.module('PaperUI.controllers.rules').service('sharedProperties', function
                 return conditionsArray;
             }
 
+        },
+
+        setModuleTypes : function(mTypes) {
+            moduleTypes = mTypes;
         }
 
     }


### PR DESCRIPTION
1) While creating a module allow only those modules types that have a visible visibility.
2) While editing a rule show only modules with a visible visibility in their module types.
fixes https://github.com/eclipse/smarthome/issues/1336.
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>