### PR TITLE
digitalSTROM-Binding-Update-1

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/ESH-INF/i18n/digitalstrom_de.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/ESH-INF/i18n/digitalstrom_de.properties
@@ -7,7 +7,7 @@ DSS_BRIDGE_LABEL = digitalSTROM-Server
 DSS_BRIDGE_DESC = Der digitalSTROM-Server repräsentiert eine Schnittstelle zum digitalSTROM-System.
 #group-parms
 DSS_BRIDGE_PARM_GROUP_CONNECTION_LABEL = Verbindungs-Konfigurationen
-DSS_BRIDGE_PARM_GROUP_CONNECTION_DESC = Einstellungen der Verbindungs-Konfigurationen, um eine Verbindung zum digitalSTROM-Server herzustellen.
+DSS_BRIDGE_PARM_GROUP_CONNECTION_DESC = Einstellungen der Verbindungs-Konfigurationen um eine Verbindung zum digitalSTROM-Server herzustellen.
 
 DSS_BRIDGE_PARM_GROUP_GENERAL_LABEL = Generelle Konfigurationen
 DSS_BRIDGE_PARM_GROUP_GENERAL_DESC = Hier können Sie generelle Einstellungen für das Binding einstellen.
@@ -23,10 +23,10 @@ DSS_BRIDGE_PARM_IP_ADDRESS_LABEL = Netzwerkadresse
 DSS_BRIDGE_PARM_IP_ADDRESS_DESC = Netzwerkadresse des digitalSTROM-Server.
 
 DSS_BRIDGE_PARM_USERNAME_LABEL = Benutzername
-DSS_BRIDGE_PARM_USERNAME_DESC = Registierter Benutzername um sich beim digitalSTROM-Server zu authentifizieren.
+DSS_BRIDGE_PARM_USERNAME_DESC = Registrierter Benutzername um sich beim digitalSTROM-Server zu authentifizieren.
 
 DSS_BRIDGE_PARM_PASSWORD_LABEL = Passwort
-DSS_BRIDGE_PARM_PASSWORD_DESC = Registiertes Passwort zum Benutzername, um sich beim digitalSTROM-Server zu authentifizieren.
+DSS_BRIDGE_PARM_PASSWORD_DESC = Registriertes Passwort zum Benutzername um sich beim digitalSTROM-Server zu authentifizieren.
 
 DSS_BRIDGE_PARM_DSID_LABEL = dSID
 DSS_BRIDGE_PARM_DSID_DESC = Die eindeutige Kennung des digitalSTORM-Servers.
@@ -35,13 +35,13 @@ DSS_BRIDGE_PARM_DS_NAME_LABEL = Name der digitalSTROM-Installation
 DSS_BRIDGE_PARM_DS_NAME_DESC = Zeigt den benutzerdefinierten Namen der digitalSTROM-Installation.
 
 DSS_BRIDGE_PARM_SENSOR_INTER_LABEL = Aktualisierungsintervall der Sensorwerte
-DSS_BRIDGE_PARM_SENSOR_INTER_DESC = Stellt den Aktualisierungsintervall in Sekunden ein, in dem die Geräte Sensorwerte, welche eine höhere Priorität als 'never' haben, aktualisiert werden.
+DSS_BRIDGE_PARM_SENSOR_INTER_DESC = Stellt den Aktualisierungsintervall in Sekunden ein, indem die Geräte Sensorwerte, welche eine höhere Priorität als 'never' haben, aktualisiert werden.
 
 DSS_BRIDGE_PARM_TOTAL_POWER_INTER_LABEL = Aktualisierungsintervall der Gesamt-Stromverbräuche 
-DSS_BRIDGE_PARM_TOTAL_POWER_INTER_DESC = Stellt den Aktualisierungsintervall in Sekunden ein, in dem der Gesamt-Stromverbrauch und Gesamt-Stromzählerwert von digitalSTROM aktualisiert werden.
+DSS_BRIDGE_PARM_TOTAL_POWER_INTER_DESC = Stellt den Aktualisierungsintervall in Sekunden ein, indem der Gesamt-Stromverbrauch und Gesamt-Stromzählerwert von digitalSTROM aktualisiert werden.
 
 DSS_BRIDGE_PARM_SENSOR_WAIT_LABEL = Wartezeit Sensorauswertung
-DSS_BRIDGE_PARM_SENSOR_WAIT_DESC = Wartezeit zwischen der Auswertung der Sensorwerte, sowie die Auslesung der Szenen in Sekunden. <b>ACHTUNG:<b> digitalSTORM Regel 8 und 9 fordern eine Wartezeit von einer Minute. Werte unter 60 Sekunden könnten das digitalSTROM-System beeinträchtigen.
+DSS_BRIDGE_PARM_SENSOR_WAIT_DESC = Wartezeit zwischen der Auswertung der Sensorwerte sowie der Auslesung der Szenen in Sekunden. <b>ACHTUNG:<b> digitalSTORM Regel 8 und 9 fordern eine Wartezeit von einer Minute. Werte unter 60 Sekunden könnten das digitalSTROM-System beeinträchtigen.
 
 DSS_BRIDGE_PARM_TRASH_DELETE_LABEL = Tage nachdem nicht ereichbare digitalSTROM-Geräte gelöscht werden
 DSS_BRIDGE_PARM_TRASH_DELETE_DESC = Tage nachdem die temporär gespeicherten digitalSTROM Gerätekonfiguration von nicht ereichbaren digitalSTROM-Geräte endgültig gelöscht werden.
@@ -73,16 +73,16 @@ DS_DEVICE_PARM_DSID_LABEL = ID
 DS_DEVICE_PARM_DSID_DESC = Die eindeutige Kennung des digitalSTROM-Geräts.
 
 DS_DEVICE_PARM_METER_DSID_LABEL = Meter dSID
-DS_DEVICE_PARM_METER_DSID_DESC = Die eindeutige Kennung des digitalSTROM-Meters an dem das Gerät angeschlossen ist.
+DS_DEVICE_PARM_METER_DSID_DESC = Die eindeutige Kennung des digitalSTROM-Meters, an dem das Gerät angeschlossen ist.
 
-DS_DEVICE_PARM_HW_INFO_LABEL = Hardware Type
-DS_DEVICE_PARM_HW_INFO_DESC = Der Hardware Type dieses digitalSTROM-Geräts.
+DS_DEVICE_PARM_HW_INFO_LABEL = Hardwaretyp
+DS_DEVICE_PARM_HW_INFO_DESC = Der Hardwaretyp dieses digitalSTROM-Geräts.
 
 DS_DEVICE_PARM_ZONE_ID_LABEL = Zonen ID
-DS_DEVICE_PARM_ZONE_ID_DESC = Die Kennung der Zone in dem dieses digitalSTROM-Gerät eingeordnet ist.
+DS_DEVICE_PARM_ZONE_ID_DESC = Die Kennung der Zone, in dem dieses digitalSTROM-Gerät eingeordnet ist.
 
 DS_DEVICE_PARM_GROUP_ID_LABEL = Gruppen IDs
-DS_DEVICE_PARM_GROUP_ID_DESC = Die Kennung der Gruppen in dem dieses digitalSTROM-Gerät eingeordnet ist. Benutzerdefinierte sowie Funktionale-Farb-Gruppen.
+DS_DEVICE_PARM_GROUP_ID_DESC = Die Kennung der Gruppen, in dem dieses digitalSTROM-Gerät eingeordnet ist. Benutzerdefinierte sowie Funktionale-Farb-Gruppen.
 
 DS_DEVICE_PARM_OUTPUTMODE_LABEL = Ausgangs-Modus
 DS_DEVICE_PARM_OUTPUTMODE_DESC = Zeigt den aktuellen Ausgangs-Modus des digitalSTROM-Geräts z.B. 22 für dimmbar.
@@ -116,13 +116,13 @@ DS_GROUP_SCENE_LABEL = Gruppen-Szene/Stimmung
 DS_GROUP_SCENE_DESC = Repräsentiert eine digitalSTROM Gruppen-Szene/Stimmung.
 
 DS_NAMED_SCENE_LABEL = Benannte-Szene/Stimmung
-DS_NAMED_SCENE_DESC = Repräsentiert eine digitalSTROM Szene/Stimmung die vom Benutzer benannt wurde.
+DS_NAMED_SCENE_DESC = Repräsentiert eine digitalSTROM Szene/Stimmung, die vom Benutzer benannt wurde.
 
 #parms
 DS_SCENE_PARM_SCENE_NAME_LABEL = Szenen/Stimmungs-Name
-DS_SCENE_PARM_SCENE_NAME_DESC = Der Name digitalSTROM-Szene/Stimmung.
+DS_SCENE_PARM_SCENE_NAME_DESC = Der Name der digitalSTROM-Szene/Stimmung.
 
-DS_SCENE_PARM_GROUP_ID_LABEL = Zonen-ID or Zonen-Name
+DS_SCENE_PARM_GROUP_ID_LABEL = Zonen-ID oder Zonen-Name
 DS_SCENE_PARM_GROUP_ID_DESC = Die Zonenkennung oder der Zonenname der aufzurufenden Szene/Stimmung. Null oder leer ist broadcast zu allen Geräten der gewählten Zone.
 
 DS_SCENE_PARM_ZONE_ID_LABEL = Gruppen-ID oder Gruppen-Name
@@ -138,8 +138,11 @@ CHANNEL_BRIGHTNESS_DESCRIPTION = Regelt die Helligkeit des Lichtes.
 CHANNEL_LIGHT_SWITCH_LABEL = Lichtschalter
 CHANNEL_LIGHT_SWITCH_DESCRIPTION = Schaltet ein Licht ein oder aus.
 
-CHANNEL_SHADE_LABEL = Schattensteuerung
-CHANNEL_SHADE_DESCRIPTION = Erlaubt die Schattensteuerung z.B. von Rollladen oder Markisen.
+CHANNEL_SHADE_LABEL = Positionssteuerung
+CHANNEL_SHADE_DESCRIPTION = Erlaubt eine relative Positionseinstellung in Prozent z.B. von Rollläden oder Markisen.
+
+CHANNEL_SHADE_ANGLE_LABEL = Lamellensteuerung
+CHANNEL_SHADE_ANGLE_DESCRIPTION = Erlaubt eine relative Einstellung der Lamellenstellung in Prozent von Jalousien. 
 
 CHANNEL_GENERAL_DIMM_LABEL = Einstellung Geräteleistung
 CHANNEL_GENERAL_DIMM_DESCRIPTION = Stellt die Leistung eines Gerätes ein z.B. eines Deckenventilators.
@@ -154,7 +157,7 @@ CHANNEL_OUTPUT_CURRENT_LABEL = Ausgangsstrom
 CHANNEL_OUTPUT_CURRENT_DESCRIPTION = Zeigt den aktuelle Ausgangsstrom des Geräts in Ampere (mA) an.
 
 CHANNEL_ELECTRIC_METER_LABEL = Stromzähler
-CHANNEL_ELECTRIC_METER_DE_DESCRIPTION = Zeigt den aktuelle gesamt Stromverbrauch des Geräts in Kilowatt pro Stunde (kWh) an.
+CHANNEL_ELECTRIC_METER_DESCRIPTION = Zeigt den aktuelle gesamt Stromverbrauch des Geräts in Kilowatt pro Stunde (kWh) an.
 
 CHANNEL_COMBINED_2_STAGE_SWITCH_LABEL = 2 Phasen Lichtschalter
 CHANNEL_COMBINED_2_STAGE_SWITCH_DESCRIPTION = Der 2 Phasen Lichtschalter Channel erlaubt es zwei angeschlossene Lampen ein oder aus zu schalten oder nur eine der beiden Lampen zu schalten.
@@ -169,7 +172,7 @@ CHANNEL_GENERAL_COMBINED_3_STAGE_SWITCH_LABEL = 3 Phasen Geräteschalter
 CHANNEL_GENERAL_COMBINED_3_STAGE_SWITCH_DESCRIPTION = Der 3 Phasen Lichtschalter Channel erlaubt es die beiden Relais ein oder aus zu schalten oder eines der beiden Relais separat von einander zu schalten.
 
 CHANNEL_SCENE_LABEL = Szene/Stimmung
-CHANNEL_SCENE_DESCRIPTION = Ruft eine Szene/Stimmung auf bzw. macht sie rückgänig.
+CHANNEL_SCENE_DESCRIPTION = Ruft eine Szene/Stimmung auf bzw. macht sie rückgängig.
 
 CHANNEL_TOTAL_ACTIVE_POWER_LABEL = gesamt Stromverbrauch
 CHANNEL_TOTAL_ACTIVE_POWER_DESCRIPTION = Der gesamt Stromverbrauch Channel zeigt den aktuellen Stromverbrauch in Watt (W) von allen am digitalSTROM-System angschlossenen Stromkreisläufen an.
@@ -217,6 +220,7 @@ AREA_3_ON = Bereich 3 an
 
 AREA_4_OFF = Bereich 4 aus
 AREA_4_ON = Bereich 4 an
+
 #presets
 PRESET_0 = Stimmung 0 (voreingestellt: Aus)
 PRESET_1 = Stimmung 1 (voreingestellt: An)
@@ -242,12 +246,16 @@ PRESET_32 = Stimmung 32
 PRESET_33 = Stimmung 33
 PRESET_34 = Stimmung 34
 
-PRESET_40 = Stimmung 40 (voreingestellt: langsam Aus)
+PRESET_40 = Stimmung 40 (voreingestellt: Aus)
 PRESET_41 = Stimmung 41 (voreingestellt: An)
 PRESET_42 = Stimmung 42
 PRESET_43 = Stimmung 43
 PRESET_44 = Stimmung 44
-#group independent scene commands */
+
+#goup scenes
+AUTO_OFF = langsam Aus
+
+#group independent scene commands
 DEEP_OFF = Deep Off
 STANDBY = Standby
 ABSENT = Gehen

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/ESH-INF/i18n/digitalstrom_en.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/ESH-INF/i18n/digitalstrom_en.properties
@@ -35,7 +35,7 @@ DSS_BRIDGE_PARM_DS_NAME_LABEL = digitalSTROM-Installation name
 DSS_BRIDGE_PARM_DS_NAME_DESC = The user defined name of the digitalSTROM-Installation.
 
 DSS_BRIDGE_PARM_SENSOR_INTER_LABEL = Sensor update interval
-DSS_BRIDGE_PARM_SENSOR_INTER_DESC = Sets the seconds after the digitalSTROM-Device sensor data will be updated. If the priority is higher then 'never'.
+DSS_BRIDGE_PARM_SENSOR_INTER_DESC = Sets the seconds after the digitalSTROM-device sensor data will be updated. If the priority is higher then 'never'.
 
 DSS_BRIDGE_PARM_TOTAL_POWER_INTER_LABEL = Total power update interval
 DSS_BRIDGE_PARM_TOTAL_POWER_INTER_DESC = Sets the interval in seconds, after the digitalSTROM total power consumption and total electric meter sensor data will be updated.
@@ -44,7 +44,7 @@ DSS_BRIDGE_PARM_SENSOR_WAIT_LABEL = Wait time sensor reading
 DSS_BRIDGE_PARM_SENSOR_WAIT_DESC = Waiting time between the evaluation of the sensor values and the reading of the scenes in seconds. <b>ATTENTION:<b> digitalSTROM Rule 8 and 9 require a waiting period of 1 minute. Values less than 60 seconds could affect the digitalSTROM system.
 
 DSS_BRIDGE_PARM_TRASH_DELETE_LABEL = Days to be slaked trash bin devices
-DSS_BRIDGE_PARM_TRASH_DELETE_DESC = Sets the days after the temporary saved digitalSTROM-Device configuration from not reachable digitalSTROM-Devices get permanently deleted.
+DSS_BRIDGE_PARM_TRASH_DELETE_DESC = Sets the days after the temporary saved digitalSTROM-device configuration from not reachable digitalSTROM-devices get permanently deleted.
 
 #device
 DS_GE_DEVICE_LABEL = GE-Device (yellow)
@@ -58,44 +58,44 @@ DS_GR_DEVICE_DSEC =  Represents a digitalSTROM shade device.
 
 #group-parms
 DS_DEVICE_PARM_GROUP_INFO_LABEL = Device information
-DS_DEVICE_PARM_GROUP_INFO_DESC = Shows information of the digitalSTROM-Device.
+DS_DEVICE_PARM_GROUP_INFO_DESC = Shows information of the digitalSTROM-device.
 
 DS_DEVICE_PARM_GROUP_SENSOR_LABEL = Sensor setup
 DS_DEVICE_PARM_GROUP_SENSOR_DESC = Here you can configure the priorities for updating the device sensor values.
   
 #parms
 DS_DEVICE_PARM_NAME_LABEL = Name
-DS_DEVICE_PARM_NAME_DESC = The name of a digitalSTROM-Device.
+DS_DEVICE_PARM_NAME_DESC = The name of a digitalSTROM-device.
 
 DS_DEVICE_PARM_DSUID_LABEL = UID
-DS_DEVICE_PARM_DSUID_DESC = The unique identifier of a digitalSTROM-Device. With virtual devices.
+DS_DEVICE_PARM_DSUID_DESC = The unique identifier of a digitalSTROM-device. With virtual devices.
 
 DS_DEVICE_PARM_DSID_LABEL = ID
-DS_DEVICE_PARM_DSID_DESC = The unique identifier of a digitalSTROM-Device.
+DS_DEVICE_PARM_DSID_DESC = The unique identifier of a digitalSTROM-device.
 
 DS_DEVICE_PARM_METER_DSID_LABEL = Meter dSID
 DS_DEVICE_PARM_METER_DSID_DESC = Identifier of the meter in which the device is connected.
 
 DS_DEVICE_PARM_HW_INFO_LABEL = Device hardware type
-DS_DEVICE_PARM_HW_INFO_DESC = The hardware type from this digitalSTROM-Device.
+DS_DEVICE_PARM_HW_INFO_DESC = The hardware type from this digitalSTROM-device.
 
 DS_DEVICE_PARM_ZONE_ID_LABEL = Zone ID
-DS_DEVICE_PARM_ZONE_ID_DESC = The digitalSTROM-Device is part of this zone.
+DS_DEVICE_PARM_ZONE_ID_DESC = The digitalSTROM-device is part of this zone.
 
 DS_DEVICE_PARM_GROUP_ID_LABEL = Group ID's
-DS_DEVICE_PARM_GROUP_ID_DESC = The digitalSTROM-Device is part of this user-defined or functional groups.
+DS_DEVICE_PARM_GROUP_ID_DESC = The digitalSTROM-device is part of this user-defined or functional groups.
 
 DS_DEVICE_PARM_OUTPUTMODE_LABEL = Output mode
-DS_DEVICE_PARM_OUTPUTMODE_DESC = The current digitalSTROM-Device output mode e.g. 22 = dimmable.
+DS_DEVICE_PARM_OUTPUTMODE_DESC = The current digitalSTROM-device output mode e.g. 22 = dimmable.
 
 DS_DEVICE_PARM_FUNC_COLOR_GROUP_LABEL = Functional color group
-DS_DEVICE_PARM_FUNC_COLOR_GROUP_DESC = The current digitalSTROM-Device functional color group e.g. yellow = light.
+DS_DEVICE_PARM_FUNC_COLOR_GROUP_DESC = The current digitalSTROM-device functional color group e.g. yellow = light.
 
 DS_DEVICE_PARM_ACTIVE_POWER_LABEL = Active power refresh priority
 DS_DEVICE_PARM_ACTIVE_POWER_DESC = Sets the refresh priority for the active power sensor value. Can be never, low priority, medium priority or high priority.
 
 DS_DEVICE_PARM_ELECTRIC_METER_LABEL = Electric meter refresh priority
-DS_DEVICE_PARM_ELECTRIC_METER_DESC = Sets the refresh priority for the Electric meter sensor value. Can be never, low priority, medium priority or high priority.
+DS_DEVICE_PARM_ELECTRIC_METER_DESC = Sets the refresh priority for the electric meter sensor value. Can be never, low priority, medium priority or high priority.
 
 DS_DEVICE_PARM_OUTPUT_CURRENT_LABEL = Output current refresh priority
 DS_DEVICE_PARM_OUTPUT_CURRENT_DESC = Sets the refresh priority for the output current sensor value. Can be never, low priority, medium priority or high priority.
@@ -144,8 +144,11 @@ CHANNEL_COMBINED_2_STAGE_SWITCH_DESCRIPTION = The 2 stage light switch channel a
 CHANNEL_COMBINED_3_STAGE_SWITCH_LABEL = 3 stage light switch
 CHANNEL_COMBINED_3_STAGE_SWITCH_DESCRIPTION = The 3 stage light switch channel allows to turn both light devices on or off or switch both light devices separated from each other on or off.
 
-CHANNEL_SHADE_LABEL = Shade control
-CHANNEL_SHADE_DESCRIPTION = The shade control channel allows to control shade device e.g. a rollershutter or awnings.
+CHANNEL_SHADE_LABEL = Position control
+CHANNEL_SHADE_DESCRIPTION = The position control channel allows to control the relative position in percent e.g. of rollershutters or awnings.
+
+CHANNEL_SHADE_ANGLE_LABEL = Slat control
+CHANNEL_SHADE_ANGLE_DESCRIPTION = The slat control channel allows to control the relative slat position in percent of blinds.
 
 CHANNEL_GENERAL_DIMM_LABEL = Device power control
 CHANNEL_GENERAL_DIMM_DESCRIPTION = The device power control channel allows to control the power of a device e.g. a ceiling fan.
@@ -157,7 +160,7 @@ CHANNEL_GENERAL_COMBINED_2_STAGE_SWITCH_LABEL = 2 stage device switch
 CHANNEL_GENERAL_COMBINED_2_STAGE_SWITCH_DESCRIPTION = The 2 stage device switch channel allows to turn both relais of the device on or off or switch only 1 of the both relais on or off.
 
 CHANNEL_GENERAL_COMBINED_3_STAGE_SWITCH_LABEL = 3 stage device switch
-CHANNEL_GENERAL_COMBINED_3_STAGE_SWITCH_DESCRIPTION = The 3 stage device device channel allows to turn both relais of the device on or off or switch both relais of the device separated from each other on or off.
+CHANNEL_GENERAL_COMBINED_3_STAGE_SWITCH_DESCRIPTION = The 3 stage device channel allows to turn both relais of the device on or off or switch both relais of the device separated from each other on or off.
 
 CHANNEL_ACTIVE_POWER_LABEL = Active power
 CHANNEL_ACTIVE_POWER_DESCRIPTION = The active power channel indicates the current active power in watt (W) of the device.
@@ -242,11 +245,14 @@ PRESET_32 = Preset 32
 PRESET_33 = Preset 33
 PRESET_34 = Preset 34
 
-PRESET_40 = Preset 40 (Default: Slow Off)
+PRESET_40 = Preset 40 (Default: Off)
 PRESET_41 = Preset 41 (Default: On)
 PRESET_42 = Preset 42
 PRESET_43 = Preset 43
 PRESET_44 = Preset 44
+
+#goup scenes
+AUTO_OFF = Fade off
 
  #group independent scene commands
 DEEP_OFF = Deep Off

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/ESH-INF/thing/GroupScene.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/ESH-INF/thing/GroupScene.xml
@@ -48,6 +48,7 @@
                     <option value="AREA_4_OFF">@text/AREA_4_OFF</option>
                     <option value="AREA_4_ON">@text/AREA_4_ON</option>
                     <option value="PRESET_0">@text/PRESET_0</option>
+                    <option value="PRESET_1">@text/PRESET_1</option>
                     <option value="PRESET_2">@text/PRESET_2</option>
                     <option value="PRESET_3">@text/PRESET_3</option>
                     <option value="PRESET_4">@text/PRESET_4</option>
@@ -71,6 +72,7 @@
                     <option value="PRESET_42">@text/PRESET_42</option>
                     <option value="PRESET_43">@text/PRESET_43</option>
                     <option value="PRESET_44">@text/PRESET_44</option>
+                    <option value="AUTO_OFF">@text/AUTO_OFF</option>
                 </options>
             </parameter>
         </config-description>

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/README.md
@@ -29,6 +29,7 @@ The following table shows all tested digitalSTROM-Devices with their output-mode
 | GE-KM200 |     switched, dimmed | yellow |
 | GE-TKM210    | switched, dimmed | yellow |
 | GE-SDM200 | switched, dimmed | yellow |
+| GE-UMV200 | 1-10V dimmed | yellow |
 | GR-KL200    | standard output-mode | grey |    
 | GR-KL210    | standard output-mode| grey |
 | GR-KL220    | standard output-mode | grey |
@@ -169,7 +170,8 @@ All devices support some of the following channels:
 | lightSwitch | Switch | The light switch channel allows to turn a light device on or off. | GE, SW | 
 | combined2StageSwitch | String| The 2 stage light switch channel allows to turn both light devices on or off or switch only 1 of the both light device on or off. | SW-UMR200 | 
 | combined3StageSwitch | String | The 3 stage light switch channel allows to turn both light devices on or off or switch both light devices separated from each other on or off. | SW-UMR200 | 
-| shade | Rollershutter | The shade control channel allows to control shade device e.g. a roller shutter or awnings. | GR | 
+| shade | Rollershutter | The shade control channel allows to control shade device e.g. a roller shutter or awnings. | GR |
+| shadeAngle | Dimmer | The slat control channel allows to control the relative slat position in percent of blinds. | GR | 
 | generalDimm | Dimmer | The device power control channel allows to control the power of a device e.g. a ceiling fan. | SW | 
 | generalSwitch | Switch | The device switch channel allows to turn a device on or off e.g. a HIFI-System. | SW | 
 | generalCombined3StageSwitch  | String | The 2 stage device switch channel allows to turn both relais of the device on or off or switch only 1 of the both relais on or off. | SW-UMR200 | 
@@ -181,6 +183,13 @@ All devices support some of the following channels:
 | totalElectricMeter | Number | The total electric meter channel indicates the current electric meter value in killowatt hours of all connected circuits to the digitalSTROM-System. | dssBridge  | 
 | scene | Switch | The scene channel allows to call or undo a scene from digitalSTROM. | Scene | 
 
+**Notes:**  
+ *Channels with accepted command type increase and decrease:*  
+  * digitalSTROM will only evaluate increase and decrease commands, if a scene was called before which turn the device on. 
+   
+ *Blinds:*  
+ * Increase, decrease and up, down commands of the shade channel changes the angle in digitalSTROM, too. If you want to set only the position, you have to set the value directly.
+ * To protect the slats digitalSTROM changes the position by setting the angle, too, if the position is very high or low. So if you want to see the correct position, you have to send a refresh or stop command, if the blind is ready. 
 
 ## Full Example
 

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/DigitalSTROMBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/DigitalSTROMBindingConstants.java
@@ -74,6 +74,10 @@ public class DigitalSTROMBindingConstants {
 
     // shade
     public static final String CHANNEL_ID_SHADE = "shade";
+    public static final String CHANNEL_ID_SHADE_ANGLE = "shadeAngle";
+
+    public static final ChannelTypeUID CHANNEL_TYPE_SHADE_ANGLE = new ChannelTypeUID(BINDING_ID,
+            CHANNEL_ID_SHADE_ANGLE);
 
     // scene
     public static final String CHANNEL_ID_SCENE = "scene";

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/BridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/BridgeHandler.java
@@ -46,6 +46,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.slf4j.Logger;
@@ -273,13 +274,13 @@ public class BridgeHandler extends BaseBridgeHandler
                     "The connection to the digitalSTROM-Server can't established, because the host address is missing. Please set the host address.");
             return null;
         }
-        if (StringUtils.isNotBlank((String) thingConfig.get(USER_NAME))) {
+        if (thingConfig.get(USER_NAME) != null) {
             config.setUserName(thingConfig.get(USER_NAME).toString());
         }
-        if (StringUtils.isNotBlank((String) thingConfig.get(PASSWORD))) {
+        if (thingConfig.get(PASSWORD) != null) {
             config.setPassword(thingConfig.get(PASSWORD).toString());
         }
-        if (StringUtils.isNotBlank((String) thingConfig.get(APPLICATION_TOKEN))) {
+        if (thingConfig.get(APPLICATION_TOKEN) != null) {
             config.setAppToken(thingConfig.get(APPLICATION_TOKEN).toString());
         }
 
@@ -323,6 +324,10 @@ public class BridgeHandler extends BaseBridgeHandler
 
     @Override
     public void handleRemoval() {
+        for (Thing thing : getThing().getThings()) {
+            // Inform Thing-Child's about removed bridge.
+            thing.getHandler().bridgeStatusChanged(ThingStatusInfoBuilder.create(ThingStatus.REMOVED).build());
+        }
         if (StringUtils.isNotBlank((String) super.getConfig().get(APPLICATION_TOKEN))) {
             if (connMan == null) {
                 Config config = loadAndCheckConnectionData(this.getConfig());
@@ -528,7 +533,8 @@ public class BridgeHandler extends BaseBridgeHandler
             switch (reason) {
                 case WRONG_APP_TOKEN:
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
-                            "User defined Application-Token is wrong.");
+                            "User defined Application-Token is wrong. "
+                                    + "Please set user name and password to generate an Application-Token or set an valide Application-Token.");
                     break;
                 case WRONG_USER_OR_PASSWORD:
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
@@ -562,7 +568,9 @@ public class BridgeHandler extends BaseBridgeHandler
             }
             // reset connection timeout counter
             connectionTimeoutCounter = 0;
-            devStatMan.stop();
+            if (devStatMan != null) {
+                devStatMan.stop();
+            }
         }
 
     }
@@ -647,7 +655,7 @@ public class BridgeHandler extends BaseBridgeHandler
                     break;
                 case STOPPED:
                     if (!getThing().getStatusInfo().equals(ThingStatusDetail.COMMUNICATION_ERROR)
-                            || !getThing().getStatusInfo().equals(ThingStatusDetail.CONFIGURATION_ERROR)) {
+                            && !getThing().getStatusInfo().equals(ThingStatusDetail.CONFIGURATION_ERROR)) {
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, "DeviceStatusManager is stopped.");
                     }
                     break;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/BridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/BridgeHandler.java
@@ -167,7 +167,7 @@ public class BridgeHandler extends BaseBridgeHandler
     @Override
     public void initialize() {
         logger.debug("Initializing digitalSTROM-BridgeHandler");
-        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING, "Checking configuration...");
+        updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING, "Checking configuration...");
         // Start an extra thread to readout the configuration and check the connection, because it takes sometimes more
         // than 5000 milliseconds and the handler will suspend (ThingStatus.UNINITIALIZED).
         Config config = loadAndCheckConfig();

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
@@ -159,7 +159,7 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
         if (bridgeStatusInfo.getStatus().equals(ThingStatus.ONLINE)) {
             if (dSID != null) {
                 if (getDssBridgeHandler() != null) {
-                    updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                    updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                             "waiting for listener registration");
                     logger.debug("Set status to {}", getThing().getStatus());
                     dssBridgeHandler.registerDeviceStatusListener(this);

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/SceneHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/SceneHandler.java
@@ -133,7 +133,7 @@ public class SceneHandler extends BaseThingHandler implements SceneStatusListene
                                         + "' does not exist, please check the configuration.");
                         break;
                     case NO_STRUC_MAN:
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                        updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                                 "Waiting for building digitalSTROM model.");
                         break;
                     case NO_SCENE:
@@ -141,7 +141,7 @@ public class SceneHandler extends BaseThingHandler implements SceneStatusListene
                         break;
                     default:
                         this.sceneThingID = sceneID;
-                        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_PENDING,
+                        updateStatus(ThingStatus.ONLINE, ThingStatusDetail.CONFIGURATION_PENDING,
                                 "Waiting for listener registration");
                         logger.debug("Set status on {}", getThing().getStatus());
                         this.bridgeHandler.registerSceneStatusListener(this);

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/DeviceDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/DeviceDiscoveryService.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.binding.digitalstrom.DigitalSTROMBindingConstants;
 import org.eclipse.smarthome.binding.digitalstrom.handler.BridgeHandler;
 import org.eclipse.smarthome.binding.digitalstrom.handler.DeviceHandler;
@@ -64,7 +65,7 @@ public class DeviceDiscoveryService extends AbstractDiscoveryService {
      */
     @Override
     public void deactivate() {
-        logger.debug("deactivate discovery service for device type " + deviceType + " thing tyspes are: "
+        logger.debug("deactivate discovery service for device type " + deviceType + " thing types are: "
                 + super.getSupportedThingTypes().toString());
         removeOlderResults(new Date().getTime());
     }
@@ -103,22 +104,25 @@ public class DeviceDiscoveryService extends AbstractDiscoveryService {
                 properties.put(DigitalSTROMBindingConstants.DEVICE_FUNCTIONAL_COLOR_GROUP,
                         device.getFunctionalColorGroup());
                 properties.put(DigitalSTROMBindingConstants.DEVICE_METER_ID, device.getMeterDSID().getValue());
-                if (device.getName() != null) {
-                    properties.put(DEVICE_NAME, device.getName());
+                String deviceName = null;
+                if (StringUtils.isNotBlank(device.getName())) {
+                    deviceName = device.getName();
                 } else {
-                    properties.put(DEVICE_NAME, device.getDSID().getValue());
+                    // if no name is set, the dSID will be used as name
+                    deviceName = device.getDSID().getValue();
                 }
+                properties.put(DEVICE_NAME, deviceName);
                 DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withProperties(properties)
-                        .withBridge(bridgeUID).withLabel(device.getName()).build();
+                        .withBridge(bridgeUID).withLabel(deviceName).build();
 
                 thingDiscovered(discoveryResult);
             } else {
-                logger.debug("discovered unsupported device hardware type '{}' with uid {}", device.getHWinfo(),
+                logger.debug("Discovered unsupported device hardware type '{}' with uid {}", device.getHWinfo(),
                         device.getDSUID());
             }
         } else {
             logger.debug(
-                    "discovered device without output value, don't add to inbox. "
+                    "Discovered device with disabled or no output mode. Device was not added to inbox. "
                             + "Device information: hardware info: {}, dSUID: {}, device-name: {}, output value: {}",
                     device.getHWinfo(), device.getDSUID(), device.getName(), device.getOutputMode());
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/SceneDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/SceneDiscoveryService.java
@@ -120,7 +120,6 @@ public class SceneDiscoveryService extends AbstractDiscoveryService {
             case STOP:
             case MINIMUM:
             case MAXIMUM:
-            case AUTO_OFF:
             case DEVICE_ON:
             case DEVICE_OFF:
             case DEVICE_STOP:

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/ConnectionManagerImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/ConnectionManagerImpl.java
@@ -219,6 +219,9 @@ public class ConnectionManagerImpl implements ConnectionManager {
                 if (connListener != null) {
                     connListener.onConnectionStateChange(ConnectionListener.NOT_AUTHENTICATED,
                             ConnectionListener.WRONG_APP_TOKEN);
+                    if (!checkUserPassword()) {
+                        return;
+                    }
                 }
             }
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/SceneManagerImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/SceneManagerImpl.java
@@ -144,6 +144,10 @@ public class SceneManagerImpl implements SceneManager {
     }
 
     private boolean isEcho(String dsid, short sceneId) {
+        // sometimes the dS-event have a dSUID saved in the dSID
+        if (structureManager.getDeviceByDSUID(dsid) != null) {
+            dsid = structureManager.getDeviceByDSUID(dsid).getDSID().getValue();
+        }
         String echo = dsid + "-" + sceneId;
         return isEcho(echo);
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/AbstractSensorJobExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/AbstractSensorJobExecutor.java
@@ -54,10 +54,10 @@ public abstract class AbstractSensorJobExecutor {
 
     private List<CircuitScheduler> circuitSchedulerList = new LinkedList<CircuitScheduler>();
 
-    private class ExecuterRunnable implements Runnable {
+    private class ExecutorRunnable implements Runnable {
         private CircuitScheduler circuit;
 
-        public ExecuterRunnable(CircuitScheduler circuit) {
+        public ExecutorRunnable(CircuitScheduler circuit) {
             this.circuit = circuit;
         }
 
@@ -113,7 +113,7 @@ public abstract class AbstractSensorJobExecutor {
             if (pollingSchedulers.get(circuit.getMeterDSID()) == null
                     || pollingSchedulers.get(circuit.getMeterDSID()).isCancelled()) {
                 pollingSchedulers.put(circuit.getMeterDSID(),
-                        scheduler.scheduleAtFixedRate(new ExecuterRunnable(circuit), circuit.getNextExecutionDelay(),
+                        scheduler.scheduleAtFixedRate(new ExecutorRunnable(circuit), circuit.getNextExecutionDelay(),
                                 config.getSensorReadingWaitTime(), TimeUnit.MILLISECONDS));
             }
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/DeviceConsumptionSensorJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/DeviceConsumptionSensorJob.java
@@ -48,8 +48,7 @@ public class DeviceConsumptionSensorJob implements SensorJob {
     @Override
     public void execute(DsAPI digitalSTROM, String token) {
         int consumption = digitalSTROM.getDeviceSensorValue(token, this.device.getDSID(), null, this.sensorType);
-        logger.debug("SensorType: " + this.sensorType + ", DeviceConsumption : " + consumption + ", DSID: "
-                + this.device.getDSID().getValue());
+        logger.debug("Executes {} new device consumption is {}", this.toString(), consumption);
         switch (this.sensorType) {
             case ACTIVE_POWER:
                 this.device.updateInternalDeviceState(
@@ -101,5 +100,16 @@ public class DeviceConsumptionSensorJob implements SensorJob {
     @Override
     public void setInitalisationTime(long time) {
         this.initalisationTime = time;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "DeviceConsumptionSensorJob [sensorType=" + sensorType + ", deviceDSID : " + device.getDSID().getValue()
+                + ", meterDSID=" + meterDSID + ", initalisationTime=" + initalisationTime + "]";
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/SceneConfigReadingJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/SceneConfigReadingJob.java
@@ -89,4 +89,15 @@ public class SceneConfigReadingJob implements SensorJob {
     public void setInitalisationTime(long time) {
         this.initalisationTime = time;
     }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "SceneConfigReadingJob [sceneID: " + sceneID + ", deviceDSID : " + device.getDSID().getValue()
+                + ", meterDSID=" + meterDSID + ", initalisationTime=" + initalisationTime + "]";
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/SceneOutputValueReadingJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/SceneOutputValueReadingJob.java
@@ -45,12 +45,16 @@ public class SceneOutputValueReadingJob implements SensorJob {
 
     @Override
     public void execute(DsAPI digitalSTROM, String token) {
-        int sceneValue = digitalSTROM.getSceneValue(token, this.device.getDSID(), this.sceneID);
+        int[] sceneValue = digitalSTROM.getSceneValue(token, this.device.getDSID(), this.sceneID);
 
-        if (sceneValue != -1) {
-            this.device.setSceneOutputValue(this.sceneID, sceneValue);
+        if (sceneValue[0] != -1) {
+            if (device.isBlind()) {
+                device.setSceneOutputValue(this.sceneID, sceneValue[0], sceneValue[1]);
+            } else {
+                device.setSceneOutputValue(this.sceneID, sceneValue[0]);
+            }
             logger.debug("UPDATED sceneOutputValue for dsid: " + this.device.getDSID() + ", sceneID: " + sceneID
-                    + ", value: " + sceneValue);
+                    + ", value: " + sceneValue[0] + ", angle: " + sceneValue[1]);
         }
     }
 
@@ -87,5 +91,16 @@ public class SceneOutputValueReadingJob implements SensorJob {
     @Override
     public void setInitalisationTime(long time) {
         this.initalisationTime = time;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "SceneOutputValueReadingJob [sceneID: " + sceneID + ", deviceDSID : " + device.getDSID().getValue()
+                + ", meterDSID=" + meterDSID + ", initalisationTime=" + initalisationTime + "]";
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverConnection/DsAPI.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverConnection/DsAPI.java
@@ -109,7 +109,7 @@ public interface DsAPI {
     public boolean turnDeviceOff(String sessionToken, DSID dSID, String deviceName);
 
     /**
-     * Sets the output value of device
+     * Sets the output value of device.
      *
      * @param dSID needs either dSID or name
      * @param deviceName needs either dSID or name
@@ -337,16 +337,18 @@ public interface DsAPI {
 
     /**
      * Returns the configured scene output value for the given sceneId of the digitalSTROM-Device with the given dSID.
+     * <br>
+     * At array position 0 is the output value and at position 1 the angle value, if the device is a blind.
      *
      * @param sessionToken required
      * @param dSID required
      * @param sceneId required
-     * @return scene value
+     * @return scene value at array position 0 and angle at position 1
      *
      * @author Michael Ochel
      * @author Matthias Siegele
      */
-    public int getSceneValue(String sessionToken, DSID dSID, short sceneId);
+    public int[] getSceneValue(String sessionToken, DSID dSID, short sceneId);
 
     /**
      * Calls the INC scene on the digitalSTROM-Device with the given dSID and returns true if the request was success.

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverConnection/impl/DsAPIImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverConnection/impl/DsAPIImpl.java
@@ -1268,8 +1268,9 @@ public class DsAPIImpl implements DsAPI {
     }
 
     @Override
-    public int getSceneValue(String token, DSID dsid, short sceneId) {
+    public int[] getSceneValue(String token, DSID dsid, short sceneId) {
         String response = null;
+        int[] value = { -1, -1 };
         response = transport.execute(
                 "/json/device/getSceneValue?dsid=" + dsid.toString() + "&sceneID=" + sceneId + "&token=" + token, 4000,
                 20000);
@@ -1278,10 +1279,14 @@ public class DsAPIImpl implements DsAPI {
         if (JSONResponseHandler.checkResponse(responseObj)) {
             JsonObject obj = JSONResponseHandler.getResultJsonObject(responseObj);
             if (obj != null && obj.get("value") != null) {
-                return obj.get("value").getAsInt();
+                value[0] = obj.get("value").getAsInt();
+                if (obj.get("angle") != null) {
+                    value[1] = obj.get("angle").getAsInt();
+                }
+                return value;
             }
         }
-        return -1;
+        return value;
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverConnection/impl/HttpTransportImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverConnection/impl/HttpTransportImpl.java
@@ -88,7 +88,7 @@ public class HttpTransportImpl implements HttpTransport {
 
     /**
      * Creates a new {@link HttpTransportImpl} with configurations of the given {@link Config} and set ignore all
-     * SSL-Certificates..
+     * SSL-Certificates.
      *
      * @param config
      * @param exeptAllCerts (true = all will ignore)

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/Device.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/Device.java
@@ -8,6 +8,7 @@
 package org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices;
 
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.config.Config;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.listener.DeviceStatusListener;
@@ -152,7 +153,7 @@ public interface Device {
      *
      * @return is shade (true = yes | false = no)
      */
-    public boolean isRollershutter();
+    public boolean isShade();
 
     /**
      * Returns true, if the device output mode isn't disabled.
@@ -312,12 +313,13 @@ public interface Device {
     public void setGroups(List<Short> newGroupList);
 
     /**
-     * Returns the scene output value of this device of the given scene id
-     * or -1 if this scene id isn't read yet.
+     * Returns the scene output value of this device of the given scene id as {@link Integer} array. The first field is
+     * the output value and the second is the angle value or -1 if no angle value exists.
+     * If the method returns null, this scene id isn't read yet.
      *
-     * @return scene output value or -1
+     * @return scene output value and scene angle value or null, if it isn't read out yet
      */
-    public int getSceneOutputValue(short sceneID);
+    public Integer[] getSceneOutputValue(short sceneID);
 
     /**
      * Sets the scene output value of this device for the given scene id and scene output value.
@@ -458,8 +460,10 @@ public interface Device {
 
     /**
      * Undo the given {@link InternalScene} on this {@link Device} and updates it.
+     *
+     * @param scene to undo
      */
-    public void undoInternalScene();
+    public void undoInternalScene(InternalScene scene);
 
     /**
      * Initial a call scene for the given scene number.
@@ -549,4 +553,81 @@ public interface Device {
      * @param config
      */
     public void setConfig(Config config);
+
+    /**
+     * Returns the current angle position of the {@link Device}.
+     *
+     * @return current angle position
+     */
+    public short getAnglePosition();
+
+    /**
+     * Adds an set angle value command as {@link DeviceStateUpdate} with the given angle value to the list of
+     * outstanding commands.
+     *
+     * @param angle
+     */
+    public void setAnglePosition(int angle);
+
+    /**
+     * Sets the scene output value and scene output angle of this device for the given scene id, scene output value and
+     * scene output angle.
+     *
+     * @param sceneId
+     * @param value
+     * @param angle
+     */
+    public void setSceneOutputValue(short sceneId, int value, int angle);
+
+    /**
+     * Returns the max angle value of the slat.
+     *
+     * @return max slat angle
+     */
+    public int getMaxSlatAngle();
+
+    /**
+     * Returns the min angle value of the slat.
+     *
+     * @return min slat angle
+     */
+    public int getMinSlatAngle();
+
+    /**
+     * Returns true, if it is a blind device.
+     *
+     * @return is blind (true = yes | false = no
+     */
+    public boolean isBlind();
+
+    /**
+     * Saves scene configurations from the given sceneProperties in the {@link Device]. <br>
+     * The {@link Map} has to be like the following format:
+     * <ul>
+     * <li><b>Key:</b> scene[sceneID]</li>
+     * <li><b>Value:</b> {Scene: [sceneID], dontcare: [don't care flag], localPrio: [local prio flag], specialMode:
+     * [special mode flag]}(0..1),
+     * {sceneValue: [sceneValue]{, sceneAngle: [scene angle]}(0..1)}(0..1)</li>
+     * </ul>
+     *
+     * @param sceneProperties
+     */
+    public void saveConfigSceneSpecificationIntoDevice(Map<String, String> sceneProperties);
+
+    /**
+     * Returns the min output value.
+     *
+     * @return min output value
+     */
+    public short getMinOutputValue();
+
+    /**
+     * Adds a slat increase command as {@link DeviceStateUpdate} to the list of outstanding commands.
+     */
+    public void increaseSlatAngle();
+
+    /**
+     * Adds a slat decrease command as {@link DeviceStateUpdate} to the list of outstanding commands.
+     */
+    public void decreaseSlatAngle();
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/DeviceConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/DeviceConstants.java
@@ -8,46 +8,54 @@
 package org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.deviceParameters;
 
 /**
- * @author Alexander Betker
- * @version digitalSTROM-API 1.14.5
+ * The {@link DeviceConstants} contains some constants for digitalSTROM devices.
+ *
+ * @author Alexander Betker - Initial contribution
+ * @author Michael Ochel - updated constants
+ * @author Matthias Siegele - updated constants
  */
 public interface DeviceConstants {
 
     /** digitalSTROM dim step for lights (this value is not in percent!) */
-    public final static short DIMM_STEP_LIGHT = 11;
+    public final static short DIM_STEP_LIGHT = 11;
 
     /** move step for roller shutters (this value is not in percent!) */
-    public final static short MOVE_STEP_ROLLERSHUTTER = 4;
+    public final static short MOVE_STEP_ROLLERSHUTTER = 983;
 
-    /** move step for slats (this value is not in percent!) */
-    public final static short MOVE_STEP_SLAT = 11;
+    /** move step for slats angle by blind/jalousie (this value is not in percent!) */
+    public final static short ANGLE_STEP_SLAT = 11;
 
     /** default move step (this value is not in percent!) */
     public final static short DEFAULT_MOVE_STEP = 11;
 
-    /** */
+    /** default max output value */
     public final static short DEFAULT_MAX_OUTPUTVALUE = 255;
 
     /** max output value if device (lamp -> yellow) is on */
     public final static short MAX_OUTPUT_VALUE_LIGHT = 255;
 
-    /** is max open (special case: awning/marquee -> closed */
-    public final static short MAX_ROLLERSHUTTER = 255;
+    /** is open (special case: awning/marquee -> closed) */
+    public final static int MAX_ROLLERSHUTTER = 65535;
 
-    /** closed (special case: awning/marquee -> open */
+    /** is closed (special case: awning/marquee -> open) */
     public final static short MIN_ROLLERSHUTTER = 0;
 
-    public final static short MAX_SLAT_POSITION = 255;
+    /** max slat angle by blind/jalousie */
+    public final static short MAX_SLAT_ANGLE = 255;
 
-    public final static short MIN_SLAT_POSITION = 0;
+    /** min slat angle by blind/jalousie */
+    public final static short MIN_SLAT_ANGLE = 0;
 
     /** you can't dim deeper than this value */
-    public final static short MIN_DIMM_VALUE = 16;
+    public final static short MIN_DIM_VALUE = 16;
 
-    /** this is the index to get the outputvalue (min-, max value) of almost all devices */
+    /** this is the index to get the output value (min-, max value) of almost all devices */
     public final static short DEVICE_SENSOR_OUTPUT = 0;
 
-    /** this index is needed to get the position of the slats (if device is a jalousie) */
-    public final static short DEVICE_SENSOR_SLAT_OUTPUT = 4;
+    /** this is the index to get the output value (min-, max value) of shade devices */
+    public final static short DEVICE_SENSOR_SLAT_POSITION_OUTPUT = 2;
+
+    /** this index is needed to get the angle of the slats (if device is a blind/jalousie) */
+    public final static short DEVICE_SENSOR_SLAT_ANGLE_OUTPUT = 4;
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/DeviceStateUpdate.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/DeviceStateUpdate.java
@@ -30,9 +30,13 @@ public interface DeviceStateUpdate {
 
     // shades
     public final static String UPDATE_SLATPOSITION = "slatposition";
+    public static final String UPDATE_SLAT_ANGLE = "slatAngle";
     public final static String UPDATE_SLAT_INCREASE = "slatIncrese";
     public final static String UPDATE_SLAT_DECREASE = "slatDecrese";
-    public final static String UPDATE_OPEN_CLOSE = "OpenClose";
+    public static final String UPDATE_SLAT_ANGLE_INCREASE = "slatAngleIncrese";
+    public static final String UPDATE_SLAT_ANGLE_DECREASE = "slatAngleDecrese";
+    public final static String UPDATE_OPEN_CLOSE = "openClose";
+    public static final String UPDATE_OPEN_CLOSE_ANGLE = "openCloseAngle";
     public final static String UPDATE_SLAT_MOVE = "slatMove";
     public final static String UPDATE_SLAT_STOP = "slatStop";
 
@@ -43,13 +47,15 @@ public interface DeviceStateUpdate {
     public final static String UPDATE_OUTPUT_VALUE = "outputValue";
 
     // scene
-    /**
-     * A scene call can have the value between 0 and 127.
-     */
+    /** A scene call can have the value between 0 and 127. */
     public final static String UPDATE_CALL_SCENE = "callScene";
     public final static String UPDATE_UNDO_SCENE = "undoScene";
     public final static String UPDATE_SCENE_OUTPUT = "sceneOutput";
     public final static String UPDATE_SCENE_CONFIG = "sceneConfig";
+
+    // general
+    /** command to refresh the output value of an device. */
+    public static final String REFRESH_OUTPUT = "refreshOutput";
 
     /**
      * Returns the state update value.

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/FunctionalColorGroupEnum.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/FunctionalColorGroupEnum.java
@@ -78,7 +78,7 @@ public enum FunctionalColorGroupEnum {
      * @param modeID
      * @return mode
      */
-    public static FunctionalColorGroupEnum getMode(Integer functionalColorGroupID) {
+    public static FunctionalColorGroupEnum getColorGroup(Integer functionalColorGroupID) {
         return colorGroups.get(functionalColorGroupID);
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/FunctionalNameAndColorGroupEnum.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/FunctionalNameAndColorGroupEnum.java
@@ -38,20 +38,20 @@ public enum FunctionalNameAndColorGroupEnum {
      * | n/a | Access | Green | Access related functions, door bell |
      *
      */
-    LIGHTS(1, FunctionalColorGroupEnum.getMode(1)),
-    BLINDS(2, FunctionalColorGroupEnum.getMode(2)),
-    CURTAINS(12, FunctionalColorGroupEnum.getMode(12)),
-    HEATING(3, FunctionalColorGroupEnum.getMode(3)),
-    COOLING(9, FunctionalColorGroupEnum.getMode(9)),
-    VENTILATION(10, FunctionalColorGroupEnum.getMode(10)),
-    WINDOW(11, FunctionalColorGroupEnum.getMode(11)),
-    TEMPERATION_CONTROL(48, FunctionalColorGroupEnum.getMode(48)),
-    AUDIO(4, FunctionalColorGroupEnum.getMode(4)),
-    VIDEO(5, FunctionalColorGroupEnum.getMode(5)),
-    JOKER(8, FunctionalColorGroupEnum.getMode(8)),
-    SINGLE_DEVICE(-1, FunctionalColorGroupEnum.getMode(-1)),
-    SECURITY(-2, FunctionalColorGroupEnum.getMode(-2)),
-    ACCESS(-3, FunctionalColorGroupEnum.getMode(-3));
+    LIGHTS(1, FunctionalColorGroupEnum.getColorGroup(1)),
+    BLINDS(2, FunctionalColorGroupEnum.getColorGroup(2)),
+    CURTAINS(12, FunctionalColorGroupEnum.getColorGroup(12)),
+    HEATING(3, FunctionalColorGroupEnum.getColorGroup(3)),
+    COOLING(9, FunctionalColorGroupEnum.getColorGroup(9)),
+    VENTILATION(10, FunctionalColorGroupEnum.getColorGroup(10)),
+    WINDOW(11, FunctionalColorGroupEnum.getColorGroup(11)),
+    TEMPERATION_CONTROL(48, FunctionalColorGroupEnum.getColorGroup(48)),
+    AUDIO(4, FunctionalColorGroupEnum.getColorGroup(4)),
+    VIDEO(5, FunctionalColorGroupEnum.getColorGroup(5)),
+    JOKER(8, FunctionalColorGroupEnum.getColorGroup(8)),
+    SINGLE_DEVICE(-1, FunctionalColorGroupEnum.getColorGroup(-1)),
+    SECURITY(-2, FunctionalColorGroupEnum.getColorGroup(-2)),
+    ACCESS(-3, FunctionalColorGroupEnum.getColorGroup(-3));
 
     private final int colorGroup;
     private final FunctionalColorGroupEnum color;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/OutputModeEnum.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/OutputModeEnum.java
@@ -43,7 +43,12 @@ public enum OutputModeEnum {
      * | 40 | Relay with wiped mode scene table configuration |
      * | 41 | Relay with saving mode scene table configuration |
      * | 42 | Positioning control for uncalibrated shutter |
-     * | 43 | combined switch | (from ds web configurator, it dosn't stand in the ds-basic.pdf from 19.08.2015)
+     * | 43 | combined switch | (from dS web configurator, it dosn't stand in the ds-basic.pdf from 19.08.2015)
+     * | 49 | dimmed 0-10V [dimming with 0-10V control power] | (from dS web configurator, it dosn't stand in the
+     * ds-basic.pdf from 02.06.2015)
+     * | 51 | dimmed 1-10V [dimming with 1-10V control power] | (from dS web configurator, it dosn't stand in the
+     * ds-basic.pdf from 02.06.2015)
+     *
      */
     DISABLED(0),
     SWITCHED(16),
@@ -63,7 +68,9 @@ public enum OutputModeEnum {
     WIPE(40),
     POWERSAVE(41),
     POSITION_CON_US(42),
-    COMBINED_SWITCH(43);
+    COMBINED_SWITCH(43),
+    DIMMED_0_10V(49),
+    DIMMED_1_10V(51);
 
     private final int mode;
 
@@ -79,10 +86,77 @@ public enum OutputModeEnum {
      * Returns true, if the output mode id contains in digitalSTROM, otherwise false.
      *
      * @param modeID
-     * @return true if contains otherwise false
+     * @return true, if contains, otherwise false
      */
     public static boolean containsMode(Integer modeID) {
         return outputModes.keySet().contains(modeID);
+    }
+
+    /**
+     * Returns true, if the output mode is a dimmable output mode, otherwise false.
+     *
+     * @param outputMode
+     * @return true, if outputMode is dimmable, otherwise false
+     */
+    public static boolean outputModeIsDimmable(OutputModeEnum outputMode) {
+        if (outputMode == null) {
+            return false;
+        }
+        switch (outputMode) {
+            case RMS_DIMMER:
+            case RMS_DIMMER_CC:
+            case PC_DIMMER:
+            case PC_DIMMER_CC:
+            case RPC_DIMMER:
+            case RPC_DIMMER_CC:
+            case DIMMED_0_10V:
+            case DIMMED_1_10V:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Returns true, if the output mode is a switchable output mode, otherwise false.
+     *
+     * @param outputMode
+     * @return true, if outputMode is switchable, otherwise false
+     */
+    public static boolean outputModeIsSwitch(OutputModeEnum outputMode) {
+        if (outputMode == null) {
+            return false;
+        }
+        switch (outputMode) {
+            case SWITCHED:
+            case SWITCH:
+            case COMBINED_SWITCH:
+            case SINGLE_SWITCH:
+            case WIPE:
+            case POWERSAVE:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Returns true, if the output mode is a shade control output mode, otherwise false.
+     * 
+     * @param outputMode
+     * @return true, if outputMode is for shade control, otherwise false
+     */
+    public static boolean outputModeIsShade(OutputModeEnum outputMode) {
+        if (outputMode == null) {
+            return false;
+        }
+        switch (outputMode) {
+            case POSITION_CON:
+            case POSITION_CON_US:
+                return true;
+            default:
+                return false;
+        }
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/providers/DsChannelTypeProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/providers/DsChannelTypeProvider.java
@@ -51,7 +51,8 @@ public class DsChannelTypeProvider implements ChannelTypeProvider {
             DigitalSTROMBindingConstants.CHANNEL_ID_OUTPUT_CURRENT,
             DigitalSTROMBindingConstants.CHANNEL_ID_ACTIVE_POWER,
             DigitalSTROMBindingConstants.CHANNEL_ID_TOTAL_ACTIVE_POWER,
-            DigitalSTROMBindingConstants.CHANNEL_ID_TOTAL_ELECTRIC_METER);
+            DigitalSTROMBindingConstants.CHANNEL_ID_TOTAL_ELECTRIC_METER,
+            DigitalSTROMBindingConstants.CHANNEL_ID_SHADE_ANGLE);
 
     private I18nProvider i18n = null;
     private Bundle bundle = null;
@@ -180,7 +181,12 @@ public class DsChannelTypeProvider implements ChannelTypeProvider {
                             getCombinedStageDescription((short) 3, true, locale), null);
                 case DigitalSTROMBindingConstants.CHANNEL_ID_SHADE:
                     return new ChannelType(channelTypeUID, false, SHADE, getText("CHANNEL_SHADE_LABEL", locale),
-                            getText("CHANNEL_SHADE_DESCRIPTION", locale), "Energy",
+                            getText("CHANNEL_SHADE_DESCRIPTION", locale), "Blinds",
+                            Sets.newHashSet(getText("GREY", locale), getText("DS", locale), getText("SHADE", locale)),
+                            null, null);
+                case DigitalSTROMBindingConstants.CHANNEL_ID_SHADE_ANGLE:
+                    return new ChannelType(channelTypeUID, false, DIMMER, getText("CHANNEL_SHADE_ANGLE_LABEL", locale),
+                            getText("CHANNEL_SHADE_ANGLE_DESCRIPTION", locale), "Blinds",
                             Sets.newHashSet(getText("GREY", locale), getText("DS", locale), getText("SHADE", locale)),
                             null, null);
                 case DigitalSTROMBindingConstants.CHANNEL_ID_ACTIVE_POWER:


### PR DESCRIPTION
# First update for the digitalSTROM-Binding

## Bug fixes:
 * Fix rollershutters showing wrong position. Bug-Fix: #1530
 * Rollershutters showing more exact positions and scene calls work.
 * Auto load sensor channels will work again.
 * Handling of stop event takes no more than 5000 ms.
 * Scene behavior by call/undo other scenes or devices will work correct.

## new supports:
 * Binding supports GE-UMV200
 * Binding supports GR-KL210 (Complete behavior test of GR-KL200, 210 and 220 by digitalSTROM-Testserver (no real roller shutters, awnings or blinds))
 * Add new Channel slatAngle and set angle support by device objects for GR-KL210.
 * Add group scene fade off/auto off

## changes:
 * Outputvalue in percent will be rounded
 * Add methods for output mode check at the OutputModeEnum to make adding OutputModes more maintainable.
 * Move method for loading Scene-Config from DeviceThingHandler to Device.
 * Add refresh for output channels
 * Add check for output value before sending a command  send to the dSS. That commands which have no effect will not be send.
 * Change method bridgeHandlerInizilased to new method brigdeStateChanged.

## other:
 * Fix some typos of the code
 * Some more little fixes/changes

Also-by: Matthias Siegele <digitalSTROM-ESH-binding@web.de>
Signed-off-by: Michael Ochel <michael.ochel@koeln.de>