### PR TITLE
avoid NPE in LIFX handler if no url info is set yet

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
@@ -2007,6 +2007,9 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
     }
 
     private boolean isPlayingStream(String currentURI) {
+        if (currentURI == null) {
+            return false;
+        }
         return currentURI.contains("x-sonosapi-stream:");
     }
 


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>