### PR TITLE
add another fine tuning of the jersey start levels

### DIFF
--- a/features/karaf-tp/src/main/feature/feature.xml
+++ b/features/karaf-tp/src/main/feature/feature.xml
@@ -51,21 +51,21 @@
 
   <feature name="esh-kat.cpy-jersey-min-2.22.2" version="${project.version}">
     <feature>http</feature>
-    <bundle start-level="30">mvn:org.glassfish.jersey.containers/jersey-container-servlet/2.22.2</bundle>
-    <bundle start-level="30">mvn:org.glassfish.jersey.media/jersey-media-sse/2.22.2</bundle>
-    <bundle start-level="30">mvn:org.glassfish.jersey.media/jersey-media-multipart/2.22.2</bundle>
-    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.containers/jersey-container-servlet-core/2.22.2</bundle>
-    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.core/jersey-common/2.22.2</bundle>
-    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.bundles.repackaged/jersey-guava/2.22.2</bundle>
-    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.core/jersey-server/2.22.2</bundle>
-    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.core/jersey-client/2.22.2</bundle>
-    <bundle start-level="30" dependency="true">mvn:org.glassfish.jersey.media/jersey-media-jaxb/2.22.2</bundle>
-    <bundle dependency="true">mvn:org.glassfish.hk2/hk2-api/2.4.0-b34</bundle>
-    <bundle dependency="true">mvn:org.glassfish.hk2/hk2-locator/2.4.0-b34</bundle>
-    <bundle dependency="true">mvn:org.glassfish.hk2/hk2-utils/2.4.0-b34</bundle>
-    <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/1.0.1</bundle>
-    <bundle dependency="true">mvn:org.glassfish.hk2.external/javax.inject/2.4.0-b34</bundle>
-    <bundle dependency="true">mvn:org.glassfish.hk2.external/aopalliance-repackaged/2.4.0-b34</bundle>
+    <bundle start-level="36">mvn:org.glassfish.jersey.containers/jersey-container-servlet/2.22.2</bundle>
+    <bundle start-level="36">mvn:org.glassfish.jersey.media/jersey-media-sse/2.22.2</bundle>
+    <bundle start-level="36">mvn:org.glassfish.jersey.media/jersey-media-multipart/2.22.2</bundle>
+    <bundle start-level="36" dependency="true">mvn:org.glassfish.jersey.containers/jersey-container-servlet-core/2.22.2</bundle>
+    <bundle start-level="36" dependency="true">mvn:org.glassfish.jersey.core/jersey-common/2.22.2</bundle>
+    <bundle start-level="36" dependency="true">mvn:org.glassfish.jersey.bundles.repackaged/jersey-guava/2.22.2</bundle>
+    <bundle start-level="36" dependency="true">mvn:org.glassfish.jersey.core/jersey-server/2.22.2</bundle>
+    <bundle start-level="36" dependency="true">mvn:org.glassfish.jersey.core/jersey-client/2.22.2</bundle>
+    <bundle start-level="36" dependency="true">mvn:org.glassfish.jersey.media/jersey-media-jaxb/2.22.2</bundle>
+    <bundle start-level="33" dependency="true">mvn:org.glassfish.hk2/hk2-api/2.4.0-b34</bundle>
+    <bundle start-level="33" dependency="true">mvn:org.glassfish.hk2/hk2-locator/2.4.0-b34</bundle>
+    <bundle start-level="33" dependency="true">mvn:org.glassfish.hk2/hk2-utils/2.4.0-b34</bundle>
+    <bundle start-level="33" dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/1.0.1</bundle>
+    <bundle start-level="33" dependency="true">mvn:org.glassfish.hk2.external/javax.inject/2.4.0-b34</bundle>
+    <bundle start-level="33" dependency="true">mvn:org.glassfish.hk2.external/aopalliance-repackaged/2.4.0-b34</bundle>
     <bundle dependency="true">mvn:javax.annotation/javax.annotation-api/1.2</bundle>
     <bundle dependency="true">mvn:javax.validation/validation-api/1.1.0.Final</bundle>
     <bundle dependency="true">mvn:javax.ws.rs/javax.ws.rs-api/2.0.1</bundle>


### PR DESCRIPTION
Without this start-level tuning you can run in a
HTTP ERROR 503: Jersey is not ready yet!

The OSGi console log could look similar to this one:

```text
2016-05-04 17:27:10,704 | ERROR | lixDispatchQueue | sse                              | 172 - org.eclipse.smarthome.io.rest.sse - 0.8.0.a16 | FrameworkEvent ERROR - org.eclipse.smarthome.io.rest.sse
org.osgi.framework.BundleException: Activator start error in bundle org.eclipse.smarthome.io.rest.sse [172].
	at org.apache.felix.framework.Felix.activateBundle(Felix.java:2276)[org.apache.felix.framework-5.4.0.jar:]
	at org.apache.felix.framework.Felix.startBundle(Felix.java:2144)[org.apache.felix.framework-5.4.0.jar:]
	at org.apache.felix.framework.Felix.setActiveStartLevel(Felix.java:1371)[org.apache.felix.framework-5.4.0.jar:]
	at org.apache.felix.framework.FrameworkStartLevelImpl.run(FrameworkStartLevelImpl.java:308)[org.apache.felix.framework-5.4.0.jar:]
	at java.lang.Thread.run(Thread.java:745)[:1.8.0_74]
Caused by: java.lang.ExceptionInInitializerError
	at org.eclipse.smarthome.io.rest.sse.internal.SseActivator.start(SseActivator.java:44)
	at org.apache.felix.framework.util.SecureAction.startActivator(SecureAction.java:697)
	at org.apache.felix.framework.Felix.activateBundle(Felix.java:2226)
	... 4 more
Caused by: java.lang.RuntimeException: java.lang.ClassNotFoundException: Provider org.glassfish.jersey.server.internal.RuntimeDelegateImpl could not be instantiated: java.lang.IllegalStateException: No generator was provided and there is no default generator registered
	at javax.ws.rs.ext.RuntimeDelegate.findDelegate(RuntimeDelegate.java:152)[34:javax.ws.rs-api:2.0.1]
	at javax.ws.rs.ext.RuntimeDelegate.getInstance(RuntimeDelegate.java:120)[34:javax.ws.rs-api:2.0.1]
	at javax.ws.rs.core.MediaType.valueOf(MediaType.java:179)[34:javax.ws.rs-api:2.0.1]
	at org.glassfish.jersey.media.sse.SseFeature.<clinit>(SseFeature.java:62)[218:org.glassfish.jersey.media.jersey-media-sse:2.22.2]
	... 7 more
Caused by: java.lang.ClassNotFoundException: Provider org.glassfish.jersey.server.internal.RuntimeDelegateImpl could not be instantiated: java.lang.IllegalStateException: No generator was provided and there is no default generator registered
	at javax.ws.rs.ext.FactoryFinder.newInstance(FactoryFinder.java:122)[34:javax.ws.rs-api:2.0.1]
	at javax.ws.rs.ext.FactoryFinder.find(FactoryFinder.java:213)[34:javax.ws.rs-api:2.0.1]
	at javax.ws.rs.ext.RuntimeDelegate.findDelegate(RuntimeDelegate.java:135)[34:javax.ws.rs-api:2.0.1]
	... 10 more
Caused by: java.lang.IllegalStateException: No generator was provided and there is no default generator registered
	at org.glassfish.hk2.internal.ServiceLocatorFactoryImpl.internalCreate(ServiceLocatorFactoryImpl.java:308)[205:org.glassfish.hk2.api:2.4.0.b34]
	at org.glassfish.hk2.internal.ServiceLocatorFactoryImpl.create(ServiceLocatorFactoryImpl.java:293)[205:org.glassfish.hk2.api:2.4.0.b34]
	at org.glassfish.jersey.internal.inject.Injections._createLocator(Injections.java:138)[215:org.glassfish.jersey.core.jersey-common:2.22.2]
	at org.glassfish.jersey.internal.inject.Injections.createLocator(Injections.java:109)[215:org.glassfish.jersey.core.jersey-common:2.22.2]
	at org.glassfish.jersey.server.internal.RuntimeDelegateImpl.<init>(RuntimeDelegateImpl.java:64)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)[:1.8.0_74]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)[:1.8.0_74]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)[:1.8.0_74]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)[:1.8.0_74]
	at java.lang.Class.newInstance(Class.java:442)[:1.8.0_74]
	at javax.ws.rs.ext.FactoryFinder.newInstance(FactoryFinder.java:118)[34:javax.ws.rs-api:2.0.1]
	... 12 more
```

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>