### PR TITLE
Reduced size of header tags in parameter description

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -908,3 +908,27 @@ md-dialog-content .dayParameter {
 .itemSet md-chips {
 	padding-bottom: 10px;
 }
+
+.includeConfig .parameter .hint h1 {
+    font-size:15px;
+}
+
+.includeConfig .parameter .hint h2 {
+    font-size:14px;
+}
+
+.includeConfig .parameter .hint h3 {
+    font-size:13px;
+}
+
+.includeConfig .parameter .hint h4 {
+    font-size:12px;
+}
+
+.includeConfig .parameter .hint h5 {
+    font-size:11px;
+}
+
+.includeConfig .parameter .hint h6 {
+    font-size:10px;
+}


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/1970
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>