### PR TITLE
temporarily ignore failing test

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/src/test/groovy/org/eclipse/smarthome/automation/module/core/internal/RuntimeRuleTest.groovy
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/src/test/groovy/org/eclipse/smarthome/automation/module/core/internal/RuntimeRuleTest.groovy
@@ -344,7 +344,7 @@ class RuntimeRuleTest extends OSGiTest{
 
     }
 
-    @Test
+    @Test @Ignore
     public void 'assert that RuleEnableHandlerWorks'() {
         def ruleRegistry = getService(RuleRegistry)
         def firstRuleUID = "FirstTestRule"


### PR DESCRIPTION
@plamen-peev This test was introduced by https://github.com/eclipse/smarthome/pull/1914, but it fails. In order to get the build green again, I temporarily deactivate it. Could you please look into it and come up with a fix?

Signed-off-by: Kai Kreuzer <kai@openhab.org>