### PR TITLE
use swagger-jersey2 feature instead of mega bundle

### DIFF
--- a/features/karaf-tp/src/main/feature/feature.xml
+++ b/features/karaf-tp/src/main/feature/feature.xml
@@ -44,7 +44,6 @@
 
   <feature name="esh-tp-jax-rs-min" version="${project.version}">
     <capability>esh.tp;feature=jax-rs-min;version=5.3.1</capability>
-
     <feature dependency="true">http</feature>
     <feature dependency="true">esh-kat.cpy-jersey-min-2.22.2</feature>
     <bundle>mvn:com.eclipsesource.jaxrs/publisher/5.3.1</bundle>
@@ -74,6 +73,33 @@
     <bundle dependency="true">mvn:org.jvnet.mimepull/mimepull/1.9.6</bundle>
   </feature>
 
+  <feature name="esh-kat.cpy-swagger-jersey2-1.5.7" version="${project.version}">
+    <feature dependency="true">esh-kat.cpy-jersey-min-2.22.2</feature>
+    <bundle>mvn:de.maggu2810.thirdparty.modified.io.swagger/swagger-jersey2-jaxrs/1.5.7.v20160429-1435</bundle>
+    <bundle dependency="true">mvn:io.swagger/swagger-annotations/1.5.7</bundle>
+    <bundle dependency="true">mvn:io.swagger/swagger-core/1.5.7</bundle>
+    <bundle dependency="true">mvn:io.swagger/swagger-jaxrs/1.5.7</bundle>
+    <bundle dependency="true">mvn:io.swagger/swagger-models/1.5.7</bundle>
+    <bundle dependency="true">mvn:de.maggu2810.thirdparty.modified.org.reflections/reflections/0.9.10.v20160429-1435</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.datatype/jackson-datatype-joda/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.4.5</bundle>
+    <bundle dependency="true">mvn:com.google.code.findbugs/annotations/2.0.1</bundle>
+    <bundle dependency="true">mvn:com.google.guava/guava/18.0</bundle>
+    <bundle dependency="true">mvn:joda-time/joda-time/2.2</bundle>
+    <bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.2.1</bundle>
+    <bundle dependency="true">mvn:org.codehaus.woodstox/stax2-api/3.1.4</bundle>
+    <bundle dependency="true">mvn:org.javassist/javassist/3.19.0-GA</bundle>
+    <bundle dependency="true">mvn:org.slf4j/slf4j-api/1.7.7</bundle>
+    <bundle dependency="true">mvn:org.yaml/snakeyaml/1.12</bundle>
+  </feature>
+
   <feature name="esh-tp-jax-rs-provider-gson" version="${project.version}">
     <capability>esh.tp;feature=jax-rs-provider-gson;version=2.3</capability>
     <feature dependency="true">esh-tp-jax-rs-min</feature>
@@ -82,10 +108,10 @@
   </feature>
 
   <feature name="esh-tp-jax-rs-provider-swagger" version="${project.version}">
-    <capability>esh.tp;feature=jax-rs-provider-swagger;version=2.3</capability>
+    <capability>esh.tp;feature=jax-rs-provider-swagger;version=1.1.1</capability>
     <feature dependency="true">esh-tp-jax-rs-min</feature>
-    <bundle>mvn:de.maggu2810.thirdparty.modified.com.eclipsesource.jaxrs/swagger-all/1.5.5.sp1</bundle>
-    <bundle>mvn:com.eclipsesource.jaxrs/provider-swagger/1.1</bundle>
+    <feature>esh-kat.cpy-swagger-jersey2-1.5.7</feature>
+    <bundle>mvn:com.eclipsesource.jaxrs/provider-swagger/1.1.1</bundle>
   </feature>
 
   <feature name="esh-tp-jupnp" description=" UPnP/DLNA library for Java" version="${project.version}">


### PR DESCRIPTION
This commit does the same for swagger-all that has been done for jersey-min in #1436

This has been two really fat bundles.

* jersey-min about 4.4 MB
* swagger-all about 6.6 MB
