### PR TITLE
Added not null checks for GroupItem addMember and removeMember operation

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -92,7 +92,16 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         }
     }
 
+    /**
+     * Adds the given item to the members of this group item.
+     *
+     * @param item the item to be added (must not be null)
+     * @throws IllegalArgumentException if the given item is null
+     */
     public void addMember(Item item) {
+        if (item == null) {
+            throw new IllegalArgumentException("Item must not be null!");
+        }
         members.add(item);
         if (item instanceof GenericItem) {
             GenericItem genericItem = (GenericItem) item;
@@ -100,7 +109,16 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         }
     }
 
+    /**
+     * Removes the given item from the members of this group item.
+     *
+     * @param item the item to be removed (must not be null)
+     * @throws IllegalArgumentException if the given item is null
+     */
     public void removeMember(Item item) {
+        if (item == null) {
+            throw new IllegalArgumentException("Item must not be null!");
+        }
         members.remove(item);
         if (item instanceof GenericItem) {
             GenericItem genericItem = (GenericItem) item;


### PR DESCRIPTION
The problem is if you add a null value to the group item members then you will get a NPE once you invoke the getMembers operation (because of Guavas ImmutableSet.copyOf that throws NPE for null elements)

Signed-off-by: Thomas Höfer <t.hoefer@telekom.de>