### PR TITLE
DimmerItems were not converting DecimalTypes correctly, also group it…

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunctionTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunctionTest.java
@@ -78,7 +78,7 @@ public class ArithmeticGroupFunctionTest {
     @Test
     public void testOrFunction_differntTypes() {
         DimmerItem dimmer1 = new DimmerItem("TestDimmer1");
-        dimmer1.setState(new DecimalType("42"));
+        dimmer1.setState(new PercentType("42"));
         DimmerItem dimmer2 = new DimmerItem("TestDimmer2");
         dimmer2.setState(new DecimalType("0"));
         SwitchItem switch1 = new SwitchItem("TestSwitch1");

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -52,7 +52,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * Returns the base item of this {@link GroupItem}. This method is only
      * intended to allow instance checks of the underlying BaseItem. It must
      * not be changed in any way.
-     * 
+     *
      * @return the base item of this GroupItem
      */
     public GenericItem getBaseItem() {
@@ -62,7 +62,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     /**
      * Returns the direct members of this {@link GroupItem} regardless if these
      * members are {@link GroupItem}s as well.
-     * 
+     *
      * @return the direct members of this {@link GroupItem}
      */
     public Set<Item> getMembers() {
@@ -73,7 +73,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * Returns the direct members of this {@link GroupItem} and recursively all
      * members of the potentially contained {@link GroupItem}s as well. The {@link GroupItem}s itself aren't contained.
      * The returned items are unique.
-     * 
+     *
      * @return all members of this and all contained {@link GroupItem}s
      */
     public Set<Item> getAllMembers() {
@@ -112,7 +112,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * The accepted data types of a group item is the same as of the underlying base item.
      * If none is defined, the intersection of all sets of accepted data types of all group
      * members is used instead.
-     * 
+     *
      * @return the accepted data types of this group item
      */
     @Override
@@ -139,7 +139,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * The accepted command types of a group item is the same as of the underlying base item.
      * If none is defined, the intersection of all sets of accepted command types of all group
      * members is used instead.
-     * 
+     *
      * @return the accepted command types of this group item
      */
     @Override
@@ -248,7 +248,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @{inheritDoc
      */
     @Override
-    public void stateChanged(Item item, State oldState, State newState) { 
+    public void stateChanged(Item item, State oldState, State newState) {
     }
 
     /**
@@ -263,9 +263,15 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         }
     }
 
+    @Override
     public void setState(State state) {
         State oldState = this.state;
-        this.state = state;
+        if (baseItem != null) {
+            baseItem.setState(state);
+            this.state = baseItem.getState();
+        } else {
+            this.state = state;
+        }
         notifyListeners(oldState, state);
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
@@ -51,7 +51,7 @@ public class DimmerItem extends SwitchItem {
         super(CoreItemFactory.DIMMER, name);
     }
 
-    /* package */DimmerItem(String type, String name) {
+    /* package */ DimmerItem(String type, String name) {
         super(type, name);
     }
 
@@ -79,6 +79,8 @@ public class DimmerItem extends SwitchItem {
             super.setState(PercentType.ZERO);
         } else if (state == OnOffType.ON) {
             super.setState(PercentType.HUNDRED);
+        } else if (state.getClass() == DecimalType.class) {
+            super.setState(new PercentType(((DecimalType) state).toBigDecimal().multiply(new BigDecimal(100))));
         } else {
             super.setState(state);
         }
@@ -96,8 +98,8 @@ public class DimmerItem extends SwitchItem {
             return state.equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON;
         } else if (typeClass == DecimalType.class) {
             if (state instanceof PercentType) {
-                return new DecimalType(((PercentType) state).toBigDecimal().divide(new BigDecimal(100), 8,
-                        RoundingMode.UP));
+                return new DecimalType(
+                        ((PercentType) state).toBigDecimal().divide(new BigDecimal(100), 8, RoundingMode.UP));
             }
         } else if (typeClass == PercentType.class) {
             if (state instanceof DecimalType) {


### PR DESCRIPTION
…ems where not using the their base item when setting state.  This fixes #1476

Signed-off-by: Dan Cunningham <dan@digitaldan.com>