### PR TITLE
removed required flag for locale

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/ESH-INF/config/locale.xml
+++ b/bundles/core/org.eclipse.smarthome.core/ESH-INF/config/locale.xml
@@ -5,10 +5,10 @@
         http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="system:locale">
-		<parameter name="language" type="text" required="true">
+		<parameter name="language" type="text">
 			<label>Language</label>
 			<description><![CDATA[
-                 <p>The default language that should be used.</p>
+                 <p>The default language that should be used. If not specified, the system default locale is used.</p>
                  <p>The ISO 639 alpha-2 or alpha-3 language code (if there is no alpha-2 one).</p>
                  <p>Example: "en" (English), "de" (German), "ja" (Japanese), "kok" (Konkani)</p>
              ]]>


### PR DESCRIPTION
The system configuration currently always shows an error, because no default value is set for the locale:

<img width="547" alt="screen shot 2016-09-14 at 09 58 26" src="https://cloud.githubusercontent.com/assets/3244965/18504306/ead2c50e-7a61-11e6-9cea-b062b2115117.png">

As it is not mandatory for the user to fill out something, this field should not be defined as required.
This PR fixes this.

Signed-off-by: Kai Kreuzer <kai@openhab.org>