### PR TITLE
Also allow Double if the value is an integer number

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuntimeRule.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuntimeRule.java
@@ -222,7 +222,8 @@ public class RuntimeRule extends Rule {
             case BOOLEAN:
                 return configValue instanceof Boolean;
             case INTEGER:
-                return configValue instanceof BigDecimal || configValue instanceof Integer;
+                return configValue instanceof BigDecimal || configValue instanceof Integer
+                        || configValue instanceof Double && ((Double) configValue).intValue() == (double) configValue;
             case DECIMAL:
                 return configValue instanceof BigDecimal || configValue instanceof Double;
         }


### PR DESCRIPTION
JSON parses all integers to doubles, hence we have to deal with this situation as well.
It probably makes sense to merge all this validation logic with the ConfigValidation code soon.

Signed-off-by: Kai Kreuzer <kai@openhab.org>