### PR TITLE
Sonos binding: fix issues #1875 #1900 #1902

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
@@ -126,6 +126,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
         @Override
         public void run() {
             try {
+                logger.debug("Polling job");
                 updateZoneInfo();
                 updateRunningAlarmProperties();
                 updateLed();
@@ -156,7 +157,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
     @Override
     public void dispose() {
-        logger.debug("Handler disposed.");
+        logger.debug("Handler disposed for thing {}", getThing().getUID());
 
         if (pollingJob != null && !pollingJob.isCancelled()) {
             pollingJob.cancel(true);
@@ -169,6 +170,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
     @Override
     public void initialize() {
+        logger.debug("initializing handler for thing {}", getThing().getUID());
 
         if (migrateThingType()) {
             // we change the type, so we might need a different handler -> let's finish
@@ -223,7 +225,11 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                 setNotificationSoundVolume(command);
                 break;
             case STOP:
-                getCoordinatorHandler().stop();
+                try {
+                    getCoordinatorHandler().stop();
+                } catch (IllegalStateException e) {
+                    logger.warn("Cannot handle stop command ({})", e.getMessage());
+                }
                 break;
             case VOLUME:
                 setVolumeForGroup(command);
@@ -280,22 +286,26 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                 playLineIn(command);
                 break;
             case CONTROL:
-                if (command instanceof PlayPauseType) {
-                    if (command == PlayPauseType.PLAY) {
-                        getCoordinatorHandler().play();
-                    } else if (command == PlayPauseType.PAUSE) {
-                        getCoordinatorHandler().pause();
+                try {
+                    if (command instanceof PlayPauseType) {
+                        if (command == PlayPauseType.PLAY) {
+                            getCoordinatorHandler().play();
+                        } else if (command == PlayPauseType.PAUSE) {
+                            getCoordinatorHandler().pause();
+                        }
                     }
-                }
-                if (command instanceof NextPreviousType) {
-                    if (command == NextPreviousType.NEXT) {
-                        getCoordinatorHandler().next();
-                    } else if (command == NextPreviousType.PREVIOUS) {
-                        getCoordinatorHandler().previous();
+                    if (command instanceof NextPreviousType) {
+                        if (command == NextPreviousType.NEXT) {
+                            getCoordinatorHandler().next();
+                        } else if (command == NextPreviousType.PREVIOUS) {
+                            getCoordinatorHandler().previous();
+                        }
                     }
-                }
-                if (command instanceof RewindFastforwardType) {
-                    // Rewind and Fast Forward are currently not implemented by the binding
+                    if (command instanceof RewindFastforwardType) {
+                        // Rewind and Fast Forward are currently not implemented by the binding
+                    }
+                } catch (IllegalStateException e) {
+                    logger.warn("Cannot handle control command ({})", e.getMessage());
                 }
                 break;
             case SLEEPTIMER:
@@ -310,7 +320,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     private void restoreAllPlayerState() {
         Collection<Thing> allThings = thingRegistry.getAll();
         for (Thing aThing : allThings) {
-            if (aThing.getThingTypeUID().equals(this.getThing().getThingTypeUID())) {
+            if (SonosBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(aThing.getThingTypeUID())) {
                 ZonePlayerHandler handler = (ZonePlayerHandler) aThing.getHandler();
                 handler.restoreState();
             }
@@ -320,7 +330,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     private void saveAllPlayerState() {
         Collection<Thing> allThings = thingRegistry.getAll();
         for (Thing aThing : allThings) {
-            if (aThing.getThingTypeUID().equals(this.getThing().getThingTypeUID())) {
+            if (SonosBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(aThing.getThingTypeUID())) {
                 ZonePlayerHandler handler = (ZonePlayerHandler) aThing.getHandler();
                 handler.saveState();
             }
@@ -360,29 +370,29 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
             // update the appropriate channel
             switch (variable) {
                 case "TransportState": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), STATE),
-                            (stateMap.get("TransportState") != null) ? new StringType(stateMap.get("TransportState"))
-                                    : UnDefType.UNDEF);
+                    updateState(STATE, (stateMap.get("TransportState") != null)
+                            ? new StringType(stateMap.get("TransportState")) : UnDefType.UNDEF);
                     if (stateMap.get("TransportState").equals("PLAYING")) {
-                        updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), CONTROL),
-                                PlayPauseType.PLAY);
+                        updateState(CONTROL, PlayPauseType.PLAY);
                     }
                     if (stateMap.get("TransportState").equals("STOPPED")) {
-                        updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), CONTROL),
-                                PlayPauseType.PAUSE);
+                        updateState(CONTROL, PlayPauseType.PAUSE);
                     }
                     if (stateMap.get("TransportState").equals("PAUSED_PLAYBACK")) {
-                        updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), CONTROL),
-                                PlayPauseType.PAUSE);
+                        updateState(CONTROL, PlayPauseType.PAUSE);
                     }
 
                     if (isCoordinator()) {
                         // update member states
                         for (String member : getOtherZoneGroupMembers()) {
-                            ZonePlayerHandler memberHandler = getHandlerByName(member);
-                            if (memberHandler != null && memberHandler.getThing() != null
-                                    && ThingStatus.ONLINE.equals(memberHandler.getThing().getStatus())) {
-                                memberHandler.onValueReceived("TransportState", value, service);
+                            try {
+                                ZonePlayerHandler memberHandler = getHandlerByName(member);
+                                if (memberHandler != null && memberHandler.getThing() != null
+                                        && ThingStatus.ONLINE.equals(memberHandler.getThing().getStatus())) {
+                                    memberHandler.onValueReceived("TransportState", value, service);
+                                }
+                            } catch (IllegalStateException e) {
+                                logger.warn("Cannot update playback state for group member ({})", e.getMessage());
                             }
                         }
                     }
@@ -397,113 +407,108 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                             newState = OnOffType.OFF;
                         }
                     }
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), LED), newState);
+                    updateState(LED, newState);
+                    break;
+                }
+                case "ZoneName": {
+                    updateState(ZONENAME, (stateMap.get("ZoneName") != null) ? new StringType(stateMap.get("ZoneName"))
+                            : UnDefType.UNDEF);
                     break;
                 }
                 case "CurrentZoneName": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), ZONENAME),
-                            (stateMap.get("CurrentZoneName") != null) ? new StringType(stateMap.get("CurrentZoneName"))
-                                    : UnDefType.UNDEF);
+                    updateState(ZONENAME, (stateMap.get("CurrentZoneName") != null)
+                            ? new StringType(stateMap.get("CurrentZoneName")) : UnDefType.UNDEF);
+                    break;
                 }
                 case "ZoneGroupState": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), ZONEGROUP),
-                            (stateMap.get("ZoneGroupState") != null) ? new StringType(stateMap.get("ZoneGroupState"))
-                                    : UnDefType.UNDEF);
+                    updateState(ZONEGROUP, (stateMap.get("ZoneGroupState") != null)
+                            ? new StringType(stateMap.get("ZoneGroupState")) : UnDefType.UNDEF);
 
                     // Update coordinator after a change is made to the grouping of Sonos players
                     updateGroupCoordinator();
                     break;
                 }
                 case "LocalGroupUUID": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), ZONEGROUPID),
-                            (stateMap.get("LocalGroupUUID") != null) ? new StringType(stateMap.get("LocalGroupUUID"))
-                                    : UnDefType.UNDEF);
+                    updateState(ZONEGROUPID, (stateMap.get("LocalGroupUUID") != null)
+                            ? new StringType(stateMap.get("LocalGroupUUID")) : UnDefType.UNDEF);
                     break;
                 }
                 case "GroupCoordinatorIsLocal": {
                     State newState = UnDefType.UNDEF;
                     if (stateMap.get("GroupCoordinatorIsLocal") != null) {
-                        if (stateMap.get("GroupCoordinatorIsLocal").equals("On")) {
+                        if (stateMap.get("GroupCoordinatorIsLocal").equals("true")) {
                             newState = OnOffType.ON;
                         } else {
                             newState = OnOffType.OFF;
                         }
                     }
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), LOCALCOORDINATOR),
-                            newState);
+                    updateState(LOCALCOORDINATOR, newState);
                     break;
                 }
                 case "VolumeMaster": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), VOLUME),
-                            (stateMap.get("VolumeMaster") != null) ? new PercentType(stateMap.get("VolumeMaster"))
-                                    : UnDefType.UNDEF);
+                    updateState(VOLUME, (stateMap.get("VolumeMaster") != null)
+                            ? new PercentType(stateMap.get("VolumeMaster")) : UnDefType.UNDEF);
                     break;
                 }
                 case "MuteMaster": {
                     State newState = UnDefType.UNDEF;
                     if (stateMap.get("MuteMaster") != null) {
-                        if (stateMap.get("MuteMaster").equals("On")) {
+                        if (stateMap.get("MuteMaster").equals("1")) {
                             newState = OnOffType.ON;
                         } else {
                             newState = OnOffType.OFF;
                         }
                     }
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), MUTE), newState);
+                    updateState(MUTE, newState);
                     break;
                 }
                 case "LineInConnected": {
                     State newState = UnDefType.UNDEF;
                     if (stateMap.get("LineInConnected") != null) {
-                        if (stateMap.get("LineInConnected").equals("On")) {
+                        if (stateMap.get("LineInConnected").equals("true")) {
                             newState = OnOffType.ON;
                         } else {
                             newState = OnOffType.OFF;
                         }
                     }
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), LINEIN), newState);
+                    updateState(LINEIN, newState);
                     break;
                 }
                 case "AlarmRunning": {
                     State newState = UnDefType.UNDEF;
                     if (stateMap.get("AlarmRunning") != null) {
-                        if (stateMap.get("AlarmRunning").equals("On")) {
+                        if (stateMap.get("AlarmRunning").equals("1")) {
                             newState = OnOffType.ON;
                         } else {
                             newState = OnOffType.OFF;
                         }
                     }
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), ALARMRUNNING),
-                            newState);
+                    updateState(ALARMRUNNING, newState);
                     break;
                 }
                 case "RunningAlarmProperties": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), ALARMPROPERTIES),
-                            (stateMap.get("RunningAlarmProperties") != null)
-                                    ? new StringType(stateMap.get("RunningAlarmProperties")) : UnDefType.UNDEF);
+                    updateState(ALARMPROPERTIES, (stateMap.get("RunningAlarmProperties") != null)
+                            ? new StringType(stateMap.get("RunningAlarmProperties")) : UnDefType.UNDEF);
                     break;
                 }
                 case "CurrentURIFormatted": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), CURRENTTRACK),
-                            (stateMap.get("CurrentURIFormatted") != null)
-                                    ? new StringType(stateMap.get("CurrentURIFormatted")) : UnDefType.UNDEF);
+                    updateState(CURRENTTRACK, (stateMap.get("CurrentURIFormatted") != null)
+                            ? new StringType(stateMap.get("CurrentURIFormatted")) : UnDefType.UNDEF);
                     break;
                 }
                 case "CurrentTitle": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), CURRENTTITLE),
-                            (stateMap.get("CurrentTitle") != null) ? new StringType(stateMap.get("CurrentTitle"))
-                                    : UnDefType.UNDEF);
+                    updateState(CURRENTTITLE, (stateMap.get("CurrentTitle") != null)
+                            ? new StringType(stateMap.get("CurrentTitle")) : UnDefType.UNDEF);
                     break;
                 }
                 case "CurrentArtist": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), CURRENTARTIST),
-                            (stateMap.get("CurrentArtist") != null) ? new StringType(stateMap.get("CurrentArtist"))
-                                    : UnDefType.UNDEF);
+                    updateState(CURRENTARTIST, (stateMap.get("CurrentArtist") != null)
+                            ? new StringType(stateMap.get("CurrentArtist")) : UnDefType.UNDEF);
                     break;
                 }
                 case "CurrentAlbum": {
-                    updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), CURRENTALBUM),
-                            (stateMap.get("CurrentAlbum") != null) ? new StringType(stateMap.get("CurrentAlbum"))
-                                    : UnDefType.UNDEF);
+                    updateState(CURRENTALBUM, (stateMap.get("CurrentAlbum") != null)
+                            ? new StringType(stateMap.get("CurrentAlbum")) : UnDefType.UNDEF);
                     break;
                 }
                 case "CurrentTrackMetaData": {
@@ -515,9 +520,18 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                     break;
                 }
 
+                case "CurrentSleepTimerGeneration": {
+                    if (value.equals("0")) {
+                        updateState(SLEEPTIMER, new DecimalType(0));
+                    }
+                    break;
+                }
+
                 case "SleepTimerGeneration": {
                     if (value.equals("0")) {
                         updateState(SLEEPTIMER, new DecimalType(0));
+                    } else {
+                        updateSleepTimerDuration();
                     }
                     break;
                 }
@@ -563,9 +577,13 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     }
 
     private void updateGroupCoordinator() {
-        updateState(new ChannelUID(getThing().getThingTypeUID(), getThing().getUID(), COORDINATOR),
-                new StringType(getCoordinator()));
-        coordinatorHandler = getHandlerByName(getCoordinator());
+        updateState(COORDINATOR, new StringType(getCoordinator()));
+        try {
+            coordinatorHandler = getHandlerByName(getCoordinator());
+        } catch (IllegalStateException e) {
+            logger.warn("Cannot update the group coordinator ({})", e.getMessage());
+            coordinatorHandler = null;
+        }
     }
 
     private void removeSubscription() {
@@ -706,58 +724,75 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
     protected void updateTrackMetaData() {
 
-        ZonePlayerHandler coordinatorHandler = getCoordinatorHandler();
-        SonosMetaData currentTrack = getTrackMetadata();
+        try {
+            ZonePlayerHandler coordinatorHandler = getCoordinatorHandler();
+            SonosMetaData currentTrack = getTrackMetadata();
 
-        if (coordinatorHandler != null && coordinatorHandler != this) {
-            coordinatorHandler.updateMediaInfo();
-            currentTrack = coordinatorHandler.getTrackMetadata();
-        }
-
-        String artist = null;
-        String title = null;
-        String album = null;
-        if (currentTrack != null) {
-            if (currentTrack.getAlbumArtist().equals("")) {
-                artist = currentTrack.getCreator();
-            } else {
-                artist = currentTrack.getAlbumArtist();
+            if (coordinatorHandler != null && coordinatorHandler != this) {
+                coordinatorHandler.updateMediaInfo();
+                currentTrack = coordinatorHandler.getTrackMetadata();
             }
 
-            if (!currentTrack.getTitle().contains("x-sonosapi-stream")) {
-                title = currentTrack.getTitle();
-            }
-            album = currentTrack.getAlbum();
-        }
+            String artist = null;
+            String title = null;
+            String album = null;
+            if (currentTrack != null) {
+                if (currentTrack.getAlbumArtist().equals("")) {
+                    artist = currentTrack.getCreator();
+                } else {
+                    artist = currentTrack.getAlbumArtist();
+                }
 
-        // update individual variables
-        for (String member : getZoneGroupMembers()) {
-            ZonePlayerHandler memberHandler = getHandlerByName(member);
-            if (memberHandler != null && memberHandler.getThing() != null
-                    && ThingStatus.ONLINE.equals(memberHandler.getThing().getStatus())) {
-                memberHandler.onValueReceived("CurrentArtist", (artist != null) ? artist : "", "AVTransport");
-                memberHandler.onValueReceived("CurrentTitle", (title != null) ? title : "", "AVTransport");
-                memberHandler.onValueReceived("CurrentAlbum", (album != null) ? album : "", "AVTransport");
+                if (!currentTrack.getTitle().contains("x-sonosapi-stream")) {
+                    title = currentTrack.getTitle();
+                }
+                album = currentTrack.getAlbum();
             }
+
+            // update individual variables
+            for (String member : getZoneGroupMembers()) {
+                try {
+                    ZonePlayerHandler memberHandler = getHandlerByName(member);
+                    if (memberHandler != null && memberHandler.getThing() != null
+                            && ThingStatus.ONLINE.equals(memberHandler.getThing().getStatus())) {
+                        memberHandler.onValueReceived("CurrentArtist", (artist != null) ? artist : "", "AVTransport");
+                        memberHandler.onValueReceived("CurrentTitle", (title != null) ? title : "", "AVTransport");
+                        memberHandler.onValueReceived("CurrentAlbum", (album != null) ? album : "", "AVTransport");
+                    }
+                } catch (IllegalStateException e) {
+                    logger.warn("Cannot update track data for group member ({})", e.getMessage());
+                }
+            }
+            updateMediaInfo();
+
+        } catch (IllegalStateException e) {
+            logger.warn("Cannot update track data ({})", e.getMessage());
         }
-        updateMediaInfo();
     }
 
     protected void updateCurrentURIFormatted(String URI) {
 
         String currentURI = URI;
         SonosMetaData currentTrack = null;
-        ZonePlayerHandler coordinatorHandler = getCoordinatorHandler();
 
-        if (coordinatorHandler != null && coordinatorHandler != this) {
-            if (currentURI.contains("x-rincon-stream")) {
-                coordinatorHandler.updateMediaInfo();
+        try {
+            ZonePlayerHandler coordinatorHandler = getCoordinatorHandler();
+
+            if (coordinatorHandler != null && coordinatorHandler != this) {
+                if (currentURI.contains("x-rincon-stream")) {
+                    coordinatorHandler.updateMediaInfo();
+                }
+                currentURI = coordinatorHandler.getCurrentURI();
+                currentTrack = coordinatorHandler.getTrackMetadata();
+            } else {
+                // currentURI = getCurrentURI();
+                currentTrack = getTrackMetadata();
             }
-            currentURI = coordinatorHandler.getCurrentURI();
-            currentTrack = coordinatorHandler.getTrackMetadata();
-        } else {
-            // currentURI = getCurrentURI();
-            currentTrack = getTrackMetadata();
+
+        } catch (IllegalStateException e) {
+            logger.warn("Cannot handle current URI ({})", e.getMessage());
+            currentURI = null;
+            currentTrack = null;
         }
 
         if (currentURI != null) {
@@ -839,12 +874,16 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
             if (needsUpdating) {
                 for (String member : getZoneGroupMembers()) {
-                    ZonePlayerHandler memberHandler = getHandlerByName(member);
-                    if (memberHandler != null && memberHandler.getThing() != null
-                            && ThingStatus.ONLINE.equals(memberHandler.getThing().getStatus())) {
-                        memberHandler.onValueReceived("CurrentURIFormatted", (resultString != null) ? resultString : "",
-                                "AVTransport");
-                        memberHandler.onValueReceived("CurrentTitle", (title != null) ? title : "", "AVTransport");
+                    try {
+                        ZonePlayerHandler memberHandler = getHandlerByName(member);
+                        if (memberHandler != null && memberHandler.getThing() != null
+                                && ThingStatus.ONLINE.equals(memberHandler.getThing().getStatus())) {
+                            memberHandler.onValueReceived("CurrentURIFormatted",
+                                    (resultString != null) ? resultString : "", "AVTransport");
+                            memberHandler.onValueReceived("CurrentTitle", (title != null) ? title : "", "AVTransport");
+                        }
+                    } catch (IllegalStateException e) {
+                        logger.warn("Cannot update title for group member ({})", e.getMessage());
                     }
                 }
             }
@@ -854,7 +893,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     public boolean isGroupCoordinator() {
         String value = stateMap.get("GroupCoordinatorIsLocal");
         if (value != null) {
-            return value.equals("1") ? true : false;
+            return value.equals("true") ? true : false;
         }
 
         return false;
@@ -1245,7 +1284,11 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
         if (isAdHocGroup() || isStandalonePlayer()) {
             setVolume(command);
         } else {
-            getCoordinatorHandler().setVolume(command);
+            try {
+                getCoordinatorHandler().setVolume(command);
+            } catch (IllegalStateException e) {
+                logger.warn("Cannot set group volume ({})", e.getMessage());
+            }
         }
     }
 
@@ -1448,11 +1491,10 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
         if (command != null && command instanceof StringType) {
 
-            String remotePlayerName = command.toString();
-            ZonePlayerHandler coordinatorHandler = getCoordinatorHandler();
-            ZonePlayerHandler remoteHandler = getHandlerByName(remotePlayerName);
-
-            if (coordinatorHandler != null && remoteHandler != null) {
+            try {
+                String remotePlayerName = command.toString();
+                ZonePlayerHandler coordinatorHandler = getCoordinatorHandler();
+                ZonePlayerHandler remoteHandler = getHandlerByName(remotePlayerName);
 
                 // stop whatever is currently playing
                 coordinatorHandler.stop();
@@ -1465,13 +1507,21 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
                 // start jammin'
                 coordinatorHandler.play();
+
+            } catch (IllegalStateException e) {
+                logger.warn("Cannot play line-in ({})", e.getMessage());
             }
         }
     }
 
-    private ZonePlayerHandler getCoordinatorHandler() {
+    private ZonePlayerHandler getCoordinatorHandler() throws IllegalStateException {
         if (coordinatorHandler == null) {
-            coordinatorHandler = getHandlerByName(getCoordinator());
+            try {
+                coordinatorHandler = getHandlerByName(getCoordinator());
+            } catch (IllegalStateException e) {
+                coordinatorHandler = null;
+                throw new IllegalStateException("Missing group coordinator " + getCoordinator());
+            }
         }
         return coordinatorHandler;
     }
@@ -1510,30 +1560,23 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
         return zoneGroupMembers;
     }
 
-    protected ZonePlayerHandler getHandlerByName(String remotePlayerName) {
+    protected ZonePlayerHandler getHandlerByName(String remotePlayerName) throws IllegalStateException {
         if (thingRegistry != null) {
             for (ThingTypeUID supportedThingType : SonosBindingConstants.SUPPORTED_THING_TYPES_UIDS) {
                 Thing thing = thingRegistry.get(new ThingUID(supportedThingType, remotePlayerName));
-
-                if (thing == null) {
-                    Collection<Thing> allThings = thingRegistry.getAll();
-                    for (Thing aThing : allThings) {
-                        if (aThing.getThingTypeUID().equals(this.getThing().getThingTypeUID())) {
-                            if (aThing.getConfiguration().get(UDN).equals(remotePlayerName)) {
-                                thing = aThing;
-                                break;
-                            }
-                        }
-                    }
-                }
-
                 if (thing != null) {
                     return (ZonePlayerHandler) thing.getHandler();
                 }
             }
+            Collection<Thing> allThings = thingRegistry.getAll();
+            for (Thing aThing : allThings) {
+                if (SonosBindingConstants.SUPPORTED_THING_TYPES_UIDS.contains(aThing.getThingTypeUID())
+                        && aThing.getConfiguration().get(UDN).equals(remotePlayerName)) {
+                    return (ZonePlayerHandler) aThing.getHandler();
+                }
+            }
         }
-        return null;
-
+        throw new IllegalStateException("Could not find handler for " + remotePlayerName);
     }
 
     public void setMute(Command command) {
@@ -1720,7 +1763,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     }
 
     public Boolean isLineInConnected() {
-        return stateMap.get("LineInConnected").equals("1") ? true : false;
+        return stateMap.get("LineInConnected").equals("true") ? true : false;
     }
 
     public void becomeStandAlonePlayer() {
@@ -1735,7 +1778,11 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     public void addMember(Command command) {
         if (command != null && command instanceof StringType) {
             SonosEntry entry = new SonosEntry("", "", "", "", "", "", "", "x-rincon:" + getUDN());
-            getHandlerByName(command.toString()).setCurrentURI(entry);
+            try {
+                getHandlerByName(command.toString()).setCurrentURI(entry);
+            } catch (IllegalStateException e) {
+                logger.warn("Cannot add group member ({})", e.getMessage());
+            }
         }
     }
 
@@ -1754,22 +1801,32 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
             // add all other players to this new group
             for (SonosZoneGroup group : currentSonosZoneGroups) {
                 for (String player : group.getMembers()) {
-                    ZonePlayerHandler somePlayer = getHandlerByName(player);
-                    if (somePlayer != this) {
-                        somePlayer.becomeStandAlonePlayer();
-                        somePlayer.stop();
-                        addMember(StringType.valueOf(somePlayer.getUDN()));
+                    try {
+                        ZonePlayerHandler somePlayer = getHandlerByName(player);
+                        if (somePlayer != this) {
+                            somePlayer.becomeStandAlonePlayer();
+                            somePlayer.stop();
+                            addMember(StringType.valueOf(somePlayer.getUDN()));
+                        }
+                    } catch (IllegalStateException e) {
+                        logger.warn("Cannot add to group ({})", e.getMessage());
                     }
                 }
             }
 
-            // set the URI of the group to the line-in
-            ZonePlayerHandler coordinator = getCoordinatorHandler();
-            SonosEntry entry = new SonosEntry("", "", "", "", "", "", "", "x-rincon-stream:" + getUDN());
-            coordinator.setCurrentURI(entry);
-            coordinator.play();
+            try {
+                ZonePlayerHandler coordinator = getCoordinatorHandler();
+                // set the URI of the group to the line-in
+                SonosEntry entry = new SonosEntry("", "", "", "", "", "", "", "x-rincon-stream:" + getUDN());
+                coordinator.setCurrentURI(entry);
+                coordinator.play();
 
-            return true;
+                return true;
+
+            } catch (IllegalStateException e) {
+                logger.warn("Cannot handle command ({})", e.getMessage());
+                return false;
+            }
 
         } else {
             logger.warn("Line-in of {} is not connected", this);
@@ -1788,32 +1845,37 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
         if (command != null && command instanceof StringType) {
 
-            String url = command.toString();
+            try {
+                String url = command.toString();
 
-            ZonePlayerHandler coordinator = getCoordinatorHandler();
+                ZonePlayerHandler coordinator = getCoordinatorHandler();
 
-            // stop whatever is currently playing
-            coordinator.stop();
+                // stop whatever is currently playing
+                coordinator.stop();
 
-            // clear any tracks which are pending in the queue
-            coordinator.removeAllTracksFromQueue();
+                // clear any tracks which are pending in the queue
+                coordinator.removeAllTracksFromQueue();
 
-            // add the new track we want to play to the queue
-            // The url will be prefixed with x-file-cifs if it is NOT a http URL
-            if (!url.startsWith("x-") && (!url.startsWith("http"))) {
-                // default to file based url
-                url = "x-file-cifs:" + url;
+                // add the new track we want to play to the queue
+                // The url will be prefixed with x-file-cifs if it is NOT a http URL
+                if (!url.startsWith("x-") && (!url.startsWith("http"))) {
+                    // default to file based url
+                    url = "x-file-cifs:" + url;
+                }
+                coordinator.addURIToQueue(url, "", 0, true);
+
+                // set the current playlist to our new queue
+                coordinator.setCurrentURI("x-rincon-queue:" + getUDN() + "#0", "");
+
+                // take the system off mute
+                coordinator.setMute(OnOffType.OFF);
+
+                // start jammin'
+                coordinator.play();
+
+            } catch (IllegalStateException e) {
+                logger.warn("Cannot play URI ({})", e.getMessage());
             }
-            coordinator.addURIToQueue(url, "", 0, true);
-
-            // set the current playlist to our new queue
-            coordinator.setCurrentURI("x-rincon-queue:" + getUDN() + "#0", "");
-
-            // take the system off mute
-            coordinator.setMute(OnOffType.OFF);
-
-            // start jammin'
-            coordinator.play();
         }
 
     }
@@ -1838,19 +1900,25 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     public void playNotificationSoundURI(Command notificationURL) {
 
         if (notificationURL != null && notificationURL instanceof StringType) {
-            ZonePlayerHandler coordinator = getCoordinatorHandler();
-            String currentURI = coordinator.getCurrentURI();
+            try {
+                ZonePlayerHandler coordinator = getCoordinatorHandler();
 
-            if (isPlayingStream(currentURI)) {
-                handleRadioStream(currentURI, notificationURL, coordinator);
-            } else if (isPlayingQueue(currentURI)) {
-                handleSharedQueue(notificationURL, coordinator);
-            } else if (isPlaylistEmpty(coordinator)) {
-                handleEmptyQueue(notificationURL, coordinator);
+                String currentURI = coordinator.getCurrentURI();
+
+                if (isPlayingStream(currentURI)) {
+                    handleRadioStream(currentURI, notificationURL, coordinator);
+                } else if (isPlayingQueue(currentURI)) {
+                    handleSharedQueue(notificationURL, coordinator);
+                } else if (isPlaylistEmpty(coordinator)) {
+                    handleEmptyQueue(notificationURL, coordinator);
+                }
+                synchronized (notificationLock) {
+                    notificationLock.notify();
+                }
+
+            } catch (IllegalStateException e) {
+                logger.warn("Cannot play sound ({})", e.getMessage());
             }
-        }
-        synchronized (notificationLock) {
-            notificationLock.notify();
         }
     }
 
@@ -2031,16 +2099,21 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     }
 
     public void playQueue(Command command) {
-        ZonePlayerHandler coordinator = getCoordinatorHandler();
+        try {
+            ZonePlayerHandler coordinator = getCoordinatorHandler();
 
-        // set the current playlist to our new queue
-        coordinator.setCurrentURI("x-rincon-queue:" + getUDN() + "#0", "");
+            // set the current playlist to our new queue
+            coordinator.setCurrentURI("x-rincon-queue:" + getUDN() + "#0", "");
 
-        // take the system off mute
-        coordinator.setMute(OnOffType.OFF);
+            // take the system off mute
+            coordinator.setMute(OnOffType.OFF);
 
-        // start jammin'
-        coordinator.play();
+            // start jammin'
+            coordinator.play();
+
+        } catch (IllegalStateException e) {
+            logger.warn("Cannot play queue ({})", e.getMessage());
+        }
     }
 
     public void setLed(Command command) {
@@ -2059,6 +2132,9 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                 }
 
                 Map<String, String> result = service.invokeAction(this, "DeviceProperties", "SetLEDState", inputs);
+                Map<String, String> result2 = service.invokeAction(this, "DeviceProperties", "GetLEDState", null);
+
+                result.putAll(result2);
 
                 for (String variable : result.keySet()) {
                     this.onValueReceived(variable, result.get(variable), "DeviceProperties");
@@ -2069,12 +2145,16 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
     public void removeMember(Command command) {
         if (command != null && command instanceof StringType) {
-            ZonePlayerHandler oldmemberHandler = getHandlerByName(command.toString());
+            try {
+                ZonePlayerHandler oldmemberHandler = getHandlerByName(command.toString());
 
-            oldmemberHandler.becomeStandAlonePlayer();
-            SonosEntry entry = new SonosEntry("", "", "", "", "", "", "",
-                    "x-rincon-queue:" + oldmemberHandler.getUDN() + "#0");
-            oldmemberHandler.setCurrentURI(entry);
+                oldmemberHandler.becomeStandAlonePlayer();
+                SonosEntry entry = new SonosEntry("", "", "", "", "", "", "",
+                        "x-rincon-queue:" + oldmemberHandler.getUDN() + "#0");
+                oldmemberHandler.setCurrentURI(entry);
+            } catch (IllegalStateException e) {
+                logger.warn("Cannot remove group member ({})", e.getMessage());
+            }
         }
     }
 
@@ -2095,11 +2175,12 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     }
 
     public void playRadio(Command command) {
-        List<SonosEntry> stations = getFavoriteRadios();
-        SonosEntry theEntry = null;
 
         if (command instanceof StringType) {
             String station = command.toString();
+            List<SonosEntry> stations = getFavoriteRadios();
+
+            SonosEntry theEntry = null;
             // search for the appropriate radio based on its name (title)
             for (SonosEntry someStation : stations) {
                 if (someStation.getTitle().equals(station)) {
@@ -2110,9 +2191,13 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
             // set the URI of the group coordinator
             if (theEntry != null) {
-                ZonePlayerHandler coordinator = getCoordinatorHandler();
-                coordinator.setCurrentURI(theEntry);
-                coordinator.play();
+                try {
+                    ZonePlayerHandler coordinator = getCoordinatorHandler();
+                    coordinator.setCurrentURI(theEntry);
+                    coordinator.play();
+                } catch (IllegalStateException e) {
+                    logger.warn("Cannot play radio ({})", e.getMessage());
+                }
             }
         }
 
@@ -2142,57 +2227,65 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
             // set the URI of the group coordinator
             if (theEntry != null) {
-                ZonePlayerHandler coordinator = getCoordinatorHandler();
+                try {
+                    ZonePlayerHandler coordinator = getCoordinatorHandler();
 
-                /**
-                 * If this is a playlist we need to treat it as such
-                 */
-                if (theEntry.getResourceMetaData() != null
-                        && theEntry.getResourceMetaData().getUpnpClass().equals("object.container.playlistContainer")) {
-                    coordinator.removeAllTracksFromQueue();
-                    coordinator.addURIToQueue(theEntry);
-                    coordinator.setCurrentURI("x-rincon-queue:" + coordinator.getUDN() + "#0", "");
-                    if (stateMap != null) {
-                        String firstTrackNumberEnqueued = stateMap.get("FirstTrackNumberEnqueued");
-                        if (firstTrackNumberEnqueued != null) {
-                            coordinator.seek("TRACK_NR", firstTrackNumberEnqueued);
+                    /**
+                     * If this is a playlist we need to treat it as such
+                     */
+                    if (theEntry.getResourceMetaData() != null && theEntry.getResourceMetaData().getUpnpClass()
+                            .equals("object.container.playlistContainer")) {
+                        coordinator.removeAllTracksFromQueue();
+                        coordinator.addURIToQueue(theEntry);
+                        coordinator.setCurrentURI("x-rincon-queue:" + coordinator.getUDN() + "#0", "");
+                        if (stateMap != null) {
+                            String firstTrackNumberEnqueued = stateMap.get("FirstTrackNumberEnqueued");
+                            if (firstTrackNumberEnqueued != null) {
+                                coordinator.seek("TRACK_NR", firstTrackNumberEnqueued);
+                            }
                         }
+                    } else {
+                        coordinator.setCurrentURI(theEntry);
                     }
-                } else {
-                    coordinator.setCurrentURI(theEntry);
+                    coordinator.play();
+                } catch (IllegalStateException e) {
+                    logger.warn("Cannot paly favorite ({})", e.getMessage());
                 }
-                coordinator.play();
             }
+
         }
     }
 
     public void playTrack(Command command) {
 
         if (command != null && command instanceof DecimalType) {
-            ZonePlayerHandler coordinator = getCoordinatorHandler();
+            try {
+                ZonePlayerHandler coordinator = getCoordinatorHandler();
 
-            String trackNumber = command.toString();
+                String trackNumber = command.toString();
 
-            // seek the track - warning, we do not check if the tracknumber falls in the boundary of the queue
-            setPositionTrack(trackNumber);
+                // seek the track - warning, we do not check if the tracknumber falls in the boundary of the queue
+                setPositionTrack(trackNumber);
 
-            // take the system off mute
-            coordinator.setMute(OnOffType.OFF);
+                // take the system off mute
+                coordinator.setMute(OnOffType.OFF);
 
-            // start jammin'
-            coordinator.play();
+                // start jammin'
+                coordinator.play();
+            } catch (IllegalStateException e) {
+                logger.warn("Cannot play track ({})", e.getMessage());
+            }
         }
 
     }
 
     public void playPlayList(Command command) {
-        List<SonosEntry> playlists = getPlayLists();
-        SonosEntry theEntry = null;
 
         if (command != null && command instanceof StringType) {
-
             String playlist = command.toString();
+            List<SonosEntry> playlists = getPlayLists();
 
+            SonosEntry theEntry = null;
             // search for the appropriate play list based on its name (title)
             for (SonosEntry somePlaylist : playlists) {
                 if (somePlaylist.getTitle().equals(playlist)) {
@@ -2203,19 +2296,23 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
             // set the URI of the group coordinator
             if (theEntry != null) {
+                try {
+                    ZonePlayerHandler coordinator = getCoordinatorHandler();
 
-                ZonePlayerHandler coordinator = getCoordinatorHandler();
-                // coordinator.setCurrentURI(theEntry);
-                coordinator.addURIToQueue(theEntry);
+                    // coordinator.setCurrentURI(theEntry);
+                    coordinator.addURIToQueue(theEntry);
 
-                if (stateMap != null) {
-                    String firstTrackNumberEnqueued = stateMap.get("FirstTrackNumberEnqueued");
-                    if (firstTrackNumberEnqueued != null) {
-                        coordinator.seek("TRACK_NR", firstTrackNumberEnqueued);
+                    if (stateMap != null) {
+                        String firstTrackNumberEnqueued = stateMap.get("FirstTrackNumberEnqueued");
+                        if (firstTrackNumberEnqueued != null) {
+                            coordinator.seek("TRACK_NR", firstTrackNumberEnqueued);
+                        }
                     }
-                }
 
-                coordinator.play();
+                    coordinator.play();
+                } catch (IllegalStateException e) {
+                    logger.warn("Cannot play playlist ({})", e.getMessage());
+                }
             }
         }
     }
@@ -2325,7 +2422,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     protected void updateSleepTimerDuration() {
         Map<String, String> result = service.invokeAction(this, "AVTransport", "GetRemainingSleepTimerDuration", null);
         for (String variable : result.keySet()) {
-            this.onValueReceived(variable, result.get(variable), "DeviceProperties");
+            this.onValueReceived(variable, result.get(variable), "AVTransport");
         }
     }
 


### PR DESCRIPTION
Player UI actions are now working when applied to a slave member of a group.
Implement exception for missing zone player handler
Fix NPE when no thing is defined for the group coordinator
Change of state is fixed for GroupCoordinatorIsLocal, MuteMaster, LineInConnected and AlarmRunning.
saveAllPlayerState and restoreAllPlayerState are now considering really all Sonos players.
Deprecated calls to updateState have been updated.
Fix: method onValueReceived: add a missing break in the java switch
Fix: method updateSleepTimerDuration: onValueRecived was called with service "DeviceProperties" rather than "AVTransport"
Enhancement: add a warning message if the handler for a zone player is not found (when searching the handler of the group coordinator)
Enhancement: quick refresh of the zone name without waiting for the polling job
Enhancement: quick refresh of the sleep timer when updated from the Sonos application (without waiting for the polling job)
Enhancement: quick refresh of the LED state when updated from Eclipse Smarthome / openHAB

Signed-off-by: Laurent Garnier <lg.hc@free.fr>