### PR TITLE
fix CME in ExpressionThreadPoolExecutor

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolManager.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -70,7 +71,7 @@ public class ExpressionThreadPoolManager extends ThreadPoolManager {
     public static class ExpressionThreadPoolExecutor extends ScheduledThreadPoolExecutor {
 
         private List<Runnable> running = Collections.synchronizedList(new ArrayList<Runnable>());
-        private Map<Expression, Runnable> scheduled = Collections.synchronizedMap(new HashMap<Expression, Runnable>());
+        private Map<Expression, Runnable> scheduled = new ConcurrentHashMap<>();
         private Map<Runnable, Future<?>> futures = Collections.synchronizedMap(new HashMap<Runnable, Future<?>>());
         private Map<Future<?>, Date> timestamps = Collections.synchronizedMap(new HashMap<Future<?>, Date>());
         private Thread monitor;


### PR DESCRIPTION
We must not iterate on a `synchronized map` without manually
synchronization statements.

See JavaDoc:
https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedMap(java.util.Map)

```text
It is imperative that the user manually synchronize on the returned map when iterating over any of its collection views:
```
```
  Map m = Collections.synchronizedMap(new HashMap());
      ...
  Set s = m.keySet();  // Needn't be in synchronized block
      ...
  synchronized (m) {  // Synchronizing on m, not s!
      Iterator i = s.iterator(); // Must be in synchronized block
      while (i.hasNext())
          foo(i.next());
  }
```
```text
Failure to follow this advice may result in non-deterministic behavior.
```

Fixes: https://github.com/eclipse/smarthome/issues/2107