### PR TITLE
Improve logging of ConfigStatus events

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusService.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusService.java
@@ -85,7 +85,7 @@ public final class ConfigStatusService implements ConfigStatusCallback {
 
                 if (info != null) {
                     if (eventPublisher != null) {
-                        eventPublisher.post(new ConfigStatusInfoEvent(configStatusSource.getTopic(), info, null));
+                        eventPublisher.post(new ConfigStatusInfoEvent(configStatusSource.getTopic(), info));
                     } else {
                         logger.warn("EventPublisher not available. Cannot post new config status for entity "
                                 + configStatusSource.entityId);

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/events/ConfigStatusEventFactory.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/events/ConfigStatusEventFactory.java
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.config.core.status.events;
 
 import java.util.Set;
 
+import org.eclipse.smarthome.config.core.status.ConfigStatusInfo;
 import org.eclipse.smarthome.core.events.AbstractEventFactory;
 import org.eclipse.smarthome.core.events.Event;
 
@@ -31,10 +32,19 @@ public final class ConfigStatusEventFactory extends AbstractEventFactory {
         super(SUPPORTED_EVENT_TYPES);
     }
 
+    private Event createStatusInfoEvent(String topic, String payload) throws Exception {
+        String[] topicElements = getTopicElements(topic);
+        if (topicElements.length != 5) {
+            throw new IllegalArgumentException("ConfigStatusInfoEvent creation failed, invalid topic: " + topic);
+        }
+        ConfigStatusInfo thingStatusInfo = deserializePayload(payload, ConfigStatusInfo.class);
+        return new ConfigStatusInfoEvent(topic, thingStatusInfo);
+    }
+
     @Override
     protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
         if (ConfigStatusInfoEvent.TYPE.equals(eventType)) {
-            return new ConfigStatusInfoEvent(topic, payload, source);
+            return createStatusInfoEvent(topic, payload);
         }
         throw new IllegalArgumentException(
                 eventType + " not supported by " + ConfigStatusEventFactory.class.getSimpleName());

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/events/ConfigStatusInfoEvent.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/events/ConfigStatusInfoEvent.java
@@ -21,6 +21,8 @@ public final class ConfigStatusInfoEvent extends AbstractEvent {
 
     static final String TYPE = "ConfigStatusInfoEvent";
 
+    private final ConfigStatusInfo configStatusInfo;
+
     private static final Gson gson = new Gson();
 
     /**
@@ -28,25 +30,19 @@ public final class ConfigStatusInfoEvent extends AbstractEvent {
      *
      * @param topic the topic of the event
      * @param configStatusInfo the corresponding configuration status information to be put as payload into the event
-     * @param source the source of the event
      */
-    public ConfigStatusInfoEvent(String topic, ConfigStatusInfo configStatusInfo, String source) {
-        this(topic, gson.toJson(configStatusInfo), source);
-    }
-
-    /**
-     * Creates a new {@link ConfigStatusInfoEvent}.
-     *
-     * @param topic the topic of the event
-     * @param payload the payload of the event
-     * @param source the source of the event
-     */
-    ConfigStatusInfoEvent(String topic, String payload, String source) {
-        super(topic, payload, source);
+    public ConfigStatusInfoEvent(String topic, ConfigStatusInfo configStatusInfo) {
+        super(topic, gson.toJson(configStatusInfo), null);
+        this.configStatusInfo = configStatusInfo;
     }
 
     @Override
     public String getType() {
         return TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return configStatusInfo.toString();
     }
 }


### PR DESCRIPTION
Adapted implementation to be similar to ThingStatus events, which enables a proper toString() implementation (and thus improves event log files).

Signed-off-by: Kai Kreuzer <kai@openhab.org>