### PR TITLE
Ease the pain of the incompatible change introduced with #1433.

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -110,6 +110,14 @@ public class Configuration {
         return fields;
     }
 
+    /**
+     * @deprecated Use {@link #get(String)} instead.
+     */
+    @Deprecated
+    public Object get(Object key) {
+        return this.get((String) key);
+    }
+
     public Object get(String key) {
         synchronized (this) {
             return properties.get(key);
@@ -120,6 +128,14 @@ public class Configuration {
         synchronized (this) {
             return properties.put(key, value);
         }
+    }
+
+    /**
+     * @deprecated Use {@link #remove(String)} instead.
+     */
+    @Deprecated
+    public Object remove(Object key) {
+        return remove((String) key);
     }
 
     public Object remove(String key) {


### PR DESCRIPTION
In #1433, a binary incompatible change was introduced, leading to more irritations than expected (#1437, #1446)... 

Therefore, this PR could ease the pain during the transition phase. Once all bindings in the downstream products have been compiled again, we can safely remove the deprecated methods again.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>