### PR TITLE
Replaced buttons with clickable icons in rules

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -937,3 +937,13 @@ md-dialog-content .dayParameter {
 	min-height: 35px;
 	min-width: 35px;
 }
+
+.rule .actions i {
+	margin: 10px 17px 10px 17px;
+}
+
+.rule .actions i:hover, .rules .actions span:hover {
+	cursor: pointer;
+	box-shadow: 0px 0px 4px 2px #dedede;
+	border-radius: 100%;
+}

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/rules.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/rules.html
@@ -21,9 +21,7 @@
 							<p ng-bind-html="rule.description"></p>
 							<p>{{rule.uid}}</p>
 							<div class="actions">
-								<md-button ng-click="toggleEnabled(rule, $event)" aria-label="Toggle Enable"> <i class="material-icons">{{rule.enabled ? "alarm_on" : "alarm_off"}}</i></md-button>
-								<md-button ng-click="configure(rule, $event)" aria-label="Configure"> <i class="material-icons">settings</i></md-button>
-								<md-button ng-click="remove(rule, $event)" aria-label="Remove"> <i class="material-icons">delete</i></md-button>
+								<i class="material-icons" aria-label="Toggle Enable" ng-click="toggleEnabled(rule, $event)">{{rule.enabled ? "alarm_on" : "alarm_off"}}</i> <i class="material-icons" aria-label="Configure" ng-click="configure(rule, $event)">settings</i> <i class="material-icons" aria-label="Remove" ng-click="remove(rule, $event)">delete</i>
 							</div>
 						</div>
 						<hr class="border-line" ng-show="!$last" />


### PR DESCRIPTION
partially fixes https://github.com/eclipse/smarthome/issues/2072. Icons in the header are left for now.
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>