### PR TITLE
Do not cut of script exception

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptExecutionThread.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptExecutionThread.java
@@ -40,19 +40,14 @@ public class ScriptExecutionThread extends Thread {
         super.run();
         try {
             result = script.execute(context);
-        } catch (ScriptExecutionException e) {
-            String msg = e.getCause().getMessage();
-            if (msg == null) {
-                logger.error("Error during the execution of rule '{}'", getName(), e.getCause());
-            } else {
-                logger.error("Error during the execution of rule '{}': {}", new Object[] { getName(), msg });
-            }
+        } catch (final ScriptExecutionException ex) {
+            logger.error("Error during the execution of rule '{}'.", getName(), ex);
         }
     }
 
     /**
      * Returns the script evaluation result (or null, if thread is still active)
-     * 
+     *
      * @return the script evaluation result
      */
     public Object getResult() {

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptExecutionThread.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptExecutionThread.java
@@ -40,14 +40,19 @@ public class ScriptExecutionThread extends Thread {
         super.run();
         try {
             result = script.execute(context);
-        } catch (final ScriptExecutionException ex) {
-            logger.error("Error during the execution of rule '{}'.", getName(), ex);
+        } catch (ScriptExecutionException e) {
+            String msg = e.getMessage();
+            if (msg == null) {
+                logger.error("Error during the execution of rule '{}'", getName(), e.getCause());
+            } else {
+                logger.error("Error during the execution of rule '{}': {}", new Object[] { getName(), msg });
+            }
         }
     }
 
     /**
      * Returns the script evaluation result (or null, if thread is still active)
-     *
+     * 
      * @return the script evaluation result
      */
     public Object getResult() {


### PR DESCRIPTION
This is related to:
https://github.com/eclipse/smarthome/issues/1393#issuecomment-211540325
Which message should be shown, the message of the exception themselves
or the message of the exception that is the cause of the excpetion.
I do not see any reason to handle all the different cases here and
generate a suitable message itself.
We should not limit the information of the exception for logging.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>