### PR TITLE
karaf-tp: drop mega bundles and use features instead

### DIFF
--- a/features/karaf-tp/src/main/feature/feature.xml
+++ b/features/karaf-tp/src/main/feature/feature.xml
@@ -37,17 +37,41 @@
   </feature>
 
   <feature name="esh-tp-jax-rs" version="${project.version}">
-    <capability>esh.tp;feature=jax-rs;version=5.3</capability>
+    <capability>esh.tp;feature=jax-rs;version=5.3.1</capability>
     <feature>esh-tp-jax-rs-min</feature>
     <feature>esh-tp-jax-rs-provider-gson</feature>
   </feature>
 
   <feature name="esh-tp-jax-rs-min" version="${project.version}">
-    <capability>esh.tp;feature=jax-rs-min;version=5.3</capability>
+    <capability>esh.tp;feature=jax-rs-min;version=5.3.1</capability>
 
     <feature dependency="true">http</feature>
-    <bundle dependency="true">mvn:com.eclipsesource.jaxrs/jersey-min/2.22.1</bundle>
-    <bundle>mvn:com.eclipsesource.jaxrs/publisher/5.3</bundle>
+    <feature dependency="true">esh-kat.cpy-jersey-min-2.22.2</feature>
+    <bundle>mvn:com.eclipsesource.jaxrs/publisher/5.3.1</bundle>
+  </feature>
+
+  <feature name="esh-kat.cpy-jersey-min-2.22.2" version="${project.version}">
+    <feature dependency="true">http</feature>
+    <bundle>mvn:org.glassfish.jersey.containers/jersey-container-servlet/2.22.2</bundle>
+    <bundle>mvn:org.glassfish.jersey.media/jersey-media-sse/2.22.2</bundle>
+    <bundle>mvn:org.glassfish.jersey.media/jersey-media-multipart/2.22.2</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.containers/jersey-container-servlet-core/2.22.2</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-common/2.22.2</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.bundles.repackaged/jersey-guava/2.22.2</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-server/2.22.2</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-client/2.22.2</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.media/jersey-media-jaxb/2.22.2</bundle>
+    <bundle dependency="true">mvn:org.glassfish.hk2/hk2-api/2.4.0-b34</bundle>
+    <bundle dependency="true">mvn:org.glassfish.hk2/hk2-locator/2.4.0-b34</bundle>
+    <bundle dependency="true">mvn:org.glassfish.hk2/hk2-utils/2.4.0-b34</bundle>
+    <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/1.0.1</bundle>
+    <bundle dependency="true">mvn:org.glassfish.hk2.external/javax.inject/2.4.0-b34</bundle>
+    <bundle dependency="true">mvn:org.glassfish.hk2.external/aopalliance-repackaged/2.4.0-b34</bundle>
+    <bundle dependency="true">mvn:javax.annotation/javax.annotation-api/1.2</bundle>
+    <bundle dependency="true">mvn:javax.validation/validation-api/1.1.0.Final</bundle>
+    <bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/2.0.1</bundle>
+    <bundle dependency="true">mvn:org.javassist/javassist/3.18.1-GA</bundle>
+    <bundle dependency="true">mvn:org.jvnet.mimepull/mimepull/1.9.6</bundle>
   </feature>
 
   <feature name="esh-tp-jax-rs-provider-gson" version="${project.version}">
@@ -93,7 +117,10 @@
     <bundle dependency="true">mvn:org.eclipse.emf/org.eclipse.emf.ecore/2.11.1-v20150805-0538</bundle>
     <bundle dependency="true">mvn:org.eclipse.emf/org.eclipse.emf.ecore.xmi/2.11.1-v20150805-0538</bundle>
     <bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtext.common.types/2.9.2</bundle>
+
     <bundle dependency="true">mvn:de.maggu2810.thirdparty.modified.org.eclipse.xtext/org.eclipse.xtext.xbase/2.9.2.sp1</bundle>
+    <bundle dependency="true">mvn:javax.annotation/javax.annotation-api/1.2</bundle>
+
     <bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtext.xbase.lib/2.9.2</bundle>
     <bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtext.smap/2.9.2</bundle>
     <bundle dependency="true">mvn:org.eclipse.xtext/org.eclipse.xtext.util/2.9.2</bundle>


### PR DESCRIPTION
At the moment there is a jersey-min bundle used, that is a collection of multiple other bundles.
This could involve that stuff is installed multiple times (e.g. javax apis) instead of sharing them.

This PR will drop the usage of that "mega meta" bundle and use a feature instead.