### PR TITLE
fixed parsing yyyy-MM-dd'T'HH:mm:ss.SSSZ times

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DateTimeTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DateTimeTypeTest.java
@@ -125,6 +125,8 @@ public class DateTimeTypeTest {
                         "2014-03-30T10:58:47.033+0200") },
                 { new ParameterSet(TimeZone.getTimeZone("CET"), "2014-03-30T10:58:47UTS",
                         "2014-03-30T10:58:47.000+0200") },
+                { new ParameterSet(TimeZone.getTimeZone("GMT+5"), "2014-03-30T10:58:47.000Z",
+                        "2014-03-30T15:58:47.000+0500") },
                 { new ParameterSet(TimeZone.getTimeZone("GMT"), initTimeMap(), TimeZone.getTimeZone("GMT"),
                         "2014-03-30T10:58:47.033+0000") },
                 { new ParameterSet(TimeZone.getTimeZone("GMT+2"), initTimeMap(), TimeZone.getTimeZone("GML"),

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
@@ -22,6 +22,7 @@ public class DateTimeType implements PrimitiveType, State, Command {
     public static final String DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss";
     public static final String DATE_PATTERN_WITH_TZ = "yyyy-MM-dd'T'HH:mm:ssz";
     public static final String DATE_PATTERN_WITH_TZ_AND_MS = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+    public static final String DATE_PATTERN_WITH_TZ_AND_MS_ISO = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
 
     private Calendar calendar;
 
@@ -41,9 +42,13 @@ public class DateTimeType implements PrimitiveType, State, Command {
                 date = new SimpleDateFormat(DATE_PATTERN_WITH_TZ_AND_MS).parse(calendarValue);
             } catch (ParseException fpe3) {
                 try {
-                    date = new SimpleDateFormat(DATE_PATTERN_WITH_TZ).parse(calendarValue);
-                } catch (ParseException fpe2) {
-                    date = new SimpleDateFormat(DATE_PATTERN).parse(calendarValue);
+                    date = new SimpleDateFormat(DATE_PATTERN_WITH_TZ_AND_MS_ISO).parse(calendarValue);
+                } catch (ParseException fpe4) {
+                    try {
+                        date = new SimpleDateFormat(DATE_PATTERN_WITH_TZ).parse(calendarValue);
+                    } catch (ParseException fpe2) {
+                        date = new SimpleDateFormat(DATE_PATTERN).parse(calendarValue);
+                    }
                 }
             }
         } catch (ParseException fpe) {


### PR DESCRIPTION
The ISO spec allows 2014-03-30T10:58:47.000Z as a shorthand
for +0000 (UTC). Therefore simply trying to parse ISO
timezones as a fallback.

fixes #1746
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>