### PR TITLE
Manually parse DateTimeItem in Control ui

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -86,11 +86,11 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
         }
         var state = item.type === 'NumberItem' ? parseFloat(item.state) : item.state;
 
-        if (!item.stateDescription || !item.stateDescription.pattern) {
-            return state;
-        } else if (item.type === 'DateTimeItem') {
+        if (item.type === 'DateTimeItem') {
             var date = new Date(item.state);
             return $filter('date')(date, "dd.MM.yyyy hh:mm:ss");
+        } else if (!item.stateDescription || !item.stateDescription.pattern) {
+            return state;
         } else {
             return sprintf(item.stateDescription.pattern, state);
         }

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -75,7 +75,7 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
         $scope.masonry();
     });
     $scope.refresh();
-}).controller('ControlController', function($scope, $timeout, itemService) {
+}).controller('ControlController', function($scope, $timeout, $filter, itemService) {
     $scope.getItemName = function(itemName) {
         return itemName.replace(/_/g, ' ');
     }
@@ -88,6 +88,9 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
 
         if (!item.stateDescription || !item.stateDescription.pattern) {
             return state;
+        } else if (item.type === 'DateTimeItem') {
+            var date = new Date(item.state);
+            return $filter('date')(date, "dd.MM.yyyy hh:mm:ss");
         } else {
             return sprintf(item.stateDescription.pattern, state);
         }


### PR DESCRIPTION
A temporary solution to script crashing error caused by sprintf library while parsing DateTimeItem with defined pattern. This solution does not consider pattern field of DateTimeItem for now.
Should fix https://github.com/eclipse/smarthome/issues/564
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>