### PR TITLE
Redirect only after response on items page

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.items.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.items.js
@@ -74,9 +74,11 @@ angular.module('PaperUI.controllers.configuration').controller('ItemSetupControl
                 itemName : $scope.item.name
             }, $scope.item).$promise.then(function() {
                 toastService.showDefaultToast(text);
+                $location.path('configuration/items');
+            }, function(failed) {
+                $location.path('configuration/items');
             });
         }
-        $location.path('configuration/items');
     }
 
     $scope.renderIcon = function() {


### PR DESCRIPTION
This needs to be implemented throughout PaperUI.
Fixes https://github.com/eclipse/smarthome/issues/1592.
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>