### PR TITLE
adapted groovy version

### DIFF
--- a/targetplatform/smarthome.target
+++ b/targetplatform/smarthome.target
@@ -102,8 +102,8 @@
 <repository location="http://download.eclipse.org/modeling/emf/emf/updates/2.11/core/R201506010402"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.codehaus.groovy23.feature.feature.group" version="2.9.1.xx-201411061335-e44-RELEASE"/>
-<repository location="http://dist.springsource.org/release/GRECLIPSE/e4.4/"/>
+<unit id="org.codehaus.groovy23.feature.feature.group" version="2.9.2.xx-201608111517-e46"/>
+<repository location="http://dist.springsource.org/snapshot/GRECLIPSE/e4.6/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.equinox.sdk.feature.group" version="3.10.0.v20140606-1602"/>


### PR DESCRIPTION
Just in case I'm not the only one who sees the following when running plain unit tests within Eclipse:

```
java.lang.ExceptionInInitializerError
    at org.codehaus.groovy.runtime.InvokerHelper.<clinit>(InvokerHelper.java:61)
    [...]
Caused by: groovy.lang.GroovyRuntimeException: Conflicting module versions. Module [groovy-all is loaded in version 2.3.7 and you are trying to load version 2.3.10
    at org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl$DefaultModuleListener.onModule(MetaClassRegistryImpl.java:510)
    [...]
    ... 28 more
```

If I'm not mistaken, this happens because of the mismatch between the p2 repositories referenced in [smarthome.target](https://github.com/eclipse/smarthome/blob/master/targetplatform/smarthome.target) and [EclipseSmartHome.setup](https://github.com/eclipse/smarthome/blob/master/targetplatform/EclipseSmartHome.setup) (i.e. e4.4 vs. e4.6). 

Updating the p2 repository and referencing groovy-eclipse 2.9.2 instead of 2.9.1 at least fixed this annoyance for me.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>