### PR TITLE
add the isInitialized function to the thing itself

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -150,7 +150,7 @@ public abstract class BaseThingHandler implements ThingHandler {
             configuration.put(configurationParmeter.getKey(), configurationParmeter.getValue());
         }
 
-        if (ThingHandlerHelper.isHandlerInitialized(this)) {
+        if (isInitialized()) {
             // persist new configuration and reinitialize handler
             dispose();
             updateConfiguration(configuration);
@@ -576,14 +576,11 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     /**
-     * Returns whether the thing has already been initialized.
+     * Returns whether the handler has already been initialized.
      *
-     * @return true if thing is initialized, false otherwise
-     * @deprecated use {@link ThingHandlerHelper#isHandlerInitialized(Thing)} or
-     *             {@link ThingHandlerHelper#isHandlerInitialized(ThingHandler)}
+     * @return true if handler is initialized, false otherwise
      */
-    @Deprecated
-    protected boolean thingIsInitialized() {
+    protected boolean isInitialized() {
         return ThingHandlerHelper.isHandlerInitialized(this);
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -31,6 +31,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.type.TypeResolver;
+import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
@@ -149,7 +150,7 @@ public abstract class BaseThingHandler implements ThingHandler {
             configuration.put(configurationParmeter.getKey(), configurationParmeter.getValue());
         }
 
-        if (thingIsInitialized()) {
+        if (ThingHandlerHelper.isHandlerInitialized(this)) {
             // persist new configuration and reinitialize handler
             dispose();
             updateConfiguration(configuration);
@@ -578,9 +579,12 @@ public abstract class BaseThingHandler implements ThingHandler {
      * Returns whether the thing has already been initialized.
      *
      * @return true if thing is initialized, false otherwise
+     * @deprecated use {@link ThingHandlerHelper#isHandlerInitialized(Thing)} or
+     *             {@link ThingHandlerHelper#isHandlerInitialized(ThingHandler)}
      */
+    @Deprecated
     protected boolean thingIsInitialized() {
-        return getThing().getStatus() == ThingStatus.ONLINE || getThing().getStatus() == ThingStatus.OFFLINE;
+        return ThingHandlerHelper.isHandlerInitialized(this);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -61,6 +61,7 @@ import org.eclipse.smarthome.core.thing.events.ThingEventFactory;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
+import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.osgi.framework.Bundle;
@@ -177,7 +178,8 @@ public class ThingManager extends AbstractItemEventSubscriber
 
         private void handleBridgeStatusUpdate(Bridge bridge, ThingStatusInfo statusInfo,
                 ThingStatusInfo oldStatusInfo) {
-            if (isInitialized(bridge) && oldStatusInfo.getStatus() == ThingStatus.INITIALIZING) {
+            if (ThingHandlerHelper.isHandlerInitialized(bridge)
+                    && oldStatusInfo.getStatus() == ThingStatus.INITIALIZING) {
                 // bridge has just been initialized: initialize child things as well
                 registerChildHandlers(bridge);
             } else if (!statusInfo.equals(oldStatusInfo)) {
@@ -187,7 +189,8 @@ public class ThingManager extends AbstractItemEventSubscriber
         }
 
         private void handleBridgeChildStatusUpdate(Thing thing, ThingStatusInfo oldStatusInfo) {
-            if (isInitialized(thing) && oldStatusInfo.getStatus() == ThingStatus.INITIALIZING) {
+            if (ThingHandlerHelper.isHandlerInitialized(thing)
+                    && oldStatusInfo.getStatus() == ThingStatus.INITIALIZING) {
                 // child thing has just been initialized: notify bridge about it
                 notifyBridgeAboutChildHandlerInitialization(thing);
             }
@@ -342,7 +345,7 @@ public class ThingManager extends AbstractItemEventSubscriber
                 if (thing != null) {
                     final ThingHandler handler = thing.getHandler();
                     if (handler != null) {
-                        if (isInitialized(thing)) {
+                        if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                             logger.debug("Delegating command '{}' for item '{}' to handler for channel '{}'", command,
                                     itemName, channelUID);
                             try {
@@ -392,7 +395,7 @@ public class ThingManager extends AbstractItemEventSubscriber
                 if (thing != null) {
                     final ThingHandler handler = thing.getHandler();
                     if (handler != null) {
-                        if (isInitialized(thing)) {
+                        if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                             logger.debug("Delegating update '{}' for item '{}' to handler for channel '{}'", newState,
                                     itemName, channelUID);
                             try {
@@ -491,7 +494,7 @@ public class ThingManager extends AbstractItemEventSubscriber
             if (oldThing != thing) {
                 thing.setHandler(thingHandler);
             }
-            if (isInitialized(thing)) {
+            if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                 try {
                     // prevent infinite loops by not informing handler about self-initiated update
                     if (!thingUpdatedLock.contains(thingUID)) {
@@ -561,7 +564,7 @@ public class ThingManager extends AbstractItemEventSubscriber
                     doRegisterHandler(thing, thingHandlerFactory);
                 } else {
                     Bridge bridge = getBridge(thing.getBridgeUID());
-                    if (bridge != null && isInitialized(bridge)) {
+                    if (bridge != null && ThingHandlerHelper.isHandlerInitialized(bridge)) {
                         doRegisterHandler(thing, thingHandlerFactory);
                     } else {
                         setThingStatus(thing,
@@ -781,10 +784,6 @@ public class ThingManager extends AbstractItemEventSubscriber
         }
     }
 
-    private boolean isInitialized(Thing thing) {
-        return thing.getStatus() == ThingStatus.ONLINE || thing.getStatus() == ThingStatus.OFFLINE;
-    }
-
     private boolean isInitializing(Thing thing) {
         return thing.getStatus() == ThingStatus.INITIALIZING;
     }
@@ -904,7 +903,7 @@ public class ThingManager extends AbstractItemEventSubscriber
                     public void run() {
                         try {
                             ThingHandler handler = child.getHandler();
-                            if (handler != null && isInitialized(child)) {
+                            if (handler != null && ThingHandlerHelper.isHandlerInitialized(child)) {
                                 handler.bridgeStatusChanged(bridgeStatus);
                             }
                         } catch (Exception e) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.events.ThingStatusInfoChangedEvent;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.TypeResolver;
+import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -253,7 +254,7 @@ public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusIn
 
     private void informHandlerAboutLinkedChannel(Thing thing, Channel channel) {
         // Don't notify the thing if the thing isn't initialised
-        if (thing.getStatus() != ThingStatus.ONLINE && thing.getStatus() != ThingStatus.OFFLINE) {
+        if (!ThingHandlerHelper.isHandlerInitialized(thing)) {
             return;
         }
 
@@ -272,7 +273,7 @@ public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusIn
 
     private void informHandlerAboutUnlinkedChannel(Thing thing, Channel channel) {
         // Don't notify the thing if the thing isn't initialised
-        if (thing.getStatus() != ThingStatus.ONLINE && thing.getStatus() != ThingStatus.OFFLINE) {
+        if (!ThingHandlerHelper.isHandlerInitialized(thing)) {
             return;
         }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHandlerHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHandlerHelper.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.util;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+
+/**
+ * This class provides utility methods related to the {@link ThingHandler} class.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+public class ThingHandlerHelper {
+
+    private ThingHandlerHelper() {
+    }
+
+    /**
+     * Checks if the thing handler has been initialized.
+     *
+     * @return true if the thing handler has been initialized, otherwise false.
+     */
+    public static boolean isHandlerInitialized(final Thing thing) {
+        final ThingStatus thingStatus = thing.getStatus();
+        return thingStatus == ThingStatus.OFFLINE || thingStatus == ThingStatus.ONLINE;
+    }
+
+    /**
+     * Checks if the thing handler has been initialized.
+     *
+     * @return true if the thing handler has been initialized, otherwise false.
+     */
+    public static boolean isHandlerInitialized(final ThingHandler handler) {
+        return isHandlerInitialized(handler.getThing());
+    }
+}


### PR DESCRIPTION
The BaseThingHandler, the ThingManager and the ThingLinkManager contains a method to check if a thing has been initialized.
I moved that logic to a function of the thing itself, so there is only one implementation.

I didn't remove the old (protected) method of the BaseThingHandler but marked it deprecated. So bindings using this method have some time to change their implementation.
