### PR TITLE
add category power

### DIFF
--- a/docs/documentation/development/bindings/thing-definition.md
+++ b/docs/documentation/development/bindings/thing-definition.md
@@ -153,6 +153,7 @@ The channel type definition allows to specify a category. Together with the defi
 | Motion        | R               | Switch                 |
 | MoveControl   | RW              | String                 |
 | Player        | RW              | Player                 |
+| Power         | R               | Number                 |
 | PowerOutlet   | RW              | Switch                 |
 | Pressure      | R               | Number                 |
 | QualityOfService      | R       | Number                 |


### PR DESCRIPTION
There is already a category energy.
A lot of devices that report the energy (the whole energy that has been
consumed over the time), also report the (currently used) power.
Perhaps an official category could be useful.
