### PR TITLE
JS disabled  & unavailable SSE warning

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/layout.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/layout.css
@@ -443,3 +443,27 @@ md-toast {
 		font-weight: 400;
 	}
 }
+
+.eventSourceWarning, .eventSourceWarning .header-toolbar,
+	.eventSourceWarning .section-header, .eventSourceWarning header {
+	margin-top: 20px;
+}
+
+@media all and (max-width: 721px) {
+	.eventSourceWarning, .eventSourceWarning .header-toolbar,
+		.eventSourceWarning .section-header, .eventSourceWarning header {
+		margin-top: 40px;
+	}
+}
+
+.jsDisabled {
+	position: absolute;
+	top: 0px;
+	background-color: #AE0000;
+	color: white;
+	z-index: 100;
+	font-weight: bold;
+	font-size: 120%;
+	width: 100%;
+	text-align: center;
+}

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/index.html
@@ -33,14 +33,23 @@
 
 <meta name="apple-mobile-web-app-capable" content="yes" />
 
+<noscript>
+	<div class="jsDisabled">Sorry! PaperUI requires JavaScript to run. Please enable it in your browser.</div>
+	<style>
+.jsEnabled {
+	display: none;
+}
+</style>
+</noscript>
 </head>
 
-<body ng-controller="BodyController">
+<body ng-controller="BodyController" ng-class="{'eventSourceWarning':!eventSourceDefined}">
 	<div id="authentication" data-access-token="{{ACCESS_TOKEN}}"></div>
-	<div ng-include="'partials/include.extension.html'"></div>
-	<div ng-include="'partials/navigation.menu.html'"></div>
+	<div ng-show="!eventSourceDefined">PaperUI works best with modern browsers. Please use Chrome, Firefox, Opera or Safari instead.</div>
+	<div class="jsEnabled" ng-include="'partials/include.extension.html'"></div>
+	<div class="jsEnabled" ng-include="'partials/navigation.menu.html'"></div>
 
-	<div id="wrapper">
+	<div class="jsEnabled" id="wrapper">
 		<header>
 			<a href="#" class="open-menu">&#x2261;</a>
 			<div class="title">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
@@ -112,6 +112,7 @@ angular.module('PaperUI.controllers', [ 'PaperUI.constants' ]).controller('BodyC
         }
     });
 
+    $scope.eventSourceDefined = typeof (EventSource) !== "undefined";
     discoveryResultRepository.getAll();
     bindingRepository.getAll();
 }).controller('PreferencesPageController', function($rootScope, $scope, $window, $location, toastService) {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
@@ -41,7 +41,9 @@ angular.module('PaperUI.services', [ 'PaperUI.constants' ]).config(function($htt
             });
         });
     }
-    initializeEventService();
+    if (typeof (EventSource) !== "undefined") {
+        initializeEventService();
+    }
 
     return new function() {
         this.onEvent = function(topic, callback) {


### PR DESCRIPTION
1) Fixes https://github.com/eclipse/smarthome/issues/2235
2) Makes PaperUI run on Edge (without SSE).
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>