### PR TITLE
increase default timeout for waitFor[Assert]

### DIFF
--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
@@ -142,13 +142,13 @@ abstract class OSGiTest {
      * The condition is specified by a closure, that must return a boolean object. When the condition is
      * not fulfilled Thread.sleep is called at the current Thread for a specified time. After this time
      * the condition is checked again. By a default the specified sleep time is 50 ms. The default timeout
-     * is 1000 ms.
+     * is 10000 ms.
      *
      * @param condition closure that must not have an argument and must return a boolean value
-     * @param timeout timeout, default is 1000ms
+     * @param timeout timeout, default is 10000ms
      * @param sleepTime interval for checking the condition, default is 50ms
      */
-    protected void waitFor(Closure<?> condition, int timeout = 1000, int sleepTime = 50) {
+    protected void waitFor(Closure<?> condition, int timeout = 10000, int sleepTime = 50) {
         def waitingTime = 0
         while(!condition() && waitingTime < timeout) {
             waitingTime += sleepTime
@@ -161,13 +161,13 @@ abstract class OSGiTest {
      * The assertion is specified by a closure, that must throw an Exception, if the assertion is not fulfilled.
      * When the assertion is not fulfilled Thread.sleep is called at the current Thread for a specified time.
      * After this time the condition is checked again. By a default the specified sleep time is 50 ms.
-     * The default timeout is 1000 ms.
+     * The default timeout is 10000 ms.
      *
      * @param condition closure that must not have an argument
-     * @param timeout timeout, default is 1000ms
+     * @param timeout timeout, default is 10000ms
      * @param sleepTime interval for checking the condition, default is 50ms
      */
-    protected void waitForAssert(Closure<?> assertion, int timeout = 1000, int sleepTime = 50) {
+    protected void waitForAssert(Closure<?> assertion, int timeout = 10000, int sleepTime = 50) {
         def waitingTime = 0
         while(waitingTime < timeout) {
             try {


### PR DESCRIPTION
As discussed here: https://github.com/eclipse/smarthome/pull/1704#issuecomment-227425654