### PR TITLE
Inbox items label and discover result toggle changed

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
@@ -239,6 +239,11 @@ angular.module('PaperUI.controllers.setup', []).controller('SetupPageController'
     $scope.filter = function(discoveryResult) {
         return $scope.showIgnored || discoveryResult.flag === 'NEW';
     }
+    $scope.areEntriesIgnored = function(discoveryResults) {
+        return $.grep(discoveryResults, function(discoveryResult) {
+            return discoveryResult.flag === 'IGNORED';
+        }).length > 0;
+    }
 }).controller('SetupWizardBindingsController', function($scope, bindingRepository, discoveryService) {
     $scope.setSubtitle([ 'Choose Binding' ]);
     $scope.setHeaderText('Choose a Binding for which you want to add new things.');

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.inbox.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.inbox.html
@@ -2,9 +2,9 @@
 	<md-button title="Add" class="md-fab green" ng-click="approve(discoveryResult.thingUID,discoveryResult.thingTypeUID, $event)" aria-label="Approve"> <i class="material-icons">done</i></md-button>
 	<div class="item-content">
 		<h3>
-			{{getThingTypeLabel(discoveryResult.thingTypeUID)}} <small ng-show="discoveryResult.flag === 'IGNORED'" class="badge">IGNORED</small>
+			{{discoveryResult.label}} <small ng-show="discoveryResult.flag === 'IGNORED'" class="badge">IGNORED</small>
 		</h3>
-		<p>{{discoveryResult.label}}</p>
+		<p>{{getThingTypeLabel(discoveryResult.thingTypeUID)}}</p>
 		<p>{{discoveryResult.thingUID}}</p>
 		<div class="actions">
 			<md-button ng-show="discoveryResult.flag === 'IGNORED'" ng-click="unignore(discoveryResult.thingUID)" aria-label="Unignore"> <i class="material-icons">visibility</i></md-button>
@@ -15,5 +15,5 @@
 	<hr class="border-line" ng-show="!$last" />
 </div>
 <p class="text-center">
-	<button class="md-button" ng-click="toggleShowIgnored()" aria-label="Toggle Show Ignored">{{showIgnored ? 'Hide Ignored' : 'Show Ignored'}}</button>
+	<button ng-show="areEntriesIgnored(data.discoveryResults)" class="md-button" ng-click="toggleShowIgnored()" aria-label="Toggle Show Ignored">{{showIgnored ? 'Hide Ignored' : 'Show Ignored'}}</button>
 </p>


### PR DESCRIPTION
Inbox label position change, and 
toggle button hidden when there are no ignored items.
fixes https://github.com/eclipse/smarthome/issues/1807 & https://github.com/eclipse/smarthome/issues/1806

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>