### PR TITLE
Added setPercentageProgress(int progress, boolean silent) to Progress…

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackTest.groovy
@@ -9,24 +9,24 @@ package org.eclipse.smarthome.core.thing.firmware
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 
-import java.util.Locale;
+import java.util.Locale
 
 import org.eclipse.smarthome.core.events.Event
 import org.eclipse.smarthome.core.events.EventPublisher
 import org.eclipse.smarthome.core.i18n.I18nProvider
-import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
-import org.eclipse.smarthome.core.thing.binding.firmware.Firmware;
+import org.eclipse.smarthome.core.thing.binding.firmware.Firmware
 import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUID
-import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler;
-import org.eclipse.smarthome.core.thing.binding.firmware.ProgressCallback;
-import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep;
+import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler
+import org.eclipse.smarthome.core.thing.binding.firmware.ProgressCallback
+import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.osgi.framework.Bundle;
+import org.osgi.framework.Bundle
 
 /**
  * Testing the {@link ProgressCallback}.
@@ -39,6 +39,7 @@ public final class ProgressCallbackTest {
     List<Event> postedEvents
     ThingUID expectedThingUID
     FirmwareUID expectedFirmwareUID
+    String cancelMessageKey = "update-canceled"
     def usedMessagedKey
 
     @Before
@@ -46,7 +47,7 @@ public final class ProgressCallbackTest {
         def thingType = new ThingTypeUID("thing:type")
         expectedThingUID = new ThingUID(thingType, "thingid")
         expectedFirmwareUID = new FirmwareUID(thingType, "1")
-        postedEvents = new LinkedList<>();
+        postedEvents = new LinkedList<>()
         def publisher = [
             post : { event -> postedEvents.add(event) }
         ] as EventPublisher
@@ -54,77 +55,183 @@ public final class ProgressCallbackTest {
             getText:  { bundle, key, defaultText, locale, arguments ->
                 usedMessagedKey = key
                 return "Dummy Message"
-            } 
+            }
         ] as I18nProvider
         sut = new ProgressCallbackImpl(new DummyFirmwareHandler(),publisher, i18nProvider, expectedThingUID, expectedFirmwareUID, null)
+    }
+
+    @Test(expected=IllegalStateException)
+    void 'assert that update throws IllegalStateException if update is finished'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING)
+        sut.next()
+        sut.success()
+        assertThatUpdateResultEventIsValid(postedEvents.get(1), null, FirmwareUpdateResult.SUCCESS)
+        sut.update(100)
+    }
+    
+    @Test(expected=IllegalArgumentException)
+    void 'assert that defineSequence throws IllegalArguumentException if sequence is empty'(){
+        sut.defineSequence()
+    }
+
+    @Test(expected=IllegalArgumentException)
+    void 'assert that defineSequence throws IllegalArguumentException if sequence is null'(){
+        sut.defineSequence(null)
+    }
+    
+    
+    @Test(expected=IllegalArgumentException)
+    void 'assert that failed throws IllegalArguumentException if message key is empty'(){
+        sut.failed("", null)
+    }
+
+    @Test(expected=IllegalArgumentException)
+    void 'assert that failed throws IllegalArguumentException if message key is null'(){
+        sut.failed(null, null)
+    }
+
+
+    @Test(expected=IllegalStateException)
+    void 'assert that success throws IllegalStateException if progress is not at 100 percent'(){
+        sut.update(99)
+        sut.success()
+    }
+    
+    @Test(expected=IllegalStateException)
+    void 'assert that success throws IllegalStateException for failed updates'(){
+        sut.failed(cancelMessageKey, null)
+        assertThatUpdateResultEventIsValid(postedEvents.get(0), cancelMessageKey, FirmwareUpdateResult.ERROR)
+        sut.success()
+    }
+
+    @Test(expected=IllegalStateException)
+    void 'assert that success throws IllegalStateException if last progress step is not reached'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.next()
+        sut.success()
+    }
+
+    @Test(expected=IllegalArgumentException)
+    void 'assert that update throws IllegalArgumentException if progress smaller 0'(){
+        sut.update(-1)
+    }
+
+    @Test(expected=IllegalArgumentException)
+    void 'assert that update throws IllegalArgumentException if progress greater 100'(){
+        sut.update(101)
+    }
+
+    @Test(expected=IllegalArgumentException)
+    void 'assert that update throws IllegalArgumentException if new progress is smaller than old progress'(){
+        sut.update(10)
+        sut.update(9)
+    }
+
+    @Test
+    void 'assert that defining a sequence is optional if percentage progress is used'(){
+        sut.update(5)
+        assertThatProgressInfoEventIsValid(postedEvents.get(0), null, false, 5)
+        sut.update(11)
+        assertThatProgressInfoEventIsValid(postedEvents.get(1), null, false, 11)
+        sut.update(22)
+        assertThatProgressInfoEventIsValid(postedEvents.get(2), null, false, 22)
+        sut.update(44)
+        assertThatProgressInfoEventIsValid(postedEvents.get(3), null, false, 44)
+        sut.pending()
+        assertThatProgressInfoEventIsValid(postedEvents.get(4), null, true, 44)
+        sut.update(50)
+        assertThatProgressInfoEventIsValid(postedEvents.get(5), null, false, 50)
+        sut.update(70)
+        assertThatProgressInfoEventIsValid(postedEvents.get(6), null, false, 70)
+        sut.update(89)
+        assertThatProgressInfoEventIsValid(postedEvents.get(7), null, false, 89)
+        sut.update(100)
+        assertThatProgressInfoEventIsValid(postedEvents.get(8), null, false, 100)
+        sut.success()
+        assertThatUpdateResultEventIsValid(postedEvents.get(9), null, FirmwareUpdateResult.SUCCESS)
+        assertThat postedEvents.size(), is(10)
+    }
+
+    @Test
+    void 'assert that update results not in FirmwareUpdateProgressInfo event if progress not changed'(){
+        sut.defineSequence(ProgressStep.UPDATING)
+        sut.update(10)
+        sut.update(10)
+        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.UPDATING, false, 10)
+        assertThat postedEvents.size(), is(1)
     }
 
     @Test
     void 'assert that setting the progess to pending results in a FirmwareUpdateProgressInfo event'(){
         sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
         sut.pending()
-        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, true)
+        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, true, null)
     }
-    
+
     @Test
     void 'assert that pending does not change ProgressStep'(){
         sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
         sut.pending()
-        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, true)
+        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, true, null)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(1), ProgressStep.DOWNLOADING, false)
+        assertThatProgressInfoEventIsValid(postedEvents.get(1), ProgressStep.DOWNLOADING, false, null)
         sut.pending()
-        assertThatProgressInfoEventIsValid(postedEvents.get(2), ProgressStep.DOWNLOADING, true)
+        assertThatProgressInfoEventIsValid(postedEvents.get(2), ProgressStep.DOWNLOADING, true, null)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(3), ProgressStep.DOWNLOADING, false)
+        assertThatProgressInfoEventIsValid(postedEvents.get(3), ProgressStep.DOWNLOADING, false, null)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(4), ProgressStep.TRANSFERRING, false)
+        assertThatProgressInfoEventIsValid(postedEvents.get(4), ProgressStep.TRANSFERRING, false, null)
         sut.pending()
-        assertThatProgressInfoEventIsValid(postedEvents.get(5), ProgressStep.TRANSFERRING, true)
+        assertThatProgressInfoEventIsValid(postedEvents.get(5), ProgressStep.TRANSFERRING, true, null)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(6), ProgressStep.TRANSFERRING, false)
-        assertThat postedEvents.size(), is(7)
+        assertThatProgressInfoEventIsValid(postedEvents.get(6), ProgressStep.TRANSFERRING, false, null)
+        sut.success()
+        assertThatUpdateResultEventIsValid(postedEvents.get(7), null, FirmwareUpdateResult.SUCCESS)
+        assertThat postedEvents.size(), is(8)
     }
 
     @Test
     void 'assert that next changes ProgressStep if not pending'(){
         sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING, ProgressStep.UPDATING)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, false)
+        assertThatProgressInfoEventIsValid(postedEvents.get(0), ProgressStep.DOWNLOADING, false, null)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(1), ProgressStep.TRANSFERRING, false)
+        assertThatProgressInfoEventIsValid(postedEvents.get(1), ProgressStep.TRANSFERRING, false, null)
         sut.pending()
-        assertThatProgressInfoEventIsValid(postedEvents.get(2), ProgressStep.TRANSFERRING, true)
+        assertThatProgressInfoEventIsValid(postedEvents.get(2), ProgressStep.TRANSFERRING, true, null)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(3), ProgressStep.TRANSFERRING, false)
+        assertThatProgressInfoEventIsValid(postedEvents.get(3), ProgressStep.TRANSFERRING, false, null)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(4), ProgressStep.UPDATING, false)
+        assertThatProgressInfoEventIsValid(postedEvents.get(4), ProgressStep.UPDATING, false, null)
         sut.pending()
-        assertThatProgressInfoEventIsValid(postedEvents.get(5), ProgressStep.UPDATING, true)
+        assertThatProgressInfoEventIsValid(postedEvents.get(5), ProgressStep.UPDATING, true, null)
         sut.next()
-        assertThatProgressInfoEventIsValid(postedEvents.get(6), ProgressStep.UPDATING, false)
-        assertThat postedEvents.size(), is(7)
+        assertThatProgressInfoEventIsValid(postedEvents.get(6), ProgressStep.UPDATING, false, null)
+        sut.success()
+        assertThatUpdateResultEventIsValid(postedEvents.get(7), null, FirmwareUpdateResult.SUCCESS)
+        assertThat postedEvents.size(), is(8)
     }
-        
+
     @Test(expected=IllegalStateException)
     void 'assert that cancel throws IllegalStateException if update is finished'(){
         sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.next()
+        sut.next()
         sut.success()
+        assertThatUpdateResultEventIsValid(postedEvents.get(2), null, FirmwareUpdateResult.SUCCESS)
         sut.canceled()
     }
-    
+
     @Test
     void 'assert that calling cancel results in a FirmwareUpdateResultInfoEvent'(){
         sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
         sut.canceled()
-        
         assertThat postedEvents.size(), is(1)
         assertThat postedEvents.get(0), is(instanceOf(FirmwareUpdateResultInfoEvent))
         FirmwareUpdateResultInfoEvent resultEvent = postedEvents.get(0) as FirmwareUpdateResultInfoEvent
         assertThat resultEvent.getThingUID(), is(expectedThingUID)
         assertThat resultEvent.firmwareUpdateResultInfo.result, is(FirmwareUpdateResult.CANCELED)
-        assertThat usedMessagedKey, is(ProgressCallbackImpl.UPDATE_CANCELED_MESSAGE_KEY)
-        
+        assertThat usedMessagedKey, is(cancelMessageKey)
     }
 
     /*
@@ -143,33 +250,52 @@ public final class ProgressCallbackTest {
 
     @Test
     void 'assert that getProgressStep returns current step if next was called before'(){
-        def steps = [
-            ProgressStep.DOWNLOADING,
-            ProgressStep.TRANSFERRING,
-            ProgressStep.UPDATING,
-            ProgressStep.REBOOTING] as ProgressStep[]
+        def steps = [ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING, ProgressStep.UPDATING, ProgressStep.REBOOTING] as ProgressStep[]
         sut.defineSequence(steps)
         sut.next()
-        for (int i = 0; i< steps.length-1;i++){
+        for (int i = 0; i< steps.length-1; i++){
             assertThat sut.getCurrentStep(), is (steps[i])
             sut.next()
         }
     }
 
-    @Test(expected=IllegalStateException)
-    void 'assert that pending throws IllegalStateException if step sequence is not defined'(){
+    @Test(expected=IllegalArgumentException)
+    void 'assert that pending throws IllegalArgumentException if step sequence is not defined and no progress was set'(){
         sut.pending()
     }
-    
+
+    @Test
+    void 'assert that pending throws no IllegalStateException if step sequence is not defined and progress was set'(){
+        sut.update(0)
+        sut.pending()
+        assertThatProgressInfoEventIsValid(postedEvents.get(1), null, true, 0)
+    }
+
+    @Test
+    void 'assert that cancel throws no IllegalStateException if step sequence is not defined'(){
+        sut.canceled()
+        assertThatUpdateResultEventIsValid(postedEvents.get(0), cancelMessageKey, FirmwareUpdateResult.CANCELED)
+    }
+
     @Test(expected=IllegalStateException)
     void 'assert that failed throws IllegalStateException if its called multiple times'(){
         sut.failed("DummyMessageKey")
         sut.failed("DummyMessageKey")
     }
+    
+    @Test(expected=IllegalStateException)
+    void 'assert that failed throws IllegalStateException for successful updates'(){
+        sut.update(100)
+        sut.success()
+        assertThatUpdateResultEventIsValid(postedEvents.get(1), null, FirmwareUpdateResult.SUCCESS)
+        sut.failed("DummyMessageKey")
+    }
 
     @Test(expected=IllegalStateException)
     void 'assert that success throws IllegalStateException if its called multiple times'(){
+        sut.update(100)
         sut.success()
+        assertThatUpdateResultEventIsValid(postedEvents.get(1), null, FirmwareUpdateResult.SUCCESS)
         sut.success()
     }
 
@@ -179,14 +305,14 @@ public final class ProgressCallbackTest {
         sut.failed("DummyMessageKey")
         sut.pending()
     }
-    
+
     @Test(expected=IllegalStateException)
     void 'assert that next throws IllegalStateException if update is not pending and no further steps available'(){
         sut.defineSequence(ProgressStep.DOWNLOADING)
         sut.next()
         sut.next()
     }
-    
+
     void 'assert that next throws no IllegalStateException if update is pending and no further steps available'(){
         sut.defineSequence(ProgressStep.DOWNLOADING)
         sut.next()
@@ -198,25 +324,35 @@ public final class ProgressCallbackTest {
     @Test(expected=IllegalStateException)
     void 'assert that pending throws IllegalStateException if update was successful'(){
         sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.next()
+        sut.next()
         sut.success()
         sut.pending()
     }
 
-    def assertThatProgressInfoEventIsValid(Event event, ProgressStep expectedStep, boolean isPending){
+    def assertThatProgressInfoEventIsValid(Event event, ProgressStep expectedStep, boolean expectedPending, Integer expectedProgress){
         assertThat event, is(instanceOf(FirmwareUpdateProgressInfoEvent))
         def fpiEvent = event as FirmwareUpdateProgressInfoEvent
         assertThat fpiEvent.getThingUID(), is(expectedThingUID)
         assertThat fpiEvent.getProgressInfo().getFirmwareUID(), is(expectedFirmwareUID)
         assertThat fpiEvent.getProgressInfo().getProgressStep(), is(expectedStep)
-        // Is update in PENDING state?
-        assertThat fpiEvent.getProgressInfo().isPending(), (is(isPending))
+        assertThat fpiEvent.getProgressInfo().getProgress(), is(expectedProgress)
+        assertThat fpiEvent.getProgressInfo().isPending(), (is(expectedPending))
     }
     
+    def assertThatUpdateResultEventIsValid(Event event, String expectedMessageKey, FirmwareUpdateResult expectedResult){
+        assertThat event, is(instanceOf(FirmwareUpdateResultInfoEvent))
+        def fpiEvent = event as FirmwareUpdateResultInfoEvent
+        assertThat usedMessagedKey, is(expectedMessageKey)
+        assertThat fpiEvent.getThingUID(), is(expectedThingUID)
+        assertThat fpiEvent.getFirmwareUpdateResultInfo().getResult(), is(expectedResult)
+    }
+
     class DummyFirmwareHandler implements FirmwareUpdateHandler {
 
         @Override
         public Thing getThing() {
-            return null;
+            return null
         }
 
         @Override
@@ -229,7 +365,7 @@ public final class ProgressCallbackTest {
 
         @Override
         public boolean isUpdateExecutable() {
-            return false;
+            return false
         }
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/ProgressCallback.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/ProgressCallback.java
@@ -11,8 +11,21 @@ package org.eclipse.smarthome.core.thing.binding.firmware;
  * The {@link ProgressCallback} is injected into the
  * {@link FirmwareUpdateHandler#updateFirmware(Firmware, ProgressCallback)} operation in order to post progress
  * information about the firmware update process.
- *
+ * 
+ * The progress of a firmware update can be defined by a sequence of {@link ProgressStep}s, a percentage progress or
+ * both.
+ * 
+ * In order to use a sequence of {@link ProgressStep}s to indicate the update progress, it is necessary to first define
+ * a sequence using the method {@link ProgressCallback#defineSequence(ProgressStep...)}. To indicate that the next
+ * progress step is going to be executed the method {@link ProgressCallback#next()} has to be used.
+ * 
+ * For updates which are based on a percentage progress it is optional to define a sequence of {@link ProgressStep}s and
+ * to use the {@link ProgressCallback#next()} method. In order to indicate that the percentage progress has changed, the
+ * method {@link ProgressCallback#update(progress)} has to be used. It allows to update the percentage progress to a
+ * value between 0 and 100.
+ * 
  * @author Thomas Höfer - Initial contribution
+ * @author Christop Knauf - Added canceled, pending and update
  */
 public interface ProgressCallback {
 
@@ -57,21 +70,41 @@ public interface ProgressCallback {
      * @param arguments the arguments to be injected into the internationalized error message (can be null)
      *
      * @throws IllegalArgumentException if given error message key is null or empty
+     * @throws IllegalStateException if update is already finished
      */
     void failed(String errorMessageKey, Object... arguments);
 
     /**
      * Callback operation to indicate that the firmware update was successful.
+     * 
+     * @throws IllegalStateException if update is finished
      */
     void success();
 
     /**
      * Callback operation to indicate that the firmware update is pending.
+     * 
+     * @throws IllegalStateException if update is finished
      */
     void pending();
 
     /**
      * Callback operation to indicate that the firmware update was canceled.
+     * 
+     * @throws IllegalStateException if update is finished
      */
     void canceled();
+
+    /**
+     * Callback operation to update the percentage progress of the firmware update.
+     * This method can be used to provide detailed progress information additional to the sequence or even without a
+     * previous defined sequence.
+     * 
+     * @param progress the progress between 0 and 100
+     * 
+     * @throws IllegalArgumentException if given progress is < 0 or > 100
+     * @throws IllegalArgumentException if given progress is smaller than old progress
+     * @throws IllegalStateException if update is finished
+     */
+    void update(int progress);
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateProgressInfo.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateProgressInfo.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
  * The {@link FirmwareUpdateProgressInfo} represents the progress indicator for a firmware update.
  *
  * @author Thomas Höfer - Initial contribution
+ * @author Christoph Knauf - Added progress and pending
  */
 public final class FirmwareUpdateProgressInfo {
 
@@ -28,6 +29,8 @@ public final class FirmwareUpdateProgressInfo {
     private Collection<ProgressStep> sequence;
 
     private boolean pending;
+
+    private Integer progress;
 
     /**
      * Default constructor. Will allow to instantiate this class by reflection.
@@ -44,20 +47,47 @@ public final class FirmwareUpdateProgressInfo {
      * @param sequence the collection of progress steps describing the sequence of the firmware update process
      *            (must not be null)
      * @param pending the flag indicating if the update is pending
+     * @param progress the progress of the update in percent
      *
      * @throws NullPointerException if firmware UID or current progress step is null
-     * @throws IllegalArgumentException if sequence is null or empty
+     * @throws IllegalArgumentException if sequence is null or empty or progress is not between 0 and 100
      */
     FirmwareUpdateProgressInfo(FirmwareUID firmwareUID, ProgressStep progressStep, Collection<ProgressStep> sequence,
-            boolean pending) {
+            boolean pending, int progress) {
         Preconditions.checkNotNull(firmwareUID, "Firmware UID must not be null.");
-        Preconditions.checkNotNull(progressStep, "Progress step must not be null.");
-        Preconditions.checkArgument(sequence != null && !sequence.isEmpty(), "Sequence must not be null or empty.");
+        Preconditions.checkArgument(progress >= 0 && progress <= 100, "The progress must be between 0 and 100.");
 
         this.firmwareUID = firmwareUID;
         this.progressStep = progressStep;
         this.sequence = sequence;
         this.pending = pending;
+        this.progress = progress;
+    }
+
+    /**
+     * Creates a new {@link FirmwareUpdateProgressInfo}.
+     *
+     * @param firmwareUID the UID of the firmware that is updated (must not be null)
+     * @param progressStep the current progress step (must not be null)
+     * @param sequence the collection of progress steps describing the sequence of the firmware update process
+     *            (must not be null)
+     * @param pending the flag indicating if the update is pending
+     *
+     * @throws NullPointerException if firmware UID or current progress step is null
+     * @throws NullPointerException if progressStep is null
+     * @throws IllegalArgumentException if sequence is null or empty
+     */
+    FirmwareUpdateProgressInfo(FirmwareUID firmwareUID, ProgressStep progressStep, Collection<ProgressStep> sequence,
+            boolean pending) {
+        Preconditions.checkNotNull(firmwareUID, "Firmware UID must not be null.");
+        Preconditions.checkArgument(sequence != null && !sequence.isEmpty(), "Sequence must not be null or empty.");
+        Preconditions.checkNotNull(progressStep, "Progress step must not be null.");
+
+        this.firmwareUID = firmwareUID;
+        this.progressStep = progressStep;
+        this.sequence = sequence;
+        this.pending = pending;
+        this.progress = null;
     }
 
     /**
@@ -87,14 +117,33 @@ public final class FirmwareUpdateProgressInfo {
         return sequence;
     }
 
+    /**
+     * Returns true if the firmware update is pending, false otherwise
+     * 
+     * @return true if pending, false otherwise
+     */
+    public boolean isPending() {
+        return pending;
+    }
+
+    /**
+     * Returns the percentage progress of the firmware update.
+     * 
+     * @return the progress between 0 and 100 or null if no progress was set
+     */
+    public Integer getProgress() {
+        return progress;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((firmwareUID == null) ? 0 : firmwareUID.hashCode());
+        result = prime * result + (pending ? 1231 : 1237);
+        result = prime * result + progress;
         result = prime * result + ((progressStep == null) ? 0 : progressStep.hashCode());
         result = prime * result + ((sequence == null) ? 0 : sequence.hashCode());
-        result = prime * result + new Boolean(pending).hashCode();
         return result;
     }
 
@@ -106,7 +155,7 @@ public final class FirmwareUpdateProgressInfo {
         if (obj == null) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof FirmwareUpdateProgressInfo)) {
             return false;
         }
         FirmwareUpdateProgressInfo other = (FirmwareUpdateProgressInfo) obj;
@@ -115,6 +164,12 @@ public final class FirmwareUpdateProgressInfo {
                 return false;
             }
         } else if (!firmwareUID.equals(other.firmwareUID)) {
+            return false;
+        }
+        if (pending != other.pending) {
+            return false;
+        }
+        if (progress != other.progress) {
             return false;
         }
         if (progressStep != other.progressStep) {
@@ -127,20 +182,13 @@ public final class FirmwareUpdateProgressInfo {
         } else if (!sequence.equals(other.sequence)) {
             return false;
         }
-        if (pending != other.pending) {
-            return false;
-        }
         return true;
     }
 
     @Override
     public String toString() {
         return "FirmwareUpdateProgressInfo [firmwareUID=" + firmwareUID + ", progressStep=" + progressStep
-                + ", sequence=" + sequence + ", pending=" + pending + "]";
-    }
-
-    public boolean isPending() {
-        return pending;
+                + ", sequence=" + sequence + ", pending=" + pending + ", progress=" + progress + "]";
     }
 
 }


### PR DESCRIPTION
…Callback

Added progress to FirmwareUpdateProgressInfo

setPercentageProgress allows users of the ProgressCallback to set the percentage progress
eigther silent (no event posted) or not silent (event is posted if progress changed).
If silent or not, the updated progress will be part of the next FirmwareUpdateProgressInfo Event (for example if the ProressStep changes).
This allows update processes driven by ProgressStep changes or percentage update progress changes.

Signed-off-by: Christoph Knauf  christoph.knauf@itemis.de
