### PR TITLE
fix jersey servlet support

### DIFF
--- a/features/karaf-tp/src/main/feature/feature.xml
+++ b/features/karaf-tp/src/main/feature/feature.xml
@@ -50,16 +50,16 @@
   </feature>
 
   <feature name="esh-kat.cpy-jersey-min-2.22.2" version="${project.version}">
-    <feature dependency="true">http</feature>
-    <bundle>mvn:org.glassfish.jersey.containers/jersey-container-servlet/2.22.2</bundle>
-    <bundle>mvn:org.glassfish.jersey.media/jersey-media-sse/2.22.2</bundle>
-    <bundle>mvn:org.glassfish.jersey.media/jersey-media-multipart/2.22.2</bundle>
-    <bundle dependency="true">mvn:org.glassfish.jersey.containers/jersey-container-servlet-core/2.22.2</bundle>
-    <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-common/2.22.2</bundle>
-    <bundle dependency="true">mvn:org.glassfish.jersey.bundles.repackaged/jersey-guava/2.22.2</bundle>
-    <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-server/2.22.2</bundle>
-    <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-client/2.22.2</bundle>
-    <bundle dependency="true">mvn:org.glassfish.jersey.media/jersey-media-jaxb/2.22.2</bundle>
+    <feature>http</feature>
+    <bundle start-level="30">mvn:org.glassfish.jersey.containers/jersey-container-servlet/2.22.2</bundle>
+    <bundle start-level="30">mvn:org.glassfish.jersey.media/jersey-media-sse/2.22.2</bundle>
+    <bundle start-level="30">mvn:org.glassfish.jersey.media/jersey-media-multipart/2.22.2</bundle>
+    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.containers/jersey-container-servlet-core/2.22.2</bundle>
+    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.core/jersey-common/2.22.2</bundle>
+    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.bundles.repackaged/jersey-guava/2.22.2</bundle>
+    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.core/jersey-server/2.22.2</bundle>
+    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.core/jersey-client/2.22.2</bundle>
+    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.media/jersey-media-jaxb/2.22.2</bundle>
     <bundle dependency="true">mvn:org.glassfish.hk2/hk2-api/2.4.0-b34</bundle>
     <bundle dependency="true">mvn:org.glassfish.hk2/hk2-locator/2.4.0-b34</bundle>
     <bundle dependency="true">mvn:org.glassfish.hk2/hk2-utils/2.4.0-b34</bundle>


### PR DESCRIPTION
If the jersey modules are initiated on the same level as the ones that
registered the ServletContainer class, this could lead to errors using
asyncrhonous processing:
javax.servlet.ServletException: java.lang.UnsupportedOperationException:
Asynchronous processing not supported on Servlet 2.x container.

See e.g.
https://gist.github.com/maggu2810/ef57c2656fa9f76052042da5f70d9d2f

This could be worked around to start the Jersey components in front of
the usage.
The important module is jersey-core-server, that adds support for
servlet 3.x.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>