### PR TITLE
Show only values of dropdown on control page

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/item.state.dropdown.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/item.state.dropdown.html
@@ -1,6 +1,6 @@
 
 <div layout="row" layout-align="end center" flex="100">
 	<div class="container options">
-		<md-select placeholder="Select" class="controlSelect" ng-model="item.state" ng-change="updateState()" aria-label={{item.label}}> <md-option ng-value="option.value" ng-repeat="option in item.stateDescription.options"> {{option.label}} ({{option.value}}) </md-option> </md-select>
+		<md-select placeholder="Select" class="controlSelect" ng-model="item.state" ng-change="updateState()" aria-label={{item.label}}> <md-option ng-value="option.value" ng-repeat="option in item.stateDescription.options"> {{option.label}} </md-option> </md-select>
 	</div>
 </div>


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/2134
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>