### PR TITLE
exclude the node and node_modules directory

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/.project
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/.project
@@ -36,4 +36,24 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1465846929365</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-true-false-node</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1465846929366</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-true-false-node_modules</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
Eclipse Neon analyzes all the JavaScript (etc.) files in this directory
and complains about a lot of errors.
The directory contains third party stuff that is downloaded by NPM
during the build phase.