### PR TITLE
Don't call handleCommand if thing is not initialised

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
@@ -191,6 +191,11 @@ public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusIn
     };
 
     private void informHandlerAboutLinkedChannel(Thing thing, Channel channel) {
+        // Don't notify the thing if the thing isn't initialised
+        if (thing.getStatus() != ThingStatus.ONLINE && thing.getStatus() != ThingStatus.OFFLINE) {
+            return;
+        }
+
         ThingHandler handler = thing.getHandler();
         if (handler != null) {
             try {
@@ -205,6 +210,11 @@ public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusIn
     }
 
     private void informHandlerAboutUnlinkedChannel(Thing thing, Channel channel) {
+        // Don't notify the thing if the thing isn't initialised
+        if (thing.getStatus() != ThingStatus.ONLINE && thing.getStatus() != ThingStatus.OFFLINE) {
+            return;
+        }
+
         ThingHandler handler = thing.getHandler();
         if (handler != null) {
             try {


### PR DESCRIPTION
This probably should close #2020 since ThingManager checks that the thing is initialised, so this should be the only place that this isn't caught (at least that I've found).
Signed-off-by: Chris Jackson <chris@cd-jackson.com>