### PR TITLE
add capability to feature because it is missing in the bundle manifest

### DIFF
--- a/features/karaf/src/main/feature/feature.xml
+++ b/features/karaf/src/main/feature/feature.xml
@@ -44,7 +44,12 @@
 
     <bundle start-level="75">mvn:org.eclipse.smarthome.core/org.eclipse.smarthome.core.thing.xml/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.core/org.eclipse.smarthome.core.transform/${project.version}</bundle>
+
     <bundle>mvn:org.eclipse.smarthome.core/org.eclipse.smarthome.core.audio/${project.version}</bundle>
+    <capability>
+      osgi.service;objectClass=org.eclipse.smarthome.core.audio.AudioHTTPServer
+    </capability>
+
     <bundle>mvn:org.eclipse.smarthome.core/org.eclipse.smarthome.core.voice/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.console/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.monitor/${project.version}</bundle>


### PR DESCRIPTION
Adds for AudioHTTPServer service capability as it is missing in the esh.core.audio bundle manifest.