### PR TITLE
Fix scrollbar bug, add responsive images

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -497,10 +497,6 @@ section#developers .section-header {
 
 /* Text Pages */
 
-section.text {
-    overflow-x: scroll;
-}
-
 section.text h1 {
 	font-size: 2.0rem;
 	line-height: 3.0rem;
@@ -721,6 +717,10 @@ body.documentation .content-wrapper {
     }
 }
 
+body.documentation section#documentation .content img {
+	max-width: 100%;
+	height: auto;
+}
 body.documentation section#documentation .content > h1:first-child {
 	margin-top: 0px;
 }


### PR DESCRIPTION
Copy of: https://github.com/openhab/openhab-docs/pull/56

------- 

Fixes https://community.openhab.org/t/documenting-openhab-2/10568/84

Sorry for piggybacking :o)

The "bug" behind Link 1 is actually a feature added by the original author of style.css to be able to look at big pictures.
I included the changes suggested by Link 2 to fix that in the right way.
However not as a class, I like this solution better after all.

Outlook: At some point in the future, if one image needs to be half size or with a pink frame, this would be possible by adding a class:

      ![title](image.png){: .half-pink-img}

