### PR TITLE
fix minimum / maximum text

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -97,7 +97,7 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
     }
 
     $scope.getMinText = function(item) {
-        if (!item.stateDescription || !item.stateDescription.minimum) {
+        if (!item.stateDescription || isNaN(item.stateDescription.minimum)) {
             return '';
         } else if (!item.stateDescription.pattern) {
             return item.stateDescription.minimum;
@@ -107,7 +107,7 @@ angular.module('PaperUI.controllers.control', []).controller('ControlPageControl
     }
 
     $scope.getMaxText = function(item) {
-        if (!item.stateDescription || !item.stateDescription.maximum) {
+        if (!item.stateDescription || isNaN(item.stateDescription.maximum)) {
             return '';
         } else if (!item.stateDescription.pattern) {
             return item.stateDescription.maximum;


### PR DESCRIPTION
If the minimum / maximim is set to some value that evaluates to false
(e.g. 0, 0.0, ...) then the minimum / maximum text is not shown.
The slider element is shown only if the minimum and maximum text
evaluates to true.
So with the current test no slider is shown if the min / max is e.g. 0,
0.0, ...

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>