### PR TITLE
Merge things loaded from DSLs with info from ThingTypes

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/DumbThingHandlerFactory.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/DumbThingHandlerFactory.java
@@ -22,10 +22,10 @@ import com.google.common.collect.Sets;
 
 /**
  * {@link ThingHandlerFactory} that can be switched into <code>dumb</code> mode
- * 
+ *
  * In <code>dumb</code> mode, it behaves as if the XML configuration files have not been processed yet,
  * i.e. it returns <code>null</code> on {@link #createThing(ThingTypeUID, Configuration, ThingUID, ThingUID)}
- * 
+ *
  * @author Simon Kaufmann - Initial contribution and API
  */
 public class DumbThingHandlerFactory extends BaseThingHandlerFactory {
@@ -54,13 +54,9 @@ public class DumbThingHandlerFactory extends BaseThingHandlerFactory {
             return null;
         } else {
             if (SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
-                Thing ret = super.createThing(thingTypeUID, configuration, thingUID, null);
-                // set a property so that the test case may detect that the thing got created here
-                ret.setProperty("funky", "true");
-                return ret;
+                return super.createThing(thingTypeUID, configuration, thingUID, null);
             }
-            throw new IllegalArgumentException(
-                    "The thing type " + thingTypeUID + " is not supported by the hue binding.");
+            throw new IllegalArgumentException("The thing type " + thingTypeUID + " is not supported by the mock.");
         }
     }
 

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/DumbThingTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/DumbThingTypeProvider.java
@@ -9,12 +9,16 @@ package org.eclipse.smarthome.model.thing.test.hue;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,9 +34,13 @@ public class DumbThingTypeProvider implements ThingTypeProvider {
     public DumbThingTypeProvider() {
         logger.debug("DumbThingTypeProvider created");
         try {
+            ChannelDefinition channel1 = new ChannelDefinition("channel1",
+                    new ChannelTypeUID(DumbThingHandlerFactory.BINDING_ID, "channel1"));
+            List<ChannelDefinition> channelDefinitions = Collections.singletonList(channel1);
+
             thingTypes.put(DumbThingHandlerFactory.THING_TYPE_TEST,
-                    new ThingType(DumbThingHandlerFactory.THING_TYPE_TEST, null, "DUMB", "Funky Thing", false, null,
-                            null, null, new URI("dumb", "DUMB", null)));
+                    new ThingType(DumbThingHandlerFactory.THING_TYPE_TEST, null, "DUMB", "Funky Thing", false,
+                            channelDefinitions, null, null, new URI("dumb:DUMB")));
         } catch (Exception e) {
             logger.error(e.getMessage());
         }

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest3.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest3.groovy
@@ -7,23 +7,30 @@
  */
 package org.eclipse.smarthome.model.thing.tests;
 
-import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
-import org.eclipse.smarthome.core.thing.ThingRegistry;
-import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.config.core.ConfigDescription
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder
+import org.eclipse.smarthome.config.core.ConfigDescriptionProvider
+import org.eclipse.smarthome.core.thing.ThingRegistry
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory
+import org.eclipse.smarthome.core.thing.type.ChannelType
+import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID
 import org.eclipse.smarthome.model.core.ModelRepository
-import org.eclipse.smarthome.model.thing.test.hue.DumbThingHandlerFactory;
-import org.eclipse.smarthome.test.OSGiTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.osgi.service.component.ComponentContext;
+import org.eclipse.smarthome.model.thing.test.hue.DumbThingHandlerFactory
+import org.eclipse.smarthome.test.OSGiTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.osgi.service.component.ComponentContext
 
 /**
  * Test asynchronous loading behavior of DSL based thing descriptions.
- * 
+ *
  * @author Simon Kaufmann - Initial contribution and API
  *
  */
@@ -32,15 +39,17 @@ class GenericThingProviderTest3 extends OSGiTest{
 
     private final static String TESTMODEL_NAME = "testModel3.things"
 
-    ModelRepository modelRepository;
-    ThingRegistry thingRegistry;
+    ModelRepository modelRepository
+    ThingRegistry thingRegistry
 
     @Before
     public void setUp() {
         thingRegistry = getService ThingRegistry
         assertThat thingRegistry, is(notNullValue())
+
         modelRepository = getService ModelRepository
         assertThat modelRepository, is(notNullValue())
+
         modelRepository.removeModel(TESTMODEL_NAME)
 
         def componentContextMock = [
@@ -55,12 +64,25 @@ class GenericThingProviderTest3 extends OSGiTest{
 
         String model =
                 '''
-            dumb:DUMB:boo {
-                Switch : notification [ duration = "5" ]
+            dumb:DUMB:boo "Test Label" @ "Test Location" [
+                testConf="foo"
+            ]
+            {
+                Switch : manual [ duration = "5" ]
             }
-			'''
+            '''
         modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.bytes))
         registerService(dumbThingHandlerFactory, ThingHandlerFactory.class.name)
+
+        def configDescription = new ConfigDescription(new URI("test:test"), [
+            ConfigDescriptionParameterBuilder.create("testAdditional", ConfigDescriptionParameter.Type.TEXT).withRequired(false).withDefault("hello world").build(),
+            ConfigDescriptionParameterBuilder.create("testConf", ConfigDescriptionParameter.Type.TEXT).withRequired(false).withDefault("bar").build()
+        ] as List);
+
+        registerService([
+            getConfigDescription: {uri, locale -> configDescription}
+        ] as ConfigDescriptionProvider)
+
 
     }
 
@@ -74,23 +96,40 @@ class GenericThingProviderTest3 extends OSGiTest{
     public void 'assert that things are updated once the xml files have been processed'() {
         assertThat thingRegistry.getAll().size(), is(1)
         assertThat thingRegistry.getAll().first().UID.toString(), is("dumb:DUMB:boo")
+        assertThat thingRegistry.getAll().first().getChannels().size(), is(1)
+        assertThat thingRegistry.getAll().first().getChannel("manual"), is(notNullValue())
+        assertThat thingRegistry.getAll().first().getLabel(), is("Test Label")
+        assertThat thingRegistry.getAll().first().getLocation(), is("Test Location")
+        assertThat thingRegistry.getAll().first().getConfiguration().getProperties().get("testConf"), is("foo")
 
-        // ensure the property is not set,
-        // i.e. the thing was created generically
-        assertThat thingRegistry.getAll().first().getProperties().containsKey("funky"), is(false)
 
         // now become smart again...
         dumbThingHandlerFactory.setDumb(false)
+        ChannelType channelType1 = new ChannelType(new ChannelTypeUID(DumbThingHandlerFactory.BINDING_ID, "channel1"), false, "String", "Channel 1", null, null, null, null, null)
+        def channelTypeProvider = [
+            getChannelType: {ChannelTypeUID channelTypeUID, Locale locale ->
+                if (channelType1.getUID().id.equals("channel1")) {
+                    return channelType1
+                }
+                return null
+            }
+        ] as ChannelTypeProvider
+        registerService(channelTypeProvider)
 
-        def waited = 0;
-        while (waited < 600 && !thingRegistry.getAll().first().getProperties().containsKey("funky")) {
-            Thread.sleep(100)
-            waited++
-        }
+        // ensure thing type was considered and manual and predefined values are there.
+        waitForAssert({
+            assertThat thingRegistry.getAll().first().getLabel(), is("Test Label")
+            assertThat thingRegistry.getAll().first().getLocation(), is("Test Location")
+            assertThat thingRegistry.getAll().first().getChannels().size(), is(2)
+            assertThat thingRegistry.getAll().first().getChannel("manual"), is(notNullValue())
+            assertThat thingRegistry.getAll().first().getChannel("channel1"), is(notNullValue())
 
-        // ensure the property now has been set,
-        // i.e. the thing was created by our handler factory and was refreshed
-        assertThat thingRegistry.getAll().first().getProperties().containsKey("funky"), is(true)
+            // there is a default, so make sure the manually configured one (from the DSL) wins
+            assertThat thingRegistry.getAll().first().getConfiguration().getProperties().get("testConf"), is("foo")
+
+            // it's not manually configured, but the thing type defines a default, so ensure it's in
+            assertThat thingRegistry.getAll().first().getConfiguration().getProperties().get("testAdditional"), is("hello world")
+        })
+
     }
-
 }

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
@@ -233,6 +233,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
         targetThing.configuration.merge(sourceThing.configuration)
         targetThing.merge(sourceThing.channels)
         targetThing.location = sourceThing.location
+        targetThing.label = sourceThing.label
     }
 
     def dispatch void merge(Configuration target, Configuration source) {
@@ -436,7 +437,6 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                             qc.bridgeUID)
                         if (thing != null) {
                             queue.remove(qc)
-                            thing.label = qc.label
                             logger.debug("Successfully loaded '{}' during retry", qc.thingUID)
                             newThings.add(thing)
                         }
@@ -448,6 +448,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                             ]
                             val oldThing = thingsMap.get(modelName).findFirst[it.UID == newThing.UID]
                             if (oldThing != null) {
+                                newThing.merge(oldThing)
                                 thingsMap.get(modelName).remove(oldThing)
                                 thingsMap.get(modelName).add(newThing)
                                 logger.debug("Refreshing thing '{}' after successful retry", newThing.UID)


### PR DESCRIPTION
...as soon as they become available. So far, they simply
were replaced, hence losing the data coming from the DSL.

fixes #2042
relates to #365
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>