### PR TITLE
Use monospace font only in script's text area

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -611,7 +611,7 @@ md-progress-circular.md-default-theme .md-inner .md-left .md-half-circle
 .config-textInput {
     font-size: 10.5px;
     color: rgba(0,0,0,0.54);
-    margin-left: 4px;
+    margin-left: 2px;
 }
 
 .icontrol .md-button, .thing .md-button, .item-content .actions .md-button, .header-toolbar .md-button,
@@ -672,7 +672,7 @@ md-progress-circular.md-default-theme .md-inner .md-left .md-half-circle
 }
 
 md-input-container textarea.md-input.scriptArea, md-input-container textarea.md-input.ng-invalid.ng-dirty,
-	md-input-container.md-input-focused .md-input {
+	md-input-container textarea.md-input-focused .md-input {
 	max-width: 550px;
 	max-height: 250px;
 	overflow: scroll;


### PR DESCRIPTION
Use normal font for all edit fields except for field of context type script.
fixes https://github.com/eclipse/smarthome/issues/1344
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>