### PR TITLE
Default text field if there is no widget for context

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
@@ -129,6 +129,9 @@ angular.module('PaperUI.services', [ 'PaperUI.constants' ]).config(function($htt
                         parameter.element = 'textarea';
                         parameter.inputType = 'text';
                         parameter.label = parameter.label && parameter.label.length > 0 ? parameter.label : 'Script';
+                    } else {
+                        parameter.element = 'input';
+                        parameter.inputType = 'text';
                     }
                 } else if (parameter.type.toUpperCase() === 'TEXT') {
                     if (parameter.options && parameter.options.length > 0) {


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/1699#issuecomment-227219992
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>