### PR TITLE
add / remove provider logic requires active component

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleRegistryImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleRegistryImpl.java
@@ -87,7 +87,8 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation and other fixes
  * @author Benedikt Niehues - added events for rules
  */
-public class RuleRegistryImpl extends AbstractRegistry<Rule, String>implements RuleRegistry, StatusInfoCallback {
+public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvider>
+        implements RuleRegistry, StatusInfoCallback {
 
     private RuleEngine ruleEngine;
     private Logger logger;
@@ -105,6 +106,7 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String>implements R
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public RuleRegistryImpl(RuleEngine ruleEngine, TemplateManager tManager, final BundleContext bc) {
+        super(null);
         logger = LoggerFactory.getLogger(getClass());
         this.ruleEngine = ruleEngine;
         this.templateManager = tManager;

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ItemChannelLinkRegistry.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ItemChannelLinkRegistry.xml
@@ -13,7 +13,6 @@
    <service>
       <provide interface="org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry"/>
    </service>
-   <reference bind="addProvider" cardinality="0..n" interface="org.eclipse.smarthome.core.thing.link.ItemChannelLinkProvider" name="ItemChannelLinkProvider" policy="dynamic" unbind="removeProvider"/>
    <reference bind="setManagedProvider" cardinality="0..1" interface="org.eclipse.smarthome.core.thing.link.ManagedItemChannelLinkProvider" name="ManagedItemChannelLinkProvider" policy="dynamic" unbind="removeManagedProvider"/>
    <reference bind="setThingRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="static" unbind="unsetThingRegistry"/>
    <reference bind="setEventPublisher" cardinality="0..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="dynamic" unbind="unsetEventPublisher"/>

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingRegistry.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingRegistry.xml
@@ -13,7 +13,6 @@
    <service>
       <provide interface="org.eclipse.smarthome.core.thing.ThingRegistry"/>
    </service>
-   <reference bind="addProvider" cardinality="0..n" interface="org.eclipse.smarthome.core.thing.ThingProvider" name="ThingProvider" policy="dynamic" unbind="removeProvider"/>
    <reference bind="setManagedProvider" cardinality="0..1" interface="org.eclipse.smarthome.core.thing.ManagedThingProvider" name="ManagedThingProvider" policy="dynamic" unbind="removeManagedProvider"/>
    <reference bind="setEventPublisher" cardinality="0..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="dynamic" unbind="unsetEventPublisher"/>
    <reference bind="addThingHandlerFactory" cardinality="0..n" interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory" name="ThingHandlerFactory" policy="dynamic" unbind="removeThingHandlerFactory"/>   

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -18,6 +18,7 @@ import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingProvider;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -36,13 +37,17 @@ import org.slf4j.LoggerFactory;
  * @author Chris Jackson - ensure thing added event is sent before linked events
  * @auther Thomas Höfer - Added config description validation exception to updateConfiguration operation
  */
-public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID>implements ThingRegistry {
+public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingProvider> implements ThingRegistry {
 
     private Logger logger = LoggerFactory.getLogger(ThingRegistryImpl.class.getName());
 
     private List<ThingTracker> thingTrackers = new CopyOnWriteArrayList<>();
 
     private List<ThingHandlerFactory> thingHandlerFactories = new CopyOnWriteArrayList<>();
+
+    public ThingRegistryImpl() {
+        super(ThingProvider.class);
+    }
 
     /**
      * Adds a thing tracker.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLinkRegistry.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
+import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.thing.UID;
 
 /**
@@ -23,7 +24,12 @@ import org.eclipse.smarthome.core.thing.UID;
  * @param <L>
  *            Concrete type of the abstract link
  */
-public abstract class AbstractLinkRegistry<L extends AbstractLink> extends AbstractRegistry<L, String> {
+public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Provider<L>>
+        extends AbstractRegistry<L, String, P> {
+
+    protected AbstractLinkRegistry(final Class<P> providerClazz) {
+        super(providerClazz);
+    }
 
     /**
      * Returns if an item for a given item name is linked to a channel or thing for a

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
@@ -24,9 +24,13 @@ import org.eclipse.smarthome.core.thing.link.events.LinkEventFactory;
  * @author Dennis Nobel - Initial contribution
  *
  */
-public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLink> {
+public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLink, ItemChannelLinkProvider> {
 
     private ThingRegistry thingRegistry;
+
+    public ItemChannelLinkRegistry() {
+        super(ItemChannelLinkProvider.class);
+    }
 
     /**
      * Returns a set of bound channels for the given item name.

--- a/bundles/core/org.eclipse.smarthome.core/OSGI-INF/itemregistry.xml
+++ b/bundles/core/org.eclipse.smarthome.core/OSGI-INF/itemregistry.xml
@@ -10,7 +10,6 @@
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.core.itemregistry">
    <implementation class="org.eclipse.smarthome.core.internal.items.ItemRegistryImpl"/>
-   <reference bind="addProvider" cardinality="0..n" interface="org.eclipse.smarthome.core.items.ItemProvider" name="ItemProvider" policy="dynamic" unbind="removeProvider"/>
    <reference bind="setManagedProvider" cardinality="0..1" interface="org.eclipse.smarthome.core.items.ManagedItemProvider" name="ManagedItemProvider" policy="dynamic" unbind="removeManagedProvider"/>
    <service>
       <provide interface="org.eclipse.smarthome.core.items.ItemRegistry"/>

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -51,7 +51,8 @@ import org.slf4j.LoggerFactory;
  * @author Stefan Bußweiler - Migration to new event mechanism
  *
  */
-public class ItemRegistryImpl extends AbstractRegistry<Item, String>implements ItemRegistry, ItemsChangeListener {
+public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvider>
+        implements ItemRegistry, ItemsChangeListener {
 
     private final Logger logger = LoggerFactory.getLogger(ItemRegistryImpl.class);
 
@@ -61,6 +62,10 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String>implements I
             .synchronizedList(new ArrayList<StateDescriptionProvider>());
 
     private Map<String, Integer> stateDescriptionProviderRanking = new ConcurrentHashMap<>();
+
+    public ItemRegistryImpl() {
+        super(ItemProvider.class);
+    }
 
     @Override
     public void allItemsChanged(ItemProvider provider, Collection<String> oldItemNames) {
@@ -391,14 +396,17 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String>implements I
         postEvent(ItemEventFactory.createUpdateEvent(element, oldElement));
     }
 
-    protected void activate(ComponentContext componentContext) {
+    protected void activate(final ComponentContext componentContext) {
+        super.activate(componentContext.getBundleContext());
         stateDescriptionProviderTracker = new StateDescriptionProviderTracker(componentContext.getBundleContext());
         stateDescriptionProviderTracker.open();
     }
 
-    protected void deactivate(ComponentContext componentContext) {
+    @Override
+    protected void deactivate() {
         stateDescriptionProviderTracker.close();
         stateDescriptionProviderTracker = null;
+        super.deactivate();
     }
 
     private final class StateDescriptionProviderTracker


### PR DESCRIPTION
After some modifications of the ItemChannelLinkRegistry yesterday (which
have been never going upstream) I realized that the AbstractRegistry
implementation relies on an active component if provider are added (and
removed).
Using the multiple (0..n) cardinality and policy static the providers
could be added / removed if the component is active but also if the
component is not active.
Regardless if the error is currently thrown this is an error in the
design and should be fixed.

This PR introduce a service tracker to track the providers as long as
the component is active.
