### PR TITLE
introduced "Default" widget type for sitemaps that is dynamically resolved

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
@@ -15,7 +15,7 @@ Widget:
 	(LinkableWidget | NonLinkableWidget);
 
 NonLinkableWidget:
-	Switch | Selection | Slider | List | Setpoint | Video | Chart | Webview | Colorpicker | Mapview;
+	Switch | Selection | Slider | List | Setpoint | Video | Chart | Webview | Colorpicker | Mapview | Default;
 
 LinkableWidget:
 	(Text | Group | Image | Frame)
@@ -112,6 +112,13 @@ Setpoint:
 
 Colorpicker:
 	'Colorpicker' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? & ('sendFrequency=' frequency=INT)? & 
+		('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
+		('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
+		('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)* ']'))?);
+
+Default:
+	'Default' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? & 
+		('height=' height=INT)? &
 		('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
 		('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
 		('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)* ']'))?);

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/FrameRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/FrameRenderer.java
@@ -53,6 +53,6 @@ public class FrameRenderer extends AbstractWidgetRenderer {
         snippet = processColor(w, snippet);
 
         sb.append(snippet);
-        return ((Frame) w).getChildren();
+        return itemUIRegistry.getChildren((Frame) w);
     }
 }

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/PageRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/PageRenderer.java
@@ -105,7 +105,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
             EObject firstChild = children.get(0);
             EObject parent = firstChild.eContainer();
             if (!(firstChild instanceof Frame || parent instanceof Frame || parent instanceof Sitemap
-                    || parent instanceof List)) {
+                    || parent instanceof org.eclipse.smarthome.model.sitemap.List)) {
                 String frameSnippet = getSnippet("frame");
                 frameSnippet = StringUtils.replace(frameSnippet, "%label%", "");
                 frameSnippet = StringUtils.replace(frameSnippet, "%frame_class%", "mdl-form--no-label");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/FrameRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/FrameRenderer.java
@@ -45,6 +45,6 @@ public class FrameRenderer extends AbstractWidgetRenderer {
         snippet = processColor(w, snippet);
 
         sb.append(snippet);
-        return ((Frame) w).getChildren();
+        return itemUIRegistry.getChildren((Frame) w);
     }
 }


### PR DESCRIPTION
This partially addresses #635 as it is now possible to simply use a "Default" widget with a Player item, so that the switch buttons are rendered.

Signed-off-by: Kai Kreuzer <kai@openhab.org>