### PR TITLE
Set correct percent value for Rollershutter item

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/RollershutterItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/RollershutterItemTest.java
@@ -1,0 +1,45 @@
+package org.eclipse.smarthome.core.library.items;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+
+public class RollershutterItemTest {
+
+    @Test
+    public void setState_stateDown_returnPercent100() {
+        RollershutterItem sut = new RollershutterItem("Test");
+        State state = UpDownType.DOWN;
+        sut.setState(state);
+        assertEquals(PercentType.HUNDRED, sut.getState());
+    }
+
+    @Test
+    public void setState_stateUp_returnPercent0() {
+        RollershutterItem sut = new RollershutterItem("Test");
+        State state = UpDownType.UP;
+        sut.setState(state);
+        assertEquals(PercentType.ZERO, sut.getState());
+    }
+
+    @Test
+    public void setState_statePercent50_returnPercent50() {
+        RollershutterItem sut = new RollershutterItem("Test");
+        State state = new PercentType(50);
+        sut.setState(state);
+        assertEquals(state, sut.getState());
+    }
+
+    @Test
+    public void setState_stateDecimal050_returnPercent50() {
+        RollershutterItem sut = new RollershutterItem("Test");
+        State state = new DecimalType(0.50);
+        sut.setState(state);
+        assertEquals(new PercentType(50), sut.getState());
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/RollershutterItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/RollershutterItem.java
@@ -85,6 +85,8 @@ public class RollershutterItem extends GenericItem {
             super.setState(PercentType.ZERO);
         } else if (state == UpDownType.DOWN) {
             super.setState(PercentType.HUNDRED);
+        } else if (state.getClass() == DecimalType.class) {
+            super.setState(new PercentType(((DecimalType) state).toBigDecimal().multiply(new BigDecimal(100))));
         } else {
             super.setState(state);
         }


### PR DESCRIPTION
When setting DecimalType state for a Rollershutter item,
the state should be converted to PercentType.
Otherwise the group functions will present an error
of factor 100.

Fixes #1845

Signed-off-by: Hans Hazelius <hans@hazelius.se>