### PR TITLE
Added the SleepTimer Channel

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
@@ -48,6 +48,7 @@
 			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
 			<channel id="linein" typeId="linein" />
 	        <channel id="playlinein" typeId="playlinein" />
+	        <channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
@@ -49,6 +49,7 @@
 			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
 			<channel id="linein" typeId="linein" />
 	        <channel id="playlinein" typeId="playlinein" />
+	        <channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
@@ -46,6 +46,7 @@
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
 			<channel id="coordinator" typeId="coordinator" />
+            <channel id="sleeptimer" typeId="sleeptimer" />    
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
@@ -46,6 +46,7 @@
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
 			<channel id="coordinator" typeId="coordinator" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
@@ -49,6 +49,7 @@
 			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
 			<channel id="linein" typeId="linein" />
 	        <channel id="playlinein" typeId="playlinein" />
+	        <channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
@@ -45,6 +45,7 @@
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
 			<channel id="coordinator" typeId="coordinator" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
@@ -46,6 +46,7 @@
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
 			<channel id="coordinator" typeId="coordinator" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
@@ -246,4 +246,9 @@
 		<description>Play the Line-in of the the Zone Player corresponding to the given UIN</description>
 	</channel-type>
 
+    <channel-type id="sleeptimer" advanced="true">
+        <item-type>String</item-type>
+        <label>Sleep Timer</label>
+        <description>Set/show the duration of the Sleeptimer</description>
+    </channel-type> 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
@@ -44,6 +44,7 @@
 			<channel id="zonegroup" typeId="zonegroup" />
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 
 		<config-description>
@@ -268,5 +269,11 @@
 		<label>Zone Name</label>
 		<description>Name of the Zone Group the Zone Player belongs to</description>
 	</channel-type>
+	
+    <channel-type id="sleeptimer" advanced="true">
+        <item-type>String</item-type>
+        <label>Sleep Timer</label>
+        <description>Duration of the Sleeptimer</description>
+    </channel-type>	
 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/SonosBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/SonosBindingConstants.java
@@ -18,7 +18,7 @@ import com.google.common.collect.Sets;
 /**
  * The {@link SonosBinding} class defines common constants, which are
  * used across the whole binding.
- * 
+ *
  * @author Karel Goderis - Initial contribution
  */
 public class SonosBindingConstants {
@@ -87,5 +87,6 @@ public class SonosBindingConstants {
     public final static String ZONENAME = "zonename";
     public final static String COORDINATOR = "coordinator";
     public final static String MODELID = "modelId";
+    public final static String SLEEPTIMER = "sleeptimer";
 
 }


### PR DESCRIPTION
Hi,

I added the channel for the sleep timer of Sonos.
For me it works fine. Only issue I still have is, that the classic UI (and Android App) does not show the remaining time (basic UI does). Switches works fine in both UIs.
Here the example snippets:

Items:
```
Switch DemoSwitch                          "Switch"
String SleepTimerSwitch                  "SleepTimerSwitch" 
```

Sitemap:
```
Switch item=SleepTimerSwitch mappings=[""="OFF", "00:30:00"="30 min", "01:00:00"="1h"]
Text item=SleepTimerRemain
```

Rule:
```
rule "TestSleepTimer" 
    when
        Item SleepTimerSwitch received update
    then
        sendCommand(SleepTimerRemain,SleepTimerSwitch.state.toString())
        logInfo("Sonos-SleepTimer", "sleep "+SleepTimerSwitch.state.toString()))
end
```
I use the SleepTimer mainly in rules => for me the problem with the classic UI is not a real problem, but maybe you have a hint, what could be the problem.

lg, Jürgen