### PR TITLE
Provide DiscoveryServices access to existing Results and Thing

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceMock.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceMock.groovy
@@ -17,8 +17,8 @@ import org.eclipse.smarthome.core.thing.ThingUID
  * The {@link DiscoveryServiceMock} is a mock for a {@link DiscoveryService}
  * which can simulate a working and faulty discovery.<br>
  * If this mock is configured to be faulty, an exception is thrown if the
- * discovery is enforced or aborted. 
- * 
+ * discovery is enforced or aborted.
+ *
  * @author Michael Grammling - Initial Contribution
  * @author Thomas Höfer - Added representation
  */

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/ExtendedDiscoveryServiceMock.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/ExtendedDiscoveryServiceMock.groovy
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.setup.test.discovery
+
+import org.eclipse.smarthome.config.discovery.DiscoveryServiceCallback
+import org.eclipse.smarthome.config.discovery.ExtendedDiscoveryService
+import org.eclipse.smarthome.config.discovery.internal.DiscoveryResultImpl
+import org.eclipse.smarthome.core.thing.ThingTypeUID
+import org.eclipse.smarthome.core.thing.ThingUID
+
+
+/**
+ * The {@link DiscoveryServiceMock} is a mock for a {@link DiscoveryService}
+ * which behaves like an @{ExtendedDiscoveryService}.<br>
+ *
+ * @author Simon Kaufmann - Initial Contribution
+ */
+class ExtendedDiscoveryServiceMock extends DiscoveryServiceMock implements ExtendedDiscoveryService {
+
+    public DiscoveryServiceCallback discoveryServiceCallback
+
+    public ExtendedDiscoveryServiceMock(thingType, timeout, faulty = false) {
+        super(thingType, timeout)
+    }
+
+    @Override
+    public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback) {
+        this.discoveryServiceCallback = discoveryServiceCallback
+    }
+
+    @Override
+    public void startScan() {
+        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, "foo"), null, null, null, null, DEFAULT_TTL))
+    }
+}

--- a/bundles/config/org.eclipse.smarthome.config.discovery/OSGI-INF/DiscoveryServiceRegistry.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/OSGI-INF/DiscoveryServiceRegistry.xml
@@ -14,4 +14,6 @@
       <provide interface="org.eclipse.smarthome.config.discovery.DiscoveryServiceRegistry"/>
    </service>
    <reference bind="addDiscoveryService" cardinality="0..n" interface="org.eclipse.smarthome.config.discovery.DiscoveryService" name="DiscoveryService" policy="dynamic" unbind="removeDiscoveryService"/>
+   <reference bind="setThingRegistry" cardinality="0..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="dynamic" unbind="unsetThingRegistry"/>
+   <reference bind="setInbox" cardinality="0..1" interface="org.eclipse.smarthome.config.discovery.inbox.Inbox" name="Inbox" policy="dynamic" unbind="unsetInbox"/>
 </scr:component>

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryServiceCallback.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryServiceCallback.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.discovery;
+
+import java.util.List;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingUID;
+
+/**
+ * This interface provides helper methods for {@link DiscoveryService}s in order to access core framework capabilities.
+ * <p>
+ * This interface must not be implemented by bindings.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ */
+public interface DiscoveryServiceCallback {
+
+    /**
+     * Get an existing {@link Thing} from the ThingRegistry, it it exists.
+     *
+     * @param thingUID the {@link ThingUID} by which the {@link Thing} is identified
+     * @return the {@link Thing} if it exists or <code>null</code> otherwise
+     */
+    public Thing getExistingThing(ThingUID thingUID);
+
+    /**
+     * Get the already existing {@link DiscoveryResult}s from the Inbox(es).
+     *
+     * @param thingUID the {@link ThingUID} which identify the {@link DiscoveryResult}
+     * @return a {@link List} of {@link DiscoveryResult}s which are stored in the Inbox(es), never <code>null</code>
+     */
+    public DiscoveryResult getExistingDiscoveryResult(ThingUID thingUID);
+
+}

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/ExtendedDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/ExtendedDiscoveryService.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.discovery;
+
+/**
+ * By implementing this interface, a {@link DiscoveryService} implementation may indicate that it requires extended
+ * access to the core framework.
+ *
+ * The {@link DiscoveryService} will get a {@link DiscoveryServiceCallback}, which provides the extended framework
+ * capabilities.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+public interface ExtendedDiscoveryService {
+
+    /**
+     * Provides the callback, which a {@link DiscoveryService} may use in order to access core features.
+     *
+     * @param discoveryServiceCallback
+     */
+    public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback);
+
+}

--- a/docs/documentation/development/bindings/discovery-services.md
+++ b/docs/documentation/development/bindings/discovery-services.md
@@ -91,6 +91,40 @@ Normally, older discovery results already in the inbox are left untouched by a n
     }
 ```
 
+### Compare with existing results
+
+In some cases it might be of interest for a discovery service if the same device was discovered before or even a Thing already exists. Therefore, a discovery service may implement the ExtendedDiscoveryService interface and use the injected callback in order to access the DiscoveryResult or Thing for a given ThingUID, if it exists. 
+
+```java
+    public class SampleDiscoveryService extends AbstractDiscoveryService implements ExtendedDiscoveryService {
+
+        private DiscoveryServiceCallback discoveryServiceCallback;
+
+        @Override
+        public void setDiscoveryServiceCallback(DiscoveryServiceCallback discoveryServiceCallback) {
+            this.discoveryServiceCallback = discoveryServiceCallback;
+        }
+
+        public void discoverSomething() {
+            
+            [...]
+               
+            ThingUID thingUID = [...]
+        
+            if (discoveryServiceCallback.getExistingDiscoveryResult(thingUID) != null) {
+                // "Thing " + thingUID.toString() + " was already discovered"
+            }
+            if (discoveryServiceCallback.getExistingThing(thingUID) != null) {
+                // "Thing " + thingUID.toString() + " already exists"
+            }
+            
+            thingDiscovered(discoveryResult);
+        }
+    }
+``` 
+
+
+
 ## UPnP Discovery
 
 UPnP discovery is implemented in the framework as `UpnpDiscoveryService`. It is widely used in bindings. To facilitate the development, binding developers only need to implement a `UpnpDiscoveryParticipant`. Here the developer only needs to implement three simple methods: 


### PR DESCRIPTION
With this PR, I would like to get back to  the discussion from #1791. 

The mechanism of injecting the callback is a bit uncommon, but we use it for ThingHandlers as well. I took into consideration the following aspects:

* DiscoveryServices should get access to the "real" objects from the framework, not only to the caches they maintain themselves
* It should not require every DiscoveryService to declare additional service dependencies 
* The level of abstraction should be kept intact and no direct dependencies to the ThingRegistry/PersistentInbox should be introduced
* The API should be extensible, i.e. must not break if we want to introduce further framework access methods in future

fixes #1791 
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>