### PR TITLE
Paper UI: fix broken bridge configuration

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -539,14 +539,20 @@ angular.module('PaperUI.controllers.configuration', []).controller('Configuratio
                 thingRepository.update(thing);
             });
         }
-
+        var dict = {};
+        var update = false;
         if (originalThing.label !== thing.label) {
+            dict.label = thing.label;
+            update = true;
+        }
+        if (originalThing.bridgeUID !== thing.bridgeUID) {
+            dict.bridgeUID = thing.bridgeUID
+            update = true;
+        }
+        if (update) {
             thingService.update({
                 thingUID : thing.UID
-            }, {
-                label : thing.label,
-                configuration : {}
-            });
+            }, dict);
         }
         toastService.showDefaultToast('Thing updated');
         $scope.navigateTo('things/view/' + thing.UID);


### PR DESCRIPTION
If you edit a thing the Paper UI itself allows to edit the label, the
bridge and the configuration.
The JavaScript does not send a changed Bridge UID.
