### PR TITLE
Added ThingStatusDetail FIRMWARE_UPDATE_PENDING

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackTest.groovy
@@ -1,0 +1,194 @@
+/**
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.firmware
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+
+import java.util.Locale;
+
+import org.eclipse.smarthome.core.events.Event
+import org.eclipse.smarthome.core.events.EventPublisher
+import org.eclipse.smarthome.core.i18n.I18nProvider
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID
+import org.eclipse.smarthome.core.thing.ThingUID
+import org.eclipse.smarthome.core.thing.binding.firmware.Firmware;
+import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUID
+import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler;
+import org.eclipse.smarthome.core.thing.binding.firmware.ProgressCallback;
+import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep;
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.osgi.framework.Bundle;
+
+/**
+ * Testing the {@link ProgressCallback}.
+ *
+ * @author Christoph Knauf - Initial contribution
+ */
+public final class ProgressCallbackTest {
+
+    ProgressCallback sut
+    List<Event> postedEvents
+    ThingUID expectedThingUID
+    FirmwareUID expectedFirmwareUID
+    def usedMessagedKey
+
+    @Before
+    void setUp(){
+        def thingType = new ThingTypeUID("thing:type")
+        expectedThingUID = new ThingUID(thingType, "thingid")
+        expectedFirmwareUID = new FirmwareUID(thingType, "1")
+        postedEvents = new LinkedList<>();
+        def publisher = [
+            post : { event -> postedEvents.add(event) }
+        ] as EventPublisher
+        def i18nProvider = [
+            getText:  { bundle, key, defaultText, locale, arguments ->
+                usedMessagedKey = key
+                return "Dummy Message"
+            } 
+        ] as I18nProvider
+        sut = new ProgressCallbackImpl(new DummyFirmwareHandler(),publisher, i18nProvider, expectedThingUID, expectedFirmwareUID, null)
+    }
+
+    @Test
+    void 'assert that setting the progess to pending results in a FirmwareUpdateProgressInfo event'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.pending()
+        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, true)
+    }
+    
+    @Test
+    void 'assert that pending does not change ProgressStep'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.pending()
+        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, true)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(1), ProgressStep.DOWNLOADING, false)
+        sut.pending()
+        assertThatProgressInfoEventIsValid(postedEvents.get(2), ProgressStep.DOWNLOADING, true)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(3), ProgressStep.TRANSFERRING, false)
+        assertThat postedEvents.size(), is(4)
+    }
+    
+    @Test(expected=IllegalStateException)
+    void 'assert that cancel throws IllegalStateException if update is finished'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.success()
+        sut.canceled()
+    }
+    
+    @Test
+    void 'assert that calling cancel results in a FirmwareUpdateResultInfoEvent'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.canceled()
+        
+        assertThat postedEvents.size(), is(1)
+        assertThat postedEvents.get(0), is(instanceOf(FirmwareUpdateResultInfoEvent))
+        FirmwareUpdateResultInfoEvent resultEvent = postedEvents.get(0) as FirmwareUpdateResultInfoEvent
+        assertThat resultEvent.getThingUID(), is(expectedThingUID)
+        assertThat resultEvent.firmwareUpdateResultInfo.result, is(FirmwareUpdateResult.CANCELED)
+        assertThat usedMessagedKey, is(ProgressCallbackImpl.UPDATE_CANCELED_MESSAGE_KEY)
+        
+    }
+
+    /*
+     * Special behaviour because of pending state: 
+     *
+     * Before calling next the ProgressStep is null which means the update was not started 
+     * but a valid ProgressStep is needed to create a FirmwareUpdateProgressInfoEvent. 
+     * As workaround the first step is returned to provide a valid ProgressStep.
+     * This could be the case if the update directly goes in PENDING state after trying to start it.      
+     */
+    @Test
+    void 'assert that getProgressStep returns first step if next was not called before'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        assertThat sut.getCurrentStep(), is (ProgressStep.DOWNLOADING)
+    }
+
+    @Test
+    void 'assert that getProgressStep returns current step if next was called before'(){
+        def steps = [
+            ProgressStep.DOWNLOADING,
+            ProgressStep.TRANSFERRING,
+            ProgressStep.UPDATING,
+            ProgressStep.REBOOTING] as ProgressStep[]
+        sut.defineSequence(steps)
+        sut.next()
+        for (int i = 0; i< steps.length-1;i++){
+            assertThat sut.getCurrentStep(), is (steps[i])
+            sut.next()
+        }
+    }
+
+    @Test(expected=IllegalStateException)
+    void 'assert that pending throws IllegalStateException if step sequence is not defined'(){
+        sut.pending()
+    }
+    
+    @Test(expected=IllegalStateException)
+    void 'assert that failed throws IllegalStateException if its called multiple times'(){
+        sut.failed("DummyMessageKey")
+        sut.failed("DummyMessageKey")
+    }
+
+    @Test(expected=IllegalStateException)
+    void 'assert that success throws IllegalStateException if its called multiple times'(){
+        sut.success()
+        sut.success()
+    }
+
+    @Test(expected=IllegalStateException)
+    void 'assert that pending throws IllegalStateException if update failed'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.failed("DummyMessageKey")
+        sut.pending()
+    }
+
+    @Test(expected=IllegalStateException)
+    void 'assert that pending throws IllegalStateException if update was successful'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.success()
+        sut.pending()
+    }
+
+    def assertThatProgressInfoEventIsValid(Event event, ProgressStep expectedStep, boolean isPending){
+        assertThat event, is(instanceOf(FirmwareUpdateProgressInfoEvent))
+        def fpiEvent = event as FirmwareUpdateProgressInfoEvent
+        assertThat fpiEvent.getThingUID(), is(expectedThingUID)
+        assertThat fpiEvent.getProgressInfo().getFirmwareUID(), is(expectedFirmwareUID)
+        assertThat fpiEvent.getProgressInfo().getProgressStep(), is(expectedStep)
+        // Is update in PENDING state?
+        assertThat fpiEvent.getProgressInfo().isPending(), (is(isPending))
+    }
+    
+    class DummyFirmwareHandler implements FirmwareUpdateHandler {
+
+        @Override
+        public Thing getThing() {
+            return null;
+        }
+
+        @Override
+        public void updateFirmware(Firmware firmware, ProgressCallback progressCallback) {
+        }
+
+        @Override
+        public void cancel() {
+        }
+
+        @Override
+        public boolean isUpdateExecutable() {
+            return false;
+        }
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/ESH-INF/i18n/firmware.properties
+++ b/bundles/core/org.eclipse.smarthome.core.thing/ESH-INF/i18n/firmware.properties
@@ -1,2 +1,5 @@
 unexpected-handler-error=An unexpected error occurred during firmware update.
 timeout-error=A timeout occurred during firmware update.
+unexpected-handler-error-during-cancel=An unexpected error occurred during canceling of firmware update.
+timeout-error-during-cancel=A timeout occurred during canceling of firmware update.
+update-canceled=The firmware update was canceled. 

--- a/bundles/core/org.eclipse.smarthome.core.thing/ESH-INF/i18n/firmware_de.properties
+++ b/bundles/core/org.eclipse.smarthome.core.thing/ESH-INF/i18n/firmware_de.properties
@@ -1,2 +1,5 @@
 unexpected-handler-error=Es ist ein unerwarteter Fehler während des Firmware-Updates aufgetreten.
 timeout-error=Das Firmware-Update ist aufgrund einer Zeitüberschreitung fehlgeschlagen.
+unexpected-handler-error-during-cancel=Es ist ein unerwarteter Fehler während des Abbruchs eines Firmware-Updates aufgetreten.
+timeout-error-during-cancel=Das Abbrechen des Firmware-Updates ist aufgrund einer Zeitüberschreitung fehlgeschlagen.
+update-canceled=Das Firmware-Update wurde abgebrochen. 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/FirmwareUpdateHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/FirmwareUpdateHandler.java
@@ -39,6 +39,11 @@ public interface FirmwareUpdateHandler {
     void updateFirmware(Firmware firmware, ProgressCallback progressCallback);
 
     /**
+     * Cancels a previous started firmware update.
+     */
+    void cancel(); 
+    
+    /**
      * Returns true, if this firmware update handler is in a state in which the firmware update can be executed,
      * otherwise false (e.g. the thing is {@link ThingStatus#OFFLINE} or its status detail is already
      * {@link ThingStatusDetail#FIRMWARE_UPDATING.)

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/ProgressCallback.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/ProgressCallback.java
@@ -63,4 +63,14 @@ public interface ProgressCallback {
      * Callback operation to indicate that the firmware update was successful.
      */
     void success();
+    
+    /**
+     * Callback operation to indicate that the firmware update is pending.
+     */
+    void pending(); 
+    
+    /**
+     * Callback operation to indicate that the firmware update was canceled.
+     */
+    void canceled(); 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateProgressInfo.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateProgressInfo.java
@@ -27,6 +27,8 @@ public final class FirmwareUpdateProgressInfo {
 
     private Collection<ProgressStep> sequence;
 
+    private boolean pending;
+
     /**
      * Default constructor. Will allow to instantiate this class by reflection.
      */
@@ -41,11 +43,13 @@ public final class FirmwareUpdateProgressInfo {
      * @param progressStep the current progress step (must not be null)
      * @param sequence the collection of progress steps describing the sequence of the firmware update process
      *            (must not be null)
+     * @param pending the flag indicating if the update is pending
      *
      * @throws NullPointerException if firmware UID or current progress step is null
      * @throws IllegalArgumentException if sequence is null or empty
      */
-    FirmwareUpdateProgressInfo(FirmwareUID firmwareUID, ProgressStep progressStep, Collection<ProgressStep> sequence) {
+    FirmwareUpdateProgressInfo(FirmwareUID firmwareUID, ProgressStep progressStep, Collection<ProgressStep> sequence,
+            boolean pending) {
         Preconditions.checkNotNull(firmwareUID, "Firmware UID must not be null.");
         Preconditions.checkNotNull(progressStep, "Progress step must not be null.");
         Preconditions.checkArgument(sequence != null && !sequence.isEmpty(), "Sequence must not be null or empty.");
@@ -53,6 +57,7 @@ public final class FirmwareUpdateProgressInfo {
         this.firmwareUID = firmwareUID;
         this.progressStep = progressStep;
         this.sequence = sequence;
+        this.pending = pending;
     }
 
     /**
@@ -89,6 +94,7 @@ public final class FirmwareUpdateProgressInfo {
         result = prime * result + ((firmwareUID == null) ? 0 : firmwareUID.hashCode());
         result = prime * result + ((progressStep == null) ? 0 : progressStep.hashCode());
         result = prime * result + ((sequence == null) ? 0 : sequence.hashCode());
+        result = prime * result + new Boolean(pending).hashCode();
         return result;
     }
 
@@ -121,13 +127,20 @@ public final class FirmwareUpdateProgressInfo {
         } else if (!sequence.equals(other.sequence)) {
             return false;
         }
+        if (pending != other.pending) {
+            return false;
+        }
         return true;
     }
 
     @Override
     public String toString() {
         return "FirmwareUpdateProgressInfo [firmwareUID=" + firmwareUID + ", progressStep=" + progressStep
-                + ", sequence=" + sequence + "]";
+                + ", sequence=" + sequence + ", pending=" + pending + "]";
+    }
+
+    public boolean isPending() {
+        return pending;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateResult.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateResult.java
@@ -18,5 +18,8 @@ public enum FirmwareUpdateResult {
     SUCCESS,
 
     /** Indicates that the firmware update has failed. */
-    ERROR;
+    ERROR,
+    
+    /** Indicates that the firmware update was canceled. */
+    CANCELED;
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateResultInfo.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateResultInfo.java
@@ -41,7 +41,7 @@ public final class FirmwareUpdateResultInfo {
         Preconditions.checkNotNull(result, "Firmware update result must not be null");
         this.result = result;
 
-        if (result == FirmwareUpdateResult.ERROR) {
+        if (result != FirmwareUpdateResult.SUCCESS) {
             Preconditions.checkArgument(errorMessage != null && !errorMessage.isEmpty(),
                     "Error message must not be null or empty for erroneous firmare updates");
             this.errorMessage = errorMessage;


### PR DESCRIPTION
Introducing pending state for firmware updates. Adds ability to cancel started firmware updates. 

Added pending to ProgressCallback and reverted previous changes. This
reduces the impact of the changes regarding pending updates

Introduced cancel method in FirmwareUpdateHandler

Sending FirmwareUpdateProgressInfo events for pending updates.Implemented
cancelFirmwareUpdate in FirmwareUpdateService.java

Added tests

Signed-off-by: Christoph Knauf  <christoph.knauf@itemis.de>