### PR TITLE
Thing properties are never persisted 

### DIFF
--- a/docs/documentation/development/bindings/thing-handler.md
+++ b/docs/documentation/development/bindings/thing-handler.md
@@ -229,7 +229,7 @@ protected void devicePropertiesChanged(DeviceInfo deviceInfo) {
 }
 ```
 
-If only one property must be changed, there is also a convenient method `updateProperty(String name, String value)`. Both methods will only inform the framework that the thing was modified, if at least one property was added, removed or updated. 
+If only one property must be changed, there is also a convenient method `updateProperty(String name, String value)`. Note, that in contrast to configuration updates, property changes are never persisted. The framework is not notified about changed properties. 
 
 ### Updating the Thing Structure
 


### PR DESCRIPTION
Removed callback.thingUpdated(…) from BaseThingHandler#updateProperties and #updateProperty

fixes: #588

Signed-off-by: Andre Fuechsel <andre.fuechsel@telekom.de>