### PR TITLE
Updated interface for UPnP participant (enh #1941)

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/src/main/java/org/eclipse/smarthome/io/transport/upnp/UpnpIOParticipant.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/src/main/java/org/eclipse/smarthome/io/transport/upnp/UpnpIOParticipant.java
@@ -23,9 +23,17 @@ public interface UpnpIOParticipant {
     public void onValueReceived(String variable, String value, String service);
 
     /**
+     * Called to notify if a GENA subscription succeeded or failed.
+     *
+     * @param service - the UPnP service subscribed
+     * @param succeeded - true if the subscription succeeded; false if failed
+     */
+    public void onServiceSubscribed(String service, boolean succeeded);
+
+    /**
      * Called when the UPNP IO service is unable to poll the UDN of the participant, given that
      * a addStatusListener is registered.
-     * 
+     *
      * @param status - false, if the poll fails when the polling was previously successful; true if the poll succeeds
      *            when the polling was previously failing
      */

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/discovery/WemoLinkDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/discovery/WemoLinkDiscoveryService.java
@@ -78,7 +78,7 @@ public class WemoLinkDiscoveryService extends AbstractDiscoveryService implement
      * Job which will do the background scanning
      */
     private WemoLinkScan scanningRunnable;
-    
+
     /**
      * Schedule for scanning
      */
@@ -142,10 +142,10 @@ public class WemoLinkDiscoveryService extends AbstractDiscoveryService implement
                                 "</DeviceLists>");
 
                         stringParser = StringEscapeUtils.unescapeXml(stringParser);
-                        
+
                         // check if there are already paired devices with WeMo Link
-                        if("0".equals(stringParser)) {
-                        	logger.debug("There are no devices connected with WeMo Link. Exit discovery");
+                        if ("0".equals(stringParser)) {
+                            logger.debug("There are no devices connected with WeMo Link. Exit discovery");
                             return;
                         }
 
@@ -254,6 +254,10 @@ public class WemoLinkDiscoveryService extends AbstractDiscoveryService implement
     @Override
     public String getUDN() {
         return (String) this.wemoBridgeHandler.getThing().getConfiguration().get(UDN);
+    }
+
+    @Override
+    public void onServiceSubscribed(String service, boolean succeeded) {
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoHandler.java
@@ -185,6 +185,10 @@ public class WemoHandler extends BaseThingHandler implements UpnpIOParticipant, 
     }
 
     @Override
+    public void onServiceSubscribed(String service, boolean succeeded) {
+    }
+
+    @Override
     public void onValueReceived(String variable, String value, String service) {
 
         if (getThing().getStatus() == ThingStatus.ONLINE) {

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoLightHandler.java
@@ -342,6 +342,10 @@ public class WemoLightHandler extends BaseThingHandler implements UpnpIOParticip
     }
 
     @Override
+    public void onServiceSubscribed(String service, boolean succeeded) {
+    }
+
+    @Override
     public void onValueReceived(String variable, String value, String service) {
         logger.trace("Received pair '{}':'{}' (service '{}') for thing '{}'",
                 new Object[] { variable, value, service, this.getThing().getUID() });

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoMakerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoMakerHandler.java
@@ -318,6 +318,10 @@ public class WemoMakerHandler extends BaseThingHandler implements UpnpIOParticip
     }
 
     @Override
+    public void onServiceSubscribed(String service, boolean succeeded) {
+    }
+
+    @Override
     public void onValueReceived(String variable, String value, String service) {
     }
 


### PR DESCRIPTION
Allows bindings to be notified when a GENA service subscription succeeded or failed.
Wemo binding updated to be compliant with the updated interface.
Sonos binding updated to be compliant with the updated interface and to implement a retry mechanism in case the service subscriptions failed.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>