### PR TITLE
Cleanup discovered children if a Bridge Thing was removed

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
@@ -40,6 +40,7 @@ import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.storage.Storage;
 import org.eclipse.smarthome.core.storage.StorageService;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
@@ -319,7 +320,9 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
 
     @Override
     public void removed(Thing thing) {
-        // nothing to do
+        if (thing instanceof Bridge) {
+            removeResultsForBridge(thing.getUID());
+        }
     }
 
     @Override


### PR DESCRIPTION
When DiscoveryResults had been found via a Bridge, and this Bridge
was removed, so far these DiscoveryResults remained in the inbox.
However, as we assume that a Thing having a Bridge actually requires
it in order to communicate successfully, it does not make sense
anymore to keep it in the inbox without the Bridge. There won't be
any useful result when approving it, therefore we easily can clean
them up.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>