### PR TITLE
LIFX binding: Fix #1915 IllegalMonitorStateException may occur when u…

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxNetworkThrottler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxNetworkThrottler.java
@@ -85,8 +85,10 @@ public class LifxNetworkThrottler {
     public static void unlock() {
 
         for (String key : locks.keySet()) {
-            timestamps.put(key, System.currentTimeMillis());
-            locks.get(key).unlock();
+            if (locks.get(key).isHeldByCurrentThread()) {
+                timestamps.put(key, System.currentTimeMillis());
+                locks.get(key).unlock();
+            }
         }
 
     }


### PR DESCRIPTION
…nlocking after sending broadcast packet

Signed-off-by: Wouter Born <eclipse@maindrain.net>