### PR TITLE
aligned key types in Configuration

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -110,7 +110,7 @@ public class Configuration {
         return fields;
     }
 
-    public Object get(Object key) {
+    public Object get(String key) {
         synchronized (this) {
             return properties.get(key);
         }
@@ -122,7 +122,7 @@ public class Configuration {
         }
     }
 
-    public Object remove(Object key) {
+    public Object remove(String key) {
         synchronized (this) {
             return properties.remove(key);
         }


### PR DESCRIPTION
Internally the Keys are Strings and some methods (e.g. put(), keySet(),...) have Strings already, so I don't see why it should not be consistent...

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>