### PR TITLE
Little fix of AudioFormat class

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioFormat.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioFormat.java
@@ -143,7 +143,6 @@ public class AudioFormat {
      */
     public AudioFormat(String container, String codec, Boolean bigEndian, Integer bitDepth, Integer bitRate,
             Long frequency) {
-        super();
         this.container = container;
         this.codec = codec;
         this.bigEndian = bigEndian;


### PR DESCRIPTION
Removed unnecessary explicit call of parent constructor (since parent class is the Object class). As stated [here](https://docs.oracle.com/javase/tutorial/java/IandI/super.html), "...if a constructor does not explicitly invoke a superclass constructor, the Java compiler automatically inserts a call to the no-argument constructor of the superclass." In the current case, the class does not extend any other class, which means that the constructor of the parent Object class is implicitly called, making the super() call unnecessary.

Signed-off-by: Alexander Kostadinov <alexander.g.kostadinov@gmail.com>