### PR TITLE
removing generics from OSGiTest base class

### DIFF
--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
@@ -32,7 +32,7 @@ import org.osgi.framework.ServiceRegistration
 abstract class OSGiTest {
 
     BundleContext bundleContext
-    Map<String, ServiceRegistration<?>> registeredServices = [:]
+    Map<String, ServiceRegistration> registeredServices = [:]
 
     @Before
     public void bindBundleContext() {


### PR DESCRIPTION
since the framework requires minimum OSGi version 4.2
Generics was added  to ServiceReference in OSGi v.4.3

Signed-off-by: Miki Jankov <miki.jankov87@gmail.com>