### PR TITLE
fixed Thing comparison to consider labels and locations

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/util/ThingHelperTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/util/ThingHelperTest.groovy
@@ -85,4 +85,34 @@ class ThingHelperTest {
 		assertFalse ThingHelper.equals(thingA, thingB)
 	}
 
+
+    @Test
+    void 'Two things are different after label was modified'() {
+        Thing thingA = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withConfiguration(new Configuration()).withLabel("foo").build()
+
+        Thing thingB = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withConfiguration(new Configuration()).withLabel("foo").build()
+
+        assertTrue ThingHelper.equals(thingA, thingB)
+
+        thingB.setLabel("bar")
+
+        assertFalse ThingHelper.equals(thingA, thingB)
+    }
+
+    @Test
+    void 'Two things are different after location was modified'() {
+        Thing thingA = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withConfiguration(new Configuration()).withLocation("foo").build()
+
+        Thing thingB = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withConfiguration(new Configuration()).withLocation("foo").build()
+
+        assertTrue ThingHelper.equals(thingA, thingB)
+
+        thingB.setLocation("bar")
+
+        assertFalse ThingHelper.equals(thingA, thingB)
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/util/ThingHelper.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.internal.BridgeImpl;
 import org.eclipse.smarthome.core.thing.internal.ThingImpl;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
 
 /**
  * {@link ThingHelper} provides a utility method to create and bind items.
@@ -53,17 +54,20 @@ public class ThingHelper {
         if (!a.getUID().equals(b.getUID())) {
             return false;
         }
-        if (a.getBridgeUID() == null && b.getBridgeUID() != null) {
-            return false;
-        }
-        if (a.getBridgeUID() != null && !a.getBridgeUID().equals(b.getBridgeUID())) {
+        // bridge
+        if (!Objects.equal(a.getBridgeUID(), b.getBridgeUID())) {
             return false;
         }
         // configuration
-        if (a.getConfiguration() == null && b.getConfiguration() != null) {
+        if (!Objects.equal(a.getConfiguration(), b.getConfiguration())) {
             return false;
         }
-        if (a.getConfiguration() != null && !a.getConfiguration().equals(b.getConfiguration())) {
+        // label
+        if (!Objects.equal(a.getLabel(), b.getLabel())) {
+            return false;
+        }
+        // location
+        if (!Objects.equal(a.getLocation(), b.getLocation())) {
             return false;
         }
         // channels


### PR DESCRIPTION
So far, Things where those fields changed have been considered to
be equal and therefore were not updated in the registry.

fixes #2089
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>