### PR TITLE
initial contribution of a web audio sink

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioHTTPServer.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioHTTPServer.java
@@ -26,6 +26,7 @@ public interface AudioHTTPServer {
      * Note that the HTTP header only contains "Content-length", if the passed stream is an instance of
      * {@link FixedLengthAudioStream}.
      * If the client that requests the url expects this header field to be present, make sure to pass such an instance.
+     * Streams are closed after having been served.
      *
      * @param stream the stream to serve on HTTP
      * @return the absolute URL to access the stream (using the primary network interface)
@@ -37,6 +38,7 @@ public interface AudioHTTPServer {
      * frame.
      * This method only accepts {@link FixedLengthAudioStream}s, since it needs to be able to create multiple concurrent
      * streams from it, which isn't possible with a regular {@link AudioStream}.
+     * Streams are closed, once they expire.
      *
      * @param stream the stream to serve on HTTP
      * @param seconds number of seconds for which the stream is available through HTTP

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/.classpath
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/.project
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.io.webaudio</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/META-INF/MANIFEST.MF
@@ -1,0 +1,18 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Web Audio Support
+Bundle-SymbolicName: org.eclipse.smarthome.io.webaudio
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: javax.sound.sampled,
+ org.apache.commons.collections,
+ org.apache.commons.io,
+ org.eclipse.smarthome.core.audio,
+ org.eclipse.smarthome.core.events,
+ org.eclipse.smarthome.core.library.types,
+ org.osgi.framework,
+ org.slf4j
+Bundle-ActivationPolicy: lazy
+Service-Component: OSGI-INF/*.xml

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/OSGI-INF/sseaudiosink.xml
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/OSGI-INF/sseaudiosink.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.io.sseaudiosink">
+   <implementation class="org.eclipse.smarthome.io.webaudio.internal.SSEAudioSink"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.core.audio.AudioSink"/>
+   </service>
+   <reference bind="setAudioHTTPServer" cardinality="1..1" interface="org.eclipse.smarthome.core.audio.AudioHTTPServer" name="AudioHTTPServer" policy="static" unbind="unsetAudioHTTPServer"/>
+   <reference bind="setEventPublisher" cardinality="1..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="static" unbind="unsetEventPublisher"/>
+</scr:component>

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/OSGI-INF/webaudioeventfactory.xml
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/OSGI-INF/webaudioeventfactory.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.io.webaudio.eventfactory">
+   <implementation class="org.eclipse.smarthome.io.webaudio.internal.WebAudioEventFactory"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.core.events.EventFactory"/>
+   </service>
+</scr:component>

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/about.html
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>&lt;<em>May 12, 2015</em>&gt;</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/build.properties
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/build.properties
@@ -1,0 +1,6 @@
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               about.html
+source.. = src/main/java/

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/pom.xml
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.smarthome.io</groupId>
+    <artifactId>pom</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.eclipse.smarthome.io.webaudio</artifactId>
+  <packaging>eclipse-plugin</packaging>
+
+  <name>Eclipse SmartHome Web Audio Support</name>
+
+</project>

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/src/main/java/org/eclipse/smarthome/io/webaudio/internal/PlayURLEvent.java
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/src/main/java/org/eclipse/smarthome/io/webaudio/internal/PlayURLEvent.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.webaudio.internal;
+
+import org.eclipse.smarthome.core.events.AbstractEvent;
+
+/**
+ * This is an {@link Event} that is sent when a web client should play an audio stream from a url.
+ *
+ * @author Kai Kreuzer - Initial contribution and API
+ */
+public class PlayURLEvent extends AbstractEvent {
+
+    /**
+     * The extension event type.
+     */
+    public final static String TYPE = PlayURLEvent.class.getSimpleName();
+
+    private String url;
+
+    /**
+     * Constructs a new extension event object.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param url the url to play
+     */
+    public PlayURLEvent(String topic, String payload, String url) {
+        super(topic, payload, null);
+        this.url = url;
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return "Play URL '" + url + "'.";
+    }
+}

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/src/main/java/org/eclipse/smarthome/io/webaudio/internal/SSEAudioSink.java
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/src/main/java/org/eclipse/smarthome/io/webaudio/internal/SSEAudioSink.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.smarthome.core.audio.AudioFormat;
 import org.eclipse.smarthome.core.audio.AudioHTTPServer;
 import org.eclipse.smarthome.core.audio.AudioSink;
@@ -52,10 +53,7 @@ public class SSEAudioSink implements AudioSink {
             // it is an external URL, so we can directly pass this on.
             URLAudioStream urlAudioStream = (URLAudioStream) audioStream;
             sendEvent(urlAudioStream.getURL());
-            try {
-                audioStream.close();
-            } catch (IOException e) {
-            }
+            IOUtils.closeQuietly(audioStream);
         } else {
             // we serve it on our own HTTP server
             if (audioStream instanceof FixedLengthAudioStream) {
@@ -64,7 +62,8 @@ public class SSEAudioSink implements AudioSink {
                 String url = audioHTTPServer.serve((FixedLengthAudioStream) audioStream, 10).toString();
                 sendEvent(url);
             } else {
-                logger.warn("Only FixedLengthAudioStream are supported for web audio sink");
+                logger.warn("Only FixedLengthAudioStream are supported for the web audio sink.");
+                IOUtils.closeQuietly(audioStream);
             }
         }
     }

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/src/main/java/org/eclipse/smarthome/io/webaudio/internal/SSEAudioSink.java
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/src/main/java/org/eclipse/smarthome/io/webaudio/internal/SSEAudioSink.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.webaudio.internal;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.audio.AudioFormat;
+import org.eclipse.smarthome.core.audio.AudioHTTPServer;
+import org.eclipse.smarthome.core.audio.AudioSink;
+import org.eclipse.smarthome.core.audio.AudioStream;
+import org.eclipse.smarthome.core.audio.FixedLengthAudioStream;
+import org.eclipse.smarthome.core.audio.URLAudioStream;
+import org.eclipse.smarthome.core.audio.UnsupportedAudioFormatException;
+import org.eclipse.smarthome.core.events.EventPublisher;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an audio sink that publishes an event through SSE and temporarily serves the stream via HTTP for web players
+ * to pick it up.
+ *
+ * @author Kai Kreuzer - Initial contribution and API
+ */
+public class SSEAudioSink implements AudioSink {
+
+    private final Logger logger = LoggerFactory.getLogger(SSEAudioSink.class);
+
+    private static final HashSet<AudioFormat> supportedFormats = new HashSet<>();
+
+    static {
+        supportedFormats.add(AudioFormat.WAV);
+        supportedFormats.add(AudioFormat.MP3);
+    }
+
+    private AudioHTTPServer audioHTTPServer;
+
+    private EventPublisher eventPublisher;
+
+    @Override
+    public void process(AudioStream audioStream) throws UnsupportedAudioFormatException {
+        logger.debug("Received audio stream of format {}", audioStream.getFormat());
+        if (audioStream instanceof URLAudioStream) {
+            // it is an external URL, so we can directly pass this on.
+            URLAudioStream urlAudioStream = (URLAudioStream) audioStream;
+            sendEvent(urlAudioStream.getURL());
+            try {
+                audioStream.close();
+            } catch (IOException e) {
+            }
+        } else {
+            // we serve it on our own HTTP server
+            if (audioStream instanceof FixedLengthAudioStream) {
+                // we need to serve it for a while and make it available to multiple clients, hence
+                // only FixedLengthAudioStreams are supported
+                String url = audioHTTPServer.serve((FixedLengthAudioStream) audioStream, 10).toString();
+                sendEvent(url);
+            } else {
+                logger.warn("Only FixedLengthAudioStream are supported for web audio sink");
+            }
+        }
+    }
+
+    private void sendEvent(String url) {
+        PlayURLEvent event = WebAudioEventFactory.createPlayURLEvent(url);
+        eventPublisher.post(event);
+    }
+
+    @Override
+    public Set<AudioFormat> getSupportedFormats() {
+        return supportedFormats;
+    }
+
+    @Override
+    public String getId() {
+        return "webaudio";
+    }
+
+    @Override
+    public String getLabel(Locale locale) {
+        return "Web Audio";
+    }
+
+    @Override
+    public PercentType getVolume() throws IOException {
+        return PercentType.HUNDRED;
+    }
+
+    @Override
+    public void setVolume(final PercentType volume) throws IOException {
+        throw new IOException("Web Audio sink does not support volume level changes.");
+    }
+
+    protected void setEventPublisher(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    protected void unsetEventPublisher(EventPublisher eventPublisher) {
+        this.eventPublisher = null;
+    }
+
+    protected void setAudioHTTPServer(AudioHTTPServer audioHTTPServer) {
+        this.audioHTTPServer = audioHTTPServer;
+    }
+
+    protected void unsetAudioHTTPServer(AudioHTTPServer audioHTTPServer) {
+        this.audioHTTPServer = null;
+    }
+
+}

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/src/main/java/org/eclipse/smarthome/io/webaudio/internal/WebAudioEventFactory.java
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/src/main/java/org/eclipse/smarthome/io/webaudio/internal/WebAudioEventFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.webaudio.internal;
+
+import java.util.Collections;
+
+import org.eclipse.smarthome.core.events.AbstractEventFactory;
+import org.eclipse.smarthome.core.events.Event;
+import org.eclipse.smarthome.core.events.EventFactory;
+
+/**
+ * This is an {@link EventFactory} for creating web audio events.
+ * The only currently supported event type is {@link PlayURLEvent}.
+ *
+ * @author Kai Kreuzer - Initial contribution and API
+ */
+public class WebAudioEventFactory extends AbstractEventFactory {
+
+    static final String PLAY_URL_TOPIC = "smarthome/webaudio/playurl";
+
+    /**
+     * Constructs a new WebAudioEventFactory.
+     */
+    public WebAudioEventFactory() {
+        super(Collections.singleton(PlayURLEvent.TYPE));
+    }
+
+    @Override
+    protected Event createEventByType(String eventType, String topic, String payload, String source) throws Exception {
+        if (PlayURLEvent.TYPE.equals(eventType)) {
+            String url = deserializePayload(payload, String.class);
+            return createPlayURLEvent(url);
+        }
+        return null;
+    }
+
+    /**
+     * Creates a PlayURLEvent event.
+     *
+     * @param url the url to play
+     * @return the according event
+     */
+    public static PlayURLEvent createPlayURLEvent(String url) {
+        String topic = PLAY_URL_TOPIC;
+        String payload = serializePayload(url);
+        return new PlayURLEvent(topic, payload, url);
+    }
+
+}

--- a/extensions/io/pom.xml
+++ b/extensions/io/pom.xml
@@ -17,6 +17,7 @@
 
   <modules>
     <module>org.eclipse.smarthome.io.javasound</module>
+    <module>org.eclipse.smarthome.io.webaudio</module>
   </modules>
 
 </project>

--- a/features/karaf/src/main/feature/feature.xml
+++ b/features/karaf/src/main/feature/feature.xml
@@ -380,6 +380,11 @@
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.javasound/${project.version}</bundle>
   </feature>
 
+  <feature name="esh-io-webaudio" description="Web Audio Support" version="${project.version}">
+    <feature>esh-base</feature>
+    <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.webaudio/${project.version}</bundle>
+  </feature>
+
   <feature name="esh-voice-mactts" description="MacOS Text-to-Speech" version="${project.version}">
     <feature>esh-base</feature>
     <bundle>mvn:org.eclipse.smarthome.voice/org.eclipse.smarthome.voice.mactts/${project.version}</bundle>

--- a/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
@@ -249,4 +249,11 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+
+   <plugin
+         id="org.eclipse.smarthome.io.webaudio"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 </feature>


### PR DESCRIPTION
This is a new audio sink implementation which simply creates an event with a url for the audio stream to be played from. This event can be retrieved by web clients through SSE.

As a first user of this feature, I would like to see the Paper UI as it already subscribes to all SSE events.

Signed-off-by: Kai Kreuzer <kai@openhab.org>