### PR TITLE
Fixes startup and reload behaviour of DSL rules

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/ModelRepositoryImpl.java
@@ -184,6 +184,7 @@ public class ModelRepositoryImpl implements ModelRepository {
                         // The quick & dirts solution is to reparse the whole resource.
                         // We trigger this by dummy updating the resource.
                         xtextResource.update(1, 0, "");
+                        notifyListeners(resource.getURI().lastSegment(), EventType.MODIFIED);
                     }
                 }
             }

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptImpl.java
@@ -89,8 +89,8 @@ public class ScriptImpl implements Script {
                 if (e instanceof ScriptExecutionException) {
                     throw (ScriptExecutionException) e;
                 } else {
-                    throw new ScriptExecutionException("An error occured during the script execution: "
-                            + e.getMessage(), e);
+                    throw new ScriptExecutionException(
+                            "An error occured during the script execution: " + e.getMessage(), e);
                 }
             }
         } else {


### PR DESCRIPTION
- Make sure that only loaded rule resources are used.
- When items are changed, notify the rule engine that all rules are reloaded.

Signed-off-by: Kai Kreuzer <kai@openhab.org>