### PR TITLE
WatchService Provides File Name Instead of Relative Path

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.groovy
@@ -1,0 +1,158 @@
+package org.eclipse.smarthome.core.service
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+import static org.junit.matchers.JUnitMatchers.*
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+import java.io.IOException;
+import java.nio.file.Path
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchService
+import java.nio.file.WatchEvent.Kind
+
+import org.eclipse.smarthome.core.service.AbstractWatchServiceTest.FullEvent;
+import org.eclipse.smarthome.test.OSGiTest
+import org.junit.After
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test for {@link AbstractWatchService}.
+ * 
+ * @author Dimitar Ivanov
+ *
+ */
+class AbstractWatchServiceTest extends OSGiTest {
+
+    def static ROOT = "testRoot" + File.separatorChar + "files"
+
+    RelativeWatchService relativeService
+
+    @BeforeClass
+    static void setUpBeforeClass(){
+        File root = new File(ROOT);
+        root.mkdirs()
+    }
+
+    @AfterClass
+    static void tearDownClass(){
+        File root = new File(ROOT);
+        root.deleteDir()
+    }
+
+    @Before
+    public void setUp(){
+        relativeService = new RelativeWatchService(ROOT)
+        relativeService.activate()
+    }
+
+    @After
+    public void tearDown(){
+        relativeService.deactivate()
+    }
+
+    @Test
+    void 'AbstractWatchQueueReader processWatchEvent path provided with correct arguments'() {
+        // File created
+        def fileName = "watchFile"
+        File watchFile1 = new File(ROOT,fileName)
+        watchFile1.createNewFile()
+
+        fullEventAssertionsByKind(fileName,ENTRY_CREATE,false)
+
+        // File modified
+        watchFile1 << "Additional content"
+        fullEventAssertionsByKind(fileName,ENTRY_MODIFY,false)
+
+        // File deleted
+        boolean isDeleted = watchFile1.delete()
+        assertThat "Test file is not deleted", isDeleted,is(true)
+        fullEventAssertionsByKind(fileName,ENTRY_DELETE,true)
+    }
+
+    void fullEventAssertionsByKind(fileName, kind, osSpecific){
+        // Wait one second for any change to be detected by the watch service
+        sleep 1000
+
+        // As the implementation of the watch events is OS specific, it can happen that when the file is deleted two events are fired - ENTRY_MODIFY followed by an ENTRY_DELETE
+        // This is usually observed on Windows and below is the workaround
+        // Related discussion in StackOverflow: http://stackoverflow.com/questions/28201283/watchservice-windows-7-when-deleting-a-file-it-fires-both-entry-modify-and-e
+        boolean isDeletedWithPrecedingModify = osSpecific && kind.equals(ENTRY_DELETE) && relativeService.allFullEvents.size() == 2 && relativeService.allFullEvents[0].eventKind.equals(ENTRY_MODIFY)
+        if(isDeletedWithPrecedingModify){
+            // Remove the ENTRY_MODIFY element as it is not needed
+            relativeService.allFullEvents.remove(0)
+        }
+
+        waitForAssert {assertThat "Only one event for file $fileName is expected shortly after the file has been altered. Here are the found events: " + relativeService.allFullEvents, relativeService.allFullEvents.size(), is(1)}
+        FullEvent fullEvent = relativeService.allFullEvents[0]
+
+        assertThat "The path of the processed event should be relative to the root", fullEvent.eventPath.toString(), is(ROOT + File.separatorChar + fileName)
+        assertThat "An event of corresponding kind $kind is expected", fullEvent.eventKind, is(kind)
+        assertThat "At least one watch event of kind $kind is expected", fullEvent.watchEvent.count() >= 1, is(true)
+        assertThat "The watch event kind should be the same as the kind provided", fullEvent.watchEvent.kind(), is(fullEvent.eventKind)
+        assertThat "The watch event context have to be the file name only", fullEvent.watchEvent.context().toString(),is(fileName)
+
+        // Remove the only event as it is already asserted
+        relativeService.allFullEvents.clear()
+    }
+
+    class RelativeWatchService extends AbstractWatchService{
+
+        String rootWatchPath
+
+        def allFullEvents = []
+
+        RelativeWatchService(String rootPath){
+            rootWatchPath = rootPath
+        }
+
+
+        @Override
+        protected AbstractWatchQueueReader buildWatchQueueReader(WatchService watchService, Path toWatch) {
+            return new AbstractWatchQueueReader(watchService, toWatch) {
+                                @Override
+                                protected void processWatchEvent(WatchEvent<?> event, Kind<?> kind, Path path) {
+                                    allFullEvents << new FullEvent(event,kind,path)
+                                }
+                            };
+        }
+
+        @Override
+        protected String getSourcePath() {
+            return rootWatchPath
+        }
+
+        @Override
+        protected void registerDirectory(Path subDir) throws IOException {
+            subDir.register(watchService,ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
+        }
+
+        @Override
+        protected boolean watchSubDirectories() {
+            return true;
+        }
+    }
+
+    class FullEvent{
+        WatchEvent<?> watchEvent
+        Kind<?> eventKind
+        Path eventPath
+
+        public FullEvent(WatchEvent<?> event, Kind<?> kind, Path path){
+            watchEvent = event
+            eventKind = kind
+            eventPath = path
+        }
+
+        @Override
+        public String toString() {
+            return "Watch event: " + watchEvent +  ", kind: " + eventKind + ", path: " + eventPath;
+        }
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.groovy
@@ -11,15 +11,19 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import java.io.IOException;
 import java.nio.file.Path
 import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey
 import java.nio.file.WatchService
 import java.nio.file.WatchEvent.Kind
+import java.util.Map
 
+import org.apache.commons.lang.SystemUtils;
 import org.eclipse.smarthome.core.service.AbstractWatchServiceTest.FullEvent;
 import org.eclipse.smarthome.test.OSGiTest
 import org.junit.After
 import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.BeforeClass
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -30,97 +34,293 @@ import org.junit.Test;
  */
 class AbstractWatchServiceTest extends OSGiTest {
 
-    def static ROOT = "testRoot" + File.separatorChar + "files"
+    def static WATCHED_DIRECTORY = "watchDirectory"
 
-    RelativeWatchService relativeService
+    // Fail if no event has been received within the given timeout
+    def static NO_EVENT_TIMEOUT_IN_SECONDS = 3;
+
+    RelativeWatchService watchService
 
     @BeforeClass
     static void setUpBeforeClass(){
-        File root = new File(ROOT);
-        root.mkdirs()
+        File watchDir = new File(WATCHED_DIRECTORY);
+        watchDir.mkdirs()
     }
 
     @AfterClass
     static void tearDownClass(){
-        File root = new File(ROOT);
-        root.deleteDir()
-    }
-
-    @Before
-    public void setUp(){
-        relativeService = new RelativeWatchService(ROOT)
-        relativeService.activate()
+        File watchedDirectory = new File(WATCHED_DIRECTORY);
+        watchedDirectory.deleteDir()
     }
 
     @After
     public void tearDown(){
-        relativeService.deactivate()
+        watchService.deactivate()
+        clearWatchedDir()
+        watchService.allFullEvents.clear()
+    }
+
+    void clearWatchedDir(){
+        File watchedDirectory = new File(WATCHED_DIRECTORY)
+        watchedDirectory.listFiles().each { File mockedFile ->
+            mockedFile.isFile() ? mockedFile.delete() : mockedFile.deleteDir()
+        }
     }
 
     @Test
-    void 'AbstractWatchQueueReader processWatchEvent path provided with correct arguments'() {
-        // File created
-        def fileName = "watchFile"
-        File watchFile1 = new File(ROOT,fileName)
-        watchFile1.createNewFile()
+    void 'AbstractWatchQueueReader processWatchEvent path in root provided with correct arguments'() {
+        watchService = new RelativeWatchService(WATCHED_DIRECTORY,true,false)
 
-        fullEventAssertionsByKind(fileName,ENTRY_CREATE,false)
-
-        // File modified
-        watchFile1 << "Additional content"
-        fullEventAssertionsByKind(fileName,ENTRY_MODIFY,false)
-
-        // File deleted
-        boolean isDeleted = watchFile1.delete()
-        assertThat "Test file is not deleted", isDeleted,is(true)
-        fullEventAssertionsByKind(fileName,ENTRY_DELETE,true)
+        // File created in the watched directory
+        assertByRelativePath("rootWatchFile")
     }
 
-    void fullEventAssertionsByKind(fileName, kind, osSpecific){
-        // Wait one second for any change to be detected by the watch service
-        sleep 1000
+    @Test
+    void 'AbstractWatchQueueReader processWatchEvent path in subdir provided with correct arguments'() {
+        watchService = new RelativeWatchService(WATCHED_DIRECTORY,true,false)
 
+        // File created in a subdirectory of the watched directory
+        assertByRelativePath("subdir" + File.separatorChar + "subDirWatchFile")
+    }
+
+    @Test
+    void 'AbstractWatchQueueReader processWatchEvent path in subsubdir provided with correct arguments'() {
+        watchService = new RelativeWatchService(WATCHED_DIRECTORY,true,false)
+
+        // File created in a sub sub directory of the watched directory
+        assertByRelativePath("subDir" + File.separatorChar + "subSubDir" + File.separatorChar + "innerWatchFile")
+    }
+
+    @Test
+    void 'same file names in root and subdir are correctly processed'(){
+        watchService = new RelativeWatchService(WATCHED_DIRECTORY,true,false)
+
+        def fileName = "duplicateFile"
+        def innerFileName = "duplicateDir" + File.separatorChar + fileName
+
+        File innerfile = new File(WATCHED_DIRECTORY + File.separatorChar + innerFileName)
+
+        // Make all the directories needed
+        innerfile.getParentFile().mkdirs()
+
+        // Activate the service when the subdir is also present. Else the subdir will not be registered
+        watchService.activate()
+
+        boolean isCreated = innerfile.createNewFile()
+        assertThat "The file '$innerfile.absolutePath' was not created successfully", isCreated, is(true)
+
+        // Assure that the ordering of the events will be always the same
+        sleep 200
+
+        File file = new File(WATCHED_DIRECTORY + File.separatorChar + fileName)
+        isCreated = file.createNewFile()
+        assertThat "The file '$file.absolutePath' was not created successfully", isCreated, is(true)
+
+        waitForAssert({assertThat "Exactly two watch events were expected within $NO_EVENT_TIMEOUT_IN_SECONDS seconds, but were: " + watchService.allFullEvents, watchService.allFullEvents.size(), is(2)},NO_EVENT_TIMEOUT_IN_SECONDS*1000,1000)
+
+        FullEvent innerFileEvent = watchService.allFullEvents[0]
+        assertThat "The inner file '$innerfile.absolutePath' creation was not detected. All events detected: " + watchService.allFullEvents,innerFileEvent.eventKind,is(ENTRY_CREATE)
+        assertThat "The path of the first detected event should be for $innerFileName", innerFileEvent.eventPath.toString(), is(innerFileName)
+
+        FullEvent fileEvent = watchService.allFullEvents[1]
+        assertThat "The root file '$file.absolutePath' creation  was not detected. All events detected: " + watchService.allFullEvents,fileEvent.eventKind,is(ENTRY_CREATE)
+        assertThat "The path of the second event should be for $fileName", fileEvent.eventPath.toString(), is(fileName)
+    }
+
+    @Test
+    void 'directory changes are watched correctly'(){
+        // Watch subdirectories and their modifications
+        watchService = new RelativeWatchService(WATCHED_DIRECTORY,true,true)
+
+        def subDirName = "correctlyWatchedSubDir"
+        def fileName = "correctSubDirInnerFile"
+        def innerFileName = subDirName + File.separatorChar + fileName
+
+        File innerFile = new File(WATCHED_DIRECTORY + File.separatorChar + innerFileName)
+
+        // Make all the subdirectories before running the service
+        innerFile.getParentFile().mkdirs()
+
+        watchService.activate()
+
+        boolean isCreated = innerFile.createNewFile()
+        assertThat "The file '$innerFile.absolutePath' was not created successfully", isCreated, is(true)
+
+        //This could vary across different platforms. For more information see "Platform dependencies" section in the WatchService documentation
+        def expectedEvents = SystemUtils.IS_OS_WINDOWS ? 2 : 1
+        waitForAssert({assertThat "Exactly $expectedEvents watch events were expected within $NO_EVENT_TIMEOUT_IN_SECONDS seconds, but were: " + watchService.allFullEvents, watchService.allFullEvents.size(), is(expectedEvents)},NO_EVENT_TIMEOUT_IN_SECONDS*1000,1000)
+
+        FullEvent fileEvent = watchService.allFullEvents[0]
+        assertThat "File '$innerFile.absolutePath' creation was not detected. All events detected: " + watchService.allFullEvents, fileEvent.eventKind, is(ENTRY_CREATE)
+        assertThat "File '$innerFile.absolutePath' name expected in the modified event. All events detected: " + watchService.allFullEvents, fileEvent.eventPath.toString(), is(innerFileName)
+
+        if(SystemUtils.IS_OS_WINDOWS){
+            FullEvent dirEvent = watchService.allFullEvents[1]
+            assertThat "Directory $subDirName modification was not detected. All events detected: " + watchService.allFullEvents, dirEvent.eventKind, is(ENTRY_MODIFY)
+            assertThat "Subdirectory was not found in the modified event", dirEvent.eventPath.toString(), is(subDirName)
+        }
+    }
+
+    @Test
+    void 'subdirs are not registered and not watched'(){
+        // Do not watch the subdirectories of the root directory
+        watchService = new RelativeWatchService(WATCHED_DIRECTORY,false,false)
+
+        def innerFileName = "watchRequestSubDir"+ File.separatorChar + "watchRequestInnerFile"
+
+        File innerFile = new File(WATCHED_DIRECTORY + File.separatorChar + innerFileName)
+        innerFile.getParentFile().mkdirs()
+
+        watchService.activate()
+
+        // Consequent creation and deletion in order to generate any watch events for the subdirectory
+        boolean isCreated = innerFile.createNewFile()
+        assertThat "The file '$innerFile.absolutePath' was not created successfully", isCreated, is(true)
+
+        boolean isDeleted = innerFile.delete()
+        assertThat "Inner file is not deleted", isDeleted, is(true)
+
+        // Wait for a possible event for the maximum timeout
+        sleep NO_EVENT_TIMEOUT_IN_SECONDS*1000
+
+        assertThat "No watch events are expected, but were: " + watchService.allFullEvents, watchService.allFullEvents.size(), is(0)
+    }
+
+    @Test
+    void 'subdirs are not watched, but dirs modifications are watched'(){
+        // Do not watch the subdirectories of the root directory, but watch directory modifications
+        watchService = new RelativeWatchService(WATCHED_DIRECTORY,false,true)
+
+        def subDirName = "subDirModifications"
+        def innerFileName = subDirName + File.separatorChar + "modificationsInnerFile"
+
+        File innerFile = new File(WATCHED_DIRECTORY + File.separatorChar + innerFileName)
+        innerFile.getParentFile().mkdirs()
+
+        watchService.activate()
+
+        boolean isCreated = innerFile.createNewFile()
+        assertThat "The file '$innerFile.absolutePath' was not created successfully", isCreated, is(true)
+
+        // Wait for possible watch event for the maximum timeout
+        sleep NO_EVENT_TIMEOUT_IN_SECONDS*1000
+
+        if(SystemUtils.IS_OS_WINDOWS){
+            // This behavior could vary depending on the Platform (see the WatchService documentation)
+            assertThat "Exactly one event is expected, but were: " + watchService.allFullEvents, watchService.allFullEvents.size(), is(1)
+            FullEvent event = watchService.allFullEvents[0]
+            assertThat "Modification event for subdir '$subDirName' on file creation within it is expected", event.eventKind , is(ENTRY_MODIFY)
+            assertThat "The watch event does not contain the path of the modified directory", event.eventPath.toString() , is(subDirName)
+        }else {
+            assertThat "No events are expected if not Windows OS" + watchService.allFullEvents, watchService.allFullEvents.size(), is(0)
+        }
+
+        // Clear the asserted event
+        watchService.allFullEvents.clear()
+
+        boolean isDeleted = innerFile.delete()
+        assertThat "Inner file '$innerFile.absolutePath' is not deleted", isDeleted, is(true)
+
+        // Wait for a possible event for the maximum timeout
+        sleep NO_EVENT_TIMEOUT_IN_SECONDS*1000
+
+        assertThat "No event is expected, but were: " + watchService.allFullEvents, watchService.allFullEvents.size(), is(0)
+    }
+
+    void assertByRelativePath(String fileName) {
+        File file = new File(WATCHED_DIRECTORY + File.separatorChar + fileName)
+        file.getParentFile().mkdirs()
+
+        assertThat "The file '$file.absolutePath' should not be present before the watch service activation", file.exists(), is(false)
+
+        // We have to be sure that all the subdirectories of the watched directory are created when the watched service is activated
+        watchService.activate()
+
+        boolean isCreated = file.createNewFile()
+        assertThat "The file '$file.absolutePath' was not created successfully", isCreated, is(true)
+
+        fullEventAssertionsByKind(fileName, ENTRY_CREATE, false)
+
+        // File modified
+        file << "Additional content"
+        fullEventAssertionsByKind(fileName, ENTRY_MODIFY, false)
+
+        // File deleted
+        boolean isDeleted = file.delete()
+        assertThat "Test file '$file.absolutePath' is not deleted", isDeleted, is(true)
+        fullEventAssertionsByKind(fileName, ENTRY_DELETE, true)
+    }
+
+    void fullEventAssertionsByKind(String fileName, kind, osSpecific){
+        waitForAssert({
+            assertThat "At least one watch event is expected within $NO_EVENT_TIMEOUT_IN_SECONDS seconds.",
+                            watchService.allFullEvents.size() >= 1,
+                            is(true)},NO_EVENT_TIMEOUT_IN_SECONDS*1000,1000);
+
+        if(osSpecific && kind.equals(ENTRY_DELETE)){
+            // There is possibility that one more modify event is triggered on some OS
+            // so sleep a bit extra time
+            sleep 500
+            cleanUpOsSpecificModifyEvent()
+        }
+
+        waitForAssert {assertThat "Exactly one event of kind $kind for file $fileName is expected shortly after the file has been altered. Here are the found events: " + watchService.allFullEvents, watchService.allFullEvents.size(), is(1)}
+        FullEvent fullEvent = watchService.allFullEvents[0]
+
+        assertThat "The path of the processed $kind event should be relative to the watched directory", fullEvent.eventPath.toString(), is(fileName)
+        assertThat "An event of corresponding kind $kind is expected for file $fileName", fullEvent.eventKind, is(kind)
+        assertThat "At least one watch event of kind $kind is expected", fullEvent.watchEvent.count() >= 1, is(true)
+        assertThat "The watch event kind should be the same as the kind provided", fullEvent.watchEvent.kind(), is(fullEvent.eventKind)
+        def fileNameOnly = fileName.contains(File.separatorChar.toString()) ? fileName.substring(fileName.lastIndexOf(File.separatorChar.toString()) + 1,fileName.length()) : fileName
+        assertThat "The watch event context have to be the file name only", fullEvent.watchEvent.context().toString(),is(fileNameOnly)
+
+        // Clear all the asserted events
+        watchService.allFullEvents.clear()
+    }
+
+    /**
+     * Cleanup the OS specific ENTRY_MODIFY event as it will not be needed for the assertion
+     */
+    private cleanUpOsSpecificModifyEvent() {
         // As the implementation of the watch events is OS specific, it can happen that when the file is deleted two events are fired - ENTRY_MODIFY followed by an ENTRY_DELETE
         // This is usually observed on Windows and below is the workaround
         // Related discussion in StackOverflow: http://stackoverflow.com/questions/28201283/watchservice-windows-7-when-deleting-a-file-it-fires-both-entry-modify-and-e
-        boolean isDeletedWithPrecedingModify = osSpecific && kind.equals(ENTRY_DELETE) && relativeService.allFullEvents.size() == 2 && relativeService.allFullEvents[0].eventKind.equals(ENTRY_MODIFY)
+        boolean isDeletedWithPrecedingModify = watchService.allFullEvents.size() == 2 && watchService.allFullEvents[0].eventKind.equals(ENTRY_MODIFY)
         if(isDeletedWithPrecedingModify){
             // Remove the ENTRY_MODIFY element as it is not needed
-            relativeService.allFullEvents.remove(0)
+            watchService.allFullEvents.remove(0)
         }
-
-        waitForAssert {assertThat "Only one event for file $fileName is expected shortly after the file has been altered. Here are the found events: " + relativeService.allFullEvents, relativeService.allFullEvents.size(), is(1)}
-        FullEvent fullEvent = relativeService.allFullEvents[0]
-
-        assertThat "The path of the processed event should be relative to the root", fullEvent.eventPath.toString(), is(ROOT + File.separatorChar + fileName)
-        assertThat "An event of corresponding kind $kind is expected", fullEvent.eventKind, is(kind)
-        assertThat "At least one watch event of kind $kind is expected", fullEvent.watchEvent.count() >= 1, is(true)
-        assertThat "The watch event kind should be the same as the kind provided", fullEvent.watchEvent.kind(), is(fullEvent.eventKind)
-        assertThat "The watch event context have to be the file name only", fullEvent.watchEvent.context().toString(),is(fileName)
-
-        // Remove the only event as it is already asserted
-        relativeService.allFullEvents.clear()
     }
 
     class RelativeWatchService extends AbstractWatchService{
 
         String rootWatchPath
 
-        def allFullEvents = []
+        boolean watchSubDirs
 
-        RelativeWatchService(String rootPath){
+        boolean watchDirectoryChanges
+
+        // Synchronize list as several watcher threads can write into it
+        def allFullEvents = [].asSynchronized()
+
+        RelativeWatchService(String rootPath, boolean watchSubDirectories, boolean watchDirChanges){
             rootWatchPath = rootPath
+            watchSubDirs = watchSubDirectories
+            watchDirectoryChanges = watchDirChanges
         }
 
 
         @Override
-        protected AbstractWatchQueueReader buildWatchQueueReader(WatchService watchService, Path toWatch) {
-            return new AbstractWatchQueueReader(watchService, toWatch) {
+        protected AbstractWatchQueueReader buildWatchQueueReader(WatchService watchService, Path toWatch,Map<WatchKey, Path> registeredKeys) {
+            def queueReader = new AbstractWatchQueueReader(watchService, toWatch,registeredKeys) {
                                 @Override
                                 protected void processWatchEvent(WatchEvent<?> event, Kind<?> kind, Path path) {
-                                    allFullEvents << new FullEvent(event,kind,path)
+                                    FullEvent fullEvent = new FullEvent(event,kind,path)
+                                    allFullEvents << fullEvent
                                 }
                             };
+            queueReader.setWatchingDirectoryChanges(watchDirectoryChanges)
+            return queueReader
         }
 
         @Override
@@ -129,13 +329,14 @@ class AbstractWatchServiceTest extends OSGiTest {
         }
 
         @Override
-        protected void registerDirectory(Path subDir) throws IOException {
-            subDir.register(watchService,ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
+        protected WatchKey registerDirectory(Path path) throws IOException {
+            WatchKey registrationKey = path.register(watchService,ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY)
+            return registrationKey
         }
 
         @Override
         protected boolean watchSubDirectories() {
-            return true;
+            return watchSubDirs;
         }
     }
 
@@ -152,7 +353,7 @@ class AbstractWatchServiceTest extends OSGiTest {
 
         @Override
         public String toString() {
-            return "Watch event: " + watchEvent +  ", kind: " + eventKind + ", path: " + eventPath;
+            return "Watch Event: count " + watchEvent.count +  "; kind: " + eventKind + "; path: " + eventPath;
         }
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchQueueReader.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchQueueReader.java
@@ -45,8 +45,7 @@ public abstract class AbstractWatchQueueReader implements Runnable {
     /**
      * Perform a simple cast of given event to WatchEvent
      * 
-     * @param event
-     *            the event to cast
+     * @param event the event to cast
      * @return the casted event
      */
     @SuppressWarnings("unchecked")
@@ -58,12 +57,11 @@ public abstract class AbstractWatchQueueReader implements Runnable {
      * Build the object with the given parameters. The directory changes will be watched by default, e.g.
      * watchingDirectoryChanges will be set to <code>true</code> (see {@link #setWatchingDirectoryChanges(boolean)})
      * 
-     * @param watchService
-     *            the watch service
+     * @param watchService the watch service
      * 
-     * @param watchedDir - the base directory, watched by the watch service
+     * @param watchedDir the base directory, watched by the watch service
      * 
-     * @param registeredKeys - a mapping between the {@link WatchKey}s and their corresponding directories, registered
+     * @param registeredKeys a mapping between the {@link WatchKey}s and their corresponding directories, registered
      *            in the watch service.
      */
     public AbstractWatchQueueReader(WatchService watchService, Path watchedDir, Map<WatchKey, Path> registeredKeys) {
@@ -76,15 +74,14 @@ public abstract class AbstractWatchQueueReader implements Runnable {
     /**
      * Build the object with the given parameters
      * 
-     * @param watchService
-     *            the watch service
+     * @param watchService the watch service
      * 
-     * @param watchedDir - the base directory, watched by the watch service
+     * @param watchedDir the base directory, watched by the watch service
      * 
-     * @param registeredKeys - a mapping between the {@link WatchKey}s and their corresponding directories, registered
+     * @param registeredKeys a mapping between the {@link WatchKey}s and their corresponding directories, registered
      *            in the watch service.
      * 
-     * @param watchingDirectoryChanges - whether the queue reader will be watching the directory changes, when the watch
+     * @param watchingDirectoryChanges whether the queue reader will be watching the directory changes, when the watch
      *            events are processed (for more information see
      *            {@link AbstractWatchQueueReader#setWatchingDirectoryChanges(boolean)}).
      */
@@ -199,10 +196,10 @@ public abstract class AbstractWatchQueueReader implements Runnable {
      * generated when a new file is created within the directory. However, this behavior could vary a lot, depending on
      * the platform (for more information see "Platform dependencies" section in the {@link WatchService} documentation)
      * 
-     * @param watchDirectoryChanges - set to <code>true</code> if the directory events have to be processed and
+     * @param watchDirectoryChanges set to <code>true</code> if the directory events have to be processed and
      *            <code>false</code> otherwise
      */
-    public void setWatchingDirectoryChanges(boolean watchDirectoryChanges) {
+    public final void setWatchingDirectoryChanges(boolean watchDirectoryChanges) {
         this.watchingDirectoryChanges = watchDirectoryChanges;
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchQueueReader.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchQueueReader.java
@@ -22,10 +22,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Base class for watch queue readers
- *
+ * 
  * @author Fabio Marini
  * @author Dimitar Ivanov - use relative path in watch events. Added option to watch directory events or not
- *
  */
 public abstract class AbstractWatchQueueReader implements Runnable {
 
@@ -54,13 +53,13 @@ public abstract class AbstractWatchQueueReader implements Runnable {
     }
 
     /**
-     * Build the object with the given parameters. The directory changes will be watched by default, e.g.
-     * watchingDirectoryChanges will be set to <code>true</code> (see {@link #setWatchingDirectoryChanges(boolean)})
+     * Build the {@link AbstractWatchQueueReader} object with the given parameters. The directory changes will be
+     * watched by default, e.g. watchingDirectoryChanges will be set to <code>true</code> (see
+     * {@link #setWatchingDirectoryChanges(boolean)})
      * 
-     * @param watchService the watch service
-     * 
-     * @param watchedDir the base directory, watched by the watch service
-     * 
+     * @param watchService the watch service. Available to subclasses as {@link #watchService}
+     * @param watchedDir the base directory, watched by the watch service. Available to subclasses as
+     *            {@link #baseWatchedDir}
      * @param registeredKeys a mapping between the {@link WatchKey}s and their corresponding directories, registered
      *            in the watch service.
      */
@@ -72,18 +71,18 @@ public abstract class AbstractWatchQueueReader implements Runnable {
     }
 
     /**
-     * Build the object with the given parameters
+     * Build the {@link AbstractWatchQueueReader} object with the given parameters. The directory changes will be
+     * watched by default, e.g. watchingDirectoryChanges will be set to <code>true</code> (see
+     * {@link #setWatchingDirectoryChanges(boolean)})
      * 
      * @param watchService the watch service
-     * 
-     * @param watchedDir the base directory, watched by the watch service
-     * 
+     * @param watchedDir the base directory, watched by the watch service. Available to subclasses as
+     *            {@link #baseWatchedDir}
      * @param registeredKeys a mapping between the {@link WatchKey}s and their corresponding directories, registered
      *            in the watch service.
-     * 
-     * @param watchingDirectoryChanges whether the queue reader will be watching the directory changes, when the watch
+     * @param watchingDirectoryChanges whether this queue reader will be watching the directory changes when the watch
      *            events are processed (for more information see
-     *            {@link AbstractWatchQueueReader#setWatchingDirectoryChanges(boolean)}).
+     *            {@link #setWatchingDirectoryChanges(boolean)}).
      */
     public AbstractWatchQueueReader(WatchService watchService, Path watchedDir, Map<WatchKey, Path> registeredKeys,
             boolean watchingDirectoryChanges) {
@@ -169,14 +168,12 @@ public abstract class AbstractWatchQueueReader implements Runnable {
     }
 
     /**
-     * Processes the given watch event. Note that there is
+     * Processes the given watch event. Note that the kind and the number of the events for the watched directory is a
+     * platform dependent (see the "Platform dependencies" sections of {@link WatchService}).
      * 
-     * @param event
-     *            the watch event to perform
-     * @param kind
-     *            the event's kind
-     * @param name
-     *            the path of event
+     * @param event the watch event to be handled
+     * @param kind the event's kind
+     * @param path the path of the event (relative to the {@link #baseWatchedDir}
      */
     protected abstract void processWatchEvent(WatchEvent<?> event, WatchEvent.Kind<?> kind, Path path);
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchQueueReader.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchQueueReader.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
  * Base class for watch queue readers
  *
  * @author Fabio Marini
+ * @author Dimitar Ivanov - use complete path in watch event
  *
  */
 public abstract class AbstractWatchQueueReader implements Runnable {
@@ -87,10 +88,7 @@ public abstract class AbstractWatchQueueReader implements Runnable {
                         continue;
                     }
 
-                    // Context for directory entry event is the file name of
-                    // entry
-                    WatchEvent<Path> ev = cast(event);
-                    Path path = ev.context();
+                    Path path = resolveToPath(key, event);
 
                     processWatchEvent(event, kind, path);
                 }
@@ -103,6 +101,19 @@ public abstract class AbstractWatchQueueReader implements Runnable {
 
             return;
         }
+    }
+
+    private Path resolveToPath(WatchKey key, WatchEvent<?> event) {
+        WatchEvent<Path> ev = cast(event);
+        // Context for directory entry event is the file name of
+        // entry
+        Path contextPath = ev.context();
+
+        Path directoryWatched = (Path) key.watchable();
+        // Resolve the relative file name against the watched directory
+        Path path = directoryWatched.resolve(contextPath);
+
+        return path;
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchService.java
@@ -129,9 +129,9 @@ public abstract class AbstractWatchService {
     /**
      * Build a queue reader to process the watch events, provided by the watch service for the given directory
      * 
-     * @param watchService - the watch service, providing the watch events for the watched directory
-     * @param toWatch - the directory being watched by the watch service
-     * @param registredWatchKeys - a mapping between the registered directories and their {@link WatchKey registration
+     * @param watchService the watch service, providing the watch events for the watched directory
+     * @param toWatch the directory being watched by the watch service
+     * @param registredWatchKeys a mapping between the registered directories and their {@link WatchKey registration
      *            keys}.
      * @return the concrete queue reader
      */
@@ -156,9 +156,9 @@ public abstract class AbstractWatchService {
      * Registers a directory to be watched by the watch service. The {@link WatchKey} of the registration should be
      * provided.
      * 
-     * @param directory - the directory, which will be registered in the watch service
-     * @return The {@link WatchKey} of the registration or <code>null</code> if not registration has been done.
-     * @throws IOException - if an erro occurs while processing the given path
+     * @param directory the directory, which will be registered in the watch service
+     * @return The {@link WatchKey} of the registration or <code>null</code> if no registration has been done.
+     * @throws IOException if an error occurs while processing the given path
      */
     protected abstract WatchKey registerDirectory(Path directory) throws IOException;
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchService.java
@@ -14,8 +14,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -28,6 +31,7 @@ import org.slf4j.LoggerFactory;
  * >java docs</a> for more details
  *
  * @author Fabio Marini
+ * @author Dimitar Ivanov - added javadoc; introduced WatchKey to directory mapping for the queue reader
  *
  */
 public abstract class AbstractWatchService {
@@ -74,6 +78,7 @@ public abstract class AbstractWatchService {
         if (StringUtils.isNotBlank(pathToWatch)) {
             Path toWatch = Paths.get(pathToWatch);
             try {
+                final Map<WatchKey, Path> registeredWatchKeys = new HashMap<>();
                 if (watchSubDirectories()) {
                     watchService = FileSystems.getDefault().newWatchService();
 
@@ -81,16 +86,16 @@ public abstract class AbstractWatchService {
                         @Override
                         public FileVisitResult preVisitDirectory(Path subDir, BasicFileAttributes attrs)
                                 throws IOException {
-                            registerDirectory(subDir);
+                            registerDirectoryInternal(subDir, registeredWatchKeys);
                             return FileVisitResult.CONTINUE;
                         }
                     });
                 } else {
                     watchService = toWatch.getFileSystem().newWatchService();
-                    registerDirectory(toWatch);
+                    registerDirectoryInternal(toWatch, registeredWatchKeys);
                 }
 
-                AbstractWatchQueueReader reader = buildWatchQueueReader(watchService, toWatch);
+                AbstractWatchQueueReader reader = buildWatchQueueReader(watchService, toWatch, registeredWatchKeys);
 
                 Thread qr = new Thread(reader, "Dir Watcher");
                 qr.start();
@@ -100,25 +105,38 @@ public abstract class AbstractWatchService {
         }
     }
 
+    private void registerDirectoryInternal(Path directory, Map<WatchKey, Path> registredWatchKeys) throws IOException {
+        WatchKey registrationKey = registerDirectory(directory);
+        if (registrationKey != null) {
+            registredWatchKeys.put(registrationKey, directory);
+        } else {
+            logger.info("The directory '{}' was not registered in the watch service", directory);
+        }
+    }
+
     protected void stopWatchService() {
-    	if(watchService != null) {
-	    	try {
-	            watchService.close();
-	        } catch (IOException e) {
-	            logger.warn("Cannot deactivate folder watcher", e);
-	        }
-	
-	        watchService = null;
-    	}
+        if (watchService != null) {
+            try {
+                watchService.close();
+            } catch (IOException e) {
+                logger.warn("Cannot deactivate folder watcher", e);
+            }
+
+            watchService = null;
+        }
     }
 
     /**
+     * Build a queue reader to process the watch events, provided by the watch service for the given directory
      * 
-     * @param watchService
-     * @param toWatch
-     * @return
+     * @param watchService - the watch service, providing the watch events for the watched directory
+     * @param toWatch - the directory being watched by the watch service
+     * @param registredWatchKeys - a mapping between the registered directories and their {@link WatchKey registration
+     *            keys}.
+     * @return the concrete queue reader
      */
-    protected abstract AbstractWatchQueueReader buildWatchQueueReader(WatchService watchService, Path toWatch);
+    protected abstract AbstractWatchQueueReader buildWatchQueueReader(WatchService watchService, Path toWatch,
+            Map<WatchKey, Path> registredWatchKeys);
 
     /**
      * 
@@ -127,14 +145,20 @@ public abstract class AbstractWatchService {
     protected abstract String getSourcePath();
 
     /**
+     * Determines whether the subdirectories of the root path will be watched or not.
      * 
-     * @return
+     * @return <code>true</code> if the subdirectories will be watched and <code>false</code> if only the root directory
+     *         will be watched
      */
     protected abstract boolean watchSubDirectories();
 
     /**
-     * @param subDir
-     * @throws IOException
+     * Registers a directory to be watched by the watch service. The {@link WatchKey} of the registration should be
+     * provided.
+     * 
+     * @param directory - the directory, which will be registered in the watch service
+     * @return The {@link WatchKey} of the registration or <code>null</code> if not registration has been done.
+     * @throws IOException - if an erro occurs while processing the given path
      */
-    protected abstract void registerDirectory(Path subDir) throws IOException;
+    protected abstract WatchKey registerDirectory(Path directory) throws IOException;
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/AbstractWatchService.java
@@ -114,6 +114,9 @@ public abstract class AbstractWatchService {
         }
     }
 
+    /**
+     * This method will close the {@link #watchService}.
+     */
     protected void stopWatchService() {
         if (watchService != null) {
             try {
@@ -139,16 +142,17 @@ public abstract class AbstractWatchService {
             Map<WatchKey, Path> registredWatchKeys);
 
     /**
-     * 
-     * @return
+     * @return the path to be watched as a {@link String}. The returned path should be applicable for creating a
+     *         {@link Path} with the {@link Paths#get(String, String...)} method.
      */
     protected abstract String getSourcePath();
 
     /**
-     * Determines whether the subdirectories of the root path will be watched or not.
+     * Determines whether the subdirectories of the source path (determined by the {@link #getSourcePath()}) will be
+     * watched or not.
      * 
-     * @return <code>true</code> if the subdirectories will be watched and <code>false</code> if only the root directory
-     *         will be watched
+     * @return <code>true</code> if the subdirectories will be watched and <code>false</code> if only the source path
+     *         (determined by the {@link #getSourcePath()}) will be watched
      */
     protected abstract boolean watchSubDirectories();
 

--- a/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/folder/FolderObserver.java
+++ b/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/folder/FolderObserver.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -72,8 +73,9 @@ public class FolderObserver extends AbstractWatchService implements ManagedServi
     }
 
     @Override
-    protected AbstractWatchQueueReader buildWatchQueueReader(WatchService watchService, Path toWatch) {
-        return new WatchQueueReader(watchService, toWatch, folderFileExtMap, modelRepo);
+    protected AbstractWatchQueueReader buildWatchQueueReader(WatchService watchService, Path toWatch,
+            Map<WatchKey, Path> registeredKeys) {
+        return new WatchQueueReader(watchService, toWatch, registeredKeys, folderFileExtMap, modelRepo);
     }
 
     @Override
@@ -87,13 +89,15 @@ public class FolderObserver extends AbstractWatchService implements ManagedServi
     }
 
     @Override
-    protected void registerDirectory(Path subDir) throws IOException {
+    protected WatchKey registerDirectory(Path subDir) throws IOException {
         if (subDir != null && MapUtils.isNotEmpty(folderFileExtMap)) {
             String folderName = subDir.getFileName().toString();
             if (folderFileExtMap.containsKey(folderName)) {
-                subDir.register(watchService, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+                WatchKey registrationKey = subDir.register(watchService, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+                return registrationKey;
             }
         }
+        return null;
     }
 
     private static class WatchQueueReader extends AbstractWatchQueueReader {
@@ -102,9 +106,10 @@ public class FolderObserver extends AbstractWatchService implements ManagedServi
 
         private ModelRepository modelRepo = null;
 
-        public WatchQueueReader(WatchService watchService, Path dirToWatch, Map<String, String[]> folderFileExtMap,
+        public WatchQueueReader(WatchService watchService, Path dirToWatch, Map<WatchKey, Path> registeredKeys,
+                Map<String, String[]> folderFileExtMap,
                 ModelRepository modelRepo) {
-            super(watchService, dirToWatch);
+            super(watchService, dirToWatch,registeredKeys);
 
             this.folderFileExtMap = folderFileExtMap;
             this.modelRepo = modelRepo;


### PR DESCRIPTION
The file path, passed to the AbstractWatchQueueReader.processWatchEvent is now full (till now it was containing only the name of the target file, but not its relative to the watched directory).
Added tests for the AbstractWatchService to verify the behavior above.

**Why do we need the full path**:
When implementing the AbstractWatchService, we can provide an option to track the sub-directories by implementing the AbstractWatchService.watchSubDirectories() method. However, when the sub-directories are tracked, the AbstractWatchService.registerDirectory(Path subDir) will be called for each sub-directory. 
So we have two options - either to implement separate watch service for each of the sub-directories or to have the relative path as an argument when a watch event is detected. With this PR I assume that the second option is more convenient.

Signed-off-by: Dimitar Ivanov dstivanov@gmail.com
