### PR TITLE
next development cycle: 0.9.0-SNAPSHOT

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation API
 Bundle-SymbolicName: org.eclipse.smarthome.automation.api
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Import-Package: 
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.api/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.commands/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.commands/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.smarthome.automation.commands
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Name: Eclipse SmartHome Automation commands
 Import-Package: 
  org.apache.commons.lang,

--- a/bundles/automation/org.eclipse.smarthome.automation.commands/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.commands/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Automation Core
 Bundle-SymbolicName: org.eclipse.smarthome.automation.core.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.automation.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Core
 Bundle-SymbolicName: org.eclipse.smarthome.automation.core
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Import-Package: 
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.core/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Event Test
 Bundle-SymbolicName: org.eclipse.smarthome.automation.event.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Integration Test
 Bundle-SymbolicName: org.eclipse.smarthome.automation.integration.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Test
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.core.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Core
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.core
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.automation.module.core.internal.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Script Globals
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.defaultscope
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome JSR233 Automation Module Tests
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.automation.module.script
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Script
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.automation.module.script.internal.ScriptModuleActivator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.base,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Timer Test
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Timer
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.automation.module.timer.internal.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation GSON Parser
 Bundle-SymbolicName: org.eclipse.smarthome.automation.parser.gson
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.automation.parser.gson.internal.Activator
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.smarthome.automation.providers
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Name: Eclipse SmartHome Automation Providers
 Import-Package: 
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation REST API
 Bundle-SymbolicName: org.eclipse.smarthome.automation.rest
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: io.swagger.annotations;resolution:=optional,

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Sample Extension Java - Welcome Home Application
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.java
 Bundle-Activator: org.eclipse.smarthome.automation.sample.extension.java.Activator
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Import-Package: 
  org.apache.commons.lang,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.json
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Name: Automation Sample JSON
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Sample REST API
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.rest.api
 Bundle-Activator: org.eclipse.smarthome.automation.sample.rest.api.Activator
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Import-Package: 
  javax.servlet,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/pom.xml
+++ b/bundles/automation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Configuration Core Tests
 Bundle-SymbolicName: org.eclipse.smarthome.config.core.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.config.core

--- a/bundles/config/org.eclipse.smarthome.config.core.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config Core
 Bundle-SymbolicName: org.eclipse.smarthome.config.core
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.base,

--- a/bundles/config/org.eclipse.smarthome.config.core/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Configuration Discovery Tests
 Bundle-SymbolicName: org.eclipse.smarthome.config.discovery.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.config.discovery

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Configuration Discovery
 Bundle-SymbolicName: org.eclipse.smarthome.config.discovery
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.base,

--- a/bundles/config/org.eclipse.smarthome.config.discovery/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config Dispatcher
 Bundle-SymbolicName: org.eclipse.smarthome.config.dispatch
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.commons.io;version="2.2.0",

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config XML Tests
 Bundle-SymbolicName: org.eclipse.smarthome.config.xml.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.config.xml
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config XML
 Bundle-SymbolicName: org.eclipse.smarthome.config.xml
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.thoughtworks.xstream,

--- a/bundles/config/org.eclipse.smarthome.config.xml/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/pom.xml
+++ b/bundles/config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.eclipse.smarthome.core.autoupdate.internal
 Ignore-Package: org.eclipse.smarthome.core.autoupdate.internal
 Bundle-Name: Eclipse SmartHome AutoUpdate Binding
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.core.autoupdate.internal.AutoUpdateActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/core/org.eclipse.smarthome.core.autoupdate/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.autoupdate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Binding XML Tests
 Bundle-SymbolicName: org.eclipse.smarthome.core.binding.xml.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.binding.xml
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Binding XML
 Bundle-SymbolicName: org.eclipse.smarthome.core.binding.xml
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.thoughtworks.xstream,

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sample Extension Service
 Bundle-SymbolicName: org.eclipse.smarthome.core.extension.sample
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Import-Package: org.apache.commons.lang,
  org.eclipse.smarthome.core.extension
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome ID Tests
 Bundle-SymbolicName: org.eclipse.smarthome.core.id.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.core.id

--- a/bundles/core/org.eclipse.smarthome.core.id.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.id.test/pom.xml
@@ -4,12 +4,12 @@
   <groupId>org.eclipse.smarthome.core</groupId>
   <artifactId>org.eclipse.smarthome.core.id.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
   <name>Eclipse SmartHome Thing Tests</name>
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/bundles/core/org.eclipse.smarthome.core.id/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Core ID
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-SymbolicName: org.eclipse.smarthome.core.id

--- a/bundles/core/org.eclipse.smarthome.core.id/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.id/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/core/org.eclipse.smarthome.core.persistence/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Core Persistence
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-SymbolicName: org.eclipse.smarthome.core.persistence

--- a/bundles/core/org.eclipse.smarthome.core.persistence/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.scheduler/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.scheduler/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.eclipse.smarthome.core.scheduler.internal
 Ignore-Package: org.eclipse.smarthome.core.scheduler.internal
 Bundle-Name: Eclipse SmartHome Scheduler Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-SymbolicName: org.eclipse.smarthome.core.scheduler

--- a/bundles/core/org.eclipse.smarthome.core.scheduler/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the openHAB Core
 Bundle-SymbolicName: org.eclipse.smarthome.core.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/core/org.eclipse.smarthome.core.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Tests
 Bundle-SymbolicName: org.eclipse.smarthome.core.thing.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.core.thing

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
@@ -4,12 +4,12 @@
   <groupId>org.eclipse.smarthome.core</groupId>
   <artifactId>org.eclipse.smarthome.core.thing.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
   <name>Eclipse SmartHome Thing Tests</name>
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Thing XML Tests
 Bundle-SymbolicName: org.eclipse.smarthome.core.thing.xml.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.thing.xml
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Thing XML
 Bundle-SymbolicName: org.eclipse.smarthome.core.thing.xml
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.thoughtworks.xstream,

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Core Thing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-SymbolicName: org.eclipse.smarthome.core.thing

--- a/bundles/core/org.eclipse.smarthome.core.thing/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.transform/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.transform/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.eclipse.smarthome.binding.http.internal
 Ignore-Package: org.eclipse.smarthome.binding.http.internal
 Bundle-Name: Eclipse SmartHome Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.core.transform.internal.TransformationActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/core/org.eclipse.smarthome.core.transform/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.transform/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -26,7 +26,7 @@ Ignore-Package: org.eclipse.smarthome.core.internal.items,org.eclipse.smarthome.
 Bundle-Name: Eclipse SmartHome Core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: com.google.common.base,

--- a/bundles/core/org.eclipse.smarthome.core/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/designer/org.eclipse.smarthome.designer.core/META-INF/MANIFEST.MF
+++ b/bundles/designer/org.eclipse.smarthome.designer.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Designer Core
 Bundle-SymbolicName: org.eclipse.smarthome.designer.core;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.designer.core.CoreActivator
 Bundle-Vendor: Eclipse.org/SmartHome
 Require-Bundle: org.eclipse.core.runtime,

--- a/bundles/designer/org.eclipse.smarthome.designer.core/pom.xml
+++ b/bundles/designer/org.eclipse.smarthome.designer.core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>designer</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/designer/org.eclipse.smarthome.designer.ui/META-INF/MANIFEST.MF
+++ b/bundles/designer/org.eclipse.smarthome.designer.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Designer UI
 Bundle-SymbolicName: org.eclipse.smarthome.designer.ui;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.designer.ui.UIActivator
 Bundle-Vendor: Eclipse.org/SmartHome
 Require-Bundle: org.eclipse.ui,

--- a/bundles/designer/org.eclipse.smarthome.designer.ui/pom.xml
+++ b/bundles/designer/org.eclipse.smarthome.designer.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>designer</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/designer/pom.xml
+++ b/bundles/designer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/io/org.eclipse.smarthome.io.audio/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.audio/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Audio I/O Bundle
 Bundle-SymbolicName: org.eclipse.smarthome.io.audio
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: org.slf4j

--- a/bundles/io/org.eclipse.smarthome.io.audio/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.audio/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.console.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.eclipse/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Console for OSGi framework Eclipse Equinox
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.eclipse
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: org.apache.commons.lang,

--- a/bundles/io/org.eclipse.smarthome.io.console.eclipse/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.eclipse/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.console.karaf/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.karaf/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Console for OSGi runtime Karaf
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.karaf
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: org.apache.karaf.shell.api.console;version="4.0.0",

--- a/bundles/io/org.eclipse.smarthome.io.console.karaf/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.karaf/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.console.rfc147/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.rfc147/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Console for OSGi Console RFC 147
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.rfc147
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: org.eclipse.smarthome.io.console,

--- a/bundles/io/org.eclipse.smarthome.io.console.rfc147/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.rfc147/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Console
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: org.apache.commons.lang,

--- a/bundles/io/org.eclipse.smarthome.io.console/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Private-Package: org.eclipse.smarthome.core.monitor.internal
 Ignore-Package: org.eclipse.smarthome.core.monitor.internal
 Bundle-Name: Eclipse SmartHome Monitor
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.io.monitor.internal.MonitorActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/io/org.eclipse.smarthome.io.monitor/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Network I/O bundle
 Bundle-SymbolicName: org.eclipse.smarthome.io.net.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.io.net
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/io/org.eclipse.smarthome.io.net.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.net/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Net I/O Bundle
 Bundle-SymbolicName: org.eclipse.smarthome.io.net
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.apache.commons.codec.net,

--- a/bundles/io/org.eclipse.smarthome.io.net/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.net/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IO REST Core Tests
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.core.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.io.rest.core

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.io</groupId>

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core REST API
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.core
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.base,

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap REST API
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sitemap
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: io.swagger.annotations;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IO SSE Tests
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sse.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.io.rest.sse

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome SSE REST API
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sse
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Activator: org.eclipse.smarthome.io.rest.sse.internal.SseActivator

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IO REST Tests
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.io.rest

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.io</groupId>

--- a/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome REST Interface Bundle
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: com.google.common.base,

--- a/bundles/io/org.eclipse.smarthome.io.rest/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Bonjour/MDS Service Discovery Bundle
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mdns
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.io.transport.mdns.internal.MDNSActivator
 Service-Component: OSGI-INF/*.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome MQTT Transport Bundle
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mqtt;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.smarthome.io.transport.mqtt

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IO UPnP Tests
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.upnp.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.io.transport.upnp

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.io</groupId>

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UPnP Transport Bundle
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.upnp
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.smarthome.io.transport.upnp,
  org.jupnp,

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.voice/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.voice/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Voice I/O Bundle
 Bundle-SymbolicName: org.eclipse.smarthome.io.voice
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .

--- a/bundles/io/org.eclipse.smarthome.io.voice/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.voice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/pom.xml
+++ b/bundles/io/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Model Core
 Bundle-SymbolicName: org.eclipse.smarthome.model.core;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.model.core.internal.ModelCoreActivator
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/model/org.eclipse.smarthome.model.core/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Model Runtime
 Bundle-SymbolicName: org.eclipse.smarthome.model.item.runtime;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Import-Package: org.osgi.framework,

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Model Tests
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.item.tests; singleton:=true
 Require-Bundle: org.eclipse.core.runtime
 Import-Package: groovy.lang,

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.item.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Editor UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.item.ui;singleton:=true
 Require-Bundle: org.eclipse.smarthome.model.item;visibility:=reexport,
  org.eclipse.xtext.ui,

--- a/bundles/model/org.eclipse.smarthome.model.item.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Model
 Bundle-Vendor: openHABorg
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.item;singleton:=true
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.generator;resolution:=optional,

--- a/bundles/model/org.eclipse.smarthome.model.item/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Model Lazy Generation
 Bundle-SymbolicName: org.eclipse.smarthome.model.lazygen
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Require-Bundle: org.eclipse.xtext,

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Persistence Runtime
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.osgi.framework,

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Persistence Model Tests
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.tests
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.smarthome.core.items,

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Persistence Model UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.ui;singleton:=true
 Require-Bundle: org.eclipse.smarthome.model.persistence;visibility:=reexport,
  org.eclipse.xtext.ui,

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Persistence Model
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence;singleton:=true
 Require-Bundle: org.eclipse.xtext;bundle-version="2.1.0";visibility:=reexport,
  org.eclipse.xtext.xbase;bundle-version="2.1.0";resolution:=optional;visibility:=reexport,

--- a/bundles/model/org.eclipse.smarthome.model.persistence/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Runtime
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/ruleengine.xml,

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Model Tests
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.tests;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Require-Bundle: org.eclipse.smarthome.model.rule,

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.rule.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Model UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.ui;singleton:=true
 Require-Bundle: org.eclipse.smarthome.model.rule;visibility:=reexport,
  org.eclipse.xtext.ui,

--- a/bundles/model/org.eclipse.smarthome.model.rule.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Model
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule;singleton:=true
 Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.generator;resolution:=optional,

--- a/bundles/model/org.eclipse.smarthome.model.rule/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script Runtime
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.script.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/scriptengine.xml,

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script Tests
 Bundle-SymbolicName: org.eclipse.smarthome.model.script.tests;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Require-Bundle: org.eclipse.xtend.lib,

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.script.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.script.ui;singleton:=true
 Require-Bundle: org.eclipse.smarthome.model.script;visibility:=reexport,
  org.eclipse.xtext.ui,

--- a/bundles/model/org.eclipse.smarthome.model.script.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.script;singleton:=true
 Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.xbase;visibility:=reexport,

--- a/bundles/model/org.eclipse.smarthome.model.script/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap Runtime
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.runtime;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.osgi.framework,

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap Editor UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.ui;singleton:=true
 Require-Bundle: org.eclipse.smarthome.model.sitemap;visibility:=reexport,
  org.eclipse.xtext.ui,

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap Model
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap;singleton:=true
 Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtext.generator;resolution:=optional,

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Model Runtime
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing.runtime;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.osgi.framework,

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Model Tests
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing.tests; singleton:=true
 Require-Bundle: org.eclipse.core.runtime
 Import-Package: groovy.lang,

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.thing.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Editor UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing.ui; singleton:=true
 Require-Bundle: org.eclipse.smarthome.model.thing;visibility:=reexport,
  org.eclipse.xtext.ui,

--- a/bundles/model/org.eclipse.smarthome.model.thing.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Model
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing; singleton:=true
 Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.xbase;resolution:=optional;visibility:=reexport,

--- a/bundles/model/org.eclipse.smarthome.model.thing/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/pom.xml
+++ b/bundles/model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the openHAB MapDB Storage
 Bundle-SymbolicName: org.eclipse.smarthome.storage.mapdb.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.storage.mapdb
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>storage</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome MapDB Storage Service
 Bundle-Vendor: openHAB.org
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: com.google.gson,

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>storage</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <name>Eclipse SmartHome MapDB Storage</name>

--- a/bundles/storage/pom.xml
+++ b/bundles/storage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Export-Package: org.eclipse.smarthome.test;uses:="groovy.lang,org.osgi
 Bundle-Name: Eclipse SmartHome Test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Bundle-SymbolicName: org.eclipse.smarthome.test

--- a/bundles/test/org.eclipse.smarthome.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>test</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/test/pom.xml
+++ b/bundles/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UI Icons Tests
 Bundle-SymbolicName: org.eclipse.smarthome.ui.icon.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.ui.icon
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/pom.xml
@@ -4,12 +4,12 @@
   <groupId>org.eclipse.smarthome.ui</groupId>
   <artifactId>org.eclipse.smarthome.ui.icon.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
   <name>Eclipse SmartHome UI Icon Tests</name>
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>ui</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/bundles/ui/org.eclipse.smarthome.ui.icon/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UI Icons
 Bundle-SymbolicName: org.eclipse.smarthome.ui.icon
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: javax.servlet,

--- a/bundles/ui/org.eclipse.smarthome.ui.icon/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>ui</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome UI Tests
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Fragment-Host: org.eclipse.smarthome.ui
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/ui/org.eclipse.smarthome.ui.test/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>ui</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/ui/org.eclipse.smarthome.ui/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.eclipse.smarthome.ui.internal
 Ignore-Package: org.eclipse.smarthome.ui.internal
 Bundle-Name: Eclipse SmartHome UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.ui.internal.UIActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/bundles/ui/org.eclipse.smarthome.ui/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>ui</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/ui/pom.xml
+++ b/bundles/ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>eclipsesmarthome-incubation</artifactId>

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: DigitalSTROM Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.digitalstrom;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -16,7 +16,7 @@
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.digitalstrom</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
   
   <name>DigitalSTROM Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: FSInternetRadio Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.fsinternetradio;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: 

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.fsinternetradio</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome FSInternetRadio Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome hue Binding Tests
 Bundle-SymbolicName: org.eclipse.smarthome.binding.hue.test;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.binding.hue

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome hue Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.hue;singleton:=true
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome LIFX Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.lifx;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -16,7 +16,7 @@
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.lifx</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome LIFX Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: ntp Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.ntp;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: 

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.ntp</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome NTP Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Sonos Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.sonos
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Wemo Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.wemo;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.wemo</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome WeMo Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: YahooWeather Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.yahooweather;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: com.google.common.collect,

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.yahooweather</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome YahooWeather Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/pom.xml
+++ b/extensions/binding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Exec Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: org.eclipse.smarthome.core.transform,

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome JavaScript Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: javax.script,

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the JSonPath Transformation Service
 Bundle-SymbolicName: org.eclipse.smarthome.transform.jsonpath.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.jsonpath
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome JSonPath Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: com.jayway.jsonpath,

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Map Transformation Service
 Bundle-SymbolicName: org.eclipse.smarthome.transform.map.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.map
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.map/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Map Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: org.eclipse.smarthome.core.i18n,

--- a/extensions/transform/org.eclipse.smarthome.transform.map/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the RegEx Transformation Service
 Bundle-SymbolicName: org.eclipse.smarthome.transform.regex.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.regex
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome RegEx Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: org.eclipse.smarthome.config.core,

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Scale Transformation Service
 Bundle-SymbolicName: org.eclipse.smarthome.transform.scale.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.scale
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Scale Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: org.eclipse.smarthome.core.i18n,

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the XPath Transformation Service
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.xpath
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome XPath Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: javax.xml.parsers,

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Xslt Transformation Service
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt.test
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.transform.xslt
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Xslt Transformation Service
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: javax.xml.transform,

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/pom.xml
+++ b/extensions/transform/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/META-INF/MANIFEST.MF
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Classic IconSet
 Bundle-SymbolicName: org.eclipse.smarthome.ui.iconset.classic
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.smarthome.core.i18n,

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/pom.xml
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui.iconset</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.extension.ui.iconset</groupId>

--- a/extensions/ui/iconset/pom.xml
+++ b/extensions/ui/iconset/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Basic UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.ui.basic.internal.WebAppActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Private-Package: org.eclipse.smarthome.ui.webapp.internal
 Ignore-Package: org.eclipse.smarthome.ui.webapp.internal
 Bundle-Name: Eclipse SmartHome WebApp UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-Activator: org.eclipse.smarthome.ui.classic.internal.WebAppActivator
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.ui.classic</artifactId>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Eclipse SmartHome Paper UI
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-ManifestVersion: 2
 Bundle-License: http://www.eclipse.org/legal/epl-v10.html
 Import-Package: org.osgi.service.component,

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/extensions/ui/pom.xml
+++ b/extensions/ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: MacOS Text-to-Speech
 Bundle-SymbolicName: org.eclipse.smarthome.voice.mactts;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.8.0.qualifier
+Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: org.eclipse.smarthome.io.voice.tts,

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/pom.xml
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.voice</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.voice</groupId>
   <artifactId>org.eclipse.smarthome.voice.mactts</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome MacOS TTS</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/voice/pom.xml
+++ b/extensions/voice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/karaf-tp/pom.xml
+++ b/features/karaf-tp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>karaf-tp</artifactId>

--- a/features/karaf-verify/pom.xml
+++ b/features/karaf-verify/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>karaf-verify</artifactId>

--- a/features/karaf/pom.xml
+++ b/features/karaf/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>karaf</artifactId>

--- a/features/org.eclipse.smarthome.feature.dependencies.designer/feature.xml
+++ b/features/org.eclipse.smarthome.feature.dependencies.designer/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.dependencies.designer"
       label="Eclipse SmartHome Designer Dependencies"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.dependencies.designer/pom.xml
+++ b/features/org.eclipse.smarthome.feature.dependencies.designer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.designer/feature.xml
+++ b/features/org.eclipse.smarthome.feature.designer/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.designer"
       label="Eclipse SmartHome Designer"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org"
       plugin="org.eclipse.smarthome.designer.core">
 

--- a/features/org.eclipse.smarthome.feature.designer/pom.xml
+++ b/features/org.eclipse.smarthome.feature.designer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.automation/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.automation/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.automation"
       label="Eclipse SmartHome Automation Support"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.automation/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.automation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.binding/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.binding/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.binding"
       label="Eclipse SmartHome Binding"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.binding/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.binding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.console.equinox/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.equinox/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.console.equinox"
       label="Eclipse SmartHome Equinox Console"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.console.equinox/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.equinox/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.console.rfc147/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.rfc147/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.console.rfc147"
       label="Eclipse SmartHome RfC147 Console"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.console.rfc147/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.rfc147/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.core"
       label="Eclipse SmartHome Core"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.core/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.model/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.model/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.model"
       label="Eclipse SmartHome Model Support"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.model/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.rest/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.rest/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.rest"
       label="Eclipse SmartHome REST Support"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.rest/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.rest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.ui/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.ui/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.ui"
       label="Eclipse SmartHome UI"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.ui/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.test/feature.xml
+++ b/features/org.eclipse.smarthome.feature.test/feature.xml
@@ -11,7 +11,7 @@
 <feature
       id="org.eclipse.smarthome.feature.test"
       label="Eclipse SmartHome Test Bundles"
-      version="0.8.0.qualifier"
+      version="0.9.0.qualifier"
       provider-name="Eclipse.org">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.test/pom.xml
+++ b/features/org.eclipse.smarthome.feature.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.eclipse.smarthome</groupId>
   <artifactId>smarthome</artifactId>
-  <version>0.8.0-SNAPSHOT</version>
+  <version>0.9.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome</name>
 

--- a/products/org.eclipse.smarthome.designer.product/category.xml
+++ b/products/org.eclipse.smarthome.designer.product/category.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.smarthome.feature.dependencies.designer_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.dependencies.designer" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.dependencies.designer_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.dependencies.designer" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.designer_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.designer" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.designer_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.designer" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <category-def name="org.eclipse.smarthome" label="Eclipse SmartHome">

--- a/products/org.eclipse.smarthome.designer.product/org.eclipse.smarthome.designer.product.product
+++ b/products/org.eclipse.smarthome.designer.product/org.eclipse.smarthome.designer.product.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse SmartHome Designer" uid="org.eclipse.smarthome.designer.product" id="org.eclipse.smarthome.designer.core.product" application="org.eclipse.smarthome.designer.ui.application" version="0.8.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse SmartHome Designer" uid="org.eclipse.smarthome.designer.product" id="org.eclipse.smarthome.designer.core.product" application="org.eclipse.smarthome.designer.ui.application" version="0.9.0.qualifier" useFeatures="true" includeLaunchers="true">
 
    <aboutInfo>
       <image path="/org.eclipse.smarthome.designer.core/icons/esh400.png"/>

--- a/products/org.eclipse.smarthome.designer.product/pom.xml
+++ b/products/org.eclipse.smarthome.designer.product/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>products</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/products/org.eclipse.smarthome.repo/category.xml
+++ b/products/org.eclipse.smarthome.repo/category.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.smarthome.feature.designer_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.designer" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.designer_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.designer" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.designer.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.designer.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.test_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.test" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.test_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.test" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.test.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.test.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.core_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.core" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.core_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.core" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.runtime.core.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.core.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.model_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.model" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.model_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.model" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.runtime.model.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.model.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.rest_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.rest" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.rest_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.rest" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.runtime.rest.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.rest.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.ui_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.ui" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.ui_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.ui" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.runtime.ui.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.ui.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.binding_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.binding" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.binding_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.binding" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.runtime.binding.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.binding.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.automation_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.automation" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.automation_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.automation" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.runtime.automation.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.automation.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.console.equinox_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.equinox" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.console.equinox_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.equinox" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.runtime.console.equinox.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.equinox.source" version="0.8.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.console.rfc147_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.rfc147" version="0.8.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.console.rfc147_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.rfc147" version="0.9.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <feature url="features/org.eclipse.smarthome.feature.runtime.console.rfc147.source_0.8.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.rfc147.source" version="0.8.0.qualifier">

--- a/products/org.eclipse.smarthome.repo/pom.xml
+++ b/products/org.eclipse.smarthome.repo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>products</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/products/pom.xml
+++ b/products/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome</groupId>

--- a/tools/archetype/binding.test/pom.xml
+++ b/tools/archetype/binding.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.tools</groupId>
     <artifactId>archetype</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.archetype</groupId>

--- a/tools/archetype/binding/pom.xml
+++ b/tools/archetype/binding/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.tools</groupId>
     <artifactId>archetype</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.archetype</groupId>

--- a/tools/archetype/pom.xml
+++ b/tools/archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>tools</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
There is already a new branch "0.8.x" that uses the current master code base.

On the HIPP is created two new jobs:
* SmartHomeDistribution-Nightly-0.8.x
* SmartHomeDistributionPublishNightly-0.8.x

I used a variable for the version in the script used in `SmartHomeDistributionPublishNightly` and `SmartHomeDistributionPublishStable`.
So after accepting this PR, you should change `BUILD_VERSION="0.8.0-SNAPSHOT"` to `BUILD_VERSION="0.9.0-SNAPSHOT"` in that two jobs.