### PR TITLE
Fix mDNS discovery (bug #577 #1745)

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/MDNSClient.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/MDNSClient.java
@@ -7,7 +7,12 @@
  */
 package org.eclipse.smarthome.io.transport.mdns;
 
+import java.io.IOException;
+import java.util.Set;
+
 import javax.jmdns.JmDNS;
+import javax.jmdns.ServiceInfo;
+import javax.jmdns.ServiceListener;
 
 /**
  * This interface defines how to get an JmDNS instance
@@ -18,9 +23,60 @@ import javax.jmdns.JmDNS;
 public interface MDNSClient {
 
     /**
-     * This method returns an jmDNS instance
-     * 
+     * This method returns the set of JmDNS instances
+     *
+     * @return a set of JmDNS instances
      */
-    public JmDNS getClient();
+    public Set<JmDNS> getClientInstances();
 
+    /**
+     * Listen for services of a given type
+     *
+     * @param type: full qualified service type
+     * @param listener: listener for service updates
+     */
+    public void addServiceListener(String type, ServiceListener listener);
+
+    /**
+     * Remove listener for services of a given type
+     *
+     * @param type: full qualified service type
+     * @param listener: listener for service updates
+     */
+    public void removeServiceListener(String type, ServiceListener listener);
+
+    /**
+     * Register a service
+     *
+     * @param description: service to register, described by (@link ServiceDescription)
+     */
+    public void registerService(ServiceDescription description) throws IOException;
+
+    /**
+     * Unregister a service. The service should have been registered.
+     *
+     * @param description: service to remove, described by (@link ServiceDescription)
+     */
+    public void unregisterService(ServiceDescription description);
+
+    /**
+     * Unregister all services
+     *
+     */
+    public void unregisterAllServices();
+
+    /**
+     * Returns a list of service infos of the specified type
+     *
+     * @param type: service type name
+     *
+     * @return an array of service instance
+     */
+    public ServiceInfo[] list(String type);
+
+    /**
+     * Close properly JmDNS instances
+     *
+     */
+    public void close();
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/discovery/MDNSDiscoveryService.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/discovery/MDNSDiscoveryService.java
@@ -48,14 +48,14 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
         this.mdnsClient = mdnsClient;
         if (isBackgroundDiscoveryEnabled()) {
             for (MDNSDiscoveryParticipant participant : participants) {
-                mdnsClient.getClient().addServiceListener(participant.getServiceType(), this);
+                mdnsClient.addServiceListener(participant.getServiceType(), this);
             }
         }
     }
 
     public void unsetMDNSClient(MDNSClient mdnsClient) {
         for (MDNSDiscoveryParticipant participant : participants) {
-            mdnsClient.getClient().removeServiceListener(participant.getServiceType(), this);
+            mdnsClient.removeServiceListener(participant.getServiceType(), this);
         }
         this.mdnsClient = null;
     }
@@ -69,14 +69,14 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
             }
         }, 0, TimeUnit.SECONDS);
         for (MDNSDiscoveryParticipant participant : participants) {
-            mdnsClient.getClient().addServiceListener(participant.getServiceType(), this);
+            mdnsClient.addServiceListener(participant.getServiceType(), this);
         }
     }
 
     @Override
     protected void stopBackgroundDiscovery() {
         for (MDNSDiscoveryParticipant participant : participants) {
-            mdnsClient.getClient().removeServiceListener(participant.getServiceType(), this);
+            mdnsClient.removeServiceListener(participant.getServiceType(), this);
         }
     }
 
@@ -84,43 +84,28 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
     protected void startScan() {
         logger.debug("mDNS discovery service started");
         for (MDNSDiscoveryParticipant participant : participants) {
-            ServiceInfo[] services = mdnsClient.getClient().list(participant.getServiceType());
-            logger.debug(services.length + " services found for " + participant.getServiceType());
+            ServiceInfo[] services = mdnsClient.list(participant.getServiceType());
+            logger.debug("{} services found for {}", services.length, participant.getServiceType());
             for (ServiceInfo service : services) {
                 DiscoveryResult result = participant.createResult(service);
                 if (result != null) {
                     thingDiscovered(result);
                 }
             }
-        }
-    }
-
-    protected void initializeParticipants() {
-        for (MDNSDiscoveryParticipant participant : participants) {
-            mdnsClient.getClient().removeServiceListener(participant.getServiceType(), this);
-            ServiceInfo[] services = mdnsClient.getClient().list(participant.getServiceType());
-            logger.debug(services.length + " services found for " + participant.getServiceType());
-            for (ServiceInfo service : services) {
-                DiscoveryResult result = participant.createResult(service);
-                if (result != null) {
-                    thingDiscovered(result);
-                }
-            }
-            mdnsClient.getClient().addServiceListener(participant.getServiceType(), this);
         }
     }
 
     protected void addMdnsDiscoveryParticipant(MDNSDiscoveryParticipant participant) {
         this.participants.add(participant);
         if (mdnsClient != null && isBackgroundDiscoveryEnabled()) {
-            mdnsClient.getClient().addServiceListener(participant.getServiceType(), this);
+            mdnsClient.addServiceListener(participant.getServiceType(), this);
         }
     }
 
     protected void removeMdnsDiscoveryParticipant(MDNSDiscoveryParticipant participant) {
         this.participants.remove(participant);
         if (mdnsClient != null) {
-            mdnsClient.getClient().removeServiceListener(participant.getServiceType(), this);
+            mdnsClient.removeServiceListener(participant.getServiceType(), this);
         }
     }
 
@@ -135,16 +120,7 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
 
     @Override
     public void serviceAdded(ServiceEvent serviceEvent) {
-        for (MDNSDiscoveryParticipant participant : participants) {
-            try {
-                DiscoveryResult result = participant.createResult(serviceEvent.getInfo());
-                if (result != null) {
-                    thingDiscovered(result);
-                }
-            } catch (Exception e) {
-                logger.error("Participant '{}' threw an exception", participant.getClass().getName(), e);
-            }
-        }
+        considerService(serviceEvent);
     }
 
     @Override
@@ -163,7 +139,21 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
 
     @Override
     public void serviceResolved(ServiceEvent serviceEvent) {
-
+        considerService(serviceEvent);
     }
 
+    private void considerService(ServiceEvent serviceEvent) {
+        if (isBackgroundDiscoveryEnabled()) {
+            for (MDNSDiscoveryParticipant participant : participants) {
+                try {
+                    DiscoveryResult result = participant.createResult(serviceEvent.getInfo());
+                    if (result != null) {
+                        thingDiscovered(result);
+                    }
+                } catch (Exception e) {
+                    logger.error("Participant '{}' threw an exception", participant.getClass().getName(), e);
+                }
+            }
+        }
+    }
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
@@ -8,10 +8,20 @@
 package org.eclipse.smarthome.io.transport.mdns.internal;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import javax.jmdns.JmDNS;
+import javax.jmdns.ServiceInfo;
+import javax.jmdns.ServiceListener;
 
 import org.eclipse.smarthome.io.transport.mdns.MDNSClient;
+import org.eclipse.smarthome.io.transport.mdns.ServiceDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,29 +34,168 @@ import org.slf4j.LoggerFactory;
 public class MDNSClientImpl implements MDNSClient {
     private final Logger logger = LoggerFactory.getLogger(MDNSClientImpl.class);
 
-    private JmDNS jmdns;
+    private Set<JmDNS> jmdnsInstances = new CopyOnWriteArraySet<>();
 
+    private static Set<InetAddress> getAllInetAddresses() {
+        final Set<InetAddress> addresses = new HashSet<>();
+        Enumeration<NetworkInterface> itInterfaces;
+        try {
+            itInterfaces = NetworkInterface.getNetworkInterfaces();
+        } catch (final SocketException e) {
+            return addresses;
+        }
+        while (itInterfaces.hasMoreElements()) {
+            final NetworkInterface iface = itInterfaces.nextElement();
+            try {
+                if (!iface.isUp() || iface.isLoopback()) {
+                    continue;
+                }
+            } catch (final SocketException ex) {
+                continue;
+            }
+            final Enumeration<InetAddress> itAddresses = iface.getInetAddresses();
+            while (itAddresses.hasMoreElements()) {
+                final InetAddress address = itAddresses.nextElement();
+                if (address.isLoopbackAddress() || address.isLinkLocalAddress()) {
+                    continue;
+                }
+                addresses.add(address);
+            }
+        }
+        return addresses;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public JmDNS getClient() {
-        return jmdns;
+    public Set<JmDNS> getClientInstances() {
+        return jmdnsInstances;
     }
 
     public void activate() {
-        try {
-            jmdns = JmDNS.create();
-            logger.debug("mDNS service has been started");
-        } catch (IOException e) {
+        for (InetAddress address : getAllInetAddresses()) {
+            try {
+                JmDNS jmdns = JmDNS.create(address, "JmDNS-IP-" + (jmdnsInstances.size() + 1));
+                jmdnsInstances.add(jmdns);
+                logger.debug("mDNS service has been started ({} for IP {})", jmdns.getName(), address.getHostAddress());
+            } catch (IOException e) {
+                logger.debug("JmDNS instanciation failed ({})!", address.getHostAddress());
+            }
+        }
+        if (jmdnsInstances.isEmpty()) {
             // we must cancel the activation of this component here
-            throw new IllegalStateException(e);
+            throw new IllegalStateException("No mDNS service has been started");
         }
     }
 
     public void deactivate() {
-        if (jmdns != null) {
+        close();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addServiceListener(String type, ServiceListener listener) {
+        for (JmDNS instance : jmdnsInstances) {
+            instance.addServiceListener(type, listener);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeServiceListener(String type, ServiceListener listener) {
+        for (JmDNS instance : jmdnsInstances) {
+            instance.removeServiceListener(type, listener);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void registerService(ServiceDescription description) throws IOException {
+        for (JmDNS instance : jmdnsInstances) {
+            logger.debug("Registering new service {} at {}:{} ({})", description.serviceType,
+                    instance.getInetAddress().getHostAddress(), description.servicePort, instance.getName());
+            // Create one ServiceInfo object for each JmDNS instance
+            ServiceInfo serviceInfo = ServiceInfo.create(description.serviceType, description.serviceName,
+                    description.servicePort, 0, 0, description.serviceProperties);
+            instance.registerService(serviceInfo);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void unregisterService(ServiceDescription description) {
+        for (JmDNS instance : jmdnsInstances) {
+            try {
+                logger.debug("Unregistering service {} at {}:{} ({})", description.serviceType,
+                        instance.getInetAddress().getHostAddress(), description.servicePort, instance.getName());
+            } catch (IOException e) {
+                logger.debug("Unregistering service {} ({})", description.serviceType, instance.getName());
+            }
+            ServiceInfo serviceInfo = ServiceInfo.create(description.serviceType, description.serviceName,
+                    description.servicePort, 0, 0, description.serviceProperties);
+            instance.unregisterService(serviceInfo);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void unregisterAllServices() {
+        for (JmDNS instance : jmdnsInstances) {
+            instance.unregisterAllServices();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ServiceInfo[] list(String type) {
+        ServiceInfo[] services = new ServiceInfo[0];
+        for (JmDNS instance : jmdnsInstances) {
+            services = concatenate(services, instance.list(type));
+        }
+        return services;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        for (JmDNS jmdns : jmdnsInstances) {
             try {
                 jmdns.close();
             } catch (IOException e) {
             }
         }
+    }
+
+    /**
+     * Concatenate two arrays of ServiceInfo
+     *
+     * @param a: the first array
+     * @param b: the second array
+     * @return an array of ServiceInfo
+     */
+    private ServiceInfo[] concatenate(ServiceInfo[] a, ServiceInfo[] b) {
+        int aLen = a.length;
+        int bLen = b.length;
+
+        ServiceInfo[] c = new ServiceInfo[aLen + bLen];
+        System.arraycopy(a, 0, c, 0, aLen);
+        System.arraycopy(b, 0, c, aLen, bLen);
+
+        return c;
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSServiceImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSServiceImpl.java
@@ -12,8 +12,6 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executors;
 
-import javax.jmdns.ServiceInfo;
-
 import org.eclipse.smarthome.io.transport.mdns.MDNSClient;
 import org.eclipse.smarthome.io.transport.mdns.MDNSService;
 import org.eclipse.smarthome.io.transport.mdns.ServiceDescription;
@@ -32,7 +30,7 @@ public class MDNSServiceImpl implements MDNSService {
     private final Logger logger = LoggerFactory.getLogger(MDNSServiceImpl.class);
     private MDNSClient mdnsClient;
 
-    private Set<ServiceInfo> servicesToRegisterQueue = new CopyOnWriteArraySet<>();
+    private Set<ServiceDescription> servicesToRegisterQueue = new CopyOnWriteArraySet<>();
 
     public MDNSServiceImpl() {
     }
@@ -44,13 +42,15 @@ public class MDNSServiceImpl implements MDNSService {
             Runnable runnable = new Runnable() {
                 @Override
                 public void run() {
-                    for (ServiceInfo serviceInfo : servicesToRegisterQueue) {
+                    logger.debug("Registering {} queued services", servicesToRegisterQueue.size());
+                    for (ServiceDescription description : servicesToRegisterQueue) {
                         try {
-                            logger.debug("Registering new service " + serviceInfo.getType() + " at port "
-                                    + String.valueOf(serviceInfo.getPort()));
-                            mdnsClient.getClient().registerService(serviceInfo);
+                            mdnsClient.registerService(description);
                         } catch (IOException e) {
                             logger.error(e.getMessage());
+                        } catch (IllegalStateException e) {
+                            logger.debug("Not registering service {}, because service is already deactivated!",
+                                    description.serviceType);
                         }
                     }
                     servicesToRegisterQueue.clear();
@@ -72,23 +72,18 @@ public class MDNSServiceImpl implements MDNSService {
         if (mdnsClient == null) {
             // queue the service to register it as soon as the mDNS client is
             // available
-            ServiceInfo serviceInfo = ServiceInfo.create(description.serviceType, description.serviceName,
-                    description.servicePort, 0, 0, description.serviceProperties);
-            servicesToRegisterQueue.add(serviceInfo);
+            servicesToRegisterQueue.add(description);
         } else {
             Runnable runnable = new Runnable() {
                 @Override
                 public void run() {
-                    ServiceInfo serviceInfo = ServiceInfo.create(description.serviceType, description.serviceName,
-                            description.servicePort, 0, 0, description.serviceProperties);
                     try {
-                        logger.debug("Registering new service " + description.serviceType + " at port "
-                                + String.valueOf(description.servicePort));
-                        mdnsClient.getClient().registerService(serviceInfo);
+                        mdnsClient.registerService(description);
                     } catch (IOException e) {
                         logger.error(e.getMessage());
                     } catch (IllegalStateException e) {
-                        logger.debug("Not registering service, because service is already deactivated!");
+                        logger.debug("Not registering service {}, because service is already deactivated!",
+                                description.serviceType);
                     }
                 }
             };
@@ -101,14 +96,9 @@ public class MDNSServiceImpl implements MDNSService {
      */
     @Override
     public void unregisterService(ServiceDescription description) {
-        if (mdnsClient == null) {
-            return;
+        if (mdnsClient != null) {
+            mdnsClient.unregisterService(description);
         }
-        ServiceInfo serviceInfo = ServiceInfo.create(description.serviceType, description.serviceName,
-                description.servicePort, 0, 0, description.serviceProperties);
-        logger.debug("Unregistering service " + description.serviceType + " at port "
-                + String.valueOf(description.servicePort));
-        mdnsClient.getClient().unregisterService(serviceInfo);
     }
 
     /**
@@ -116,7 +106,7 @@ public class MDNSServiceImpl implements MDNSService {
      */
     protected void unregisterAllServices() {
         if (mdnsClient != null) {
-            mdnsClient.getClient().unregisterAllServices();
+            mdnsClient.unregisterAllServices();
         }
     }
 
@@ -126,13 +116,9 @@ public class MDNSServiceImpl implements MDNSService {
 
     public void deactivate() {
         unregisterAllServices();
-        try {
-            if (mdnsClient != null) {
-                mdnsClient.getClient().close();
-                logger.debug("mDNS service has been stopped");
-            }
-        } catch (IOException e) {
-            logger.error(e.getMessage());
+        if (mdnsClient != null) {
+            mdnsClient.close();
+            logger.debug("mDNS service has been stopped");
         }
     }
 


### PR DESCRIPTION
One JmDNS instance is now created for each local IP address.
Loopback and Link-local addresses are ignored.
Only network interfaces that are up at openHAB startup are considered.

This change is important when running openHAB on a machine having one IP
v4 and one IP v6. On such a machine, two things will now work correctly:
- the discovery of IP v4 services
- the publishing of openHAB services on IP v4 and IP v6

Signed-off-by: Laurent Garnier <lg.hc@free.fr>