### PR TITLE
Add i18n helper methods to BaseThingHandler

### DIFF
--- a/docs/documentation/development/bindings/thing-handler.md
+++ b/docs/documentation/development/bindings/thing-handler.md
@@ -266,3 +266,7 @@ The framework will take care of internationalizing the messages. For this purpos
 * config-status.warning.any-suffix
 * config-status.error.any-suffix
 * config-status.pending.any-suffix
+
+## Internationalising Strings
+
+The BaseThingHandler contains a helper method `getText(String key, String defaultText, Locale locale)` to call the `I18nProvider.getText` methods.

--- a/docs/documentation/features/internationalization.md
+++ b/docs/documentation/features/internationalization.md
@@ -186,3 +186,6 @@ If one binding supports the German language and another does not, it might occur
 
 For Binding Info and ConfigDescription, the localized objects can be retrieved via the `BindingInfoRegistry` and the `ConfigDescriptionRegistry` in the same manner as described for Thing Types.
 
+## Internationalising Strings within Bindings
+
+The BaseThingHandler contains a helper method `getText(String key, String defaultText, Locale locale)` to call the `I18nProvider.getText` methods.


### PR DESCRIPTION
It seems to make sense to provide helper functions in the BaseThingHandler to make it easier for bindings to internationalise strings rather than having to deal with the service directly. 
Signed-off-by: Chris Jackson <chris@cd-jackson.com>