### PR TITLE
Added missing import for javax.xml.bind

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Version: 0.8.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,
+ javax.xml.bind,
  org.apache.commons.lang,
  org.eclipse.smarthome.binding.lifx,
  org.eclipse.smarthome.binding.lifx.handler,


### PR DESCRIPTION
Lifx binding uses class javax.xml.bind.DatatypeConverter, but does not import javax.xml.bind in manifest xml. This causes issue when running ESH in karaf (using project https://github.com/maggu2810/shk).