### PR TITLE
Converting state into accepted types

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
@@ -7,11 +7,11 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.text.DecimalFormatSymbols;
 
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.junit.Test;
 
 /**
@@ -83,4 +83,26 @@ public class DecimalTypeTest {
         dt = new DecimalType("11.0");
         assertEquals("11" + sep + "0", dt.format("%.1f")); // "11.0"
     }
+
+    @Test
+    public void testConversionToOnOffType() {
+        assertEquals(OnOffType.ON, new DecimalType("100.0").as(OnOffType.class));
+        assertEquals(OnOffType.ON, new DecimalType("1.0").as(OnOffType.class));
+        assertEquals(OnOffType.OFF, new DecimalType("0.0").as(OnOffType.class));
+    }
+
+    @Test
+    public void testConversionToOpenCloseType() {
+        assertEquals(OpenClosedType.OPEN, new DecimalType("1.0").as(OpenClosedType.class));
+        assertEquals(OpenClosedType.CLOSED, new DecimalType("0.0").as(OpenClosedType.class));
+        assertEquals(UnDefType.UNDEF, new DecimalType("0.5").as(OpenClosedType.class));
+    }
+
+    @Test
+    public void testConversionToUpDownType() {
+        assertEquals(UpDownType.UP, new DecimalType("0.0").as(UpDownType.class));
+        assertEquals(UpDownType.DOWN, new DecimalType("1.0").as(UpDownType.class));
+        assertEquals(UnDefType.UNDEF, new DecimalType("0.5").as(OpenClosedType.class));
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/HSBTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/HSBTypeTest.java
@@ -89,4 +89,26 @@ public class HSBTypeTest {
         assertEquals(hsb.getSaturation(), hsbRgb.getSaturation());
         assertEquals(hsb.getBrightness(), hsbRgb.getBrightness());
     }
+
+    @Test
+    public void testConversionToOnOffType() {
+        assertEquals(OnOffType.ON, new HSBType("100,100,100").as(OnOffType.class));
+        assertEquals(OnOffType.ON, new HSBType("100,100,1").as(OnOffType.class));
+        assertEquals(OnOffType.OFF, new HSBType("100,100,0").as(OnOffType.class));
+    }
+
+    @Test
+    public void testConversionToDecimalType() {
+        assertEquals(new DecimalType("1.0"), new HSBType("100,100,100").as(DecimalType.class));
+        assertEquals(new DecimalType("0.01"), new HSBType("100,100,1").as(DecimalType.class));
+        assertEquals(DecimalType.ZERO, new HSBType("100,100,0").as(DecimalType.class));
+    }
+
+    @Test
+    public void testConversionToPercentType() {
+        assertEquals(PercentType.HUNDRED, new HSBType("100,100,100").as(PercentType.class));
+        assertEquals(new PercentType("1"), new HSBType("100,100,1").as(PercentType.class));
+        assertEquals(PercentType.ZERO, new HSBType("100,100,0").as(PercentType.class));
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/OnOffTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/OnOffTypeTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.library.types;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * @author Simon Kaufmann - Initial contribution and API
+ */
+public class OnOffTypeTest {
+
+    @Test
+    public void testConversionToPercentType() {
+        assertEquals(PercentType.HUNDRED, OnOffType.ON.as(PercentType.class));
+        assertEquals(PercentType.ZERO, OnOffType.OFF.as(PercentType.class));
+    }
+
+    @Test
+    public void testConversionToDecimalType() {
+        assertEquals(new DecimalType("1.0"), OnOffType.ON.as(DecimalType.class));
+        assertEquals(DecimalType.ZERO, OnOffType.OFF.as(DecimalType.class));
+    }
+
+    @Test
+    public void testConversionToHSBType() {
+        assertEquals(HSBType.WHITE, OnOffType.ON.as(HSBType.class));
+        assertEquals(HSBType.BLACK, OnOffType.OFF.as(HSBType.class));
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/OpenClosedTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/OpenClosedTypeTest.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.library.types;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * @author Simon Kaufmann - Initial contribution and API
+ */
+public class OpenClosedTypeTest {
+
+    @Test
+    public void testConversionToPercentType() {
+        assertEquals(PercentType.ZERO, OpenClosedType.CLOSED.as(PercentType.class));
+        assertEquals(PercentType.HUNDRED, OpenClosedType.OPEN.as(PercentType.class));
+    }
+
+    @Test
+    public void testConversionToDecimalType() {
+        assertEquals(DecimalType.ZERO, OpenClosedType.CLOSED.as(DecimalType.class));
+        assertEquals(new DecimalType(1), OpenClosedType.OPEN.as(DecimalType.class));
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PercentTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PercentTypeTest.java
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.core.library.types;
 
 import static org.junit.Assert.assertEquals;
 
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.junit.Test;
 
 /**
@@ -49,4 +50,33 @@ public class PercentTypeTest {
         assertEquals(true, pt3.equals(pt4));
         assertEquals(false, pt3.equals(pt1));
     }
+
+    @Test
+    public void testConversionToOnOffType() {
+        assertEquals(OnOffType.ON, new PercentType("100.0").as(OnOffType.class));
+        assertEquals(OnOffType.ON, new PercentType("1.0").as(OnOffType.class));
+        assertEquals(OnOffType.OFF, new PercentType("0.0").as(OnOffType.class));
+    }
+
+    @Test
+    public void testConversionToDecimalType() {
+        assertEquals(new DecimalType("1.0"), new PercentType("100.0").as(DecimalType.class));
+        assertEquals(new DecimalType("0.01"), new PercentType("1.0").as(DecimalType.class));
+        assertEquals(DecimalType.ZERO, new PercentType("0.0").as(DecimalType.class));
+    }
+
+    @Test
+    public void testConversionToOpenCloseType() {
+        assertEquals(OpenClosedType.OPEN, new PercentType("100.0").as(OpenClosedType.class));
+        assertEquals(OpenClosedType.CLOSED, new PercentType("0.0").as(OpenClosedType.class));
+        assertEquals(UnDefType.UNDEF, new PercentType("50.0").as(OpenClosedType.class));
+    }
+
+    @Test
+    public void testConversionToUpDownType() {
+        assertEquals(UpDownType.UP, new PercentType("0.0").as(UpDownType.class));
+        assertEquals(UpDownType.DOWN, new PercentType("100.0").as(UpDownType.class));
+        assertEquals(UnDefType.UNDEF, new PercentType("50.0").as(OpenClosedType.class));
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/UpDownTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/UpDownTypeTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.library.types;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * @author Simon Kaufmann - Initial contribution and API
+ */
+public class UpDownTypeTest {
+
+    @Test
+    public void testConversionToPercentType() {
+        assertEquals(PercentType.ZERO, UpDownType.UP.as(PercentType.class));
+        assertEquals(PercentType.HUNDRED, UpDownType.DOWN.as(PercentType.class));
+    }
+
+    @Test
+    public void testConversionToDecimalType() {
+        assertEquals(DecimalType.ZERO, UpDownType.UP.as(DecimalType.class));
+        assertEquals(new DecimalType(1), UpDownType.DOWN.as(DecimalType.class));
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLinkRegistry.java
@@ -59,7 +59,7 @@ public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Pro
      * @param uid UID
      * @return a non-null collection of item names that are linked to the given UID.
      */
-    public Set<String> getLinkedItems(UID uid) {
+    public Set<String> getLinkedItemNames(UID uid) {
         Set<String> linkedItems = new LinkedHashSet<>();
         for (AbstractLink link : getAll()) {
             if (link.getUID().equals(uid)) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -66,12 +67,24 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
     }
 
     @Override
-    public Set<String> getLinkedItems(UID uid) {
+    public Set<String> getLinkedItemNames(UID uid) {
         final Set<String> linkedItems = new LinkedHashSet<>();
         for (final AbstractLink link : getAll()) {
             final String itemName = link.getItemName();
             if (link.getUID().equals(uid) && itemRegistry.get(itemName) != null) {
                 linkedItems.add(itemName);
+            }
+        }
+        return linkedItems;
+    }
+
+    public Set<Item> getLinkedItems(UID uid) {
+        final Set<Item> linkedItems = new LinkedHashSet<>();
+        for (final AbstractLink link : getAll()) {
+            final String itemName = link.getItemName();
+            Item item = itemRegistry.get(itemName);
+            if (link.getUID().equals(uid) && item != null) {
+                linkedItems.add(item);
             }
         }
         return linkedItems;

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
@@ -300,7 +300,7 @@ public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusIn
                 Thing thing = thingRegistry.get(event.getThingUID());
                 if (thing != null) {
                     for (Channel channel : thing.getChannels()) {
-                        if (itemChannelLinkRegistry.getLinkedItems(channel.getUID()).size() > 0) {
+                        if (itemChannelLinkRegistry.getLinkedItemNames(channel.getUID()).size() > 0) {
                             informHandlerAboutLinkedChannel(thing, channel);
                         }
                     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
@@ -90,8 +91,8 @@ abstract public class GenericItem implements ActiveItem {
      */
     @Override
     public State getStateAs(Class<? extends State> typeClass) {
-        if (typeClass != null && typeClass.isInstance(state)) {
-            return state;
+        if (state instanceof Convertible) {
+            return ((Convertible) state).as(typeClass);
         } else {
             return null;
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/Item.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/Item.java
@@ -67,6 +67,12 @@ public interface Item {
      * the accepted data types would be in this case {@link PercentType}, {@link OnOffType} and {@link UnDefType}
      * </p>
      * 
+     * <p>
+     * The order of data types denotes the order of preference. So in case a state needs to be converted
+     * in order to be accepted, it will be attempted to convert it to a type from top to bottom. Therefore
+     * the type with the least information loss should be on top of the list - in the example above the
+     * {@link PercentType} carries more information than the {@link OnOffType}, hence it is listed first.
+     * </p>
      * @return a list of data types that can be used to update the item state
      */
     public List<Class<? extends State>> getAcceptedDataTypes();

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemUtil.java
@@ -7,12 +7,17 @@
  */
 package org.eclipse.smarthome.core.items;
 
+import org.eclipse.smarthome.core.types.Convertible;
+import org.eclipse.smarthome.core.types.State;
+import org.slf4j.LoggerFactory;
+
 /**
  * The {@link ItemUtil} class contains utility methods for {@link Item} objects.
  * <p>
  * This class cannot be instantiated, it only contains static methods.
  *
  * @author Michael Grammling - Initial contribution and API
+ * @author Simon Kaufmann - added type conversion
  */
 public class ItemUtil {
 
@@ -69,6 +74,25 @@ public class ItemUtil {
         if (!isValidItemName(itemName)) {
             throw new IllegalArgumentException("The specified name of the item '" + itemName + "' is not valid!");
         }
+    }
+
+    public static State convertToAcceptedState(final State state, final Item item) {
+        if (item != null && !isAccepted(item, state) && state instanceof Convertible) {
+            for (Class<? extends State> acceptedType : item.getAcceptedDataTypes()) {
+                State convertedState = ((Convertible) state).as(acceptedType);
+                if (convertedState != null) {
+                    LoggerFactory.getLogger(ItemUtil.class).debug("Converting {} '{}' to {} '{}' for item '{}'",
+                            state.getClass().getSimpleName(), state.toString(),
+                            convertedState.getClass().getSimpleName(), convertedState.toString(), item.getName());
+                    return convertedState;
+                }
+            }
+        }
+        return state;
+    }
+
+    private static boolean isAccepted(Item item, State state) {
+        return item.getAcceptedDataTypes().contains(state.getClass());
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/internal/StateConverterUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/internal/StateConverterUtil.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.library.internal;
+
+import org.eclipse.smarthome.core.types.State;
+
+/**
+ * Helper methods related to state conversion.
+ *
+ * @author Simon Kaufmann - Initial contribution and API
+ */
+public class StateConverterUtil {
+
+    public static State defaultConversion(State state, Class<? extends State> target) {
+        if (target != null && target.isInstance(state)) {
+            return state;
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
@@ -7,8 +7,6 @@
  */
 package org.eclipse.smarthome.core.library.items;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -20,6 +18,7 @@ import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -36,15 +35,15 @@ public class ColorItem extends DimmerItem {
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
 
     static {
-        acceptedDataTypes.add(OnOffType.class);
-        acceptedDataTypes.add(PercentType.class);
         acceptedDataTypes.add(HSBType.class);
+        acceptedDataTypes.add(PercentType.class);
+        acceptedDataTypes.add(OnOffType.class);
         acceptedDataTypes.add(UnDefType.class);
 
+        acceptedCommandTypes.add(HSBType.class);
+        acceptedCommandTypes.add(PercentType.class);
         acceptedCommandTypes.add(OnOffType.class);
         acceptedCommandTypes.add(IncreaseDecreaseType.class);
-        acceptedCommandTypes.add(PercentType.class);
-        acceptedCommandTypes.add(HSBType.class);
         acceptedCommandTypes.add(RefreshType.class);
     }
 
@@ -87,44 +86,11 @@ public class ColorItem extends DimmerItem {
                 super.setState(state);
             }
         } else {
-            // we map ON/OFF values to black/white and percentage values to grey scale
-            if (state == OnOffType.OFF) {
-                super.setState(HSBType.BLACK);
-            } else if (state == OnOffType.ON) {
-                super.setState(HSBType.WHITE);
-            } else if (state instanceof PercentType && !(state instanceof HSBType)) {
-                super.setState(new HSBType(DecimalType.ZERO, PercentType.ZERO, (PercentType) state));
-            } else {
-                super.setState(state);
+            if (state instanceof Convertible) {
+                state = ((Convertible) state).as(HSBType.class);
             }
+            super.setState(state);
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public State getStateAs(Class<? extends State> typeClass) {
-        if (typeClass == HSBType.class) {
-            return this.state;
-        } else if (typeClass == OnOffType.class) {
-            if (state instanceof HSBType) {
-                HSBType hsbState = (HSBType) state;
-                // if brightness is not completely off, we consider the state to be on
-                return hsbState.getBrightness().equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON;
-            }
-        } else if (typeClass == DecimalType.class) {
-            if (state instanceof HSBType) {
-                HSBType hsbState = (HSBType) state;
-                return new DecimalType(
-                        hsbState.getBrightness().toBigDecimal().divide(new BigDecimal(100), 8, RoundingMode.UP));
-            }
-        } else if (typeClass == PercentType.class) {
-            if (state instanceof HSBType) {
-                HSBType hsbState = (HSBType) state;
-                return new PercentType(hsbState.getBrightness().toBigDecimal());
-            }
-        }
-        return super.getStateAs(typeClass);
-    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ContactItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ContactItem.java
@@ -13,9 +13,7 @@ import java.util.List;
 
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
-import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
@@ -54,17 +52,4 @@ public class ContactItem extends GenericItem {
         return Collections.unmodifiableList(acceptedCommandTypes);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public State getStateAs(Class<? extends State> typeClass) {
-        if (typeClass == DecimalType.class) {
-            return state == OpenClosedType.OPEN ? new DecimalType(1) : DecimalType.ZERO;
-        } else if (typeClass == PercentType.class) {
-            return state == OpenClosedType.OPEN ? PercentType.HUNDRED : PercentType.ZERO;
-        } else {
-            return super.getStateAs(typeClass);
-        }
-    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
@@ -7,18 +7,16 @@
  */
 package org.eclipse.smarthome.core.library.items;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.smarthome.core.library.CoreItemFactory;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -37,13 +35,13 @@ public class DimmerItem extends SwitchItem {
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
 
     static {
-        acceptedDataTypes.add(OnOffType.class);
         acceptedDataTypes.add(PercentType.class);
+        acceptedDataTypes.add(OnOffType.class);
         acceptedDataTypes.add(UnDefType.class);
 
+        acceptedCommandTypes.add(PercentType.class);
         acceptedCommandTypes.add(OnOffType.class);
         acceptedCommandTypes.add(IncreaseDecreaseType.class);
-        acceptedCommandTypes.add(PercentType.class);
         acceptedCommandTypes.add(RefreshType.class);
     }
 
@@ -74,39 +72,10 @@ public class DimmerItem extends SwitchItem {
      */
     @Override
     public void setState(State state) {
-        // we map ON/OFF values to the percent values 0 and 100
-        if (state == OnOffType.OFF) {
-            super.setState(PercentType.ZERO);
-        } else if (state == OnOffType.ON) {
-            super.setState(PercentType.HUNDRED);
-        } else if (state.getClass() == DecimalType.class) {
-            super.setState(new PercentType(((DecimalType) state).toBigDecimal().multiply(new BigDecimal(100))));
-        } else {
-            super.setState(state);
+        if (state instanceof Convertible) {
+            state = ((Convertible) state).as(PercentType.class);
         }
+        super.setState(state);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public State getStateAs(Class<? extends State> typeClass) {
-        if (state.getClass() == typeClass) {
-            return state;
-        } else if (typeClass == OnOffType.class) {
-            // if it is not completely off, we consider the dimmer to be on
-            return state.equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON;
-        } else if (typeClass == DecimalType.class) {
-            if (state instanceof PercentType) {
-                return new DecimalType(
-                        ((PercentType) state).toBigDecimal().divide(new BigDecimal(100), 8, RoundingMode.UP));
-            }
-        } else if (typeClass == PercentType.class) {
-            if (state instanceof DecimalType) {
-                return new PercentType(((DecimalType) state).toBigDecimal().multiply(new BigDecimal(100)));
-            }
-        }
-
-        return super.getStateAs(typeClass);
-    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/RollershutterItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/RollershutterItem.java
@@ -7,19 +7,17 @@
  */
 package org.eclipse.smarthome.core.library.items;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -27,7 +25,7 @@ import org.eclipse.smarthome.core.types.UnDefType;
 /**
  * A RollershutterItem allows the control of roller shutters, i.e.
  * moving them up, down, stopping or setting it to close to a certain percentage.
- * 
+ *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Markus Rathgeb - Support more types for getStateAs
  *
@@ -38,9 +36,9 @@ public class RollershutterItem extends GenericItem {
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
 
     static {
-        acceptedDataTypes.add(UnDefType.class);
-        acceptedDataTypes.add(UpDownType.class);
         acceptedDataTypes.add(PercentType.class);
+        acceptedDataTypes.add(UpDownType.class);
+        acceptedDataTypes.add(UnDefType.class);
 
         acceptedCommandTypes.add(UpDownType.class);
         acceptedCommandTypes.add(StopMoveType.class);
@@ -80,45 +78,10 @@ public class RollershutterItem extends GenericItem {
      */
     @Override
     public void setState(State state) {
-        // we map UP/DOWN values to the percent values 0 and 100
-        if (state == UpDownType.UP) {
-            super.setState(PercentType.ZERO);
-        } else if (state == UpDownType.DOWN) {
-            super.setState(PercentType.HUNDRED);
-        } else if (state.getClass() == DecimalType.class) {
-            super.setState(new PercentType(((DecimalType) state).toBigDecimal().multiply(new BigDecimal(100))));
-        } else {
-            super.setState(state);
+        if (state instanceof Convertible) {
+            state = ((Convertible) state).as(PercentType.class);
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public State getStateAs(Class<? extends State> typeClass) {
-        if (state.getClass() == typeClass) {
-            return state;
-        } else if (typeClass == UpDownType.class) {
-            if (state.equals(PercentType.ZERO)) {
-                return UpDownType.UP;
-            } else if (state.equals(PercentType.HUNDRED)) {
-                return UpDownType.DOWN;
-            } else {
-                return UnDefType.UNDEF;
-            }
-        } else if (typeClass == DecimalType.class) {
-            if (state instanceof PercentType) {
-                return new DecimalType(((PercentType) state).toBigDecimal().divide(new BigDecimal(100), 8,
-                        RoundingMode.UP));
-            }
-        } else if (typeClass == PercentType.class) {
-            if (state instanceof DecimalType) {
-                return new PercentType(((DecimalType) state).toBigDecimal().multiply(new BigDecimal(100)));
-            }
-        }
-
-        return super.getStateAs(typeClass);
+        super.setState(state);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/SwitchItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/SwitchItem.java
@@ -13,9 +13,7 @@ import java.util.List;
 
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
@@ -45,7 +43,7 @@ public class SwitchItem extends GenericItem {
         super(CoreItemFactory.SWITCH, name);
     }
 
-    /* package */SwitchItem(String type, String name) {
+    /* package */ SwitchItem(String type, String name) {
         super(type, name);
     }
 
@@ -63,14 +61,4 @@ public class SwitchItem extends GenericItem {
         return Collections.unmodifiableList(acceptedCommandTypes);
     }
 
-    @Override
-    public State getStateAs(Class<? extends State> typeClass) {
-        if (typeClass == DecimalType.class) {
-            return state == OnOffType.ON ? new DecimalType(1) : DecimalType.ZERO;
-        } else if (typeClass == PercentType.class) {
-            return state == OnOffType.ON ? PercentType.HUNDRED : PercentType.ZERO;
-        } else {
-            return super.getStateAs(typeClass);
-        }
-    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -10,9 +10,12 @@ package org.eclipse.smarthome.core.library.types;
 import java.math.BigDecimal;
 import java.util.IllegalFormatConversionException;
 
+import org.eclipse.smarthome.core.library.internal.StateConverterUtil;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * The decimal type uses a BigDecimal internally and thus can be used for
@@ -21,7 +24,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
-public class DecimalType extends Number implements PrimitiveType, State, Command, Comparable<DecimalType> {
+public class DecimalType extends Number implements PrimitiveType, State, Command, Comparable<DecimalType>, Convertible {
 
     private static final long serialVersionUID = 4226845847123464690L;
 
@@ -139,4 +142,32 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
     public long longValue() {
         return value.longValue();
     }
+
+    @Override
+    public State as(Class<? extends State> target) {
+        if (target == OnOffType.class) {
+            return equals(ZERO) ? OnOffType.OFF : OnOffType.ON;
+        } else if (target == PercentType.class) {
+            return new PercentType(toBigDecimal().multiply(new BigDecimal(100)));
+        } else if (target == UpDownType.class) {
+            if (equals(ZERO)) {
+                return UpDownType.UP;
+            } else if (toBigDecimal().compareTo(new BigDecimal(1)) == 0) {
+                return UpDownType.DOWN;
+            } else {
+                return UnDefType.UNDEF;
+            }
+        } else if (target == OpenClosedType.class) {
+            if (equals(ZERO)) {
+                return OpenClosedType.CLOSED;
+            } else if (toBigDecimal().compareTo(new BigDecimal(1)) == 0) {
+                return OpenClosedType.OPEN;
+            } else {
+                return UnDefType.UNDEF;
+            }
+        } else {
+            return StateConverterUtil.defaultConversion(this, target);
+        }
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -8,11 +8,14 @@
 package org.eclipse.smarthome.core.library.types;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.eclipse.smarthome.core.library.internal.StateConverterUtil;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.ComplexType;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
 
@@ -24,7 +27,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Chris Jackson - Added fromRGB
  *
  */
-public class HSBType extends PercentType implements ComplexType, State, Command {
+public class HSBType extends PercentType implements ComplexType, State, Command, Convertible {
 
     private static final long serialVersionUID = 322902950356613226L;
 
@@ -253,5 +256,19 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
     private int convertPercentToByte(PercentType percent) {
         return percent.value.multiply(BigDecimal.valueOf(255))
                 .divide(BigDecimal.valueOf(100), 2, BigDecimal.ROUND_HALF_UP).intValue();
+    }
+
+    @Override
+    public State as(Class<? extends State> target) {
+        if (target == OnOffType.class) {
+            // if brightness is not completely off, we consider the state to be on
+            return getBrightness().equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON;
+        } else if (target == DecimalType.class) {
+            return new DecimalType(getBrightness().toBigDecimal().divide(new BigDecimal(100), 8, RoundingMode.UP));
+        } else if (target == PercentType.class) {
+            return new PercentType(getBrightness().toBigDecimal());
+        } else {
+            return StateConverterUtil.defaultConversion(this, target);
+        }
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
@@ -7,11 +7,13 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.smarthome.core.library.internal.StateConverterUtil;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
 
-public enum OnOffType implements PrimitiveType, State, Command {
+public enum OnOffType implements PrimitiveType, State, Command, Convertible {
     ON,
     OFF;
 
@@ -28,6 +30,19 @@ public enum OnOffType implements PrimitiveType, State, Command {
     @Override
     public String toFullString() {
         return super.toString();
+    }
+
+    @Override
+    public State as(Class<? extends State> target) {
+        if (target == DecimalType.class) {
+            return this == ON ? new DecimalType(1) : DecimalType.ZERO;
+        } else if (target == PercentType.class) {
+            return this == ON ? PercentType.HUNDRED : PercentType.ZERO;
+        } else if (target == HSBType.class) {
+            return this == ON ? HSBType.WHITE : HSBType.BLACK;
+        } else {
+            return StateConverterUtil.defaultConversion(this, target);
+        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
@@ -7,11 +7,13 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.smarthome.core.library.internal.StateConverterUtil;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
 
-public enum OpenClosedType implements PrimitiveType, State, Command {
+public enum OpenClosedType implements PrimitiveType, State, Command, Convertible {
     OPEN,
     CLOSED;
 
@@ -28,6 +30,17 @@ public enum OpenClosedType implements PrimitiveType, State, Command {
     @Override
     public String toFullString() {
         return super.toString();
+    }
+
+    @Override
+    public State as(Class<? extends State> target) {
+        if (target == DecimalType.class) {
+            return this == OPEN ? new DecimalType(1) : DecimalType.ZERO;
+        } else if (target == PercentType.class) {
+            return this == OPEN ? PercentType.HUNDRED : PercentType.ZERO;
+        } else {
+            return StateConverterUtil.defaultConversion(this, target);
+        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
@@ -8,6 +8,11 @@
 package org.eclipse.smarthome.core.library.types;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.eclipse.smarthome.core.library.internal.StateConverterUtil;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * The PercentType extends the {@link DecimalType} by putting constraints for its value on top (0-100).
@@ -49,6 +54,35 @@ public class PercentType extends DecimalType {
 
     public static PercentType valueOf(String value) {
         return new PercentType(value);
+    }
+
+    @Override
+    public State as(Class<? extends State> target) {
+        if (target == OnOffType.class) {
+            return equals(ZERO) ? OnOffType.OFF : OnOffType.ON;
+        } else if (target == DecimalType.class) {
+            return new DecimalType(toBigDecimal().divide(new BigDecimal(100), 8, RoundingMode.UP));
+        } else if (target == UpDownType.class) {
+            if (equals(ZERO)) {
+                return UpDownType.UP;
+            } else if (equals(HUNDRED)) {
+                return UpDownType.DOWN;
+            } else {
+                return UnDefType.UNDEF;
+            }
+        } else if (target == OpenClosedType.class) {
+            if (equals(ZERO)) {
+                return OpenClosedType.CLOSED;
+            } else if (equals(HUNDRED)) {
+                return OpenClosedType.OPEN;
+            } else {
+                return UnDefType.UNDEF;
+            }
+        } else if (target == HSBType.class) {
+            return new HSBType(DecimalType.ZERO, PercentType.ZERO, this);
+        } else {
+            return StateConverterUtil.defaultConversion(this, target);
+        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
@@ -7,11 +7,15 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import java.math.BigDecimal;
+
+import org.eclipse.smarthome.core.library.internal.StateConverterUtil;
 import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
 
-public enum UpDownType implements PrimitiveType, State, Command {
+public enum UpDownType implements PrimitiveType, State, Command, Convertible {
     UP,
     DOWN;
 
@@ -28,6 +32,17 @@ public enum UpDownType implements PrimitiveType, State, Command {
     @Override
     public String toFullString() {
         return super.toString();
+    }
+
+    @Override
+    public State as(Class<? extends State> target) {
+        if (target == DecimalType.class) {
+            return equals(UP) ? DecimalType.ZERO : new DecimalType(new BigDecimal("1.0"));
+        } else if (target == PercentType.class) {
+            return equals(UP) ? PercentType.ZERO : PercentType.HUNDRED;
+        } else {
+            return StateConverterUtil.defaultConversion(this, target);
+        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Convertible.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Convertible.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.types;
+
+/**
+ * Denotes that a {@link State} object is convertible into another type.
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ *
+ */
+public interface Convertible {
+
+    /**
+     * Convert this {@link State}'s value into another type
+     *
+     * @param target the desired {@link State} type
+     * @return the {@link State}'s value in the given type's representation, or <code>null</code> if the conversion was
+     *         not possible
+     */
+    public State as(Class<? extends State> target);
+
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -598,7 +598,7 @@ public class ThingResource implements SatisfiableRESTResource {
     private Map<String, Set<String>> getLinkedItemsMap(Thing thing) {
         Map<String, Set<String>> linkedItemsMap = new HashMap<>();
         for (Channel channel : thing.getChannels()) {
-            Set<String> linkedItems = itemChannelLinkRegistry.getLinkedItems(channel.getUID());
+            Set<String> linkedItems = itemChannelLinkRegistry.getLinkedItemNames(channel.getUID());
             linkedItemsMap.put(channel.getUID().getId(), linkedItems);
         }
         return linkedItemsMap;


### PR DESCRIPTION
This PR is intended to deal with the fact that users might be so creative and link e.g. a SwitchItem to a color channel which maintains a HSBType state. In order to get these items updated successfully whenever values change, the `State` object needs to be converted into something accepted (if possible at all...).

When implementing this, 
- I needed access to the linked items (and not only their names). Therefore I changed the `AbstractLinkRegistry.getLinkedItems()` method to `AbstractLinkRegistry.getLinkedItemNames()` because that is what it actually does and introduced a `ItemChannelLinkRegistry.getLinkedItems()` method with returns what it promises. The alternative would have been to re-add the `ThingManager` -> `ItemRegistry` dependency which I assume we all are happy was dropped.
- I decided to do the conversion in all three places: the `ThingManager`, `ItemUpdater` and `AutoUpdater`. Sending the state update event "as is" and doing the conversion in the `ItemUpdater` would lead to UIs still getting "wrong" events so they won't benefit from it. And doing it only in the `ThingManager` is not enough as there might be other origins for events having the "wrong" type. The `ItemUtil` seems like a good place for it.
- I had to change the order of the `acceptedDataTypes` in some items so they have the most meaningful type at the top of the list. I'm very well aware of the `TypeParser` and therefore I'm wondering even more why they were ordered like that before... I'm just not 100% sure if anywhere else something might rely in this order being the over way round of if if worked until now "by chance" because there was no overlap and the result will always be the same.
- I introduced the `Convertible` interface so that not all types have to implement that method. Alternatively an AbstractState could provide a default implemnentation, if you like that better. I whish we had Java 8...
- I decided to put the conversion logic into the types themselves. The conversion logic doesn't seem to be context specific, so it does not need to be within the items. Alternatively we could have something like a `TypeConverter` which takes a `State` and a target type and does the conversion. I thought it's easier to maintain like this, but if you prefer a clearer SoC, I will happily factory it out.

An example to test it with:

sample.things:

```
Bridge hue:bridge:01234567890 "Philips Hue Bridge" [ ipAddress="192.168.0.42", userName="********" ] {
    0210 1 "Hue Bulb" [ lightId="1" ]
}
```

sample.items:

```
Switch hue_switch "Hue Bulb Switch" <light> { channel="hue:0210:01234567890:1:color" }
Dimmer hue_dimmer "Hue Bulb Dimmer" <light> { channel="hue:0210:01234567890:1:color" }
Color hue_color "Hue Bulb Color" <light> { channel="hue:0210:01234567890:1:color" }
```

sample.sitemap:

```
sitemap demo label="Sample" {
    Frame label="Sample" {
        Switch item=hue_switch
        Slider item=hue_dimmer
        Colorpicker item=hue_color
    }

}

```

fixes #2253
Signed-off-by: Simon Kaufmann simon.kfm@googlemail.com
