### PR TITLE
transform.scale: drop usage of Guava

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
@@ -4,8 +4,7 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.8.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: com.google.common.collect,
- org.eclipse.smarthome.core.transform,
+Import-Package: org.eclipse.smarthome.core.transform,
  org.slf4j
 Bundle-SymbolicName: org.eclipse.smarthome.transform.scale
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/Range.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/Range.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2016 Markus Rathgeb.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.transform.scale.internal;
+
+import java.math.BigDecimal;
+
+/**
+ * Range implementation using BigDecimals.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+public class Range {
+
+    public static Range open(final BigDecimal lower, final BigDecimal upper) {
+        return new Range(lower, false, upper, false);
+    }
+
+    public static Range closed(final BigDecimal lower, final BigDecimal upper) {
+        return new Range(lower, true, upper, true);
+    }
+
+    public static Range openClosed(final BigDecimal lower, final BigDecimal upper) {
+        return new Range(lower, false, upper, true);
+    }
+
+    public static Range closedOpen(final BigDecimal lower, final BigDecimal upper) {
+        return new Range(lower, true, upper, false);
+    }
+
+    public static Range greaterThan(final BigDecimal lower) {
+        return new Range(lower, false, null, false);
+    }
+
+    public static Range atLeast(final BigDecimal lower) {
+        return new Range(lower, true, null, false);
+    }
+
+    public static Range lessThan(final BigDecimal upper) {
+        return new Range(null, false, upper, false);
+    }
+
+    public static Range atMost(final BigDecimal upper) {
+        return new Range(null, false, upper, true);
+    }
+
+    public static Range all() {
+        return new Range(null, false, null, false);
+    }
+
+    public static Range range(final BigDecimal lower, final boolean lowerInclusive, final BigDecimal upper,
+            final boolean upperInclusive) {
+        return new Range(lower, lowerInclusive, upper, upperInclusive);
+    }
+
+    final BigDecimal min;
+    final boolean minInclusive;
+    final BigDecimal max;
+    final boolean maxInclusive;
+
+    private Range(final BigDecimal min, final boolean minInclusive, final BigDecimal max, final boolean maxInclusive) {
+        this.min = min;
+        this.minInclusive = minInclusive;
+        this.max = max;
+        this.maxInclusive = maxInclusive;
+    }
+
+    public boolean contains(final BigDecimal value) {
+        final boolean minMatch;
+        if (min == null) {
+            minMatch = true;
+        } else {
+            int cmp = value.compareTo(min);
+            if (minInclusive) {
+                minMatch = cmp == 0 || cmp == 1;
+            } else {
+                minMatch = cmp == 1;
+            }
+        }
+
+        if (!minMatch) {
+            return false;
+        }
+
+        final boolean maxMatch;
+        if (max == null) {
+            maxMatch = true;
+        } else {
+            int cmp = value.compareTo(max);
+            if (maxInclusive) {
+                maxMatch = cmp == 0 || cmp == -1;
+            } else {
+                maxMatch = cmp == -1;
+            }
+        }
+
+        if (!maxMatch) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/ScaleTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/ScaleTransformationService.java
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.transform.scale.internal;
 
 import java.io.FileReader;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -22,22 +23,19 @@ import org.eclipse.smarthome.core.transform.TransformationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.BoundType;
-import com.google.common.collect.Range;
-import com.google.common.collect.Ranges;
-
 /**
  * The implementation of {@link TransformationService} which transforms the
  * input by matching it between limits of ranges in a scale file
  *
  * @author Gaël L'hopital
+ * @author Markus Rathgeb - drop usage of Guava
  */
-public class ScaleTransformationService extends AbstractFileTransformationService<Map<Range<Double>, String>> {
+public class ScaleTransformationService extends AbstractFileTransformationService<Map<Range, String>> {
 
     private final Logger logger = LoggerFactory.getLogger(ScaleTransformationService.class);
 
     /** RegEx to extract a scale definition */
-    private static final Pattern limits_pattern = Pattern.compile("(\\[|\\])(.*)\\.\\.(.*)(\\[|\\])");
+    private static final Pattern LIMITS_PATTERN = Pattern.compile("(\\[|\\])(.*)\\.\\.(.*)(\\[|\\])");
 
     /**
      * <p>
@@ -54,12 +52,12 @@ public class ScaleTransformationService extends AbstractFileTransformationServic
      *
      */
     @Override
-    protected String internalTransform(Map<Range<Double>, String> data, String source) throws TransformationException {
+    protected String internalTransform(Map<Range, String> data, String source) throws TransformationException {
 
         try {
-            Double value = new Double(source);
+            final BigDecimal value = new BigDecimal(source);
 
-            for (Range<Double> range : data.keySet()) {
+            for (final Range range : data.keySet()) {
                 if (range.contains(value)) {
                     return data.get(range);
                 }
@@ -72,39 +70,43 @@ public class ScaleTransformationService extends AbstractFileTransformationServic
     }
 
     @Override
-    protected Map<Range<Double>, String> internalLoadTransform(String filename) throws TransformationException {
+    protected Map<Range, String> internalLoadTransform(String filename) throws TransformationException {
         try {
-            Properties properties = new Properties();
+            final Properties properties = new Properties();
             properties.load(new FileReader(filename));
-            Map<Range<Double>, String> data = new HashMap<>();
+            final Map<Range, String> data = new HashMap<>();
 
             for (Entry<Object, Object> f : properties.entrySet()) {
-                String key = (String) f.getKey();
-                String value = properties.getProperty(key);
-                Matcher matcher = limits_pattern.matcher(key);
+                final String key = (String) f.getKey();
+                final String value = properties.getProperty(key);
+                final Matcher matcher = LIMITS_PATTERN.matcher(key);
                 if (matcher.matches() && (matcher.groupCount() == 4)) {
 
-                    BoundType lowBoundType = matcher.group(1).equals("]") ? BoundType.OPEN : BoundType.CLOSED;
-                    BoundType highBoundType = matcher.group(4).equals("[") ? BoundType.OPEN : BoundType.CLOSED;
+                    final boolean lowerInclusive = matcher.group(1).equals("]") ? false : true;
+                    final boolean upperInclusive = matcher.group(4).equals("[") ? false : true;
 
-                    String lowLimit = matcher.group(2);
-                    String highLimit = matcher.group(3);
+                    final String lowLimit = matcher.group(2);
+                    final String highLimit = matcher.group(3);
 
-                    Double lowValue = null;
-                    Double highValue = null;
+                    final BigDecimal lowValue;
+                    final BigDecimal highValue;
 
                     try {
-                        if (!lowLimit.isEmpty()) {
-                            lowValue = new Double(lowLimit);
+                        if (lowLimit.isEmpty()) {
+                            lowValue = null;
+                        } else {
+                            lowValue = new BigDecimal(lowLimit);
                         }
-                        if (!highLimit.isEmpty()) {
-                            highValue = new Double(highLimit);
+                        if (highLimit.isEmpty()) {
+                            highValue = null;
+                        } else {
+                            highValue = new BigDecimal(highLimit);
                         }
-                    } catch (NumberFormatException e) {
-                        throw new TransformationException("Error parsing bounds : " + lowLimit + ".." + highLimit);
+                    } catch (final NumberFormatException ex) {
+                        throw new TransformationException("Error parsing bounds: " + lowLimit + ".." + highLimit);
                     }
 
-                    Range<Double> range = getRange(lowBoundType, highBoundType, lowValue, highValue);
+                    final Range range = Range.range(lowValue, lowerInclusive, highValue, upperInclusive);
 
                     data.put(range, value);
 
@@ -113,23 +115,9 @@ public class ScaleTransformationService extends AbstractFileTransformationServic
                 }
             }
             return data;
-        } catch (IOException e) {
-            throw new TransformationException("An error occured while opening file.", e);
+        } catch (final IOException ex) {
+            throw new TransformationException("An error occured while opening file.", ex);
         }
-    }
-
-    private Range<Double> getRange(BoundType lowBoundType, BoundType highBoundType, Double lowValue, Double highValue) {
-
-        if (lowValue == null && highValue == null) {
-            return Ranges.all();
-        } else if (lowValue == null) {
-            return Ranges.upTo(highValue, highBoundType);
-        } else if (highValue == null) {
-            return Ranges.downTo(lowValue, lowBoundType);
-        } else {
-            return Ranges.range(lowValue, lowBoundType, highValue, highBoundType);
-        }
-
     }
 
 }


### PR DESCRIPTION
I think for the simple Range logic we can drop the Guava dependency at all.

It needs further tests / review, I just run the existing transform.range.tests and it succeeded.
Will report if I tested it against a previously broken system.

Fixes: openhab/openhab-distro#204
