### PR TITLE
Implemented tests for ConfigDispatcher

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/.classpath
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/test/groovy"/>
+	<classpathentry exported="true" kind="con" path="GROOVY_DSL_SUPPORT"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/.project
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/.project
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.config.dispatch.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.jdt.groovy.core.groovyNature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/ConfigDispatchTest.launch
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/ConfigDispatchTest.launch
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<stringAttribute key="application" value="org.eclipse.pde.junit.runtime.coretestapplication"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="false"/>
+<booleanAttribute key="automaticValidate" value="false"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="false"/>
+<booleanAttribute key="default_auto_start" value="true"/>
+<booleanAttribute key="includeOptional" value="true"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.eclipse.smarthome.config.dispatch.test/src/test/groovy/org/eclipse/smarthome/config/dispatch/test/ConfigDispatchTest.groovy"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="1"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value=""/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.smarthome.config.dispatch.test.ConfigDispatchTest"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.config.dispatch.test"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.equinox.p2.director.app.product"/>
+<booleanAttribute key="run_in_ui_thread" value="true"/>
+<stringAttribute key="selected_target_plugins" value="ch.qos.logback.classic@default:default,ch.qos.logback.core@default:default,ch.qos.logback.slf4j@default:false,com.eclipsesource.jaxrs.jersey-min@default:default,com.google.gson*2.2.4.v201311231704@default:default,com.google.gson*2.5.0@default:default,com.google.guava@default:default,com.ibm.icu@default:default,javax.activation@default:default,javax.annotation@default:default,javax.inject@default:default,javax.mail.glassfish@default:default,javax.servlet*3.1.0.v20140303-1611@default:default,javax.transaction@default:false,javax.xml@default:default,org.apache.ant@default:default,org.apache.batik.css@default:default,org.apache.batik.util.gui@default:default,org.apache.batik.util@default:default,org.apache.commons.codec@default:default,org.apache.commons.io@default:default,org.apache.commons.lang@default:default,org.apache.commons.logging@default:default,org.apache.httpcomponents.httpclient*4.2.6.v201311072007@default:default,org.apache.httpcomponents.httpclient*4.3.6.v201411290715@default:default,org.apache.httpcomponents.httpcore*4.2.5.v201311072007@default:default,org.apache.httpcomponents.httpcore*4.3.3.v201411290715@default:default,org.codehaus.groovy@default:default,org.eclipse.ant.core@default:default,org.eclipse.compare.core@default:default,org.eclipse.core.commands@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.databinding.observable@default:default,org.eclipse.core.databinding.property@default:default,org.eclipse.core.databinding@default:default,org.eclipse.core.expressions@default:default,org.eclipse.core.filesystem.java7@default:default,org.eclipse.core.filesystem.win32.x86_64@default:default,org.eclipse.core.filesystem@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.resources.win32.x86_64@default:default,org.eclipse.core.resources@default:default,org.eclipse.core.runtime.compatibility.registry@default:default,org.eclipse.core.runtime@default:true,org.eclipse.core.variables@default:default,org.eclipse.e4.core.commands@default:default,org.eclipse.e4.core.contexts@default:default,org.eclipse.e4.core.di.extensions@default:default,org.eclipse.e4.core.di@default:default,org.eclipse.e4.core.services@default:default,org.eclipse.e4.ui.bindings@default:default,org.eclipse.e4.ui.css.core@default:default,org.eclipse.e4.ui.css.swt.theme@default:default,org.eclipse.e4.ui.css.swt@default:default,org.eclipse.e4.ui.di@default:default,org.eclipse.e4.ui.model.workbench@default:default,org.eclipse.e4.ui.services@default:default,org.eclipse.e4.ui.widgets@default:default,org.eclipse.e4.ui.workbench.addons.swt@default:default,org.eclipse.e4.ui.workbench.renderers.swt@default:default,org.eclipse.e4.ui.workbench.swt@default:default,org.eclipse.e4.ui.workbench3@default:default,org.eclipse.e4.ui.workbench@default:default,org.eclipse.emf.common@default:default,org.eclipse.emf.ecore.change@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.bidi@default:default,org.eclipse.equinox.cm@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.ds@1:true,org.eclipse.equinox.event@default:default,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.region@default:false,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.transforms.hook@default:false,org.eclipse.equinox.util@default:default,org.eclipse.equinox.weaving.hook@default:false,org.eclipse.help@default:default,org.eclipse.jface.databinding@default:default,org.eclipse.jface@default:default,org.eclipse.osgi.compatibility.state@default:false,org.eclipse.osgi.services@default:default,org.eclipse.osgi@-1:true,org.eclipse.swt.win32.win32.x86_64@default:default,org.eclipse.swt@default:default,org.eclipse.team.core@default:default,org.eclipse.ui.trace@default:default,org.eclipse.ui.workbench@default:default,org.eclipse.ui@default:false,org.hamcrest.core@default:default,org.junit@default:default,org.jupnp@default:default,org.slf4j.api@default:default,org.slf4j.jcl@default:default,org.w3c.css.sac@default:default,org.w3c.dom.events@default:default,org.w3c.dom.smil@default:default,org.w3c.dom.svg@default:default"/>
+<stringAttribute key="selected_workspace_plugins" value="org.eclipse.smarthome.config.core@default:default,org.eclipse.smarthome.config.dispatch.test@default:false,org.eclipse.smarthome.config.dispatch@4:true,org.eclipse.smarthome.config.xml@default:default,org.eclipse.smarthome.core.autoupdate@default:default,org.eclipse.smarthome.core.test@default:default,org.eclipse.smarthome.core.thing.test@default:default,org.eclipse.smarthome.core.thing@default:default,org.eclipse.smarthome.core@default:default,org.eclipse.smarthome.io.console@default:default,org.eclipse.smarthome.test@default:default"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/META-INF/MANIFEST.MF
@@ -1,0 +1,19 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Config Dispatcher Tests
+Bundle-SymbolicName: org.eclipse.smarthome.config.dispatch.test
+Bundle-Version: 0.9.0.qualifier
+Bundle-ClassPath: .
+Fragment-Host: org.eclipse.smarthome.config.dispatch
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Import-Package: groovy.lang,
+ org.codehaus.groovy.reflection,
+ org.codehaus.groovy.runtime,
+ org.codehaus.groovy.runtime.callsite,
+ org.codehaus.groovy.runtime.typehandling,
+ org.eclipse.smarthome.test,
+ org.hamcrest;core=split,
+ org.junit,
+ org.osgi.framework,
+ org.osgi.service.component
+Service-Component: OSGI-INF/configdispatchertest.xml

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/OSGI-INF/configdispatchertest.xml
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/OSGI-INF/configdispatchertest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" name="org.eclipse.smarthome.config.dispatch.test">
+   <!--We need this service component in order to be able to control when the ConfigDispatcher is started.-->
+   <implementation class="org.eclipse.smarthome.config.dispatch.test.ConfigDispatchTest"/>
+</scr:component>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/build.properties
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/build.properties
@@ -1,0 +1,5 @@
+bin.includes = .,\
+               META-INF/,\
+               OSGI-INF/
+source.. = src/test/groovy/
+output.. = target/classes/

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/comments_conf/comments.default.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/comments_conf/comments.default.cfg
@@ -1,0 +1,2 @@
+#The line below will be used to test if the comment lines are processed.
+#comment.default.pid:comment.default.property=comment.default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/comments_conf/comments_services/comments.service.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/comments_conf/comments_services/comments.service.cfg
@@ -1,0 +1,2 @@
+#The line below will be used to test if the comment lines are processed.
+#comment.service.pid:comment.service.property=comment.service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/default_vs_services_files_conf/default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/default_vs_services_files_conf/default.file.cfg
@@ -1,0 +1,3 @@
+pid:default.and.service.global.pid
+property1=value1.1
+default.and.service.local.pid:property2=value2.1

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/default_vs_services_files_conf/default_vs_services_files_services/service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/default_vs_services_files_conf/default_vs_services_files_services/service.file.cfg
@@ -1,0 +1,3 @@
+pid:default.and.service.global.pid
+property1=value1.2
+default.and.service.local.pid:property2=value2.2

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/deleted_file_conf/deleted_file_services/deleted.file.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/deleted_file_conf/deleted_file_services/deleted.file.service.file.cfg
@@ -1,0 +1,1 @@
+deleted.file.service.pid:deleted.file.service.property=deleted.file.service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global.and.local.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global.and.local.pid.default.file.cfg
@@ -1,0 +1,4 @@
+#For the purposes of the tests, using this configuration folder, 
+#we only need to process files from services directory, 
+#but we set the file in the root directory, 
+#because otherwise the ConfigDispatcher will throw a FileNotFoundException.

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_no_conflict_services/global.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_no_conflict_services/global.pid.service.file.cfg
@@ -1,0 +1,2 @@
+pid:no.conflict.global.and.local.pid
+global.property=global.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_no_conflict_services/local.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_no_conflict_services/local.pid.service.file.cfg
@@ -1,0 +1,1 @@
+no.conflict.global.and.local.pid:local.property=local.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_global_services/a.overriding.local.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_global_services/a.overriding.local.pid.service.file.cfg
@@ -1,0 +1,1 @@
+overridden.global.pid:global.and.local.property=local.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_global_services/b.overriden.global.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_global_services/b.overriden.global.pid.service.file.cfg
@@ -1,0 +1,2 @@
+pid:overridden.global.pid
+global.and.local.property=global.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_local_services/a.overriding.global.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_local_services/a.overriding.global.pid.service.file.cfg
@@ -1,0 +1,2 @@
+pid:overridden.local.pid
+global.and.local.property=global.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_local_services/b.overriden.local.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_local_services/b.overriden.local.pid.service.file.cfg
@@ -1,0 +1,1 @@
+overridden.local.pid:global.and.local.property=local.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_conf/global.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_conf/global.pid.default.file.cfg
@@ -1,0 +1,2 @@
+pid:global.default.pid
+default.property=default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_conf/global_pid_services/global.pid.service.first.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_conf/global_pid_services/global.pid.service.first.file.cfg
@@ -1,0 +1,2 @@
+pid:global.service.first.pid
+service.property=service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_conf/global_pid_services/global.pid.service.second.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_conf/global_pid_services/global.pid.service.second.file.cfg
@@ -1,0 +1,2 @@
+pid:global.service.second.pid
+service.property=service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global.pid.default.file.cfg
@@ -1,0 +1,1 @@
+#This default file is not tested

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global_pid_different_files_conflict_services/global.pid.last.modified.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global_pid_different_files_conflict_services/global.pid.last.modified.service.file.cfg
@@ -1,0 +1,2 @@
+pid:different.files.global.pid
+property=d.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global_pid_different_files_conflict_services/global.pid.service.a.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global_pid_different_files_conflict_services/global.pid.service.a.file.cfg
@@ -1,0 +1,2 @@
+pid:different.files.global.pid
+property=a.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global_pid_different_files_conflict_services/global.pid.service.b.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global_pid_different_files_conflict_services/global.pid.service.b.file.cfg
@@ -1,0 +1,2 @@
+pid:different.files.global.pid
+property=b.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global_pid_different_files_conflict_services/global.pid.service.c.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_conflict_conf/global_pid_different_files_conflict_services/global.pid.service.c.file.cfg
@@ -1,0 +1,2 @@
+pid:different.files.global.pid
+property=c.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_no_conflict_conf/global.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_no_conflict_conf/global.pid.default.file.cfg
@@ -1,0 +1,2 @@
+pid:different.files.global.pid
+third.property=third.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_no_conflict_conf/global_pid_different_files_no_conflict_services/global.pid.service.a.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_no_conflict_conf/global_pid_different_files_no_conflict_services/global.pid.service.a.file.cfg
@@ -1,0 +1,2 @@
+pid:different.files.global.pid
+second.property=second.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_no_conflict_conf/global_pid_different_files_no_conflict_services/global.pid.service.b.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_no_conflict_conf/global_pid_different_files_no_conflict_services/global.pid.service.b.file.cfg
@@ -1,0 +1,2 @@
+pid:different.files.global.pid
+first.property=first.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_no_conflict_conf/global_pid_different_files_no_conflict_services/global.pid.service.c.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_different_files_no_conflict_conf/global_pid_different_files_no_conflict_services/global.pid.service.c.file.cfg
@@ -1,0 +1,2 @@
+pid:different.files.global.pid
+fourth.property=fourth.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_empty_conf/global.pid.empty.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_empty_conf/global.pid.empty.default.file.cfg
@@ -1,0 +1,3 @@
+pid:
+#The line above will be used to test empty-string pid
+global.default.property=global.default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_empty_conf/global_pid_empty_services/global.pid.empty.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_empty_conf/global_pid_empty_services/global.pid.empty.service.file.cfg
@@ -1,0 +1,3 @@
+pid:
+#The line above will be used to test empty-string pid
+global.service.property=global.service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_no_pair_conf/global.pid.no.pair.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_no_pair_conf/global.pid.no.pair.default.file.cfg
@@ -1,0 +1,1 @@
+pid:no.pair.default.pid

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_no_pair_conf/global_pid_no_pair_services/global.pid.no.pair.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_pid_no_pair_conf/global_pid_no_pair_services/global.pid.no.pair.service.file.cfg
@@ -1,0 +1,1 @@
+pid:no.pair.service.pid

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/ignored_global_pid_conf/ignored.global.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/ignored_global_pid_conf/ignored.global.pid.default.file.cfg
@@ -1,0 +1,2 @@
+pid:ignored.global.default.pid
+not.ignored.local.default.pid:local.default.property=local.default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/ignored_global_pid_conf/ignored_global_pid_services/ignored.global.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/ignored_global_pid_conf/ignored_global_pid_services/ignored.global.pid.service.file.cfg
@@ -1,0 +1,2 @@
+pid:ignored.global.service.pid
+not.ignored.local.service.pid:local.service.property=local.service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/last_pid_conf/last.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/last_pid_conf/last.pid.default.file.cfg
@@ -1,0 +1,4 @@
+pid:first.global.default.pid
+global.default.property1=global.default.value1
+last.local.default.pid:local.default.property=local.default.value
+global.default.property2=global.default.value2

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/last_pid_conf/last_pid_services/last.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/last_pid_conf/last_pid_services/last.pid.service.file.cfg
@@ -1,0 +1,4 @@
+pid:first.global.service.pid
+global.service.property1=global.service.value1
+last.local.service.pid:local.service.property=local.service.value
+global.service.property2=global.service.value2

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conf/local.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conf/local.pid.default.file.cfg
@@ -1,0 +1,1 @@
+local.default.pid:default.property=default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conf/local_pid_services/local.pid.service.first.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conf/local_pid_services/local.pid.service.first.file.cfg
@@ -1,0 +1,1 @@
+local.service.first.pid:service.property=service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conf/local_pid_services/local.pid.service.second.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conf/local_pid_services/local.pid.service.second.file.cfg
@@ -1,0 +1,1 @@
+local.service.second.pid:service.property=service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conflict_conf/local.pid.conflict.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conflict_conf/local.pid.conflict.default.file.cfg
@@ -1,0 +1,2 @@
+same.default.local.pid:default.property=default.value1
+same.default.local.pid:default.property=default.value2

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conflict_conf/local_pid_conflict_services/local.pid.conflict.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_conflict_conf/local_pid_conflict_services/local.pid.conflict.service.file.cfg
@@ -1,0 +1,2 @@
+same.service.local.pid:service.property=service.value1
+same.service.local.pid:service.property=service.value2

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local.pid.default.file.cfg
@@ -1,0 +1,1 @@
+#This default file is not tested.

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local_pid_different_files_conflict_services/last.modified.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local_pid_different_files_conflict_services/last.modified.service.file.cfg
@@ -1,0 +1,1 @@
+local.conflict.pid:property=d.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local_pid_different_files_conflict_services/local.pid.service.a.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local_pid_different_files_conflict_services/local.pid.service.a.file.cfg
@@ -1,0 +1,1 @@
+local.conflict.pid:property=a.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local_pid_different_files_conflict_services/local.pid.service.b.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local_pid_different_files_conflict_services/local.pid.service.b.file.cfg
@@ -1,0 +1,1 @@
+local.conflict.pid:property=b.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local_pid_different_files_conflict_services/local.pid.service.c.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_conflict_conf/local_pid_different_files_conflict_services/local.pid.service.c.file.cfg
@@ -1,0 +1,1 @@
+local.conflict.pid:property=c.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_no_conflict_conf/local.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_no_conflict_conf/local.pid.default.file.cfg
@@ -1,0 +1,1 @@
+local.pid:third.property=third.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_no_conflict_conf/local_pid_different_files_no_conflict_services/local.pid.service.a.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_no_conflict_conf/local_pid_different_files_no_conflict_services/local.pid.service.a.file.cfg
@@ -1,0 +1,1 @@
+local.pid:second.property=second.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_no_conflict_conf/local_pid_different_files_no_conflict_services/local.pid.service.b.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_no_conflict_conf/local_pid_different_files_no_conflict_services/local.pid.service.b.file.cfg
@@ -1,0 +1,1 @@
+local.pid:first.property=first.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_no_conflict_conf/local_pid_different_files_no_conflict_services/local.pid.service.c.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_different_files_no_conflict_conf/local_pid_different_files_no_conflict_services/local.pid.service.c.file.cfg
@@ -1,0 +1,1 @@
+local.pid:fourth.property=fourth.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_empty_conf/local.pid.empty.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_empty_conf/local.pid.empty.default.file.cfg
@@ -1,0 +1,1 @@
+:default.property=default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_empty_conf/local_pid_empty_services/local.pid.empty.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_empty_conf/local_pid_empty_services/local.pid.empty.service.file.cfg
@@ -1,0 +1,1 @@
+:service.property=service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_dot_conf/local.pid.no.dot.default.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_dot_conf/local.pid.no.dot.default.cfg
@@ -1,0 +1,1 @@
+default:default.property=default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_dot_conf/local_pid_no_dot_services/local.pid.no.dot.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_dot_conf/local_pid_no_dot_services/local.pid.no.dot.service.file.cfg
@@ -1,0 +1,1 @@
+service:service.property=service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_property_conf/local.pid.no.property.default.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_property_conf/local.pid.no.property.default.cfg
@@ -1,0 +1,1 @@
+no.property.default.pid:=value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_property_conf/local_pid_no_property_services/local.pid.no.property.service.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_property_conf/local_pid_no_property_services/local.pid.no.property.service.cfg
@@ -1,0 +1,1 @@
+no.property.service.pid:=value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_value_conf/local.pid.no.value.default.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_value_conf/local.pid.no.value.default.cfg
@@ -1,0 +1,1 @@
+default.pid:default.property=

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_value_conf/local_pid_no_value_services/local.pid.no.value.service.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/local_pid_no_value_conf/local_pid_no_value_services/local.pid.no.value.service.cfg
@@ -1,0 +1,1 @@
+service.pid:service.property=

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/no_pid_conf/no.pid.default.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/no_pid_conf/no.pid.default.file.cfg
@@ -1,0 +1,1 @@
+default.property=default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/no_pid_conf/no_pid_services/no.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/no_pid_conf/no_pid_services/no.pid.service.file.cfg
@@ -1,0 +1,1 @@
+service.property=service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/no_pid_no_dot_conf/default.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/no_pid_no_dot_conf/default.cfg
@@ -1,0 +1,1 @@
+no.dot.default.property=no.dot.default.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/no_pid_no_dot_conf/no_pid_no_dot_services/service.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/no_pid_no_dot_conf/no_pid_no_dot_services/service.cfg
@@ -1,0 +1,1 @@
+no.dot.service.property=no.dot.service.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/txt_conf/txt.default.txt
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/txt_conf/txt.default.txt
@@ -1,0 +1,1 @@
+txt.default.pid:txt.property=txt.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/txt_conf/txt_services/txt.service.txt
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/txt_conf/txt_services/txt.service.txt
@@ -1,0 +1,1 @@
+txt.service.pid:txt.property=txt.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/pom.xml
@@ -1,0 +1,79 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  
+  <parent>
+    <groupId>org.eclipse.smarthome.bundles</groupId>
+    <artifactId>config</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+  
+  <properties>
+    <bundle.symbolicName>org.eclipse.smarthome.config.dispatch.test</bundle.symbolicName>
+    <bundle.namespace>org.eclipse.smarthome.config.dispatch.test</bundle.namespace>
+  </properties>
+  
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eclipse.smarthome.config.dispatch</groupId>
+  <artifactId>org.eclipse.smarthome.config.dispatch.test</artifactId>
+
+  <name>Eclipse SmartHome Configuration Dispatcher Tests</name>
+
+  <packaging>eclipse-test-plugin</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.cm</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <bundleStartLevel>
+            <bundle>
+              <id>org.eclipse.equinox.cm</id>
+              <level>1</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.equinox.ds</id>
+              <level>1</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.config.core</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+          </bundleStartLevel>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/src/test/groovy/org/eclipse/smarthome/config/dispatch/test/ConfigDispatchTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/src/test/groovy/org/eclipse/smarthome/config/dispatch/test/ConfigDispatchTest.groovy
@@ -1,0 +1,782 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.config.dispatch.test
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+
+import org.apache.commons.io.IOUtils
+import org.apache.commons.lang.StringUtils
+import org.eclipse.smarthome.config.core.ConfigConstants
+import org.eclipse.smarthome.config.dispatch.internal.ConfigDispatcher
+import org.eclipse.smarthome.test.OSGiTest
+import org.junit.After
+import org.junit.AfterClass
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.osgi.service.cm.Configuration
+import org.osgi.service.cm.ConfigurationAdmin
+import org.osgi.service.component.ComponentContext
+
+/**
+ *
+ * Tests for {@link ConfigDispatcher}
+ *
+ * @author Petar Valchev
+ *
+ */
+class ConfigDispatchTest extends OSGiTest {
+    private ConfigurationAdmin configAdmin
+    // The ComponentContext is static as we expect that it is the same for all tests.
+    private static ComponentContext context
+
+    private def final CONFIGURATION_WATCH_DIRECTORY = "configurations"
+    private def final CONFIG_DISPATCHER_COMPONENT_ID = "org.eclipse.smarthome.config.dispatch"
+
+    private def static defaultConfigDir
+    private def static defaultServiceDir
+    private def static defaultConfigFile
+
+    private Configuration configuration
+
+    protected void activate(ComponentContext componentContext){
+        /* 
+         * The files in the root configuration directory are read only on the 
+         * activate() method of the ConfigDispatcher. So before every test method 
+         * the component is disabled using the component context, the watched 
+         * directories are set and then the component is enabled again using the 
+         * component context. In that way we can be sure that the files in the 
+         * root directory will be read.
+         */
+        context = componentContext
+    }
+
+    @BeforeClass
+    public static void setUpClass(){
+        // Store the default values in order to restore them after all the tests are finished.
+        defaultConfigDir = System.getProperty(ConfigConstants.CONFIG_DIR_PROG_ARGUMENT)
+        defaultServiceDir = System.getProperty(ConfigDispatcher.SERVICEDIR_PROG_ARGUMENT)
+        defaultConfigFile = System.getProperty(ConfigDispatcher.SERVICECFG_PROG_ARGUMENT)
+    }
+
+    @Before
+    public void setUp(){
+
+        /* 
+         * Disable the component of the ConfigDispatcher,so we can 
+         * set the properties for the directories to be watched,
+         * before the ConfigDispatcher is started.
+         */
+        context.disableComponent(CONFIG_DISPATCHER_COMPONENT_ID)
+
+        /* 
+         * After we disable the component we have to wait for the
+         * AbstractWatchService to stop watching the previously set 
+         * directories, because we will be setting a new ones.
+         */
+        sleep(300)
+
+        configAdmin = getService(ConfigurationAdmin)
+        assertThat "ConfigurationAdmin service cannot be found", configAdmin, is(notNullValue())
+    }
+
+    @After
+    public void tearDown(){
+        // Clear the configuration with the current pid from the persistent store.
+        if(configuration != null){
+            configuration.delete()
+        }
+    }
+
+    @AfterClass
+    public static void tearDownClass(){
+        // Set the system properties to their initial values.
+        setSystemProperty(ConfigConstants.CONFIG_DIR_PROG_ARGUMENT, defaultConfigDir)
+        setSystemProperty(ConfigDispatcher.SERVICEDIR_PROG_ARGUMENT, defaultServiceDir)
+        setSystemProperty(ConfigDispatcher.SERVICECFG_PROG_ARGUMENT, defaultConfigFile)
+    }
+
+    @Test
+    public void 'all configuration files with local PIDs are processed and configuration is updated'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/local_pid_conf"
+        def servicesDirectory = "local_pid_services"
+        def defaultConfigFileName = "$configDirectory/local.pid.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFileName)
+
+        // Assert that a file with local pid from the root configuration directory is processed.
+        verifyValueOfConfigurationProperty("local.default.pid", "default.property", "default.value")
+
+        // Assert that a file with local pid from the services directory is processed.
+        verifyValueOfConfigurationProperty("local.service.first.pid", "service.property", "service.value")
+
+        // Assert that more than one file with local pid from the services directory is processed.
+        verifyValueOfConfigurationProperty("local.service.second.pid", "service.property", "service.value")
+    }
+
+    @Test
+    public void 'when the configuration file name contains dot and no PID is defined, the file name becomes PID'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/no_pid_conf"
+        def servicesDirectory = "no_pid_services"
+        // In this test case we need configuration files, which names contain dots.
+        def defaultConfigFilePath = "$configDirectory/no.pid.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /* Assert that the configuration is updated with the name of the file in the root directory as a pid.*/
+        verifyValueOfConfigurationProperty("no.pid.default.file", "default.property", "default.value")
+
+        /* Assert that the configuration is updated with the name of the file in the services directory as a pid.*/
+        verifyValueOfConfigurationProperty("no.pid.service.file", "service.property", "service.value")
+    }
+
+    @Test
+    public void 'if no PID is defined in configuration file with no-dot name, the default namespace plus the file name becomes PID'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/no_pid_no_dot_conf"
+        def servicesDirectory = "no_pid_no_dot_services"
+        // In this test case we need configuration files, which names don't contain dots.
+        def defaultConfigFilePath = "$configDirectory/default.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /* 
+         * Assert that the configuration is updated with the default
+         * namespace the no-dot name of the file in the root directory as pid.
+         */
+        verifyValueOfConfigurationProperty("${ConfigDispatcher.SERVICE_PID_NAMESPACE}.default",
+                "no.dot.default.property",
+                "no.dot.default.value")
+
+        /* 
+         * Assert that the configuration is updated with the default namespace
+         * the no-dot name of the file in the services directory as pid.
+         */
+        verifyValueOfConfigurationProperty("${ConfigDispatcher.SERVICE_PID_NAMESPACE}.service",
+                "no.dot.service.property",
+                "no.dot.service.value")
+    }
+
+    @Test
+    public void 'when local PID does not contain dot, the default namespace plus that PID is the overall PID'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/local_pid_no_dot_conf"
+        def servicesDirectory = "local_pid_no_dot_services"
+        def defaultConfigFilePath = "$configDirectory/local.pid.no.dot.default.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /* 
+         * Assert that the configuration is updated with the default namespace
+         * the no-dot pid from the file in the the root directory.
+         */
+        verifyValueOfConfigurationProperty("${ConfigDispatcher.SERVICE_PID_NAMESPACE}.default",
+                "default.property",
+                "default.value")
+
+        /*
+         * Assert that the configuration is updated with the default namespace
+         * the no-dot pid from the file in the the services directory.
+         */
+        verifyValueOfConfigurationProperty("${ConfigDispatcher.SERVICE_PID_NAMESPACE}.service",
+                "service.property",
+                "service.value")
+    }
+
+    @Test
+    public void 'when local PID is an empty string, the default namespace plus dot is the overall PID'(){
+
+        // This test case is a corner case for the above test.
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/local_pid_empty_conf"
+        def servicesDirectory = "local_pid_empty_services"
+        def defaultConfigFilePath = "$configDirectory/local.pid.empty.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        verifyValueOfConfigurationProperty("${ConfigDispatcher.SERVICE_PID_NAMESPACE}.",
+                "default.property",
+                "default.value")
+
+        verifyValueOfConfigurationProperty("${ConfigDispatcher.SERVICE_PID_NAMESPACE}.",
+                "service.property",
+                "service.value")
+    }
+
+    @Test
+    public void 'value is still valid if it is left empty'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/local_pid_no_value_conf"
+        def servicesDirectory = "local_pid_no_value_services"
+        def defaultConfigFilePath = "$configDirectory/local.pid.no.value.default.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /* 
+         * Assert that the configuration is updated with
+         * an empty value for a file in the root directory.
+         */
+        verifyValueOfConfigurationProperty("default.pid", "default.property", "")
+
+        /*
+         * Assert that the configuration is updated with
+         * an empty value for a file in the services directory.
+         */
+        verifyValueOfConfigurationProperty("service.pid", "service.property", "")
+    }
+
+    @Test
+    public void 'if property is left empty, a configuration with the given PID will not exist'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/local_pid_no_property_conf"
+        def servicesDirectory = "local_pid_no_property_services"
+        def defaultConfigFilePath = "$configDirectory/local.pid.no.property.default.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /*
+         * Assert that the configuration is not updated with an
+         * empty-string property from the file in the root directory.
+         * */
+        verifyNoPropertiesForConfiguration("no.property.default.pid")
+
+        /* 
+         * Assert that the configuration is not updated with an
+         * empty-string property from the file in the services directory.
+         */
+        verifyNoPropertiesForConfiguration("no.property.service.pid")
+    }
+
+    @Test
+    public void 'properties for local PID can be overridden'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/local_pid_conflict_conf"
+        def servicesDirectory = "local_pid_conflict_services"
+        def defaultConfigFilePath = "$configDirectory/local.pid.conflict.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /* 
+         * Assert that the second processed property from the
+         * file in the root directory overrides the first one.
+         */
+        verifyValueOfConfigurationProperty("same.default.local.pid", "default.property", "default.value2")
+
+        /*
+         * Assert that the second processed property from the file
+         * in the services directory overrides the first one.
+         */
+        verifyValueOfConfigurationProperty("same.service.local.pid", "service.property", "service.value2")
+    }
+
+    @Test
+    public void 'comment lines are not processed'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/comments_conf"
+        def servicesDirectory = "comments_services"
+        def defaultConfigFilePath = "$configDirectory/comments.default.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /*
+         * Assert that the configuration is not updated with a
+         * pid from a comment from a file in the root directory.
+         */
+        verifyNoPropertiesForConfiguration("comment.default.pid")
+
+        /*
+         * Assert that the configuration is not updated with a
+         * pid from a comment from a file in the services directory.
+         */
+        verifyNoPropertiesForConfiguration("comment.service.pid")
+    }
+
+    @Test
+    public void 'txt files are not processed'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/txt_conf"
+        def servicesDirectory = "txt_services"
+        def defaultConfigFilePath = "$configDirectory/txt.default.txt"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /*
+         * Assert that the configuration is not updated with
+         * pid from a txt file in the root directory.
+         */
+        verifyNoPropertiesForConfiguration("txt.default.pid")
+
+        /*
+         * Assert that the configuration is not updated with
+         *  pid from a txt file in the services directory.
+         */
+        verifyNoPropertiesForConfiguration("txt.service.pid")
+    }
+
+    @Test
+    public void 'all configuration files with global PIDs are processed and configuration is updated'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/global_pid_conf"
+        def servicesDirectory = "global_pid_services"
+        def defaultConfigFilePath = "$configDirectory/global.pid.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        // Assert that a file with global pid from the root configuration directory is processed.
+        verifyValueOfConfigurationProperty("global.default.pid", "default.property", "default.value")
+
+        // Assert that a file with global pid from the services directory is processed.
+        verifyValueOfConfigurationProperty("global.service.first.pid", "service.property", "service.value")
+
+        // Assert that more than one file with global pid from the services directory is processed.
+        verifyValueOfConfigurationProperty("global.service.second.pid", "service.property", "service.value")
+    }
+
+    @Test
+    public void 'if the property=value pair is prefixed with local PID in the same file, the global PID is ignored'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/ignored_global_pid_conf"
+        def servicesDirectory = "ignored_global_pid_services"
+        def defaultConfigFilePath = "$configDirectory/ignored.global.pid.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        // Assert that the configuration is not updated with the global pid in the root directory.
+        verifyNoPropertiesForConfiguration("ignored.global.default.pid")
+
+        // Assert that the configuration is updated with the local pid in the root directory.
+        verifyValueOfConfigurationProperty("not.ignored.local.default.pid", "local.default.property", "local.default.value")
+
+        // Assert that the configuration is not updated with the global pid in the services directory.
+        verifyNoPropertiesForConfiguration("ignored.global.service.pid")
+
+        // Assert that the configuration is updated with the local pid in the services directory.
+        verifyValueOfConfigurationProperty("not.ignored.local.service.pid", "local.service.property", "local.service.value")
+    }
+
+    @Test
+    public void 'if the property is not prefixed with local PID, the last PID becomes PID for that property'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/last_pid_conf"
+        def servicesDirectory = "last_pid_services"
+        def defaultConfigFilePath = "$configDirectory/last.pid.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /*
+         * Assert that a property=value pair is associated with the global pid,
+         * defined in the above line in a file in the root directory
+         * rather than with the local pid, defined in the below line.
+         */
+        verifyValueOfConfigurationProperty("first.global.default.pid", "global.default.property1", "global.default.value1")
+        verifyNotExistingConfigurationProperty("last.local.default.pid", "global.default.property1")
+
+        /*
+         * Assert that a property=value pair is associated with the last defined local pid,
+         * rather than with the global pid, defined in the first line of a file in the root directory.
+         */
+        verifyValueOfConfigurationProperty("last.local.default.pid", "global.default.property2", "global.default.value2")
+        verifyNotExistingConfigurationProperty("first.global.default.pid", "global.default.property2")
+
+        /*
+         * Assert that a property=value pair is associated with the global pid,
+         * defined in the above line in a file in the services directory
+         * rather than with the local pid, defined in the below line.
+         */
+        verifyValueOfConfigurationProperty("first.global.service.pid", "global.service.property1", "global.service.value1")
+        verifyNotExistingConfigurationProperty("last.local.default.pid", "global.service.property1")
+
+        /*
+         * Assert that a property=value pair is associated with the last defined local pid,
+         * rather than with the global pid, defined in the first line of a file in the services directory.
+         */
+        verifyValueOfConfigurationProperty("last.local.service.pid", "global.service.property2", "global.service.value2")
+        verifyNotExistingConfigurationProperty("first.global.service.pid", "global.service.property2")
+    }
+
+    @Test
+    public void 'if there is no property=value pair for global PID, a configuration with the given PID will not exist'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/global_pid_no_pair_conf"
+        def servicesDirectory = "global_pid_no_pair_services"
+        def defaultConfigFilePath = "$configDirectory/global.pid.no.pair.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /* 
+         * Assert that pid with no property=value pair
+         * is not processed in a file in the root directory.
+         */
+        verifyNoPropertiesForConfiguration("no.pair.default.pid")
+
+        /*
+         * Assert that pid with no property=value pair
+         * is not processed in a file in the services directory.
+         */
+        verifyNoPropertiesForConfiguration("no.pair.service.pid")
+    }
+
+    @Test
+    public void 'when global PID is empty string, it remains an empty string'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/global_pid_empty_conf"
+        def servicesDirectory = "global_pid_empty_services"
+        def defaultConfigFilePath = "$configDirectory/global.pid.empty.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        // Assert that an empty-string pid from a file in the root directory is processed.
+        verifyValueOfConfigurationProperty("", "global.default.property", "global.default.value")
+
+        // Assert that an empty-string pid from a file in the services directory is processed.
+        verifyValueOfConfigurationProperty("", "global.service.property", "global.service.value")
+    }
+
+    @Test
+    public void 'property=value pairs for a local PID in different files, are still associated with that PID'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/local_pid_different_files_no_conflict_conf"
+        def servicesDirectory = "local_pid_different_files_no_conflict_services"
+        def defaultConfigFilePath = "$configDirectory/local.pid.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /*
+         * Assert that the configuration is updated with all the property=value
+         * pairs for the same local pid from all the processed files.
+         */
+        verifyValueOfConfigurationProperty("local.pid", "first.property", "first.value")
+        verifyValueOfConfigurationProperty("local.pid", "second.property", "second.value")
+        verifyValueOfConfigurationProperty("local.pid", "third.property", "third.value")
+        verifyValueOfConfigurationProperty("local.pid", "fourth.property", "fourth.value")
+    }
+
+    @Test
+    public void 'properties for the same local PID in different files must be overridden in the order they were last modified'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/local_pid_different_files_conflict_conf"
+        def servicesDirectory = "local_pid_different_files_conflict_services"
+        def defaultConfigFilePath = "$configDirectory/local.pid.default.file.cfg"
+        def lastModifiedFileName = "last.modified.service.file.cfg"
+
+        /* 
+         * Every file from servicesDirectory contains this property, but with different value.
+         * The value for this property in the last processed file must override the previous
+         * values for the same property in the configuration.
+         */
+        def conflictProperty = "property"
+
+        File fileToModify = new File("$configDirectory/$servicesDirectory/$lastModifiedFileName")
+
+        // Modify this file, so that we are sure it is the last modified file in servicesDirectory.
+        modifyFile(fileToModify)
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        String value = getLastModifiedValueForPoperty("$configDirectory/$servicesDirectory", conflictProperty)
+
+        /*
+         * Assert that the property for the same local pid in the last modified file
+         * has overridden the other properties for that pid from previously modified files.
+         */
+        verifyValueOfConfigurationProperty("local.conflict.pid", conflictProperty, value)
+    }
+
+    @Test
+    public void 'when property=value pairs for a global PID are in different files, they are still associated with that PID'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/global_pid_different_files_no_conflict_conf"
+        def servicesDirectory = "global_pid_different_files_no_conflict_services"
+        def defaultConfigFilePath = "$configDirectory/global.pid.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /*
+         * Assert that the configuration is updated with all the property=value
+         * pairs for the same global pid from all the processed files.
+         */
+        verifyValueOfConfigurationProperty("different.files.global.pid", "first.property", "first.value")
+        verifyValueOfConfigurationProperty("different.files.global.pid", "second.property", "second.value")
+        verifyValueOfConfigurationProperty("different.files.global.pid", "third.property", "third.value")
+        verifyValueOfConfigurationProperty("different.files.global.pid", "fourth.property", "fourth.value")
+    }
+
+    @Test
+    public void 'properties for the same global PID in different files must be overridden in the order they were last modified'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/global_pid_different_files_conflict_conf"
+        def servicesDirectory = "global_pid_different_files_conflict_services"
+        def defaultConfigFilePath = "$configDirectory/global.pid.default.file.cfg"
+        def lastModifiedFileName = "global.pid.last.modified.service.file.cfg"
+
+        /* 
+         * Every file from servicesDirectory contains this property, but with different value.
+         * The value for this property in the last processed file will override the previous
+         * values for the same property in the configuration.
+         */
+        def conflictProperty = "property"
+
+        File fileToModify = new File("$configDirectory/$servicesDirectory/$lastModifiedFileName")
+
+        // Modify this file, so that we are sure it is the last modified file in servicesDirectory.
+        modifyFile(fileToModify)
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        String value = getLastModifiedValueForPoperty("$configDirectory/$servicesDirectory", conflictProperty)
+
+        /*
+         * Assert that the property for the same global pid in the last modified file 
+         * has overridden the other properties for that pid from previously modified files.
+         */
+        verifyValueOfConfigurationProperty("different.files.global.pid", conflictProperty, value)
+    }
+
+    @Test
+    public void 'the same local and global PIDs in different files are considered one PID'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/global_and_local_pid_different_files_conf"
+        def servicesDirectory = "global_and_local_pid_no_conflict_services"
+        def defaultConfigFilePath = "$configDirectory/global.and.local.pid.default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        // Assert that the configuration is updated with all the properties for a pid from all the processed files.
+        verifyValueOfConfigurationProperty("no.conflict.global.and.local.pid", "global.property", "global.value")
+        verifyValueOfConfigurationProperty("no.conflict.global.and.local.pid", "local.property", "local.value")
+    }
+
+    @Test
+    public void 'local PID is overridden by global PID in different file, if the file with the global one is modified last'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/global_and_local_pid_different_files_conf"
+        def servicesDirectory = "global_and_local_pid_overridden_local_services"
+        def defaultConfigFilePath = "$configDirectory/global.and.local.pid.default.file.cfg"
+        def lastModifiedFileName = "a.overriding.global.pid.service.file.cfg"
+
+        /*
+         * Both files(with local and global pid) contain this property, but with different value.
+         * The value for this property in the last processed file must override the previous 
+         * values for the same property in the configuration.
+         */
+        def conflictProperty = "global.and.local.property"
+
+        File fileToModify = new File("$configDirectory/$servicesDirectory/$lastModifiedFileName")
+
+        // Modify this file, so that we are sure it is the last modified file in servicesDirectory.
+        modifyFile(fileToModify)
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        String value = getLastModifiedValueForPoperty("$configDirectory/$servicesDirectory", conflictProperty)
+
+        /*
+         * Assert that the global pid from the last modified file
+         * has overridden the local pid from previously processed file.
+         */
+        verifyValueOfConfigurationProperty("overridden.local.pid", conflictProperty, value)
+    }
+
+    @Test
+    public void 'global PID is overridden by local PID in different file, if the file with the local one is modified last'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/global_and_local_pid_different_files_conf"
+        def servicesDirectory = "global_and_local_pid_overridden_global_services"
+        def defaultConfigFilePath = "$configDirectory/global.and.local.pid.default.file.cfg"
+        def lastModifiedFileName = "a.overriding.local.pid.service.file.cfg"
+
+        /*
+         * Both files(with local and global pid) contain this property, but with different value.
+         * The value for this property in the last processed file must override the previous 
+         * values for the same property in the configuration.
+         */
+        def conflictProperty = "global.and.local.property"
+
+        File fileToModify = new File("$configDirectory/$servicesDirectory/$lastModifiedFileName")
+
+        // Modify this file, so that we are sure it is the last modified file in servicesDirectory.
+        modifyFile(fileToModify)
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        String value = getLastModifiedValueForPoperty("$configDirectory/$servicesDirectory", conflictProperty)
+
+        /*
+         * Assert that the local pid from the last modified file
+         * has overridden the global pid from previously processed file.
+         */
+        verifyValueOfConfigurationProperty("overridden.global.pid", conflictProperty, value)
+    }
+
+    @Test
+    public void 'properties for PID in files in services directory must override default properties'(){
+
+        def configDirectory = "$CONFIGURATION_WATCH_DIRECTORY/default_vs_services_files_conf"
+        def servicesDirectory = "default_vs_services_files_services"
+        def defaultConfigFilePath = "$configDirectory/default.file.cfg"
+
+        initialize(configDirectory, servicesDirectory, defaultConfigFilePath)
+
+        /*
+         * Assert that a file from the services directory is processed
+         * after a file from the root directory, therefore the configuration
+         * is updated with properties from the file in the services directory.
+         */
+        verifyValueOfConfigurationProperty("default.and.service.global.pid", "property1", "value1.2")
+        verifyValueOfConfigurationProperty("default.and.service.local.pid", "property2", "value2.2")
+    }
+
+    private void initialize(String configDirectory, String serviceDirectory, String defaultConfigFile){
+
+        setSystemProperties(configDirectory, serviceDirectory, defaultConfigFile)
+
+        // Start the stopped component, so that the file in the root directory will be read.
+        context.enableComponent(CONFIG_DISPATCHER_COMPONENT_ID)
+    }
+
+    private void setSystemProperties(String configDirectory, String serviceDirectory, String defaultConfigFile){
+
+        setSystemProperty(ConfigConstants.CONFIG_DIR_PROG_ARGUMENT, configDirectory)
+        setSystemProperty(ConfigDispatcher.SERVICEDIR_PROG_ARGUMENT, serviceDirectory)
+        setSystemProperty(ConfigDispatcher.SERVICECFG_PROG_ARGUMENT, defaultConfigFile)
+    }
+
+    private void verifyValueOfConfigurationProperty(String pid, String property, String value){
+
+        /* We have to wait for all the files to be processed and the configuration to be updated.
+         * Sending events, related to modification of file, is a OS specific action.
+         * So when we check if a configuration is updated, we use separate waitForAssert-s
+         * in order to be sure that the events are processed before the assertion.
+         */
+        waitForAssert {
+            configuration = configAdmin.getConfiguration(pid)
+            assertThat "The configuration for the given pid cannot be found", configuration, is(notNullValue())
+        }
+        waitForAssert {
+            assertThat "There are no properties for the configuration", configuration.getProperties(), is(notNullValue())
+        }
+        waitForAssert {
+            assertThat "There is no such '$property' in the configuration properties", configuration.getProperties().get(property), is(notNullValue())
+        }
+        waitForAssert {
+            assertThat "The value of the property '$property' for pid '$pid' is not as expected",
+                    configuration.getProperties().get(property), is(equalTo(value))
+        }
+    }
+
+    private void verifyNotExistingConfigurationProperty(String pid, String property) {
+
+        /* 
+         * If a property is not present in the configuration's properties,
+         * configuration.getProperties().get(property) should return null.
+         * 
+         * Sending events, related to modification of file, is a OS specific action.
+         * So when we check if a configuration is updated, we use separate waitForAssert-s
+         * in order to be sure that the events are processed before the assertion.
+         */
+        waitForAssert {
+            configuration = configAdmin.getConfiguration(pid)
+            assertThat "The configuration for the given pid cannot be found", configuration, is(notNullValue())
+        }
+        waitForAssert {
+            assertThat "There are no properties for the configuration", configuration.getProperties(), is(notNullValue())
+        }
+        waitForAssert {
+            assertThat "There should not be such '$property' in the configuration properties", configuration.getProperties().get(property), is(nullValue())
+        }
+    }
+
+    private void verifyNoPropertiesForConfiguration(String pid){
+
+        // We have to wait for all the files to be processed and the configuration to be updated.
+        waitForAssert {
+            configuration = configAdmin.getConfiguration(pid)
+            assertThat "Configuration properties should not be present",
+                    configuration.getProperties(), is(nullValue())
+        }
+    }
+
+    private void modifyFile(File file){
+
+        RandomAccessFile raf
+        raf = new RandomAccessFile(file, "rw")
+        def initialLength = raf.length()
+
+        try{
+            file << "modification line"
+        } catch(IOException | FileNotFoundException e){
+            fail("An exception $e was thrown, while modifying the file $file.getPath()")
+        } finally {
+            // Delete modified contents by returning the initial length of the file.
+            raf.setLength(initialLength)
+            if(raf != null){
+                raf.close()
+            }
+        }
+    }
+
+    private String getLastModifiedValueForPoperty(String path, String property){
+
+        // This method will return null, if there are no files in the directory.
+        String value
+        FileInputStream fileInputStream
+        File file
+        try{
+            file = getLastModifiedFileFromDir(path)
+            if(file == null){
+                return null
+            }
+            fileInputStream = new FileInputStream(file)
+            List<String> lines = IOUtils.readLines(fileInputStream)
+            for(String line : lines){
+                if(line.contains("$property=")){
+                    value = StringUtils.substringAfter(line, "$property=")
+                }
+            }
+        } catch(IOException e){
+            fail("An exception $e was thrown, while reading from file $file.getPath()")
+        } finally{
+            if(fileInputStream != null){
+                fileInputStream.close()
+            }
+        }
+        return value
+    }
+
+    /*
+     * Mainly used the code, provided in
+     * http://stackoverflow.com/questions/2064694/how-do-i-find-the-last-modified-file-in-a-directory-in-java
+     */
+    private File getLastModifiedFileFromDir(String dirPath){
+        File dir = new File(dirPath)
+        File[] files = dir.listFiles()
+        if (files == null || files.length == 0) {
+            return null
+        }
+
+        File lastModifiedFile = files[0]
+        for (int i = 1; i < files.length; i++) {
+            if (lastModifiedFile.lastModified() < files[i].lastModified()) {
+                lastModifiedFile = files[i]
+            }
+        }
+        return lastModifiedFile
+    }
+
+    private static void setSystemProperty(String systemProperty, String initialValue){
+
+        if(initialValue != null){
+            System.setProperty(systemProperty, initialValue)
+        } else {
+            /* A system property cannot be set to null, it has to be cleared */
+            System.clearProperty(systemProperty)
+        }
+    }
+}

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * Copyright (c) 2014-2016 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,6 +19,8 @@ import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchEvent.Kind;
 import java.nio.file.WatchService;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
@@ -67,6 +69,7 @@ import org.slf4j.LoggerFactory;
  * "pid: com.acme.smarthome.security".
  *
  * @author Kai Kreuzer - Initial contribution and API
+ * @author Petar Valchev - Added sort by modification time, when configuration files are read
  */
 public class ConfigDispatcher extends AbstractWatchService {
 
@@ -192,6 +195,13 @@ public class ConfigDispatcher extends AbstractWatchService {
         File dir = new File(getSourcePath());
         if (dir.exists()) {
             File[] files = dir.listFiles();
+            // Sort the files by modification time,
+            // so that the last modified file is processed last.
+            Arrays.sort(files, new Comparator<File>() {
+                public int compare(File left, File right) {
+                    return Long.valueOf(left.lastModified()).compareTo(right.lastModified());
+                }
+            });
             for (File file : files) {
                 try {
                     processConfigFile(file);

--- a/bundles/config/pom.xml
+++ b/bundles/config/pom.xml
@@ -18,6 +18,7 @@
   <modules>
     <module>org.eclipse.smarthome.config.core</module>
     <module>org.eclipse.smarthome.config.dispatch</module>
+    <module>org.eclipse.smarthome.config.dispatch.test</module>
     <module>org.eclipse.smarthome.config.core.test</module>
     <module>org.eclipse.smarthome.config.discovery</module>
     <module>org.eclipse.smarthome.config.discovery.test</module>


### PR DESCRIPTION
There are 24 tests, 5 of which are ignored, because I think the behavior of the ConfigDispatcher in them is unexpected:
    1) **Incorrect Overriding** - I think that the configuration should be updated with the last modified value for a specific property. In ConfigDispatcher files are processed as listFiles() method ordered them and this order is never guaranteed(https://docs.oracle.com/javase/7/docs/api/java/io/File.html#listFiles()), i.e. the order can be alphabetical or some other order, which may cause the latest value for a property to be overridden by another value of the same property.
    2) **No Update On Delete** - On delete the file should be processed and the configurations should be updated, but in ConfigDispatcher, when file is deleted, it is only processed, but not updated. An update happens only when new content is added, but not when it is deleted.

As we have seen from https://github.com/eclipse/smarthome/pull/1597 and https://github.com/eclipse/smarthome/pull/2074, the API for files watching is platform dependent. These proposed tests are behaving exactly the same way on Windows and MAC.
