### PR TITLE
differ between change und update event

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/EventTriggersTypeDefinition.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/EventTriggersTypeDefinition.json
@@ -1,12 +1,12 @@
-{  
-   "triggers":[  
-      {  
+{
+   "triggers":[
+      {
          "uid":"GenericEventTrigger",
          "label":"Basic Event Trigger",
          "description":"Triggers Rules on Events",
          "visibility":"HIDDEN",
-         "configDescriptions":[  
-            {  
+         "configDescriptions":[
+            {
                "name":"eventTopic",
                "type":"TEXT",
                "label":"Topic",
@@ -14,7 +14,7 @@
                "required":true,
                "defaultValue":"smarthome/*"
             },
-            {  
+            {
                "name":"eventSource",
                "type":"TEXT",
                "label":"Source",
@@ -22,7 +22,7 @@
                "required":true,
                "defaultValue":""
             },
-            {  
+            {
                "name":"eventTypes",
                "type":"TEXT",
                "label":"Event Type",
@@ -31,8 +31,8 @@
                "defaultValue":""
             }
          ],
-         "outputs":[  
-            {  
+         "outputs":[
+            {
                "name":"event",
                "type":"org.eclipse.smarthome.core.events.Event",
                "label":"Event",
@@ -41,12 +41,47 @@
             }
          ]
       },
-      {  
+      {
+         "uid":"ItemStateUpdateTrigger",
+         "label":"Item State Update Trigger",
+         "description":"This triggers a rule if an items state updated",
+         "configDescriptions":[
+            {
+               "name":"itemName",
+               "type":"TEXT",
+               "context":"item",
+               "label":"item name",
+               "description":"the name of the item which's state update should be observed",
+               "required":true
+            }
+         ],
+         "children":[
+            {
+               "id":"itemStateUpdateTriggerID",
+               "type":"GenericEventTrigger",
+               "configuration":{
+                  "eventSource":"$itemName",
+                  "eventTopic":"smarthome/items/*",
+                  "eventTypes":"ItemStateEvent"
+               }
+            }
+         ],
+         "outputs":[
+            {
+               "name":"event",
+               "type":"org.eclipse.smarthome.core.events.Event",
+               "description":"the event of the item state update",
+               "label":"Event",
+               "reference":"itemStateUpdateTriggerID.event"
+            }
+         ]
+      },
+      {
          "uid":"ItemStateChangeTrigger",
-         "label":"Item State Trigger",
+         "label":"Item State Change Trigger",
          "description":"This triggers a rule if an items state changed",
-         "configDescriptions":[  
-            {  
+         "configDescriptions":[
+            {
                "name":"itemName",
                "type":"TEXT",
                "context":"item",
@@ -55,23 +90,23 @@
                "required":true
             }
          ],
-         "children":[  
-            {  
+         "children":[
+            {
                "id":"itemStateChangeTriggerID",
                "type":"GenericEventTrigger",
-               "configuration":{  
+               "configuration":{
                   "eventSource":"$itemName",
                   "eventTopic":"smarthome/items/*",
-                  "eventTypes":"ItemStateEvent"
+                  "eventTypes":"ItemStateChangedEvent"
                }
             }
          ],
-         "outputs":[  
-            {  
+         "outputs":[
+            {
                "name":"event",
                "type":"org.eclipse.smarthome.core.events.Event",
                "description":"the event of the item state change",
-               "label":"event",
+               "label":"Event",
                "reference":"itemStateChangeTriggerID.event"
             }
          ]


### PR DESCRIPTION
The current trigger describe an state change but is using a state update
event. This PR fixes that and adds a new one, so we can use both trigger
types (change and update).
