### PR TITLE
Added a queueing thread pool implementation

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/common/ThreadPoolManagerTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/common/ThreadPoolManagerTest.groovy
@@ -48,7 +48,6 @@ class ThreadPoolManagerTest {
         assertTrue tpe.allowsCoreThreadTimeOut()
         assertThat tpe.getKeepAliveTime(TimeUnit.SECONDS), is(ThreadPoolManager.THREAD_TIMEOUT)
         assertThat tpe.getCorePoolSize(), is(ThreadPoolManager.DEFAULT_THREAD_POOL_CORE_SIZE)
-        assertThat tpe.getMaximumPoolSize(), is(ThreadPoolManager.DEFAULT_THREAD_POOL_MAX_SIZE)
     }
 
     @Test
@@ -70,7 +69,6 @@ class ThreadPoolManagerTest {
         ThreadPoolExecutor result = ThreadPoolManager.getPool("test4")
 
         assertThat result.getCorePoolSize(), is(4)
-        assertThat result.getMaximumPoolSize(), is(10)
     }
 
     @Test
@@ -88,16 +86,13 @@ class ThreadPoolManagerTest {
     void 'reconfiguring cached pool'() {
         ThreadPoolExecutor result = ThreadPoolManager.getPool("test6")
         assertThat result.getCorePoolSize(), is(ThreadPoolManager.DEFAULT_THREAD_POOL_CORE_SIZE)
-        assertThat result.getMaximumPoolSize(), is(ThreadPoolManager.DEFAULT_THREAD_POOL_MAX_SIZE)
 
         def tpm = new ThreadPoolManager()
         tpm.modified(["test6":"7"])
 
         assertThat result.getCorePoolSize(), is(7)
-        assertThat result.getMaximumPoolSize(), is(ThreadPoolManager.DEFAULT_THREAD_POOL_MAX_SIZE)
 
         tpm.modified(["test6":"3,8"])
         assertThat result.getCorePoolSize(), is(3)
-        assertThat result.getMaximumPoolSize(), is(8)
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/common/QueueingThreadPoolExecutorTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/common/QueueingThreadPoolExecutorTest.java
@@ -1,0 +1,314 @@
+/**
+ * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.common;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test class for the {@link QueueingThreadPoolExecutor} class, abbreviated here
+ * QueueingTPE.
+ *
+ * @author Jochen Hiller - Initial contribution
+ */
+public class QueueingThreadPoolExecutorTest {
+
+    /**
+     * we know that the QueuingTPE uses a core pool timeout of 10 seconds. Will
+     * be needed to check if all threads are down after this timeout.
+     */
+    private final static int CORE_POOL_TIMEOUT = 10000;
+
+    /**
+     * We can enable logging for all test cases.
+     */
+    @Before
+    public void setUp() {
+        // enable to see logging. See below how to include slf4j-simple
+        // enableLogging();
+        disableLogging();
+    }
+
+    /**
+     * Creates QueueingTPE instances. By default there will be NO thread
+     * created, check it.
+     */
+    @Test
+    public void testCreateInstance() {
+        String poolName = "testCreateInstance";
+        QueueingThreadPoolExecutor.createInstance(poolName, 1);
+        QueueingThreadPoolExecutor.createInstance(poolName, 2);
+        QueueingThreadPoolExecutor.createInstance(poolName, 5);
+        QueueingThreadPoolExecutor.createInstance(poolName, 10);
+        QueueingThreadPoolExecutor.createInstance(poolName, 1000);
+        QueueingThreadPoolExecutor.createInstance(poolName, 10000);
+        QueueingThreadPoolExecutor.createInstance(poolName, 100000);
+        QueueingThreadPoolExecutor.createInstance(poolName, 1000000);
+        // no threads created
+        assertFalse(areThreadsFromPoolRunning(poolName));
+    }
+
+    /**
+     * Tests what happens when poolName == null.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateInstanceInvalidArgsPoolNameNull() throws InterruptedException {
+        QueueingThreadPoolExecutor.createInstance(null, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateInstanceInvalidArgsPoolSize0() {
+        QueueingThreadPoolExecutor.createInstance("test", 0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateInstanceInvalidArgsPoolSizeMinus1() {
+        QueueingThreadPoolExecutor.createInstance("test", -1);
+    }
+
+    /**
+     * This test tests behavior of QueueingTPE for a pool of core=1, max=2 when
+     * no tasks have been scheduled. Same assumptions as above.
+     */
+    @Test
+    public void testQueuingTPEPoolSize2() throws InterruptedException {
+        String poolName = "testQueuingTPEPoolSize2";
+        ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+
+        assertEquals(pool.getActiveCount(), 0);
+        assertEquals(pool.allowsCoreThreadTimeOut(), true);
+        assertEquals(pool.getCompletedTaskCount(), 0);
+        assertEquals(pool.getCorePoolSize(), 1);
+        assertEquals(pool.getMaximumPoolSize(), 2);
+        assertEquals(pool.getLargestPoolSize(), 0);
+        assertEquals(pool.getQueue().size(), 0);
+
+        // now expect that no threads have been created
+        assertFalse(areThreadsFromPoolRunning(poolName));
+
+        // no need to wait after shutdown as no threads created
+        pool.shutdown();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPoolWithBlankPoolName() throws InterruptedException {
+        basicTestForPoolName(" ");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPoolWithEmptyPoolName() throws InterruptedException {
+        basicTestForPoolName("");
+    }
+
+    /**
+     * Basic tests of a pool with a given name. Checks thread creation and
+     * cleanup.
+     */
+    protected void basicTestForPoolName(String poolName) throws InterruptedException {
+        ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+        pool.execute(createRunnable100ms());
+        pool.execute(createRunnable100ms());
+        assertTrue(isPoolThreadActive(poolName, 1));
+        assertTrue(isPoolThreadActive(poolName, 2));
+
+        // no queue thread
+
+        // needs to wait CORE_POOL_TIMEOUT + x until all threads are down again
+        pool.shutdown();
+        Thread.sleep(CORE_POOL_TIMEOUT + 1000);
+        assertFalse(areThreadsFromPoolRunning(poolName));
+    }
+
+    /**
+     * Test basic thread creation, including thread settings (name, prio,
+     * daemon).
+     */
+    protected void basicTestPoolSize2ThreadSettings(String poolName) throws InterruptedException {
+        ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+
+        // pool 2 tasks, threads must exist
+        pool.execute(createRunnable10s());
+        assertEquals(pool.getActiveCount(), 1);
+        assertTrue(isPoolThreadActive(poolName, 1));
+        Thread t1 = getThread(poolName + "-1");
+        assertEquals(t1.isDaemon(), false);
+        // thread will be NORM prio or max prio of this thread group, which can
+        // < than NORM
+        int prio1 = Math.min(t1.getThreadGroup().getMaxPriority(), Thread.NORM_PRIORITY);
+        assertEquals(t1.getPriority(), prio1);
+
+        pool.execute(createRunnable10s());
+        assertEquals(pool.getActiveCount(), 2);
+        assertTrue(isPoolThreadActive(poolName, 2));
+        Thread t2 = getThread(poolName + "-2");
+        assertEquals(t2.isDaemon(), false);
+        // thread will be NORM prio or max prio of this thread group, which can
+        // < than NORM
+        int prio2 = Math.min(t2.getThreadGroup().getMaxPriority(), Thread.NORM_PRIORITY);
+        assertEquals(t2.getPriority(), prio2);
+
+        // 2 more tasks, will be queued, no threads
+        pool.execute(createRunnable1s());
+        // as pool size is 2, no more active threads, will stay at 2
+        assertEquals(pool.getActiveCount(), 2);
+        assertFalse(isPoolThreadActive(poolName, 3));
+        assertEquals(pool.getQueue().size(), 1);
+
+        pool.execute(createRunnable1s());
+        assertEquals(pool.getActiveCount(), 2);
+        assertFalse(isPoolThreadActive(poolName, 4));
+        assertEquals(pool.getQueue().size(), 2);
+
+        // 0 are yet executed
+        assertEquals(pool.getCompletedTaskCount(), 0);
+
+        // needs to wait CORE_POOL_TIMEOUT + 2sec-queue-thread + x until all
+        // threads are down again
+        pool.shutdown();
+        Thread.sleep(CORE_POOL_TIMEOUT + 3000);
+        assertFalse(areThreadsFromPoolRunning(poolName));
+    }
+
+    /**
+     * Tests what happens when wrong rejected execution handler will be used.
+     */
+    @Test(expected = UnsupportedOperationException.class)
+    public void testSetInvalidRejectionHandler() throws InterruptedException {
+        String poolName = "testShutdownNoEntriesIntoQueueAnymore";
+        ThreadPoolExecutor pool = QueueingThreadPoolExecutor.createInstance(poolName, 2);
+        pool.setRejectedExecutionHandler(new ThreadPoolExecutor.DiscardPolicy());
+    }
+
+    // helper methods
+
+    private void disableLogging() {
+        // disable logging
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "error");
+        System.clearProperty("org.slf4j.simpleLogger.logFile");
+        System.clearProperty("org.slf4j.simpleLogger.showDateTime");
+    }
+
+    private boolean isPoolThreadActive(String poolName, int id) {
+        return getThread(poolName + "-" + id) != null;
+    }
+
+    /**
+     * Search for thread with given name.
+     *
+     * @return found thread or null
+     */
+    private Thread getThread(String threadName) {
+        // get top level thread group
+        ThreadGroup g = Thread.currentThread().getThreadGroup();
+        while (g.getParent() != null) {
+            g = g.getParent();
+        }
+        // make buffer 10 entries bigger
+        Thread[] l = new Thread[g.activeCount() + 10];
+        int n = g.enumerate(l);
+        for (int i = 0; i < n; i++) {
+            // enable printout to see threads
+            // System.out.println("getThread:" + l[i]);
+            if (l[i].getName().equals(threadName)) {
+                return l[i];
+            }
+        }
+        return null;
+    }
+
+    private boolean areThreadsFromPoolRunning(String poolName) {
+        // get top level thread group
+        ThreadGroup g = Thread.currentThread().getThreadGroup();
+        while (g.getParent() != null) {
+            g = g.getParent();
+        }
+        boolean foundThreads = false;
+        // make buffer 10 entries bigger
+        Thread[] l = new Thread[g.activeCount() + 10];
+        int n = g.enumerate(l);
+        for (int i = 0; i < n; i++) {
+            // we can only test if name is at least one character,
+            // otherwise there will be threads found (handles poolName="")
+            if (poolName.length() > 0) {
+                if (l[i].getName().startsWith(poolName)) {
+                    // enable printout to see threads
+                    // System.out.println("areThreadsFromPoolRunning: " +
+                    // l[i].toString());
+                    foundThreads = true;
+                }
+            }
+        }
+        return foundThreads;
+    }
+
+    // Runnables for testing
+
+    private Runnable createRunnable100ms() {
+        return new Runnable100ms();
+    }
+
+    private Runnable createRunnable1s() {
+        return new Runnable1s();
+    }
+
+    private Runnable createRunnable10s() {
+        return new Runnable10s();
+    }
+
+    private static abstract class AbstractRunnable implements Runnable {
+        private static AtomicInteger runs = new AtomicInteger(0);
+
+        protected Logger logger = LoggerFactory.getLogger(this.getClass());
+
+        protected void sleep(int milliseconds) {
+            try {
+                Thread.sleep(milliseconds);
+            } catch (InterruptedException e) {
+                // ignore
+                logger.info("interrupted");
+            }
+        }
+
+        @Override
+        public void run() {
+            logger.info("run");
+            runs.incrementAndGet();
+        }
+    }
+
+    private static class Runnable100ms extends AbstractRunnable {
+        @Override
+        public void run() {
+            super.run();
+            sleep(100);
+        }
+    }
+
+    private static class Runnable1s extends AbstractRunnable {
+        @Override
+        public void run() {
+            super.run();
+            sleep(1 * 1000);
+        }
+    }
+
+    private static class Runnable10s extends AbstractRunnable {
+        @Override
+        public void run() {
+            super.run();
+            sleep(10 * 1000);
+        }
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/QueueingThreadPoolExecutor.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/QueueingThreadPoolExecutor.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2014-2016 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.common;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a thread pool executor service, which works as a developer would expect it to work.
+ * The default {@link ThreadPoolExecutor} does the following (see
+ * <a href="http://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html">the official
+ * JavaDoc)</a>:
+ * <ul>
+ * <li>If fewer than corePoolSize threads are running, the Executor always prefers adding a new thread rather than
+ * queuing.</li>
+ * <li>If corePoolSize or more threads are running, the Executor always prefers queuing a request rather than adding a
+ * new thread.</li>
+ * <li>If a request cannot be queued, a new thread is created unless this would exceed maximumPoolSize, in which case,
+ * the task will be rejected.</li>
+ * </ul>
+ *
+ * This class in contrast implements the following logic:
+ * <ul>
+ * <li>corePoolSize is 1, so threads are only created on demand</li>
+ * <li>If the number of busy threads is smaller than the threadPoolSize, the Executor always prefers adding (or reusing)
+ * a thread rather than queuing it.</li>
+ * <li>If threadPoolSize threads are busy, new requests will be put in a FIFO queue and processed as soon as a thread
+ * becomes idle.</li>
+ * <li>The queue size is unbound, i.e. requests will never be rejected.
+ * <li>Threads are terminated after being idle for at least 10 seconds.
+ * </ul>
+ * Please note that this implementation (with its partially hard-coded settings) is specifically targeted for use
+ * on embedded devices without a high throughput. If you intend to use it for mass data processing on a server, you
+ * should definitely tweak those settings.
+ *
+ * @author Kai Kreuzer - Initial contribution and API
+ *
+ */
+public class QueueingThreadPoolExecutor extends ThreadPoolExecutor {
+
+    private Logger logger = LoggerFactory.getLogger(QueueingThreadPoolExecutor.class);
+
+    /** we will use a core pool size of 1 since we allow to timeout core threads. */
+    final static int CORE_THREAD_POOL_SIZE = 1;
+
+    /** Our queue for queueing tasks that wait for a thread to become available */
+    private LinkedTransferQueue<Runnable> taskQueue = new LinkedTransferQueue<>();
+
+    /** The thread for processing the queued tasks */
+    private Thread queueThread;
+
+    final private Object semaphore = new Object();
+
+    final private String threadPoolName;
+
+    /**
+     * Allows to subclass QueueingThreadPoolExecutor.
+     */
+    protected QueueingThreadPoolExecutor(String name, int threadPoolSize) {
+        this(name, new CommonThreadFactory(name), threadPoolSize,
+                new QueueingThreadPoolExecutor.QueueingRejectionHandler());
+    }
+
+    private QueueingThreadPoolExecutor(String threadPoolName, ThreadFactory threadFactory, int threadPoolSize,
+            RejectedExecutionHandler rejectionHandler) {
+        super(CORE_THREAD_POOL_SIZE, threadPoolSize, 10L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
+                threadFactory, rejectionHandler);
+        this.threadPoolName = threadPoolName;
+        allowCoreThreadTimeOut(true);
+    }
+
+    /**
+     * Creates a new instance of {@link QueueingThreadPoolExecutor}
+     *
+     * @param name the name of the thread pool, will be used as a prefix for the name of the threads
+     * @param threadPoolSize the maximum size of the pool
+     * @return the {@link QueueingThreadPoolExecutor} instance
+     */
+    public static QueueingThreadPoolExecutor createInstance(String name, int threadPoolSize) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new IllegalArgumentException("A thread pool name must be provided!");
+        }
+        return new QueueingThreadPoolExecutor(name, new CommonThreadFactory(name), threadPoolSize,
+                new QueueingThreadPoolExecutor.QueueingRejectionHandler());
+    }
+
+    /**
+     * Adds a new task to the queue
+     *
+     * @param runnable the task to add
+     */
+    protected void addToQueue(Runnable runnable) {
+        taskQueue.add(runnable);
+
+        if (queueThread == null || !queueThread.isAlive()) {
+            synchronized (this) {
+                // check again to make sure it has not been created by another thread
+                if (queueThread == null || !queueThread.isAlive()) {
+                    logger.warn("Thread pool '{}' exhausted, queueing tasks now.", threadPoolName);
+                    queueThread = createNewQueueThread();
+                    queueThread.start();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        super.afterExecute(r, t);
+        synchronized (semaphore) {
+            semaphore.notify();
+        }
+    }
+
+    /**
+     * This implementation does not allow setting a custom handler.
+     *
+     * @throws UnsupportedOperationException if called.
+     */
+    @Override
+    public void setRejectedExecutionHandler(RejectedExecutionHandler handler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BlockingQueue<Runnable> getQueue() {
+        return taskQueue;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        // make sure that rejected tasks are executed before any new concurrently incoming tasks
+        if (taskQueue.isEmpty()) {
+            super.execute(command);
+        } else {
+            if (command == null) {
+                throw new NullPointerException();
+            }
+
+            // ignore incoming tasks when the executor is shutdown
+            if (!isShutdown()) {
+                addToQueue(command);
+            }
+        }
+    }
+
+    private Thread createNewQueueThread() {
+        Thread thread = getThreadFactory().newThread(new Runnable() {
+
+            @Override
+            public void run() {
+                while (true) {
+                    // check if some thread from the pool is idle
+                    if (QueueingThreadPoolExecutor.this.getActiveCount() < QueueingThreadPoolExecutor.this
+                            .getMaximumPoolSize()) {
+                        try {
+                            // keep waiting for max 2 seconds if further tasks are pushed to the queue
+                            Runnable runnable = taskQueue.poll(2, TimeUnit.SECONDS);
+                            if (runnable != null) {
+                                logger.debug("Executing queued task of thread pool '{}'.", threadPoolName);
+                                QueueingThreadPoolExecutor.super.execute(runnable);
+                            } else {
+                                break;
+                            }
+                        } catch (InterruptedException e) {
+                        }
+                    } else {
+                        // let's wait for a thread to become available, but max. 1 second
+                        try {
+                            synchronized (semaphore) {
+                                semaphore.wait(1000);
+                            }
+                        } catch (InterruptedException e) {
+                        }
+                    }
+                }
+                logger.debug("Queue for thread pool '{}' fully processed - terminating queue thread.", threadPoolName);
+            }
+        });
+        thread.setName(threadPoolName + "-queue");
+        return thread;
+    }
+
+    /**
+     * This is the internally used thread factory, which creates non-daemon threads and assigns them a sequentially
+     * indexed name.
+     */
+    private static class CommonThreadFactory implements ThreadFactory {
+
+        protected final ThreadGroup group;
+        protected final AtomicInteger threadNumber = new AtomicInteger(1);
+        protected final String name;
+
+        public CommonThreadFactory(String name) {
+            this.name = name;
+            SecurityManager s = System.getSecurityManager();
+            group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(group, r, name + "-" + threadNumber.getAndIncrement(), 0);
+            if (t.isDaemon()) {
+                t.setDaemon(false);
+            }
+            if (t.getPriority() != Thread.NORM_PRIORITY) {
+                t.setPriority(Thread.NORM_PRIORITY);
+            }
+
+            return t;
+        }
+    }
+
+    /**
+     * This is the internally used rejection handler, which - instead of rejecting a task - puts it to the queue of the
+     * pool.
+     */
+    private static class QueueingRejectionHandler extends ThreadPoolExecutor.DiscardPolicy {
+
+        @Override
+        public void rejectedExecution(Runnable runnable, ThreadPoolExecutor threadPoolExecutor) {
+            if (!threadPoolExecutor.isShutdown()) {
+                QueueingThreadPoolExecutor queueingThreadPoolExecutor = (QueueingThreadPoolExecutor) threadPoolExecutor;
+                queueingThreadPoolExecutor.addToQueue(runnable);
+            }
+        }
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeMethodCaller.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeMethodCaller.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2014-2016 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.smarthome.core.common;
 
 import java.util.concurrent.Callable;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -13,9 +13,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -35,9 +33,8 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The configuration can be done as
  * <br/>
- * {@code org.eclipse.smarthome.threadpool:<poolName>=<poolSize>[,<maxSize>]}
+ * {@code org.eclipse.smarthome.threadpool:<poolName>=<poolSize>}
  * <br/>
- * where maxSize is only applicable for non-scheduled thread pools and is the number of maximum threads to create.
  * All threads will time out after {@link THREAD_TIMEOUT}.
  * </p>
  *
@@ -48,7 +45,6 @@ public class ThreadPoolManager {
 
     private final static Logger logger = LoggerFactory.getLogger(ThreadPoolManager.class);
 
-    protected static final int DEFAULT_THREAD_POOL_MAX_SIZE = 10;
     protected static final int DEFAULT_THREAD_POOL_CORE_SIZE = 5;
 
     protected static final long THREAD_TIMEOUT = 65L;
@@ -56,7 +52,7 @@ public class ThreadPoolManager {
 
     static protected Map<String, ExecutorService> pools = new WeakHashMap<>();
 
-    static private Map<String, int[]> configs = new ConcurrentHashMap<>();
+    static private Map<String, Integer> configs = new ConcurrentHashMap<>();
 
     protected void activate(Map<String, Object> properties) {
         modified(properties);
@@ -74,46 +70,16 @@ public class ThreadPoolManager {
                 configs.remove(poolName);
             }
             if (config instanceof String) {
-                String[] segments = ((String) config).split(",");
-                if (segments.length > 2) {
-                    logger.warn("Ignoring invalid configuration for pool '{}': {} - config have at most 2 parts",
-                            new Object[] { poolName, config });
-                    continue;
-                }
                 try {
-                    Integer coreSize = Integer.valueOf(segments[0]);
-                    int[] cfg = (segments.length == 1)
-                            ? new int[] { coreSize,
-                                    coreSize > DEFAULT_THREAD_POOL_MAX_SIZE ? coreSize : DEFAULT_THREAD_POOL_MAX_SIZE }
-                            : new int[] { coreSize, Integer.valueOf(segments[1]) };
-                    if (cfg[0] > cfg[1]) {
-                        logger.warn(
-                                "Ignoring invalid configuration for pool '{}': {} - max value must be bigger than min value",
-                                new Object[] { poolName, config });
-                        continue;
-                    }
-                    if (cfg[0] < 0 || cfg[1] < 0) {
-                        logger.warn("Ignoring invalid configuration for pool '{}': {} - value must not be negative",
-                                new Object[] { poolName, config });
-                        continue;
-                    }
-                    configs.put(poolName, cfg);
+                    Integer poolSize = Integer.valueOf((String) config);
+                    configs.put(poolName, poolSize);
                     ThreadPoolExecutor pool = (ThreadPoolExecutor) pools.get(poolName);
                     if (pool != null) {
-                        if (pool instanceof ScheduledExecutorService) {
-                            // we only need to set the core pool size here
-                            pool.setCorePoolSize(cfg[0]);
-                            logger.debug("Updated scheduled thread pool '{}' to size {}",
-                                    new Object[] { poolName, cfg[0] });
-                        } else {
-                            pool.setCorePoolSize(cfg[0]);
-                            pool.setMaximumPoolSize(cfg[1]);
-                            logger.debug("Updated thread pool '{}' to size {}-{}",
-                                    new Object[] { poolName, cfg[0], cfg[1] });
-                        }
+                        pool.setCorePoolSize(poolSize);
+                        logger.debug("Updated thread pool '{}' to size {}", new Object[] { poolName, poolSize });
                     }
                 } catch (NumberFormatException e) {
-                    logger.warn("Ignoring invalid configuration for pool '{}': {} - entries must be integer values",
+                    logger.warn("Ignoring invalid configuration for pool '{}': {} - value must be an integer",
                             new Object[] { poolName, config });
                     continue;
                 }
@@ -135,12 +101,12 @@ public class ThreadPoolManager {
                 // do a double check if it is still null or if another thread might have created it meanwhile
                 pool = pools.get(poolName);
                 if (pool == null) {
-                    int[] cfg = getConfig(poolName);
-                    pool = Executors.newScheduledThreadPool(cfg[0], new NamedThreadFactory(poolName));
+                    int cfg = getConfig(poolName);
+                    pool = Executors.newScheduledThreadPool(cfg, new NamedThreadFactory(poolName));
                     ((ThreadPoolExecutor) pool).setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
                     ((ThreadPoolExecutor) pool).allowCoreThreadTimeOut(true);
                     pools.put(poolName, pool);
-                    logger.debug("Created scheduled thread pool '{}' of size {}", new Object[] { poolName, cfg[0] });
+                    logger.debug("Created scheduled thread pool '{}' of size {}", new Object[] { poolName, cfg });
                 }
             }
         }
@@ -165,58 +131,21 @@ public class ThreadPoolManager {
                 // do a double check if it is still null or if another thread might have created it meanwhile
                 pool = pools.get(poolName);
                 if (pool == null) {
-                    int[] cfg = getConfig(poolName);
-                    pool = new CommonThreadExecutor(poolName, cfg[0], cfg[1]);
+                    int cfg = getConfig(poolName);
+                    pool = new QueueingThreadPoolExecutor(poolName, cfg);
                     ((ThreadPoolExecutor) pool).setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
                     ((ThreadPoolExecutor) pool).allowCoreThreadTimeOut(true);
                     pools.put(poolName, pool);
-                    logger.debug("Created thread pool '{}' with size {}-{}", new Object[] { poolName, cfg[0], cfg[1] });
+                    logger.debug("Created thread pool '{}' with size {}", new Object[] { poolName, cfg });
                 }
             }
         }
         return pool;
     }
 
-    protected static int[] getConfig(String poolName) {
-        int[] cfg = configs.get(poolName);
-        return (cfg != null) ? cfg : new int[] { DEFAULT_THREAD_POOL_CORE_SIZE, DEFAULT_THREAD_POOL_MAX_SIZE };
-    }
-
-    private static class CommonThreadExecutor extends ThreadPoolExecutor {
-
-        public CommonThreadExecutor(final String poolName, int corePoolSize, int maxPoolSize) {
-            this(poolName, corePoolSize, maxPoolSize, new NamedThreadFactory(poolName),
-                    new ThreadPoolExecutor.DiscardPolicy() {
-                        // The pool is bounded and rejections will happen during shutdown
-                        @Override
-                        public void rejectedExecution(Runnable runnable, ThreadPoolExecutor threadPoolExecutor) {
-                            // Log and discard
-                            logger.warn("Thread pool '{}' rejected execution of {}",
-                                    new Object[] { poolName, runnable.getClass() });
-                            super.rejectedExecution(runnable, threadPoolExecutor);
-                        }
-                    });
-        }
-
-        public CommonThreadExecutor(String threadPool, int corePoolSize, int maxPoolSize, ThreadFactory threadFactory,
-                RejectedExecutionHandler rejectedHandler) {
-            // This is the same as Executors.newCachedThreadPool
-            super(corePoolSize, maxPoolSize, THREAD_TIMEOUT, TimeUnit.SECONDS, new SynchronousQueue<Runnable>(),
-                    threadFactory, rejectedHandler);
-        }
-
-        @Override
-        protected void afterExecute(Runnable runnable, Throwable throwable) {
-            super.afterExecute(runnable, throwable);
-            if (throwable != null) {
-                Throwable cause = throwable.getCause();
-                if (cause instanceof InterruptedException) {
-                    // Ignore this, might happen when we shutdownNow() the executor. We can't
-                    // log at this point as the logging system might be stopped already.
-                    return;
-                }
-            }
-        }
+    protected static int getConfig(String poolName) {
+        Integer cfg = configs.get(poolName);
+        return (cfg != null) ? cfg : DEFAULT_THREAD_POOL_CORE_SIZE;
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolManager.java
@@ -50,13 +50,13 @@ public class ExpressionThreadPoolManager extends ThreadPoolManager {
                 // do a double check if it is still null or if another thread might have created it meanwhile
                 pool = pools.get(poolName);
                 if (pool == null) {
-                    int[] cfg = getConfig(poolName);
-                    pool = new ExpressionThreadPoolExecutor(poolName, cfg[0]);
+                    Integer cfg = getConfig(poolName);
+                    pool = new ExpressionThreadPoolExecutor(poolName, cfg);
                     ((ThreadPoolExecutor) pool).setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
                     ((ThreadPoolExecutor) pool).allowCoreThreadTimeOut(true);
                     pools.put(poolName, pool);
                     logger.debug("Created an expression-drive scheduled thread pool '{}' of size {}",
-                            new Object[] { poolName, cfg[0] });
+                            new Object[] { poolName, cfg });
                 }
             }
         }


### PR DESCRIPTION
I noticed that I never moved the implementation that I made for jUPnP to ESH.
This PR now ports the class https://github.com/jupnp/jupnp/blob/master/bundles/org.jupnp/src/main/java/org/jupnp/QueueingThreadPoolExecutor.java and uses it for non-scheduled thread pools within ESH.

Instead of rejecting tasks, it queues them for execution until a thread from the pool becomes available and thus it fixes problems like https://github.com/eclipse/smarthome/issues/1743.

Also-by: Jochen Hiller jo.hiller@googlemail.com
Signed-off-by: Kai Kreuzer kai@openhab.org
