### PR TITLE
fixed item types in DTOs to not contain "Item" anymore

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/events/ItemEventFactoryTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/events/ItemEventFactoryTest.groovy
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.items.GroupItem
 import org.eclipse.smarthome.core.items.dto.ItemDTOMapper
 import org.eclipse.smarthome.core.items.events.ItemEventFactory.ItemEventPayloadBean
 import org.eclipse.smarthome.core.items.events.ItemEventFactory.ItemStateChangedEventPayloadBean
+import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.items.SwitchItem
 import org.eclipse.smarthome.core.library.types.OnOffType
 import org.eclipse.smarthome.core.types.RefreshType
@@ -173,7 +174,7 @@ class ItemEventFactoryTest extends OSGiTest {
         assertThat itemAddedEvent.getPayload(), is(ITEM_ADDED_EVENT_PAYLOAD)
         assertThat itemAddedEvent.getItem(), not(null)
         assertThat itemAddedEvent.getItem().name, is(ITEM_NAME)
-        assertThat itemAddedEvent.getItem().type, is("SwitchItem")
+        assertThat itemAddedEvent.getItem().type, is(CoreItemFactory.SWITCH)
     }
 
     @Test
@@ -184,6 +185,6 @@ class ItemEventFactoryTest extends OSGiTest {
         assertThat event.getTopic(), is(ITEM_ADDED_EVENT_TOPIC)
         assertThat event.getItem(), not(null)
         assertThat event.getItem().name, is(ITEM_NAME)
-        assertThat event.getItem().type, is("SwitchItem")
+        assertThat event.getItem().type, is(CoreItemFactory.SWITCH)
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableSet;
 
 public class GroupItem extends GenericItem implements StateChangeListener {
 
+    public static final String TYPE = "Group";
+
     private final Logger logger = LoggerFactory.getLogger(GroupItem.class);
 
     protected final GenericItem baseItem;
@@ -42,7 +44,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     }
 
     public GroupItem(String name, GenericItem baseItem, GroupFunction function) {
-        super("Group", name);
+        super(TYPE, name);
         members = new CopyOnWriteArraySet<Item>();
         this.function = function;
         this.baseItem = baseItem;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
@@ -47,7 +47,7 @@ public class ItemDTOMapper {
 
         GenericItem newItem = null;
         if (itemDTO.type != null) {
-            if (itemDTO instanceof GroupItemDTO && itemDTO.type.equals("GroupItem")) {
+            if (itemDTO instanceof GroupItemDTO && itemDTO.type.equals(GroupItem.TYPE)) {
                 GroupItemDTO groupItemDTO = (GroupItemDTO) itemDTO;
                 GenericItem baseItem = null;
                 if (!Strings.isNullOrEmpty(groupItemDTO.groupType)) {
@@ -59,7 +59,7 @@ public class ItemDTOMapper {
                 }
                 newItem = new GroupItem(itemDTO.name, baseItem, function);
             } else {
-                String itemType = itemDTO.type.substring(0, itemDTO.type.length() - 4);
+                String itemType = itemDTO.type;
                 newItem = createItem(itemType, itemDTO.name, itemFactories);
             }
             if (newItem != null) {
@@ -179,7 +179,7 @@ public class ItemDTOMapper {
             }
         }
         itemDTO.name = item.getName();
-        itemDTO.type = item.getClass().getSimpleName();
+        itemDTO.type = item.getType();
         itemDTO.label = item.getLabel();
         itemDTO.tags = item.getTags();
         itemDTO.category = item.getCategory();


### PR DESCRIPTION
This fixes a bug in the ItemDTOs - the mapper incorrectly set the type in there by using the item simple class name instead of the item type constants.

CAUTION: As the ItemDTOs are used for serialization of events and in the REST API, this fix can have implications on clients that might wrongly assume that "Item" should be part of the type.

@sbussweiler As far as I can see, you implemented this originally, I hope you agree that this is a bug and not on purpose?

@aounhaider1 Could you please check the implications for the Paper UI?

Signed-off-by: Kai Kreuzer <kai@openhab.org>