### PR TITLE
Sonos binding: fix issues 1600 1942 1943 1944 1045 1954

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
@@ -32,7 +32,7 @@ import org.xml.sax.helpers.XMLReaderFactory;
 /**
  * The {@link SonosXMLParser} is a class of helper functions
  * to parse XML data returned by the Zone Players
- * 
+ *
  * @author Karel Goderis - Initial contribution
  */
 public class SonosXMLParser {
@@ -87,7 +87,7 @@ public class SonosXMLParser {
             reader.setContentHandler(handler);
             reader.parse(new InputSource(new StringReader(xml)));
         } catch (IOException e) {
-            logger.error("Could not parse Alarms from string '{}", xml);
+            logger.error("Could not parse Alarms from string '{}'", xml);
         } catch (SAXException s) {
             logger.error("Could not parse Alarms from string '{}'", xml);
         }
@@ -118,7 +118,7 @@ public class SonosXMLParser {
     /**
      * Returns the meta data which is needed to play Pandora
      * (and others?) favorites
-     * 
+     *
      * @param xml
      * @return The value of the desc xml tag
      * @throws SAXException
@@ -130,7 +130,9 @@ public class SonosXMLParser {
         try {
             reader.parse(new InputSource(new StringReader(xml)));
         } catch (IOException e) {
-            logger.error("Could not parse Entries from String {}", xml);
+            logger.error("Could not parse Resource MetaData from String '{}'", xml);
+        } catch (SAXException s) {
+            logger.error("Could not parse Resource MetaData from string '{}'", xml);
         }
         return handler.getMetaData();
     }
@@ -184,7 +186,7 @@ public class SonosXMLParser {
             reader.parse(new InputSource(new StringReader(xml)));
         } catch (IOException e) {
             // This should never happen - we're not performing I/O!
-            logger.debug("Could not parse Rendering Control from string '{}'", xml);
+            logger.error("Could not parse Rendering Control from string '{}'", xml);
         } catch (SAXException s) {
             logger.error("Could not parse Rendering Control from string '{}'", xml);
         }
@@ -315,7 +317,8 @@ public class SonosXMLParser {
                 case RESMD:
                     desc.append(ch, start, length);
                     break;
-                // no default
+                case DESC:
+                    break;
             }
         }
 
@@ -333,10 +336,12 @@ public class SonosXMLParser {
                 SonosResourceMetaData md = null;
 
                 // The resource description is needed for playing favorites on pandora
-                try {
-                    md = getResourceMetaData(desc.toString());
-                } catch (SAXException ignore) {
-                    logger.debug("Failed to parse embeded", ignore);
+                if (!desc.toString().isEmpty()) {
+                    try {
+                        md = getResourceMetaData(desc.toString());
+                    } catch (SAXException ignore) {
+                        logger.debug("Failed to parse embeded", ignore);
+                    }
                 }
 
                 artists.add(new SonosEntry(id, title.toString(), parentId, album.toString(), albumArtUri.toString(),
@@ -582,7 +587,7 @@ public class SonosXMLParser {
         private final List<String> textFields = new ArrayList<String>();
         private String textField;
         private String type;
-        private String logo;
+        // private String logo;
 
         @Override
         public void startElement(String uri, String localName, String qName, Attributes attributes)
@@ -760,6 +765,8 @@ public class SonosXMLParser {
                     case albumArtist:
                         albumArtist.append(ch, start, length);
                         break;
+                    case desc:
+                        break;
                 }
             }
         }
@@ -827,7 +834,7 @@ public class SonosXMLParser {
             URL url = new URL(descriptorXML);
             reader.parse(new InputSource(url.openStream()));
         } catch (IOException | SAXException e) {
-            logger.error("Could not parse Sonos room name from string '{}", descriptorXML);
+            logger.error("Could not parse Sonos room name from string '{}'", descriptorXML);
         }
         return roomNameHandler.getRoomName();
     }
@@ -865,7 +872,7 @@ public class SonosXMLParser {
             URL url = new URL(descriptorURL.toString());
             reader.parse(new InputSource(url.openStream()));
         } catch (IOException | SAXException e) {
-            logger.error("Could not parse Sonos model name from string '{}", descriptorURL.toString());
+            logger.error("Could not parse Sonos model name from string '{}'", descriptorURL.toString());
         }
         return modelNameHandler.getModelName();
     }
@@ -897,7 +904,7 @@ public class SonosXMLParser {
 
     /**
      * The model name provided by upnp is formated like in the example form "Sonos PLAY:1" or "Sonos PLAYBAR"
-     * 
+     *
      * @param sonosModelName Sonos model name provided via upnp device
      * @return the extracted players model name without column (:) character used for ThingType creation
      */


### PR DESCRIPTION
Additionally, this PR improoves binding initialization by avoiding invoking UPnP actions and subscribing services while the UPnP transport service is not yet ready.
Correct/change few log messagess.
Avoid NPE due to entry not set in stateMap.
Use scheduleWithFixedDelay rather than scheduleAtFixedRate

Siged-off-by: Laurent Garnier <lg.hc@free.fr>