### PR TITLE
WIP: Add test to ensure that group functions persist

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/storage/ManagedItemProviderOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/storage/ManagedItemProviderOSGiTest.groovy
@@ -21,8 +21,11 @@ import org.eclipse.smarthome.core.items.ManagedItemProvider.PersistedItem
 import org.eclipse.smarthome.core.library.items.NumberItem
 import org.eclipse.smarthome.core.library.items.StringItem
 import org.eclipse.smarthome.core.library.items.SwitchItem
-import org.eclipse.smarthome.core.library.types.StringType
+import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction.And
 import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction.Avg
+import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction.Sum
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType
 import org.eclipse.smarthome.core.types.Command
 import org.eclipse.smarthome.core.types.State
 import org.eclipse.smarthome.test.OSGiTest
@@ -311,4 +314,42 @@ class ManagedItemProviderOSGiTest extends OSGiTest {
         assertThat itemProvider.getAll().size(), is(0)
     }
 
+
+    @Test
+	void 'assert group functions are stored and retrieved as well'() {
+
+        assertThat itemProvider.getAll().size(), is(0)
+
+        def function1 = new And(OnOffType.ON, OnOffType.OFF)
+        def function2 = new Sum()
+        def item1 = new GroupItem('GroupItem1', new SwitchItem('Switch'), function1)
+        def item2 = new GroupItem('GroupItem2', new NumberItem(), function2)
+
+        assertThat item1.name, is('GroupItem1')
+        assertThat item1.function, isA(And.class)
+        assertThat item1.function.parameters, is([OnOffType.ON, OnOffType.OFF] as State[])
+
+        assertThat item2.name, is('GroupItem2')
+        assertThat item2.function, isA(Sum.class)
+        assertThat item2.function.parameters, is([] as State[])
+
+        itemProvider.add item1
+        itemProvider.add item2
+
+        def items = itemProvider.getAll()
+        assertThat items.size(), is(2)
+
+        def result1 = itemProvider.remove 'GroupItem1'
+        def result2 = itemProvider.remove 'GroupItem2'
+
+        assertThat result1.name, is('GroupItem1')
+        assertThat result1.function, isA(And.class)
+        assertThat result1.function.parameters, is([OnOffType.ON, OnOffType.OFF] as State[])
+
+        assertThat result2.name, is('GroupItem2')
+        assertThat result2.function, isA(Sum.class)
+        assertThat result2.function.parameters, is([] as State[])
+
+        assertThat itemProvider.getAll().size(), is(0)
+    }
 }


### PR DESCRIPTION
With 1cf093e we can create group items with group functions via the REST API, but the group functions are not currently persisted: ManagedItemProvider.PersistedItem is missing affordances to store group functions and ManagedItemProvider is missing code making use of them.

This change adds a test to ensure that group functions are saved and restored correctly. The test is currently failing but might benefit the future implementer.

Signed-off-by: Martin Kühl martin.kuehl@gmail.com
