### PR TITLE
Issue #2069 Implemented tests for FolderObserver

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.core.test/.classpath
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/test/groovy"/>
+	<classpathentry exported="true" kind="con" path="GROOVY_DSL_SUPPORT"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/model/org.eclipse.smarthome.model.core.test/.project
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/.project
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.model.core.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.groovy.core.groovyNature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/model/org.eclipse.smarthome.model.core.test/FolderObserverTestsConfiguration.launch
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/FolderObserverTestsConfiguration.launch
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<stringAttribute key="application" value="org.eclipse.pde.junit.runtime.coretestapplication"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="false"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<listAttribute key="com.mountainminds.eclemma.core.SCOPE_IDS">
+<listEntry value="=org.eclipse.smarthome.model.core/src\/main\/java"/>
+</listAttribute>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="false"/>
+<booleanAttribute key="default_auto_start" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.eclipse.smarthome.model.core.test/src/test/groovy/org/eclipse/smarthome/model/core/internal/folder/test/FolderObserverTest.groovy"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.smarthome.model.core.internal.folder.test.FolderObserverTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.model.core.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.equinox.p2.director.app.product"/>
+<booleanAttribute key="run_in_ui_thread" value="true"/>
+<stringAttribute key="selected_target_plugins" value="ch.qos.logback.classic@default:default,ch.qos.logback.core@default:default,ch.qos.logback.slf4j@default:false,com.eclipsesource.jaxrs.jersey-min@default:default,com.google.gson*2.5.0@default:default,com.google.guava@default:default,com.google.inject@default:default,com.ibm.icu@default:default,javax.activation@default:default,javax.annotation@default:default,javax.inject@default:default,javax.mail.glassfish@default:default,javax.servlet*3.1.0.v20140303-1611@default:default,javax.transaction@default:false,javax.xml@default:default,org.antlr.runtime@default:default,org.apache.ant@default:default,org.apache.batik.css@default:default,org.apache.batik.util.gui@default:default,org.apache.batik.util@default:default,org.apache.commons.cli@default:default,org.apache.commons.collections@default:default,org.apache.commons.io@default:default,org.apache.commons.lang@default:default,org.apache.commons.logging@default:default,org.codehaus.groovy@default:default,org.eclipse.ant.core@default:default,org.eclipse.compare.core@default:default,org.eclipse.core.commands@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.databinding.observable@default:default,org.eclipse.core.databinding.property@default:default,org.eclipse.core.databinding@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.filesystem.java7@default:false,org.eclipse.core.filesystem.win32.x86_64@default:false,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.resources.win32.x86_64@default:false,org.eclipse.core.resources@default:default,org.eclipse.core.runtime.compatibility.registry@default:false,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.debug.core@default:default,org.eclipse.e4.core.commands@default:default,org.eclipse.e4.core.contexts@default:default,org.eclipse.e4.core.di.extensions@default:default,org.eclipse.e4.core.di@default:default,org.eclipse.e4.core.services@default:default,org.eclipse.e4.ui.bindings@default:default,org.eclipse.e4.ui.css.core@default:default,org.eclipse.e4.ui.css.swt.theme@default:default,org.eclipse.e4.ui.css.swt@default:default,org.eclipse.e4.ui.di@default:default,org.eclipse.e4.ui.model.workbench@default:default,org.eclipse.e4.ui.services@default:default,org.eclipse.e4.ui.widgets@default:default,org.eclipse.e4.ui.workbench.addons.swt@default:default,org.eclipse.e4.ui.workbench.renderers.swt@default:default,org.eclipse.e4.ui.workbench.swt@default:default,org.eclipse.e4.ui.workbench3@default:default,org.eclipse.e4.ui.workbench@default:default,org.eclipse.emf.codegen.ecore@default:default,org.eclipse.emf.codegen@default:default,org.eclipse.emf.common@default:default,org.eclipse.emf.ecore.change@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.emf.mwe.core@default:default,org.eclipse.emf.mwe.utils@default:default,org.eclipse.emf.mwe2.lib@default:default,org.eclipse.emf.mwe2.runtime@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.bidi@default:default,org.eclipse.equinox.cm@1:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.ds@1:true,org.eclipse.equinox.event@default:default,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.region@default:false,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.util@default:false,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.help@default:default,org.eclipse.jdt.compiler.apt@default:false,org.eclipse.jdt.compiler.tool@default:false,org.eclipse.jdt.core@default:false,org.eclipse.jdt.debug@default:false,org.eclipse.jdt.launching@default:false,org.eclipse.jface.databinding@default:default,org.eclipse.jface@default:default,org.eclipse.osgi.compatibility.state@default:false,org.eclipse.osgi.services@default:default,org.eclipse.osgi@-1:true,org.eclipse.swt.win32.win32.x86_64@default:false,org.eclipse.swt@default:default,org.eclipse.team.core@default:default,org.eclipse.text@default:default,org.eclipse.ui.trace@default:default,org.eclipse.ui.workbench@default:default,org.eclipse.ui@default:false,org.eclipse.xtend.lib.macro@default:default,org.eclipse.xtend.lib@default:default,org.eclipse.xtend.typesystem.emf@default:default,org.eclipse.xtend@default:default,org.eclipse.xtext.common.types@default:default,org.eclipse.xtext.smap@default:default,org.eclipse.xtext.util@default:default,org.eclipse.xtext.xbase.lib@default:default,org.eclipse.xtext@default:default,org.hamcrest.core@default:default,org.junit@default:default,org.objectweb.asm@default:default,org.objenesis@default:default,org.slf4j.api@default:default,org.slf4j.jcl@default:default,org.slf4j.log4j@default:default,org.w3c.css.sac@default:default,org.w3c.dom.events@default:default,org.w3c.dom.smil@default:default,org.w3c.dom.svg@default:default"/>
+<stringAttribute key="selected_workspace_plugins" value="org.eclipse.smarthome.config.core@default:default,org.eclipse.smarthome.config.xml@default:default,org.eclipse.smarthome.core.autoupdate@default:default,org.eclipse.smarthome.core.thing@default:default,org.eclipse.smarthome.core@default:default,org.eclipse.smarthome.io.console@default:default,org.eclipse.smarthome.model.core.test@default:false,org.eclipse.smarthome.model.core@default:default,org.eclipse.smarthome.test@default:default"/>
+<booleanAttribute key="show_selected_only" value="true"/>
+<stringAttribute key="templateConfig" value="${target_home}\configuration\config.ini"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/bundles/model/org.eclipse.smarthome.model.core.test/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/META-INF/MANIFEST.MF
@@ -1,0 +1,22 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Model Core Tests
+Bundle-SymbolicName: org.eclipse.smarthome.model.core.test
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.model.core
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Import-Package: groovy.json,
+ groovy.lang,
+ org.codehaus.groovy.reflection,
+ org.codehaus.groovy.runtime,
+ org.codehaus.groovy.runtime.callsite,
+ org.codehaus.groovy.runtime.typehandling,
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.core.service,
+ org.eclipse.smarthome.test,
+ org.eclipse.smarthome.test.storage,
+ org.hamcrest;core=split,
+ org.junit;version="4.0.0",
+ org.osgi.framework,
+ org.osgi.service.cm,
+ org.slf4j

--- a/bundles/model/org.eclipse.smarthome.model.core.test/about.html
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 5, 2006</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/bundles/model/org.eclipse.smarthome.model.core.test/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/build.properties
@@ -1,0 +1,3 @@
+source.. = src/test/groovy
+bin.includes = META-INF/,\
+               .

--- a/bundles/model/org.eclipse.smarthome.model.core.test/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.eclipse.smarthome.bundles</groupId>
+    <artifactId>model</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <bundle.symbolicName>org.eclipse.smarthome.model.core.test</bundle.symbolicName>
+    <bundle.namespace>org.eclipse.smarthome.model.core.test</bundle.namespace>
+  </properties>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eclipse.smarthome.model</groupId>
+  <artifactId>org.eclipse.smarthome.model.core.test</artifactId>
+
+  <name>Eclipse SmartHome Model Core Tests</name>
+
+  <packaging>eclipse-test-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.cm</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <bundleStartLevel>
+            <bundle>
+              <id>org.eclipse.equinox.cm</id>
+              <level>1</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.equinox.ds</id>
+              <level>1</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.config.core</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+          </bundleStartLevel>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/bundles/model/org.eclipse.smarthome.model.core.test/src/test/groovy/org/eclipse/smarthome/model/core/internal/folder/test/FolderObserverTest.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/src/test/groovy/org/eclipse/smarthome/model/core/internal/folder/test/FolderObserverTest.groovy
@@ -1,0 +1,520 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.model.core.internal.folder.test
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+
+import org.apache.commons.io.FileUtils
+import org.eclipse.emf.ecore.EObject
+import org.eclipse.smarthome.config.core.ConfigConstants
+import org.eclipse.smarthome.core.service.AbstractWatchQueueReader
+import org.eclipse.smarthome.model.core.*
+import org.eclipse.smarthome.model.core.internal.folder.FolderObserver
+import org.eclipse.smarthome.test.OSGiTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.After
+import org.junit.Ignore
+import org.junit.AfterClass
+import org.osgi.service.cm.Configuration
+import org.osgi.service.cm.ConfigurationAdmin
+import org.osgi.service.cm.ManagedService
+import org.apache.commons.lang.SystemUtils
+
+/**  A test class for {@link FolderObserver} class. The following test cases aim
+ *  to check if {@link FolderObserver} invokes the correct {@link ModelRepository}'s methods 
+ *  with correct arguments when certain events in the watched directory are triggered.
+ *
+ *  {@link AbstractWatchService#initializeWatchService} method is called in the
+ *  {@link FolderObserver#updated} method and initializing a new WatchService
+ *  is related to creating a new {@link AbstractWatchQueueReader} which starts in a new Thread.
+ *  Since we rely on the {@link AbstractWatchQueueReader} to "listen" for changes, we have to
+ *  be sure that it has been started.
+ *  Based on that putting the current Thread to sleep after each invocation of
+ *  {@link FolderObserver#updated} method is necessary.
+ *  On the other hand, creating, modifying and deleting files and folders causes invocation
+ *  of {@link AbstractWatchQueueReader#processWatchEvent} method. That method is called asynchronously 
+ *  and we do not know exactly when the event will be handled (it is OS specific). 
+ *  Since the assertions in the tests depend on handling the events,
+ *  putting the current Thread to sleep after the file operations is also necessary. 
+ *
+ *  @author Mihaela Memova
+ *
+ */
+
+class FolderObserverTest extends OSGiTest {
+
+	/** The directory which is watched for changes */
+	private final static String WATCHED_DIRECTORY = "watched_dir"
+	/** The name of the existing subdirectory which is used in most of the test cases */
+	private final static String EXISTING_SUBDIR_NAME = "existing_subdir"
+	/** The path of the existing subdirectory which is used in most of the test cases */
+	private final static String EXISTING_SUBDIR_PATH = WATCHED_DIRECTORY + File.separator + EXISTING_SUBDIR_NAME
+	/** Time to sleep (miliseconds) when updated() method is called, so the AbstractWatchQueueReader can start and be able to process events */
+	private final static int WAIT_ABSTRACTWATCHQUEUEREADER_TO_START = 200
+	/** Time to sleep when a file is created/modified/deleted, so the event can be handled */
+	private final static int WAIT_EVENT_TO_BE_HANDLED = 1000
+	/** Persistent identifier(PID) of the FolderObserver class, taken from folderobserver.xml */
+	private final static String FOLDEROBSERVER_PID = "org.eclipse.smarthome.folder"
+
+	/** The only element in the array of model names returned by {@link ModelRepository#getAllModelNamesOfType(String modelType)} **/
+	private static final String MOCK_MODEL_TO_BE_REMOVED = "MockFileInModelForDeletion.java"
+
+	/** Text to be inserted in the newly created files, so the tests can run properly on all OS */
+	private final String INITIAL_FILE_CONTENT = "Initial content"
+
+	private ConfigurationAdmin configAdmin
+	private FolderObserver folderObserverService
+	private Configuration config
+	/** An instance of the ModelRepoMock class which implements the ModelRepository interface */
+	private ModelRepoMock modelRepo
+	/** An instance of the ModelParserMock class which implements the ModelParser interface */
+	private ModelParserMock modelParserMock
+	/** The default watched directory */
+	private static String defaultWatchedDir
+
+	@Before
+	void setUp() {
+		setupWatchedDirectory()
+		setUpServices()
+		config = configAdmin.getConfiguration(FOLDEROBSERVER_PID)
+		assertNotNull(config)
+	}
+
+	private void setupWatchedDirectory() {
+		/* 
+		 * The main configuration folder's path is saved in the defaultWatchedDir variable 
+		 * in order to be restored after all the tests are finished. 
+		 * For the purpose of the FolderObserverTest class a new folder is created.
+		 * Its path is set to the ConfigConstants.CONFIG_DIR_PROG_ARGUMENT property.
+		 */
+		defaultWatchedDir = System.getProperty(ConfigConstants.CONFIG_DIR_PROG_ARGUMENT)
+		File watchDir = new File(WATCHED_DIRECTORY)
+		watchDir.mkdirs()
+		System.setProperty(ConfigConstants.CONFIG_DIR_PROG_ARGUMENT, watchDir.getPath())
+		new File(EXISTING_SUBDIR_PATH).mkdirs()
+	}
+
+	void setUpServices() {
+		modelParserMock = new ModelParserMock()
+		/* 
+		 * FolderObserver calls the addModelParser() method every time a ModelParser is 
+		 * registered in the service registry.
+		 * So calling that method explicitly is not necessary. 
+		 */
+		registerService(modelParserMock)
+		modelRepo = new ModelRepoMock()
+		registerService(modelRepo)
+		folderObserverService = getService(ManagedService, FolderObserver)
+		assertThat("Folder Observer service cannot be found",folderObserverService, is(notNullValue()))
+		/*
+		 * FolderObserver is referencing to the ModelRepository service using the 
+		 * cardinality "1..1". In order to be sure it will use our mock ModelRepository object,
+		 *  it is necessary to explicitly set it.
+		 */
+		folderObserverService.setModelRepository(modelRepo)
+		configAdmin = getService(ConfigurationAdmin)
+		assertThat("Configuration Admin service cannot be found",configAdmin, is(notNullValue()))
+	}
+
+	@After
+	void tearDown() {
+		/*
+		 * The FolderObserver service have to be stopped at the end of each test
+		 * as most of the tests are covering assertions on its initialization actions
+		 */
+		folderObserverService.deactivate()
+		FileUtils.deleteDirectory(new File(WATCHED_DIRECTORY))
+		modelRepo.clean()
+		config.delete()
+	}
+
+	@AfterClass
+	static void tearDownClass(){
+		/*
+		 * After all the tests are finished we need to reset the state of the system.
+		 */
+		if(defaultWatchedDir != null){
+			System.setProperty(ConfigConstants.CONFIG_DIR_PROG_ARGUMENT, defaultWatchedDir)
+		}
+		else {
+			System.clearProperty(ConfigConstants.CONFIG_DIR_PROG_ARGUMENT)
+		}
+	}
+
+	@Test
+	void 'test creation of file with valid extension in an existing subdirectory'() {
+		/*
+		 * The following method creates a file in an existing directory. The file's extension is
+		 * in the configuration properties and there is a registered ModelParser for it.
+		 * addOrRefreshModel() method invocation is expected
+		 */
+		String validExtension = "java"
+
+		Dictionary<String, String> configProps = new Hashtable<String, String>()
+		configProps.put(EXISTING_SUBDIR_NAME, "txt,jpg," + validExtension)
+		config.update(configProps)
+		sleep(WAIT_ABSTRACTWATCHQUEUEREADER_TO_START)
+
+		String mockFileWithValidExtName = "NewlyCreatedMockFile" + "." + validExtension
+		String mockFileWithValidExtPath = EXISTING_SUBDIR_PATH + File.separatorChar + mockFileWithValidExtName
+		File mockFileWithValidExt = new File(mockFileWithValidExtPath)
+		mockFileWithValidExt.createNewFile()
+		sleep(WAIT_EVENT_TO_BE_HANDLED)
+		/*
+		 * In some OS, like MacOS, creating an empty file is not related to sending an ENTRY_CREATE event. 
+		 * So, it's necessary to put some initial content in that file.
+		 */
+		if(!SystemUtils.IS_OS_WINDOWS) {
+			mockFileWithValidExt << INITIAL_FILE_CONTENT
+		}
+		
+		waitForAssert{
+			assertThat("The " + mockFileWithValidExtName +" file was not created successfully", mockFileWithValidExt.exists(), is (true))
+		}
+		waitForAssert{
+			assertThat("A model was not added/refreshed adequately on new valid file creation in the watched directory",
+					modelRepo.isAddOrRefreshModelMethodCalled,is(true))
+		}
+		waitForAssert{
+			assertThat("A model was added/refreshed with a wrong filename",
+					modelRepo.calledFileName,is(mockFileWithValidExt.getName()))
+		}
+	}
+
+	@Test
+	void 'test modification of file with valid extension in an existing subdirectory'() {
+		/* 
+		 * The following method creates a file in an existing directory. The file's extension is
+		 * in the configuration properties and there is a registered ModelParser for it.
+		 * Then the file's content is changed.
+		 * addOrRefreshModel() method invocation is expected
+		 */
+
+		String validExtension = "java"
+
+		Dictionary<String, String> configProps = new Hashtable<String, String>()
+		configProps.put(EXISTING_SUBDIR_NAME, "txt,jpg," + validExtension)
+
+		String mockFileWithValidExtName = "MockFileForModification" + "." + validExtension
+		String mockFileWithValidExtPath = EXISTING_SUBDIR_PATH + File.separatorChar + mockFileWithValidExtName
+		File mockFileWithValidExt = new File(mockFileWithValidExtPath)
+		mockFileWithValidExt.createNewFile()
+
+		/* The configuration is updated after the file creation in order to check if FolderObserver
+		 * has the expected behavior when there are existing files in the watched directory before
+		 * the updating of the configuration
+		 */
+		config.update(configProps)
+		sleep(WAIT_EVENT_TO_BE_HANDLED)
+
+		/*
+		 * In some OS, like MacOS, creating an empty file is not related to sending an ENTRY_CREATE event. So, it's necessary to put some
+		 * initial content in that file.
+		 */
+		if(!SystemUtils.IS_OS_WINDOWS) {
+			mockFileWithValidExt << INITIAL_FILE_CONTENT
+		}
+
+		waitForAssert{
+			assertThat("The " + mockFileWithValidExtName +" file was not created successfully", mockFileWithValidExt.exists(), is (true))
+		}
+		waitForAssert{
+			assertThat("The creation of the " + mockFileWithValidExtName + " file was not handled adequately and the model was not updated",
+					modelRepo.isAddOrRefreshModelMethodCalled,is(true))
+		}
+		
+		/*
+		 * setting the isAddOrRefreshModelMethodCalled variable to false,
+		 * otherwise the next assertion will always be true
+		 */
+		modelRepo.isAddOrRefreshModelMethodCalled = false;
+
+		String textToBeInsertedInTheFile= "Additional content"
+		mockFileWithValidExt << textToBeInsertedInTheFile
+		sleep(WAIT_EVENT_TO_BE_HANDLED)
+
+		waitForAssert{
+			assertThat("A model was not added/refreshed adequately on valid file modification in the watched directory",
+					modelRepo.isAddOrRefreshModelMethodCalled,is(true))
+		}
+		waitForAssert{
+			assertThat("A model was added/refreshed with a wrong filename",
+					modelRepo.calledFileName,is(mockFileWithValidExt.getName()))
+		}
+
+		String finalFileContent;
+		if(!SystemUtils.IS_OS_WINDOWS){
+			finalFileContent = INITIAL_FILE_CONTENT + textToBeInsertedInTheFile
+		} else {
+			finalFileContent = textToBeInsertedInTheFile
+		}
+
+		waitForAssert{
+			assertThat("The content of the " + mockFileWithValidExtName + " file is not updated successfully",
+					modelRepo.fileContent,is(finalFileContent))
+		}
+	}
+	@Test
+	void 'test creation of file with extension which does not have a registered ModelParser in an existing subdirectory'() {
+		/*
+		 * The following method creates a file in an existing directory. The file's extension is
+		 * in the configuration properties but there is no parser for it.
+		 * No ModelRepository's method invocation is expected
+		 */
+		String noParserExtension = "jpg"
+
+		Dictionary<String, String> configProps = new Hashtable<String, String>()
+		configProps.put(EXISTING_SUBDIR_NAME, "java,txt," + noParserExtension)
+		config.update(configProps)
+		sleep(WAIT_ABSTRACTWATCHQUEUEREADER_TO_START)
+
+		String mockFileWithNoParserExtName = "NewlyCreatedMockFile" + "." + noParserExtension
+		String mockFileWithNoParserExtPath = EXISTING_SUBDIR_PATH + File.separatorChar + mockFileWithNoParserExtName
+		File mockFileWithNoParserExt = new File(mockFileWithNoParserExtPath)
+		mockFileWithNoParserExt.createNewFile()
+		sleep(WAIT_EVENT_TO_BE_HANDLED)
+
+		waitForAssert{
+			assertThat("The " + mockFileWithNoParserExtName +" file was not created successfully", mockFileWithNoParserExt.exists(), is (true))
+		}
+		waitForAssert{
+			assertThat("A model was added/refreshed on creation of file with extension which is does not have a registered ModelParser",
+					modelRepo.isAddOrRefreshModelMethodCalled,is(false))
+		}
+		waitForAssert{
+			assertThat("A model was deleted on creation of file with extension which does not have a registered ModelParser",
+					modelRepo.isRemoveModelMethodCalled,is(false))
+		}
+	}
+
+	@Test
+	void 'test creation of file with extension which is not in the configuration properties in an existing subdirectory'() {
+		/* 
+		 * The following method creates a file in an existing directory. The file's extension is not
+		 * in the configuration properties but there is a parser for it. 
+		 * No ModelRepository's method invocation is expected
+		 */
+		String notInPropsExtension = "java"
+
+		Dictionary<String, String> configProps = new Hashtable<String, String>()
+		configProps.put(EXISTING_SUBDIR_NAME, "txt,jpg")
+		config.update(configProps)
+		sleep(WAIT_ABSTRACTWATCHQUEUEREADER_TO_START)
+
+		String mockFileWithNotInPropsExtName = "NewlyCreatedMockFile" + "." + notInPropsExtension
+		String mockFileWithNotInPropsExtPath = EXISTING_SUBDIR_PATH + File.separatorChar + mockFileWithNotInPropsExtName
+		File mockFileWithNotInPropsExt = new File(mockFileWithNotInPropsExtPath)
+		mockFileWithNotInPropsExt.createNewFile()
+		sleep(WAIT_EVENT_TO_BE_HANDLED)
+
+		waitForAssert{
+			assertThat("The " + mockFileWithNotInPropsExtName +" file was not created successfully", mockFileWithNotInPropsExt.exists(), is (true))
+		}
+		waitForAssert{
+			assertThat("A model was added/refreshed on creation of file with extension which is not in the configuration properties",
+					modelRepo.isAddOrRefreshModelMethodCalled,is(false))
+		}
+		waitForAssert{
+			assertThat("A model was added/refreshed on creation of file with extension which is not in the configuration properties",
+					modelRepo.isRemoveModelMethodCalled,is(false))
+		}
+	}
+	
+	@Test
+	void 'test deletion of a folder-extensions pair from the configuration properties when folderFileExtMap becomes empty'(){
+		/*
+		 * The following method tests the correct invocation of removeModel() method when a 
+		 * folder-extensions pair is deleted from the configuration properties 
+		 * and folderFileExtMap becomes empty
+		 */
+
+		Dictionary<String, String> configProps = new Hashtable<String, String>()
+		configProps.put(EXISTING_SUBDIR_NAME, "java,txt,jpg")
+		config.update(configProps)
+		sleep(WAIT_ABSTRACTWATCHQUEUEREADER_TO_START)
+
+		configProps.remove(EXISTING_SUBDIR_NAME)
+		config.update(configProps)
+		sleep(WAIT_ABSTRACTWATCHQUEUEREADER_TO_START)
+
+		waitForAssert{
+			assertThat("The deletion of a folder-extensions pair from the configuration properties was not handled properly and the $MOCK_MODEL_TO_BE_REMOVED was not removed.",
+					modelRepo.isRemoveModelMethodCalled,is(true))
+		}
+		waitForAssert{
+			assertThat("The $MOCK_MODEL_TO_BE_REMOVED model is expected to be removed on deletion of folder-extensions pair from the configuration properties",
+					modelRepo.calledFileName,is(MOCK_MODEL_TO_BE_REMOVED))
+		}
+	}
+
+	@Test
+	void 'test deletion of a folder-extensions pair from the configuration properties when folderFileExtMap remains non-empty'(){
+		/* 
+		 * The following method tests the correct invocation of removeModel() method when a
+		 * folder-extensions pair is deleted from the configuration properties
+		 * and folderFileExtMap remains non-empty
+		 */
+
+		new File(EXISTING_SUBDIR_PATH).mkdirs()
+
+		Dictionary<String, String> configProps = new Hashtable<String, String>()
+		configProps.put(EXISTING_SUBDIR_NAME, "java,txt,jpg")
+
+		String anotherExistingSubdirName = "another_existing_subdir"
+		String anotherExistingSubdirPath = WATCHED_DIRECTORY + File.separator + anotherExistingSubdirName
+		new File(anotherExistingSubdirPath).mkdirs()
+
+		configProps.put(anotherExistingSubdirName, "txt,jpg,java")
+		config.update(configProps)
+		sleep(WAIT_ABSTRACTWATCHQUEUEREADER_TO_START)
+
+		configProps.remove(anotherExistingSubdirName)
+		config.update(configProps)
+		sleep(WAIT_EVENT_TO_BE_HANDLED)
+
+		waitForAssert{
+			assertThat("The deletion of a folder-extensions pair from the configuration properties was not handled properly and the $MOCK_MODEL_TO_BE_REMOVED was not removed.",
+					modelRepo.isRemoveModelMethodCalled,is(true))
+		}
+		waitForAssert{
+			assertThat("The $MOCK_MODEL_TO_BE_REMOVED model is expected to be removed on deletion of folder-extensions pair from the configuration properties",
+					modelRepo.calledFileName,is(MOCK_MODEL_TO_BE_REMOVED))
+		}
+	}
+
+	@Test
+	void 'test the updating of the configuration with a non existing subdirectory'() {
+		/*
+		 * The following method test the updating of the configuration with a non existing subdirectory.
+		 * Only log message ("Directory 'non_existing_subdir' does not exist in 'watched_dir'...") is expected
+		 */
+		String nonExistingSubDirName = "non_existing_subdir"
+		String nonExistingSubDirPath = WATCHED_DIRECTORY + File.separator + nonExistingSubDirName
+
+		Dictionary<String, String> configProps = new Hashtable<String, String>()
+		configProps.put(nonExistingSubDirName, "txt,jpg,java")
+		config.update(configProps)
+		sleep(WAIT_ABSTRACTWATCHQUEUEREADER_TO_START)
+
+		waitForAssert{
+			assertThat("A model was added/refreshed on updating of the configuration with a non existing subdirectory",
+					modelRepo.isAddOrRefreshModelMethodCalled,is(false))
+		}
+		waitForAssert{
+			assertThat("A model was deleted on updating of the configuration with a non existing subdirectory",
+					modelRepo.isRemoveModelMethodCalled,is(false))
+		}
+	}
+
+	@Test
+	void 'test creation of file in subdirectory with no declared extensions'() {
+		/* 
+		 * The following method creates a file in an existing directory 
+		 * which has no valid extensions declared.
+		 * No ModelRepository's method invocation is expected
+		 */	 
+		String noExtensionsSubDirName = "no_extensions_subdir"
+		String noExtensionsSubDirPath = WATCHED_DIRECTORY + File.separator + noExtensionsSubDirName
+		File noExtensionsDirectory = new File(noExtensionsSubDirPath)
+		noExtensionsDirectory.mkdirs()
+
+		Dictionary<String, String> configProps = new Hashtable<String, String>()
+		configProps.put(noExtensionsSubDirName, "")
+		config.update(configProps)
+		sleep(WAIT_ABSTRACTWATCHQUEUEREADER_TO_START)
+
+
+		String mockFileInNoExtSubDirName = "MockFileInNoExtSubDir.txt"
+		String mockFileInNoExtSubDirPath = noExtensionsSubDirPath + File.separatorChar + mockFileInNoExtSubDirName
+		File mockFileInNoExtSubDir = new File(mockFileInNoExtSubDirPath)
+		mockFileInNoExtSubDir.createNewFile()
+		sleep(WAIT_EVENT_TO_BE_HANDLED)
+
+		waitForAssert{
+			assertThat("The " + mockFileInNoExtSubDirName +" file was not created successfully", mockFileInNoExtSubDir.exists(), is (true))
+		}
+		waitForAssert{
+			assertThat("A model was added/refreshed on creation of file in subdirectory with no declared extensions",
+					modelRepo.isAddOrRefreshModelMethodCalled,is(false))
+		}
+		waitForAssert{
+			assertThat("A model was deleted on creation of file in subdirectory with no declared extensions",
+					modelRepo.isRemoveModelMethodCalled,is(false))
+		}
+	}
+
+	private static class ModelRepoMock implements ModelRepository{
+
+		public static boolean isAddOrRefreshModelMethodCalled
+		public static boolean isRemoveModelMethodCalled
+		public static String calledFileName
+		public static String fileContent
+
+		@Override
+		public boolean addOrRefreshModel(String name, InputStream inputStream) {
+			calledFileName = name
+			isAddOrRefreshModelMethodCalled = true
+			fileContent = inputStream.getText()
+			inputStream.close()
+			return true
+		}
+
+		@Override
+		public boolean removeModel(String name) {
+			calledFileName = name
+			isRemoveModelMethodCalled = true
+			return true
+		}
+
+		/**
+		 * This method is invoked when a model is about to be deleted.
+		 * For the purposes of the FolderObserverTest class it is overridden and 
+		 * it returns an array of exactly one model name.
+		 */
+		@Override
+		public Iterable<String> getAllModelNamesOfType(String modelType) {
+
+			ArrayList<String> arrayOfModelsToBeRemoved = [MOCK_MODEL_TO_BE_REMOVED]
+			return arrayOfModelsToBeRemoved
+		}
+
+		@Override
+		public void reloadAllModelsOfType(String modelType) {
+		}
+
+		@Override
+		public void addModelRepositoryChangeListener(ModelRepositoryChangeListener listener) {
+		}
+
+		@Override
+		public void removeModelRepositoryChangeListener(ModelRepositoryChangeListener listener) {
+		}
+
+		@Override
+		public EObject getModel(String name) {
+			return null
+		}
+
+		public void clean() {
+			isAddOrRefreshModelMethodCalled = false
+			isRemoveModelMethodCalled = false
+			calledFileName = null
+			fileContent = null
+		}
+	}
+
+	private static class ModelParserMock implements ModelParser {
+
+		@Override
+		public String getExtension() {
+			return "java"
+		}
+	}
+}

--- a/bundles/model/pom.xml
+++ b/bundles/model/pom.xml
@@ -18,6 +18,7 @@
   <modules>
     <module>org.eclipse.smarthome.model.lazygen</module>
     <module>org.eclipse.smarthome.model.core</module>
+    <module>org.eclipse.smarthome.model.core.test</module>
     <module>org.eclipse.smarthome.model.item</module>
     <module>org.eclipse.smarthome.model.item.runtime</module>
     <module>org.eclipse.smarthome.model.item.ui</module>


### PR DESCRIPTION
There are 8 test cases testing the functionality of
org.eclipse.smarthome.model.core.internal.folder.FolderObserver.
They check if the correct ModelRepository's methods are invoked
when certain events in the watched directory are triggered.

Signed-off-by: Mihaela Memova <mihaela.memova@musala.com>