### PR TITLE
Fixed bug, which resulted in duplicate items in the item registry.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -9,13 +9,13 @@ package org.eclipse.smarthome.core.thing.internal;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
@@ -150,7 +150,7 @@ public class ChannelItemProvider implements ItemProvider {
                 public void run() {
                     // we wait until no further new links or items are announced in order to avoid creation of
                     // items which then must be removed again immediately.
-                    while (lastUpdate > new Date().getTime() - 2000L) {
+                    while (lastUpdate > System.nanoTime() - TimeUnit.SECONDS.toNanos(2)) {
                         try {
                             Thread.sleep(100L);
                         } catch (InterruptedException e) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -58,7 +58,7 @@ public class ChannelItemProvider implements ItemProvider {
 
     private boolean enabled = true;
     private boolean initialized = false;
-    private long lastUpdate = new Date().getTime();
+    private long lastUpdate = System.nanoTime();
 
     @Override
     public Collection<Item> getAll() {
@@ -299,7 +299,7 @@ public class ChannelItemProvider implements ItemProvider {
         @Override
         public void added(ItemChannelLink element) {
             createItemForLink(element);
-            lastUpdate = new Date().getTime();
+            lastUpdate = System.nanoTime();
         }
 
         @Override
@@ -331,7 +331,7 @@ public class ChannelItemProvider implements ItemProvider {
                     listener.removed(ChannelItemProvider.this, oldElement);
                 }
             }
-            lastUpdate = new Date().getTime();
+            lastUpdate = System.nanoTime();
         }
 
         @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -9,11 +9,13 @@ package org.eclipse.smarthome.core.thing.internal;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
 
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
@@ -55,10 +57,12 @@ public class ChannelItemProvider implements ItemProvider {
     private Map<String, Item> items = null;
 
     private boolean enabled = true;
+    private boolean initialized = false;
+    private long lastUpdate = new Date().getTime();
 
     @Override
     public Collection<Item> getAll() {
-        if (!enabled) {
+        if (!enabled || !initialized) {
             return Collections.emptySet();
         } else {
             synchronized (this) {
@@ -141,13 +145,24 @@ public class ChannelItemProvider implements ItemProvider {
         }
 
         if (enabled) {
-            logger.debug("Enabling channel item provider.");
-            for (ProviderChangeListener<Item> listener : listeners) {
-                for (Item item : getAll()) {
-                    listener.added(this, item);
+            Executors.newSingleThreadExecutor().submit(new Runnable() {
+                @Override
+                public void run() {
+                    // we wait until no further new links or items are announced in order to avoid creation of
+                    // items which then must be removed again immediately.
+                    while (lastUpdate > new Date().getTime() - 2000L) {
+                        try {
+                            Thread.sleep(100L);
+                        } catch (InterruptedException e) {
+                        }
+                    }
+                    logger.debug("Enabling channel item provider.");
+                    initialized = true;
+                    // simply call getAll() will create the items and notify all registered listeners automatically
+                    getAll();
+                    addRegistryChangeListeners();
                 }
-            }
-            addRegistryChangeListeners();
+            });
         } else {
             logger.debug("Disabling channel item provider.");
             for (ProviderChangeListener<Item> listener : listeners) {
@@ -162,6 +177,7 @@ public class ChannelItemProvider implements ItemProvider {
     protected void deactivate() {
         removeRegistryChangeListeners();
         synchronized (this) {
+            initialized = false;
             items = null;
         }
     }
@@ -283,6 +299,7 @@ public class ChannelItemProvider implements ItemProvider {
         @Override
         public void added(ItemChannelLink element) {
             createItemForLink(element);
+            lastUpdate = new Date().getTime();
         }
 
         @Override
@@ -301,15 +318,20 @@ public class ChannelItemProvider implements ItemProvider {
 
         @Override
         public void added(Item element) {
-            if (!items.values().contains(element)) {
-                // it is from some other provider, so remove ours, if we have one
-                Item oldElement = items.remove(element.getName());
-                if (oldElement != null) {
-                    for (ProviderChangeListener<Item> listener : listeners) {
-                        listener.removed(ChannelItemProvider.this, oldElement);
-                    }
+            // check, if it is our own item
+            for (Item item : items.values()) {
+                if (item == element) {
+                    return;
                 }
             }
+            // it is from some other provider, so remove ours, if we have one
+            Item oldElement = items.remove(element.getName());
+            if (oldElement != null) {
+                for (ProviderChangeListener<Item> listener : listeners) {
+                    listener.removed(ChannelItemProvider.this, oldElement);
+                }
+            }
+            lastUpdate = new Date().getTime();
         }
 
         @Override


### PR DESCRIPTION
Additionally, implemented a delay before the provider actively creates its items to avoid too many short living item creations.

Fixes #2095

Signed-off-by: Kai Kreuzer <kai@openhab.org>