### PR TITLE
Hide extensions tab if rest endpoint is unavailable

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/extensions/ExtensionResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/extensions/ExtensionResource.java
@@ -49,7 +49,7 @@ public class ExtensionResource implements RESTResource {
 
     private static final String THREAD_POOL_NAME = "extensionService";
 
-    public static final String PATH_EXTENSIONS = "/extensions";
+    public static final String PATH_EXTENSIONS = "extensions";
 
     private final Logger logger = LoggerFactory.getLogger(ExtensionResource.class);
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
@@ -74,13 +74,13 @@
 					</li>
 				</ul>
 			</li>
-			<li ng-class="{active: isActive('extensions'), hidden: isHidden('extensions')}">
+			<li ng-show="extensionEnabled" ng-class="{active: isActive('extensions'), hidden: isHidden('extensions')}">
 				<a href="#extensions">
 					<span class="icon material-icons">extension</span>
 					<span class="side-menu">Extensions</span>
 				</a>
 			</li>
-			<li ng-show="ruleEnabled" ng-class="{active: isActive('rules')}">
+			<li ng-show="ruleEnabled" ng-class="{active: isActive('rules'), hidden: isHidden('rules')}">
 				<a href="#rules">
 					<span class="icon material-icons">movie_creation</span>
 					<span class="side-menu">Rules</span>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
@@ -120,6 +120,7 @@ angular.module('PaperUI.controllers', [ 'PaperUI.constants' ]).controller('BodyC
     }
 }).controller('NavController', function($scope, $location, $http, restConfig, moduleConfig) {
     $scope.opened = null;
+    $scope.extensionEnabled;
     $scope.ruleEnabled;
     $scope.open = function(viewLocation) {
         $scope.opened = viewLocation;
@@ -141,10 +142,13 @@ angular.module('PaperUI.controllers', [ 'PaperUI.constants' ]).controller('BodyC
         $scope.opened = null;
     });
     $http.get(restConfig.restPath).then(function(response) {
+        $scope.extensionEnabled = false;
         $scope.ruleEnabled = false;
         if (response.data && response.data.links) {
             for (var i = 0; i < response.data.links.length; i++) {
-                if (response.data.links[i].type === 'rules') {
+                if (response.data.links[i].type === 'extensions') {
+                    $scope.extensionEnabled = true;
+                } else if (response.data.links[i].type === 'rules') {
                     $scope.ruleEnabled = true;
                 }
             }


### PR DESCRIPTION
This PR also restore the function to force that the rules category is hidden by configuration (#1406).