### PR TITLE
fixes invalid configurations shown in modules

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.module.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.module.js
@@ -10,7 +10,9 @@ angular.module('PaperUI.controllers.rules').controller('addModuleDialogControlle
         $scope.moduleData = objectFilter(data, {
             visibility : 'VISIBLE'
         });
-        setConfigurations();
+        if ($scope.id) {
+            setConfigurations();
+        }
     });
     $scope.id = module.id;
     $scope.type = type;

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.config.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.config.html
@@ -47,7 +47,8 @@
 								</p>
 							</div>
 							<div ng-switch-when="select">
-								<md-input-container> <label>{{parameter.label}}</label> <md-select class="config-select" isrequired="parameter.required" ng-init="focus=false" name="{{parameter.name}}" ng-model="configuration[parameter.name]" placeholder="Select a value" ng-focus="focus=true" ng-blur="focus=false" ng-required="parameter.required"> <md-option ng-value="option.value?option.value:option.name" ng-repeat="option in parameter.options"> <span style="display: inline-block;" ng-if="parameter.context=='item'">
+								<label class="config-textInput">{{parameter.label}}</label>
+								<md-input-container> <md-select class="config-select" isrequired="parameter.required" ng-init="focus=false" name="{{parameter.name}}" ng-model="configuration[parameter.name]" placeholder="Select a value" ng-focus="focus=true" ng-blur="focus=false" ng-required="parameter.required"> <md-option ng-value="option.value?option.value:option.name" ng-repeat="option in parameter.options"> <span style="display: inline-block;" ng-if="parameter.context=='item'">
 									{{ option.label?option.label:option.name }}
 									<span class="md-caption" style="color: grey;">({{ option.name?option.name:'' }}) </span>
 								</span> <span ng-if="!parameter.context">{{option.label}}</span> </md-option> </md-select>


### PR DESCRIPTION
Fixed invalid config options shown while creating a new module.
fixes https://github.com/eclipse/smarthome/issues/1346
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>