### PR TITLE
fix checkAdvance(channels) implementation

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -487,11 +487,15 @@ angular.module('PaperUI.controllers.configuration', []).controller('Configuratio
     };
 
     function checkAdvance(channels) {
-        angular.forEach(channels, function(value) {
-            if (value.advanced) {
-                return true;
+        if (channels) {
+            for (var i = 0, len = channels.length; i < len; i++) {
+                var channel = channels[i];
+                var channelType = $scope.getChannelTypeById(channel.id);
+                if (channelType && channelType.advanced) {
+                    return true;
+                }
             }
-        });
+        }
         return false;
     }
 


### PR DESCRIPTION
The advance flag is part of the channel type, not the channel.

Bug: https://github.com/eclipse/smarthome/issues/1426
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>