### PR TITLE
Added SleepTimer Channel

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
@@ -48,6 +48,7 @@
 			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
 			<channel id="linein" typeId="linein" />
 	        <channel id="playlinein" typeId="playlinein" />
+	        <channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
@@ -49,6 +49,7 @@
 			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
 			<channel id="linein" typeId="linein" />
 	        <channel id="playlinein" typeId="playlinein" />
+	        <channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="sonos"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="sonos" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -27,8 +26,8 @@
 			<channel id="notificationsound" typeId="notificationsound" />
 			<channel id="notificationvolume" typeId="notificationvolume" />
 			<channel id="playlist" typeId="playlist" />
-			<channel id="playqueue" typeId="playqueue" />			
-			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playqueue" typeId="playqueue" />
+			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />
 			<channel id="publicaddress" typeId="publicaddress" />
 			<channel id="radio" typeId="radio" />
@@ -48,14 +47,14 @@
 			<channel id="coordinator" typeId="coordinator" />
 			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
 			<channel id="linein" typeId="linein" />
-	        <channel id="playlinein" typeId="playlinein" />
-	        <channel id="sleeptimer" typeId="sleeptimer" />
+			<channel id="playlinein" typeId="playlinein" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
-		
+
 		<properties>
-        	<property name="vendor">SONOS</property>
-        	<property name="modelId">CONNECT:AMP</property>
-        </properties>
+			<property name="vendor">SONOS</property>
+			<property name="modelId">CONNECT:AMP</property>
+		</properties>
 
 		<config-description>
 			<parameter name="udn" type="text">

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
@@ -46,6 +46,7 @@
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
 			<channel id="coordinator" typeId="coordinator" />
+            <channel id="sleeptimer" typeId="sleeptimer" />    
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
@@ -46,6 +46,7 @@
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
 			<channel id="coordinator" typeId="coordinator" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
@@ -49,6 +49,7 @@
 			<!-- Extended SONOS channels (PLAY5, CONNECT & CONNECT:AMP only) -->
 			<channel id="linein" typeId="linein" />
 	        <channel id="playlinein" typeId="playlinein" />
+	        <channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
@@ -45,6 +45,7 @@
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
 			<channel id="coordinator" typeId="coordinator" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
@@ -46,6 +46,7 @@
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
 			<channel id="coordinator" typeId="coordinator" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 		
 		<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
@@ -246,4 +246,9 @@
 		<description>Play the Line-in of the the Zone Player corresponding to the given UIN</description>
 	</channel-type>
 
+    <channel-type id="sleeptimer" advanced="true">
+        <item-type>String</item-type>
+        <label>Sleep Timer</label>
+        <description>Set/show the duration of the Sleeptimer</description>
+    </channel-type> 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
@@ -250,5 +250,6 @@
         <item-type>Number</item-type>
         <label>Sleep Timer</label>
         <description>Set/show the duration of the SleepTimer in seconds</description>
+        <state min="0" max="68399" step="1" readOnly="false"> </state>
     </channel-type> 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
@@ -247,8 +247,8 @@
 	</channel-type>
 
     <channel-type id="sleeptimer" advanced="true">
-        <item-type>String</item-type>
+        <item-type>Number</item-type>
         <label>Sleep Timer</label>
-        <description>Set/show the duration of the Sleeptimer</description>
+        <description>Set/show the duration of the SleepTimer in seconds</description>
     </channel-type> 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="sonos"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="sonos" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -37,7 +36,7 @@
 		<description>Control the Zone Player, e.g. start/stop/next/previous/ffward/rewind</description>
 		<category>Player</category>
 	</channel-type>
-	
+
 	<channel-type id="currentalbum">
 		<item-type>String</item-type>
 		<label>Current Album</label>
@@ -67,7 +66,7 @@
 		<label>Favorite</label>
 		<description>Play the given favorite entry. The favorite entry has to be predefined in the Sonos Controller app</description>
 	</channel-type>
-	
+
 	<channel-type id="led" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Led</label>
@@ -88,13 +87,13 @@
 		<description>Set or get the mute state of the master volume of the Zone Player</description>
 		<category>Switch</category>
 	</channel-type>
-	
+
 	<channel-type id="notificationsound" advanced="true">
 		<item-type>String</item-type>
 		<label>Notification Sound</label>
 		<description>Play a notification sound by a given URI</description>
 	</channel-type>
-	
+
 	<channel-type id="notificationvolume" advanced="true">
 		<item-type>Dimmer</item-type>
 		<label>Notification Sound Volume</label>
@@ -119,8 +118,8 @@
 		<item-type>Number</item-type>
 		<label>Play Track</label>
 		<description>Play the given track number from the current queue</description>
-	</channel-type>	
-	
+	</channel-type>
+
 	<channel-type id="playuri" advanced="true">
 		<item-type>String</item-type>
 		<label>Play URI</label>
@@ -214,7 +213,7 @@
 		<description>XML formatted string with the current zonegroup configuration</description>
 	</channel-type>
 
-	<channel-type id="zonegroupid"  advanced="true">
+	<channel-type id="zonegroupid" advanced="true">
 		<item-type>String</item-type>
 		<label>Zone Group ID</label>
 		<description>Id of the Zone Group the Zone Player belongs to</description>
@@ -225,13 +224,13 @@
 		<label>Zone Name</label>
 		<description>Name of the Zone Group the Zone Player belongs to</description>
 	</channel-type>
-	
+
 	<channel-type id="coordinator" advanced="true">
 		<item-type>String</item-type>
 		<label>Coordinator</label>
 		<description>UDN of the coordinator for the current group</description>
-	</channel-type>	
-	
+	</channel-type>
+
 	<!-- Extended channels (for SONOS PLAY5, CONNECT & CONNECT:AMP only) -->
 	<channel-type id="linein" advanced="true">
 		<item-type>Switch</item-type>
@@ -239,17 +238,18 @@
 		<description>Indicator set to ON when the line-in of the Zone Player is connected</description>
 		<category>Switch</category>
 	</channel-type>
-	
+
 	<channel-type id="playlinein" advanced="true">
 		<item-type>String</item-type>
 		<label>Play Line-in</label>
 		<description>Play the Line-in of the the Zone Player corresponding to the given UIN</description>
 	</channel-type>
 
-    <channel-type id="sleeptimer" advanced="true">
-        <item-type>Number</item-type>
-        <label>Sleep Timer</label>
-        <description>Set/show the duration of the SleepTimer in seconds</description>
-        <state min="0" max="68399" step="1" readOnly="false"> </state>
-    </channel-type> 
+	<channel-type id="sleeptimer" advanced="true">
+		<item-type>Number</item-type>
+		<label>Sleep Timer</label>
+		<description>Set/show the duration of the SleepTimer in seconds</description>
+		<state min="0" max="68399" step="1" readOnly="false">
+		</state>
+	</channel-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
@@ -44,6 +44,7 @@
 			<channel id="zonegroup" typeId="zonegroup" />
 			<channel id="zonegroupid" typeId="zonegroupid" />
 			<channel id="zonename" typeId="zonename" />
+			<channel id="sleeptimer" typeId="sleeptimer" />
 		</channels>
 
 		<config-description>
@@ -268,5 +269,11 @@
 		<label>Zone Name</label>
 		<description>Name of the Zone Group the Zone Player belongs to</description>
 	</channel-type>
+	
+    <channel-type id="sleeptimer" advanced="true">
+        <item-type>String</item-type>
+        <label>Sleep Timer</label>
+        <description>Duration of the Sleeptimer</description>
+    </channel-type>	
 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="sonos"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="sonos" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -26,8 +25,8 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="playlinein" typeId="playlinein" />
 			<channel id="playlist" typeId="playlist" />
-			<channel id="playqueue" typeId="playqueue" />			
-			<channel id="playtrack" typeId="playtrack" />			
+			<channel id="playqueue" typeId="playqueue" />
+			<channel id="playtrack" typeId="playtrack" />
 			<channel id="playuri" typeId="playuri" />
 			<channel id="publicaddress" typeId="publicaddress" />
 			<channel id="radio" typeId="radio" />
@@ -93,8 +92,8 @@
 		<description>Control the Zone Player, e.g. start/stop/next/previous/ffward/rewind</description>
 		<category>Player</category>
 	</channel-type>
-	
-		<channel-type id="currentalbum">
+
+	<channel-type id="currentalbum">
 		<item-type>String</item-type>
 		<label>Current Album</label>
 		<description>Name of the album currently playing</description>
@@ -123,7 +122,7 @@
 		<label>Favorite</label>
 		<description>Play the given favorite entry. The favorite entry has to be predefined in the Sonos Controller app</description>
 	</channel-type>
-	
+
 	<channel-type id="led" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Led</label>
@@ -170,8 +169,8 @@
 		<item-type>Number</item-type>
 		<label>Play Track</label>
 		<description>Play the given track number from the current queue</description>
-	</channel-type>	
-	
+	</channel-type>
+
 	<channel-type id="playuri" advanced="true">
 		<item-type>String</item-type>
 		<label>Play URI</label>
@@ -269,12 +268,14 @@
 		<label>Zone Name</label>
 		<description>Name of the Zone Group the Zone Player belongs to</description>
 	</channel-type>
-	
-    <channel-type id="sleeptimer" advanced="true">
-        <item-type>Number</item-type>
-        <label>Sleep Timer</label>
-        <state min="0" max="68399" step="1" readOnly="false"> </state>
-        <description>Set/show the duration of the SleepTimer in seconds</description>
-    </channel-type> 
+
+	<channel-type id="sleeptimer" advanced="true">
+		<item-type>Number</item-type>
+		<label>Sleep Timer</label>
+		<description>Set/show the duration of the SleepTimer in seconds</description>
+		<state min="0" max="68399" step="1" readOnly="false">
+		</state>
+
+	</channel-type>
 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
@@ -273,6 +273,7 @@
     <channel-type id="sleeptimer" advanced="true">
         <item-type>Number</item-type>
         <label>Sleep Timer</label>
+        <state min="0" max="68399" step="1" readOnly="false"> </state>
         <description>Set/show the duration of the SleepTimer in seconds</description>
     </channel-type> 
 

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/thing-types.xml
@@ -271,9 +271,9 @@
 	</channel-type>
 	
     <channel-type id="sleeptimer" advanced="true">
-        <item-type>String</item-type>
+        <item-type>Number</item-type>
         <label>Sleep Timer</label>
-        <description>Duration of the Sleeptimer</description>
-    </channel-type>	
+        <description>Set/show the duration of the SleepTimer in seconds</description>
+    </channel-type> 
 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/SonosBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/SonosBindingConstants.java
@@ -18,7 +18,7 @@ import com.google.common.collect.Sets;
 /**
  * The {@link SonosBinding} class defines common constants, which are
  * used across the whole binding.
- * 
+ *
  * @author Karel Goderis - Initial contribution
  */
 public class SonosBindingConstants {
@@ -87,5 +87,6 @@ public class SonosBindingConstants {
     public final static String ZONENAME = "zonename";
     public final static String COORDINATOR = "coordinator";
     public final static String MODELID = "modelId";
+    public final static String SLEEPTIMER = "sleeptimer";
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
@@ -514,14 +514,13 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
                 case "SleepTimerGeneration": {
                     if (value.equals("0")) {
-                        updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), SLEEPTIMER),
-                                new DecimalType(0));
+                        updateState(SLEEPTIMER, new DecimalType(0));
                     }
                     break;
                 }
 
                 case "RemainingSleepTimerDuration": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), SLEEPTIMER),
+                    updateState(SLEEPTIMER,
                             (stateMap.get("RemainingSleepTimerDuration") != null)
                                     ? new DecimalType(
                                             sleepStrTimeToSeconds(stateMap.get("RemainingSleepTimerDuration")))


### PR DESCRIPTION
Hi,

I added the channel for the sleep timer of Sonos.
For me it works fine. Only issue I still have is, that the classic UI (and Android App) does not show the remaining time (basic UI does). Switches works fine in both UIs.
Here the example snippets:

Items:
```
Switch DemoSwitch                          "Switch"
String SleepTimerSwitch                  "SleepTimerSwitch" 
```

Sitemap:
```
Switch item=SleepTimerSwitch mappings=[""="OFF", "00:30:00"="30 min", "01:00:00"="1h"]
Text item=SleepTimerRemain
```

Rule:
```
rule "TestSleepTimer" 
    when
        Item SleepTimerSwitch received update
    then
        sendCommand(SleepTimerRemain,SleepTimerSwitch.state.toString())
        logInfo("Sonos-SleepTimer", "sleep "+SleepTimerSwitch.state.toString()))
end
```
I use the SleepTimer mainly in rules => for me the problem with the classic UI is not a real problem, but maybe you have a hint, what could be the problem.

lg, Jürgen


Signed-off-by: Juergen Messmer <meju@chello.at>