### PR TITLE
stabilize tests

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
@@ -95,12 +95,12 @@ class GroupItemTest extends OSGiTest {
         //State changes -> one change event is fired
         member.setState(new RawType())
 
-        def changes = events.findAll{it instanceof GroupItemStateChangedEvent}
-
         waitForAssert {
             assertThat events.size(), is(1)
-            assertThat changes.size(), is(1)
         }
+
+        def changes = events.findAll{it instanceof GroupItemStateChangedEvent}
+        assertThat changes.size(), is(1)
 
         def change = changes.getAt(0) as GroupItemStateChangedEvent
         assertTrue change.getItemName().equals(groupItem.getName())

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ChangeThingTypeOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ChangeThingTypeOSGiTest.groovy
@@ -333,8 +333,10 @@ class ChangeThingTypeOSGiTest extends OSGiTest {
         assertThat handlerOsgiService2, is(thing.getHandler())
 
         // Ensure it's initialized
-        assertThat(specificInits, is(1))
-        assertThat(genericInits, is(0))
+        waitForAssert {
+            assertThat(specificInits, is(1))
+            assertThat(genericInits, is(0))
+        }
 
         // Ensure the Thing is ONLINE again
         assertThat thing.getStatus(), is(ThingStatus.ONLINE)


### PR DESCRIPTION
The previous change does not really solve the problem.
`changes` is constructed before the waitForAssert instruction.
So, if events is empty, changes will be empty. Then we wait until events.size is 1... But this will not change the size of the already created `changes`.

The other test fails, so I added a waitFor there, too.