### PR TITLE
Bug fix: channel edit button not showing

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -419,7 +419,7 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
         if (!$scope.channelTypes) {
             return;
         }
-        thingConfigService.getChannelFromChannelTypes($scope.channelTypes, channelUID);
+        return thingConfigService.getChannelFromChannelTypes($scope.channelTypes, channelUID);
     };
 
     var getChannels = function(advanced) {


### PR DESCRIPTION
Channel edit button was not showing due to a bug introduced during https://github.com/eclipse/smarthome/pull/1288/files#diff-481f5f70afe05170ba047893fcaab2d8R407

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>