### PR TITLE
Fix ProgressCallback.next()

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackTest.groovy
@@ -76,10 +76,36 @@ public final class ProgressCallbackTest {
         sut.pending()
         assertThatProgressInfoEventIsValid(postedEvents.get(2), ProgressStep.DOWNLOADING, true)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(3), ProgressStep.TRANSFERRING, false)
-        assertThat postedEvents.size(), is(4)
+        assertThatProgressInfoEventIsValid(postedEvents.get(3), ProgressStep.DOWNLOADING, false)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(4), ProgressStep.TRANSFERRING, false)
+        sut.pending()
+        assertThatProgressInfoEventIsValid(postedEvents.get(5), ProgressStep.TRANSFERRING, true)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(6), ProgressStep.TRANSFERRING, false)
+        assertThat postedEvents.size(), is(7)
     }
-    
+
+    @Test
+    void 'assert that next changes ProgressStep if not pending'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING, ProgressStep.UPDATING)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, false)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(1), ProgressStep.TRANSFERRING, false)
+        sut.pending()
+        assertThatProgressInfoEventIsValid(postedEvents.get(2), ProgressStep.TRANSFERRING, true)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(3), ProgressStep.TRANSFERRING, false)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(4), ProgressStep.UPDATING, false)
+        sut.pending()
+        assertThatProgressInfoEventIsValid(postedEvents.get(5), ProgressStep.UPDATING, true)
+        sut.next()
+        assertThatProgressInfoEventIsValid(postedEvents.get(6), ProgressStep.UPDATING, false)
+        assertThat postedEvents.size(), is(7)
+    }
+        
     @Test(expected=IllegalStateException)
     void 'assert that cancel throws IllegalStateException if update is finished'(){
         sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
@@ -152,6 +178,21 @@ public final class ProgressCallbackTest {
         sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
         sut.failed("DummyMessageKey")
         sut.pending()
+    }
+    
+    @Test(expected=IllegalStateException)
+    void 'assert that next throws IllegalStateException if update is not pending and no further steps available'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING)
+        sut.next()
+        sut.next()
+    }
+    
+    void 'assert that next throws no IllegalStateException if update is pending and no further steps available'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING)
+        sut.next()
+        sut.pending()
+        sut.next()
+        assertThat sut.getCurrentStep(), is(ProgressStep.DOWNLOADING)
     }
 
     @Test(expected=IllegalStateException)

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/ProgressCallback.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/ProgressCallback.java
@@ -39,11 +39,12 @@ public interface ProgressCallback {
      * {@link ProgressCallback#defineSequence(ProgressStep...)} operation then the first invocation of this operation
      * will indicate that firmware update handler is going to download the firmware, the second invocation will indicate
      * that the handler is going to transfer the firmware to the device and consequently the third invocation will
-     * indicate that the handler is going to trigger the update.
+     * indicate that the handler is going to trigger the update. If the update is pending calling next indicates that
+     * the update is continued.
      *
      * @throws IllegalStateException if
      *             <ul>
-     *             <li>there is no further step to be executed</li>
+     *             <li>update is not pending and there is no further step to be executed</li>
      *             <li>if no sequence was defined</li>
      *             </ul>
      */
@@ -63,14 +64,14 @@ public interface ProgressCallback {
      * Callback operation to indicate that the firmware update was successful.
      */
     void success();
-    
+
     /**
      * Callback operation to indicate that the firmware update is pending.
      */
-    void pending(); 
-    
+    void pending();
+
     /**
      * Callback operation to indicate that the firmware update was canceled.
      */
-    void canceled(); 
+    void canceled();
 }


### PR DESCRIPTION
If ProgressCallback.next() is called and update is pending don't go to next firmware step. Resume to current instead

Signed-off-by: Christoph Knauf  <christoph.knauf@itemis.de>