### PR TITLE
Fix NPE in thing handler

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -647,6 +647,9 @@ public class ThingManager extends AbstractItemEventSubscriber implements ThingTr
     }
 
     private boolean isVetoed(final ThingHandler thingHandler) {
+        if (thingHandler == null) {
+            return true;
+        }
         boolean veto = false;
         Bundle bundle = getBundle(thingHandler.getClass());
         for (BundleProcessor proc : bundleProcessors) {


### PR DESCRIPTION
Signed-off-by: Chris Jackson <chris@cd-jackson.com>


Maybe there's a better way to solve this, but it fixes the following exception...

```
openhab> Exception in thread "Bundle processor thread" java.lang.NullPointerException
        at org.eclipse.smarthome.core.thing.internal.ThingManager.isVetoed(ThingManager.java:651)
        at org.eclipse.smarthome.core.thing.internal.ThingManager.initializeHandler(ThingManager.java:630)
        at org.eclipse.smarthome.core.thing.internal.ThingManager.bundleFinished(ThingManager.java:764)
        at org.eclipse.smarthome.config.xml.osgi.AbstractAsyncBundleProcessor.informListeners(AbstractAsyncBundleProcessor.java:253)
        at org.eclipse.smarthome.config.xml.osgi.AbstractAsyncBundleProcessor.access$3(AbstractAsyncBundleProcessor.java:251)
        at org.eclipse.smarthome.config.xml.osgi.AbstractAsyncBundleProcessor$1.run(AbstractAsyncBundleProcessor.java:242)
        at java.lang.Thread.run(Thread.java:745)
```
