### PR TITLE
Type: differ between a full and simple string representation

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/GroupItemStateChangedEvent.java
@@ -46,8 +46,6 @@ public class GroupItemStateChangedEvent extends ItemStateChangedEvent {
 
     @Override
     public String toString() {
-        return itemName + " changed from " + oldItemState.toString() + " to " + itemState.toString() + " through "
-                + memberName;
-
+        return String.format("%s through %s", super.toString(), memberName);
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -219,7 +219,7 @@ public class ItemEventFactory extends AbstractEventFactory {
         assertValidArguments(itemName, state, "state");
         String topic = buildTopic(ITEM_STATE_EVENT_TOPIC, itemName);
         ItemEventPayloadBean bean = new ItemEventPayloadBean(state.getClass().getSimpleName(),
-                state.toFullTypeString());
+                state.toFullString());
         String payload = serializePayload(bean);
         return new ItemStateEvent(topic, payload, itemName, state, source);
     }
@@ -253,8 +253,8 @@ public class ItemEventFactory extends AbstractEventFactory {
         assertValidArguments(itemName, newState, "state");
         String topic = buildTopic(ITEM_STATE_CHANGED_EVENT_TOPIC, itemName);
         ItemStateChangedEventPayloadBean bean = new ItemStateChangedEventPayloadBean(
-                newState.getClass().getSimpleName(), newState.toFullTypeString(), oldState.getClass().getSimpleName(),
-                oldState.toFullTypeString());
+                newState.getClass().getSimpleName(), newState.toFullString(), oldState.getClass().getSimpleName(),
+                oldState.toFullString());
         String payload = serializePayload(bean);
         return new ItemStateChangedEvent(topic, payload, itemName, newState, oldState);
     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -218,7 +218,8 @@ public class ItemEventFactory extends AbstractEventFactory {
     public static ItemStateEvent createStateEvent(String itemName, State state, String source) {
         assertValidArguments(itemName, state, "state");
         String topic = buildTopic(ITEM_STATE_EVENT_TOPIC, itemName);
-        ItemEventPayloadBean bean = new ItemEventPayloadBean(state.getClass().getSimpleName(), state.toString());
+        ItemEventPayloadBean bean = new ItemEventPayloadBean(state.getClass().getSimpleName(),
+                state.toFullTypeString());
         String payload = serializePayload(bean);
         return new ItemStateEvent(topic, payload, itemName, state, source);
     }
@@ -252,8 +253,8 @@ public class ItemEventFactory extends AbstractEventFactory {
         assertValidArguments(itemName, newState, "state");
         String topic = buildTopic(ITEM_STATE_CHANGED_EVENT_TOPIC, itemName);
         ItemStateChangedEventPayloadBean bean = new ItemStateChangedEventPayloadBean(
-                newState.getClass().getSimpleName(), newState.toString(), oldState.getClass().getSimpleName(),
-                oldState.toString());
+                newState.getClass().getSimpleName(), newState.toFullTypeString(), oldState.getClass().getSimpleName(),
+                oldState.toFullTypeString());
         String payload = serializePayload(bean);
         return new ItemStateChangedEvent(topic, payload, itemName, newState, oldState);
     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateChangedEvent.java
@@ -81,7 +81,7 @@ public class ItemStateChangedEvent extends AbstractEvent {
 
     @Override
     public String toString() {
-        return itemName + " changed from " + oldItemState.toString() + " to " + itemState.toString();
+        return String.format("%s changed from %s to %s", itemName, oldItemState, itemState);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateEvent.java
@@ -13,7 +13,7 @@ import org.eclipse.smarthome.core.types.State;
 /**
  * {@link ItemStateEvent}s can be used to deliver item status updates through the Eclipse SmartHome event bus.
  * State events must be created with the {@link ItemEventFactory}.
- * 
+ *
  * @author Stefan Bußweiler - Initial contribution
  */
 public class ItemStateEvent extends AbstractEvent {
@@ -29,7 +29,7 @@ public class ItemStateEvent extends AbstractEvent {
 
     /**
      * Constructs a new item state event.
-     * 
+     *
      * @param topic the topic
      * @param payload the payload
      * @param itemName the item name
@@ -49,7 +49,7 @@ public class ItemStateEvent extends AbstractEvent {
 
     /**
      * Gets the item name.
-     * 
+     *
      * @return the item name
      */
     public String getItemName() {
@@ -58,7 +58,7 @@ public class ItemStateEvent extends AbstractEvent {
 
     /**
      * Gets the item state.
-     * 
+     *
      * @return the item state
      */
     public State getItemState() {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemStateEvent.java
@@ -67,7 +67,7 @@ public class ItemStateEvent extends AbstractEvent {
 
     @Override
     public String toString() {
-        return itemName + " updated to " + itemState.toString();
+        return String.format("%s updated to %s", itemName, itemState);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
@@ -84,6 +84,11 @@ public class DateTimeType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
         return new SimpleDateFormat(DATE_PATTERN_WITH_TZ_AND_MS).format(calendar.getTime());
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
@@ -84,11 +84,11 @@ public class DateTimeType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return new SimpleDateFormat(DATE_PATTERN_WITH_TZ_AND_MS).format(calendar.getTime());
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -51,6 +51,11 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
 
     @Override
     public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
         return value.toPlainString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -51,11 +51,11 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return value.toPlainString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -90,18 +90,23 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (!(obj instanceof DecimalType))
+        }
+        if (!(obj instanceof DecimalType)) {
             return false;
+        }
         DecimalType other = (DecimalType) obj;
         if (value == null) {
-            if (other.value != null)
+            if (other.value != null) {
                 return false;
-        } else if (value.compareTo(other.value) != 0)
+            }
+        } else if (value.compareTo(other.value) != 0) {
             return false;
+        }
         return true;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -162,6 +162,11 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
 
     @Override
     public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
         return getHue() + "," + getSaturation() + "," + getBrightness();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -162,11 +162,11 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return getHue() + "," + getSaturation() + "," + getBrightness();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
@@ -11,7 +11,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 
 public enum IncreaseDecreaseType implements PrimitiveType, Command {
-    INCREASE, DECREASE;
+    INCREASE,
+    DECREASE;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
@@ -19,4 +19,14 @@ public enum IncreaseDecreaseType implements PrimitiveType, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
@@ -21,11 +21,11 @@ public enum IncreaseDecreaseType implements PrimitiveType, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/NextPreviousType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/NextPreviousType.java
@@ -25,4 +25,14 @@ public enum NextPreviousType implements PrimitiveType, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/NextPreviousType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/NextPreviousType.java
@@ -27,11 +27,11 @@ public enum NextPreviousType implements PrimitiveType, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/NextPreviousType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/NextPreviousType.java
@@ -17,7 +17,8 @@ import org.eclipse.smarthome.core.types.PrimitiveType;
  * @author Alex Tugarev
  */
 public enum NextPreviousType implements PrimitiveType, Command {
-    NEXT, PREVIOUS;
+    NEXT,
+    PREVIOUS;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
@@ -22,11 +22,11 @@ public enum OnOffType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
@@ -20,4 +20,14 @@ public enum OnOffType implements PrimitiveType, State, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
@@ -12,7 +12,8 @@ import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
 
 public enum OnOffType implements PrimitiveType, State, Command {
-    ON, OFF;
+    ON,
+    OFF;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
@@ -22,11 +22,11 @@ public enum OpenClosedType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
@@ -20,4 +20,14 @@ public enum OpenClosedType implements PrimitiveType, State, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
@@ -12,7 +12,8 @@ import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
 
 public enum OpenClosedType implements PrimitiveType, State, Command {
-    OPEN, CLOSED;
+    OPEN,
+    CLOSED;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PlayPauseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PlayPauseType.java
@@ -28,11 +28,11 @@ public enum PlayPauseType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PlayPauseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PlayPauseType.java
@@ -18,7 +18,8 @@ import org.eclipse.smarthome.core.types.State;
  * @author Alex Tugarev
  */
 public enum PlayPauseType implements PrimitiveType, State, Command {
-    PLAY, PAUSE;
+    PLAY,
+    PAUSE;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PlayPauseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PlayPauseType.java
@@ -26,4 +26,14 @@ public enum PlayPauseType implements PrimitiveType, State, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
@@ -156,6 +156,11 @@ public class PointType implements ComplexType, Command, State {
 
     @Override
     public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
         StringBuilder sb = new StringBuilder(latitude.toPlainString());
         sb.append(',');
         sb.append(longitude.toPlainString());

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
@@ -156,11 +156,11 @@ public class PointType implements ComplexType, Command, State {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         StringBuilder sb = new StringBuilder(latitude.toPlainString());
         sb.append(',');
         sb.append(longitude.toPlainString());

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RawType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RawType.java
@@ -46,13 +46,13 @@ public class RawType implements PrimitiveType, State {
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return PortableBase64.getEncoder().encode(bytes);
     }
 
     @Override
     public String format(String pattern) {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RawType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RawType.java
@@ -60,15 +60,19 @@ public class RawType implements PrimitiveType, State {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         RawType other = (RawType) obj;
-        if (!Arrays.equals(bytes, other.bytes))
+        if (!Arrays.equals(bytes, other.bytes)) {
             return false;
+        }
         return true;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RawType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RawType.java
@@ -42,12 +42,17 @@ public class RawType implements PrimitiveType, State {
 
     @Override
     public String toString() {
+        return String.format("raw type: %d bytes", bytes.length);
+    }
+
+    @Override
+    public String toFullTypeString() {
         return PortableBase64.getEncoder().encode(bytes);
     }
 
     @Override
     public String format(String pattern) {
-        return toString();
+        return toFullTypeString();
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RewindFastforwardType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RewindFastforwardType.java
@@ -28,11 +28,11 @@ public enum RewindFastforwardType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RewindFastforwardType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RewindFastforwardType.java
@@ -26,4 +26,14 @@ public enum RewindFastforwardType implements PrimitiveType, State, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RewindFastforwardType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RewindFastforwardType.java
@@ -18,7 +18,8 @@ import org.eclipse.smarthome.core.types.State;
  * @author Alex Tugarev
  */
 public enum RewindFastforwardType implements PrimitiveType, State, Command {
-    REWIND, FASTFORWARD;
+    REWIND,
+    FASTFORWARD;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StopMoveType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StopMoveType.java
@@ -11,7 +11,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 
 public enum StopMoveType implements PrimitiveType, Command {
-    STOP, MOVE;
+    STOP,
+    MOVE;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StopMoveType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StopMoveType.java
@@ -19,4 +19,14 @@ public enum StopMoveType implements PrimitiveType, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StopMoveType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StopMoveType.java
@@ -21,11 +21,11 @@ public enum StopMoveType implements PrimitiveType, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringListType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringListType.java
@@ -84,6 +84,11 @@ public class StringListType implements Command, State {
 
     @Override
     public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
         StringBuilder sb = new StringBuilder();
         for (String row : typeDetails) {
             sb.append(row.replace(DELIMITER, ESCAPED_DELIMITER));

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringListType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringListType.java
@@ -84,11 +84,11 @@ public class StringListType implements Command, State {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         StringBuilder sb = new StringBuilder();
         for (String row : typeDetails) {
             sb.append(row.replace(DELIMITER, ESCAPED_DELIMITER));

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringType.java
@@ -27,6 +27,11 @@ public class StringType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
         return value;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringType.java
@@ -27,11 +27,11 @@ public class StringType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return value;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
@@ -22,11 +22,11 @@ public enum UpDownType implements PrimitiveType, State, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
@@ -12,7 +12,8 @@ import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
 
 public enum UpDownType implements PrimitiveType, State, Command {
-    UP, DOWN;
+    UP,
+    DOWN;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
@@ -20,4 +20,14 @@ public enum UpDownType implements PrimitiveType, State, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/RefreshType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/RefreshType.java
@@ -16,4 +16,14 @@ public enum RefreshType implements PrimitiveType, Command {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/RefreshType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/RefreshType.java
@@ -18,11 +18,11 @@ public enum RefreshType implements PrimitiveType, Command {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Type.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Type.java
@@ -24,7 +24,7 @@ public interface Type {
 
     /**
      * Formats the value of this type according to a pattern (see {@link Formatter}).
-     * 
+     *
      * @param pattern the pattern to use
      * @return the formatted string
      */

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Type.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Type.java
@@ -18,7 +18,7 @@ import java.util.Formatter;
  * to be both state and command at the same time.
  *
  * @author Kai Kreuzer - Initial contribution and API
- *
+ * @author Markus Rathgeb - Add the simple and full type string methods
  */
 public interface Type {
 
@@ -28,6 +28,17 @@ public interface Type {
      * @param pattern the pattern to use
      * @return the formatted string
      */
-    public String format(String pattern);
+    String format(String pattern);
+
+    /**
+     * Get a string representation that contains the whole internal representation of the type.
+     *
+     * <p>
+     * The returned string could be consumed by the static 'valueOf(String)' method of the respective type to build a
+     * new type that is equal to this type.
+     *
+     * @return a full string representation of the type to be consumed by 'valueOf(String)'
+     */
+    String toFullTypeString();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Type.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Type.java
@@ -39,6 +39,6 @@ public interface Type {
      *
      * @return a full string representation of the type to be consumed by 'valueOf(String)'
      */
-    String toFullTypeString();
+    String toFullString();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/UnDefType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/UnDefType.java
@@ -18,7 +18,8 @@ package org.eclipse.smarthome.core.types;
  *
  */
 public enum UnDefType implements PrimitiveType, State {
-    UNDEF, NULL;
+    UNDEF,
+    NULL;
 
     @Override
     public String format(String pattern) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/UnDefType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/UnDefType.java
@@ -26,4 +26,14 @@ public enum UnDefType implements PrimitiveType, State {
         return String.format(pattern, this.toString());
     }
 
+    @Override
+    public String toString() {
+        return toFullTypeString();
+    }
+
+    @Override
+    public String toFullTypeString() {
+        return super.toString();
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/UnDefType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/UnDefType.java
@@ -28,11 +28,11 @@ public enum UnDefType implements PrimitiveType, State {
 
     @Override
     public String toString() {
-        return toFullTypeString();
+        return toFullString();
     }
 
     @Override
-    public String toFullTypeString() {
+    public String toFullString() {
         return super.toString();
     }
 


### PR DESCRIPTION
* The full string representation must be compatible to the static `valueOf(String)` method of the respective Type implementation.
* The simple string representation does not need to be compatible to the `valueOf(String)` method of the respective Type implementation.

So, whenever you need a representation that can be consumed by `valueOf(String)` later, you should consider to use the full string representation.

Until now `toString()` returns the full string representation.
To keep backward compatibility this mechanism is unchanged.
The toString() of a type should be implemented this way:
`return TypeToStringTransitionUtils.handleStringTransition(this);`

If you don't set trace log level for `org.eclipse.smarthome.core.internal.types.TypeToStringTransitionUtils` there should not be any performance impact.

If you set trace log level for that class, every usage (except ignored ones) of toString() is logged.
This has been done, so you are able to easily change your code to explicit use the 'full' method.

Related to: https://github.com/eclipse/smarthome/issues/1798