### PR TITLE
Made firmware update console command extension for all firmware updat…

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/FirmwareUpdateConsoleCommandExtension.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/FirmwareUpdateConsoleCommandExtension.xml
@@ -18,6 +18,6 @@
 
     <reference bind="setFirmwareUpdateService" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.firmware.FirmwareUpdateService" name="FirmwareUpdateService" policy="static" unbind="unsetFirmwareUpdateService" />
     <reference bind="setFirmwareRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.firmware.FirmwareRegistry" name="FirmwareRegistry" policy="static" unbind="unsetFirmwareRegistry" />
-    <reference bind="setThingRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="static" unbind="unsetThingRegistry" />
+    <reference bind="addFirmwareUpdateHandler" cardinality="0..n" interface="org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler" name="FirmwareUpdateHandler" policy="dynamic" unbind="removeFirmwareUpdateHandler"/>
 
 </scr:component>


### PR DESCRIPTION
…e handlers

In our project we have integrated some devices whose integration does not base on ESH bindings. Because of these devices must also use the ESH device firmware update concept there are firmware update handlers registered for these devices with mocked "things". In order to use the console command extension also for these devices the dependency on the thing registry has been removed.

Signed-off-by: Thomas Höfer <t.hoefer@telekom.de>