### PR TITLE
add capability to feature because it is missing in the bundle manifest

### DIFF
--- a/features/karaf/src/main/feature/feature.xml
+++ b/features/karaf/src/main/feature/feature.xml
@@ -22,6 +22,9 @@
 
     <bundle>mvn:org.eclipse.smarthome.core/org.eclipse.smarthome.core/${project.version}</bundle>
     <capability>
+      osgi.service;objectClass=org.eclipse.smarthome.core.i18n.I18nProvider
+    </capability>
+    <capability>
       osgi.service;objectClass=org.eclipse.smarthome.core.items.ItemRegistry
     </capability>
 


### PR DESCRIPTION
Adds for I18nProvider service capability as it is missing in the esh.core bundle manifest
