### PR TITLE
Fix mDNS discovery (bug #577)

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/MDNSClient.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/MDNSClient.java
@@ -7,6 +7,8 @@
  */
 package org.eclipse.smarthome.io.transport.mdns;
 
+import java.util.Set;
+
 import javax.jmdns.JmDNS;
 
 /**
@@ -18,9 +20,9 @@ import javax.jmdns.JmDNS;
 public interface MDNSClient {
 
     /**
-     * This method returns an jmDNS instance
-     * 
+     * This method returns the set of JmDNS instances
+     *
      */
-    public JmDNS getClient();
+    public Set<JmDNS> getClientInstances();
 
 }


### PR DESCRIPTION
One JmDNS instance is now created for each local IP address.
Loopback and Link-local addresses are ignored.
Only network interfaces that are up at openHAB startup are considered.

This change is important when running openHAB on a machine having one IP
v4 and one IP v6. On such a machine, two things will now work correctly:
- the discovery of IP v4 services
- the publishing of openHAB services on IP v4 and IP v6

Signed-off-by: Laurent Garnier lg.hc@free.fr