### PR TITLE
mark API dependencies as provided

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.console.karaf/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.karaf/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -28,6 +28,7 @@
       <groupId>org.apache.karaf.shell</groupId>
       <artifactId>org.apache.karaf.shell.core</artifactId>
       <version>${karaf.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The framework / product should provide the respective bundle(s) at runtime.