### PR TITLE
Bug fix: Configuration parameter values in things not shown

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -682,7 +682,9 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
         }, refresh);
     }
     $scope.$watch('configuration', function() {
-        $scope.thing.configuration = $scope.configuration;
+        if ($scope.configuration) {
+            $scope.thing.configuration = $scope.configuration;
+        }
     });
     $scope.getThing(false);
 }).controller('ChannelConfigController', function($scope, $mdDialog, toastService, thingRepository, thingService, configService, channelType, channelUID, thing) {


### PR DESCRIPTION
The values of configuration parameters is not shown on thing edit page (it currently shows only defaults). This commit fixes that.
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>