### PR TITLE
Safari controlUI icon bug

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/views.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/views.css
@@ -100,15 +100,14 @@ section#main.header-tabs {
 	{
 	margin-right: 10px;
 	border-radius: 50%;
-	width: 32px;
-	height: 32px;
+	width: 35px;
+	height: 35px;
 	background-color: #4CAF50;
 	color: white;
 	text-align: center;
 	font-size: 16px;
-	line-height: 32px;
 	padding: 10px;
-	display: inline;
+
 }
 
 .items .item md-input-container input {


### PR DESCRIPTION
Control UI Icons are not displayed correctly in Safari right now. This pull request fixes that.
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>