### PR TITLE
there is no resources directory in core.audio

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio/.classpath
+++ b/bundles/core/org.eclipse.smarthome.core.audio/.classpath
@@ -3,6 +3,5 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/core/org.eclipse.smarthome.core.audio/build.properties
+++ b/bundles/core/org.eclipse.smarthome.core.audio/build.properties
@@ -3,5 +3,4 @@ bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
                about.html
-source.. = src/main/java/,\
-           src/main/resources/
+source.. = src/main/java/


### PR DESCRIPTION
Without this changes the IDE complains about missing resource directory.
As an empty directory gets lost using Git, we should remove it from the build path