### PR TITLE
reduced logging level as it is an expected behaviour to use the whole pool

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/QueueingThreadPoolExecutor.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/QueueingThreadPoolExecutor.java
@@ -110,7 +110,7 @@ public class QueueingThreadPoolExecutor extends ThreadPoolExecutor {
             synchronized (this) {
                 // check again to make sure it has not been created by another thread
                 if (queueThread == null || !queueThread.isAlive()) {
-                    logger.warn("Thread pool '{}' exhausted, queueing tasks now.", threadPoolName);
+                    logger.debug("Thread pool '{}' exhausted, queueing tasks now.", threadPoolName);
                     queueThread = createNewQueueThread();
                     queueThread.start();
                 }


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>