### PR TITLE
defaultValue must not be mapped with String.valueOf 

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/dto/ConfigDescriptionDTOMapper.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/dto/ConfigDescriptionDTOMapper.java
@@ -56,7 +56,7 @@ public class ConfigDescriptionDTOMapper {
                     configDescriptionParameter.getStepSize(), configDescriptionParameter.getPattern(),
                     configDescriptionParameter.isRequired(), configDescriptionParameter.isReadOnly(),
                     configDescriptionParameter.isMultiple(), configDescriptionParameter.getContext(),
-                    String.valueOf(configDescriptionParameter.getDefault()), configDescriptionParameter.getLabel(),
+                    configDescriptionParameter.getDefault(), configDescriptionParameter.getLabel(),
                     configDescriptionParameter.getDescription(), mapOptions(configDescriptionParameter.getOptions()),
                     mapFilterCriteria(configDescriptionParameter.getFilterCriteria()),
                     configDescriptionParameter.getGroupName(), configDescriptionParameter.isAdvanced(),


### PR DESCRIPTION
for correct mapping of null values, String.valueOf must not be used

Signed-off-by: Andre Fuechsel <a.fuechsel@telekom.de>