### PR TITLE
Bug fix: initialize linked items array

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.repositories.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.repositories.js
@@ -195,6 +195,7 @@ angular.module('PaperUI.services.repositories', []).factory('bindingRepository',
                     return channel.uid == link.channelUID;
                 });
                 if (channel.length > 0) {
+                    channel[0].linkedItems = channel[0].linkedItems ? channel[0].linkedItems : [];
                     channel[0].linkedItems.push(link.itemName);
                 }
             });


### PR DESCRIPTION
Item linking events cause script errors when a thing is created in simple mode. This commit fixes that.
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>