### PR TITLE
When creating Things, keep their Channels in order

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -8,14 +8,15 @@
 package org.eclipse.smarthome.io.rest.core.thing;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.Consumes;
@@ -161,7 +162,7 @@ public class ThingResource implements RESTResource {
                 }
             }
             if (thingBean.channels != null) {
-                Set<Channel> channels = new HashSet<>();
+                List<Channel> channels = new ArrayList<>();
                 for (ChannelDTO channelDTO : thingBean.channels) {
                     channels.add(ChannelDTOMapper.map(channelDTO));
                 }


### PR DESCRIPTION
The `Thing` interface declares its channels property as `List<Channel>`, implying that the order of Channels on a Thing is stable. This property is kept by the rest of the code, all of it, except for `ThingResource#create`.

When a `Thing` is created via the REST interface, the `Channel`s specified by the request are collected in a `HashSet`, shuffling them.

This change collects the `Channel`s in an `ArrayList` instead, guaranteeing that the order specified in the request is kept and that `Channel`s aren't randomly shuffled.