### PR TITLE
Bug fix: item creation while channel linking

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -554,17 +554,18 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
     $scope.acceptedItemType = acceptedItemType;
     $scope.category = category;
     $scope.itemFormVisible = false;
+    $scope.itemsList = [];
     itemRepository.getAll(function(items) {
         $scope.items = items;
-        $scope.items = $filter('filter')($scope.items, {
+        $scope.itemsList = $filter('filter')(items, {
             type : $scope.acceptedItemType
         });
-        $scope.items = $.grep($scope.items, function(item) {
+        $scope.itemsList = $.grep($scope.itemsList, function(item) {
             return $scope.linkedItems.indexOf(item.name) == -1;
         });
 
-        $scope.items = $filter('orderBy')($scope.items, "name");
-        $scope.items.push({
+        $scope.itemsList = $filter('orderBy')($scope.itemsList, "name");
+        $scope.itemsList.push({
             name : "_createNew",
             type : $scope.acceptedItemType
         });

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.linkchannel.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.linkchannel.html
@@ -2,7 +2,7 @@
 <h1>Link channel</h1>
 <p>Please select the item to link:</p>
 <form name="linkForm">
-	<md-input-container class="col-xs-12 noPadding"> <label>Item</label> <md-select name="itemName" md-on-close="checkCreateOption()" required="true" ng-model="itemName"> <md-option ng-repeat="item in items" ng-value="item.name"> <span ng-class="{italic:$last}">
+	<md-input-container class="col-xs-12 noPadding"> <label>Item</label> <md-select name="itemName" md-on-close="checkCreateOption()" required="true" ng-model="itemName"> <md-option ng-repeat="item in itemsList" ng-value="item.name"> <span ng-class="{italic:$last}">
 		{{$last?'+ Create new item...':item.label}}
 		<span class="md-caption" style="color: grey;">{{!$last?'('+item.name+')':'' }} </span>
 	</span> </md-option> </md-select> </md-input-container>


### PR DESCRIPTION
Bug: While creating an item while linking a channel, the code only checks for existing itemName in the filtered item list of that type (String, Number). So if there is an item of same name in some other type, PaperUI lets user create new item which results in 409 conflict.
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>