### PR TITLE
typo in Firmware#isPrerequisiteVersion method name

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/FirmwareTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/FirmwareTest.groovy
@@ -132,30 +132,30 @@ final class FirmwareTest extends OSGiTest {
 
     @Test
     void 'test firmware prerequisite version'() {
-        assertThat valpha.isPrerequisteVersion(vbeta.getVersion()), is(false)
-        assertThat valpha.isPrerequisteVersion(null), is(false)
+        assertThat valpha.isPrerequisiteVersion(vbeta.getVersion()), is(false)
+        assertThat valpha.isPrerequisiteVersion(null), is(false)
 
-        assertThat vbeta.isPrerequisteVersion(valpha1.getVersion()), is(true)
-        assertThat vbeta.isPrerequisteVersion(valpha.getVersion()), is(false)
+        assertThat vbeta.isPrerequisiteVersion(valpha1.getVersion()), is(true)
+        assertThat vbeta.isPrerequisiteVersion(valpha.getVersion()), is(false)
 
-        assertThat vgamma.isPrerequisteVersion(vbetafix.getVersion()), is(true)
-        assertThat vgamma.isPrerequisteVersion(vbeta.getVersion()), is(false)
+        assertThat vgamma.isPrerequisiteVersion(vbetafix.getVersion()), is(true)
+        assertThat vgamma.isPrerequisiteVersion(vbeta.getVersion()), is(false)
 
-        assertThat vdelta.isPrerequisteVersion(vgamma.getVersion()), is(false)
+        assertThat vdelta.isPrerequisiteVersion(vgamma.getVersion()), is(false)
 
-        assertThat v1dot0dot2.isPrerequisteVersion(v1dot0dot1.getVersion()), is(true)
-        assertThat v1dot0dot2.isPrerequisteVersion(v1dot0dot0.getVersion()), is(false)
-        assertThat v1dot0dot2.isPrerequisteVersion(v0dot0dot9.getVersion()), is(false)
+        assertThat v1dot0dot2.isPrerequisiteVersion(v1dot0dot1.getVersion()), is(true)
+        assertThat v1dot0dot2.isPrerequisiteVersion(v1dot0dot0.getVersion()), is(false)
+        assertThat v1dot0dot2.isPrerequisiteVersion(v0dot0dot9.getVersion()), is(false)
 
-        assertThat v1dot1dot0.isPrerequisteVersion(v1dash1.getVersion()), is(true)
-        assertThat v1dot1dot0.isPrerequisteVersion(v1dot0dot3.getVersion()), is(true)
-        assertThat v1dot1dot0.isPrerequisteVersion(v1dot0dot2dashfix.getVersion()), is(true)
-        assertThat v1dot1dot0.isPrerequisteVersion(v1dot0dot2.getVersion()), is(false)
-        assertThat v1dot1dot0.isPrerequisteVersion(v1dot0dot1.getVersion()), is(false)
-        assertThat v1dot1dot0.isPrerequisteVersion(v0dot0dot9.getVersion()), is(false)
+        assertThat v1dot1dot0.isPrerequisiteVersion(v1dash1.getVersion()), is(true)
+        assertThat v1dot1dot0.isPrerequisiteVersion(v1dot0dot3.getVersion()), is(true)
+        assertThat v1dot1dot0.isPrerequisiteVersion(v1dot0dot2dashfix.getVersion()), is(true)
+        assertThat v1dot1dot0.isPrerequisiteVersion(v1dot0dot2.getVersion()), is(false)
+        assertThat v1dot1dot0.isPrerequisiteVersion(v1dot0dot1.getVersion()), is(false)
+        assertThat v1dot1dot0.isPrerequisiteVersion(v0dot0dot9.getVersion()), is(false)
 
-        assertThat v2dot0dot0.isPrerequisteVersion(v1dot11_2dasha.getVersion()), is(true)
-        assertThat v2dot0dot0.isPrerequisteVersion(v1dash11dot2_1.getVersion()), is(false)
+        assertThat v2dot0dot0.isPrerequisiteVersion(v1dot11_2dasha.getVersion()), is(true)
+        assertThat v2dot0dot0.isPrerequisiteVersion(v1dash11dot2_1.getVersion()), is(false)
     }
 
     @Test(expected=IllegalArgumentException)

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/Firmware.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/Firmware.java
@@ -251,7 +251,7 @@ public final class Firmware implements Comparable<Firmware> {
      *
      * @return true, if this firmware is valid prerequisite version of the given firmware version, otherwise false
      */
-    public boolean isPrerequisteVersion(String firmwareVersion) {
+    public boolean isPrerequisiteVersion(String firmwareVersion) {
         if (internalPrerequisiteVersion == null || firmwareVersion == null) {
             return false;
         }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
@@ -340,7 +340,7 @@ public final class FirmwareUpdateService implements EventSubscriber {
         }
 
         String firmwareVersion = getThingFirmwareVersion(firmwareUpdateHandler);
-        if (firmware.getPrerequisiteVersion() != null && !firmware.isPrerequisteVersion(firmwareVersion)) {
+        if (firmware.getPrerequisiteVersion() != null && !firmware.isPrerequisiteVersion(firmwareVersion)) {
             throw new IllegalArgumentException(String.format(
                     "Firmware with UID %s requires at least firmware version %s to get installed. But the current firmware version of the thing with UID %s is %s.",
                     firmware.getUID(), firmware.getPrerequisiteVersion(), thing.getUID(), firmwareVersion));


### PR DESCRIPTION
changed it from isPrerequisteVersion to isPrerequisiteVersion

Signed-off-by: Miki Jankov <miki.jankov87@gmail.com>