### PR TITLE
added Karaf feature for rest.voice

### DIFF
--- a/features/karaf/src/main/feature/feature.xml
+++ b/features/karaf/src/main/feature/feature.xml
@@ -173,6 +173,11 @@
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest.sitemap/${project.version}</bundle>
   </feature>
 
+  <feature name="esh-io-rest-voice" version="${project.version}">
+    <feature>esh-base</feature>
+    <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest.voice/${project.version}</bundle>
+  </feature>
+
   <feature name="esh-io-rest-mdns" version="${project.version}">
     <feature>esh-base</feature>
     <feature>esh-io-transport-mdns</feature>


### PR DESCRIPTION
I had missed this in https://github.com/eclipse/smarthome/pull/2251.

Signed-off-by: Kai Kreuzer <kai@openhab.org>