### PR TITLE
fix method name in DiscoveryServiceRegistryImpl

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -474,7 +474,7 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
         this.inbox = inbox;
     }
 
-    protected void removeInbox(Inbox inbox) {
+    protected void unsetInbox(Inbox inbox) {
         this.inbox = null;
     }
 


### PR DESCRIPTION
...as it was accidentally called removeInbox instead of unsetInbox

fixes #2038
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>