### PR TITLE
Fixes #2322 Basic UI no longer updates icons

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/SitemapSubscriptionService.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/SitemapSubscriptionService.java
@@ -111,9 +111,8 @@ public class SitemapSubscriptionService {
         String sitemapPage = pageOfSubscription.remove(subscriptionId);
         if (sitemapPage != null && !pageOfSubscription.values().contains(sitemapPage)) {
             // this was the only subscription listening on this page, so we can dispose the listener
-            PageChangeListener listener = pageChangeListeners.get(sitemapPage);
+            PageChangeListener listener = pageChangeListeners.remove(sitemapPage);
             if (listener != null) {
-                pageChangeListeners.remove(sitemapPage);
                 listener.dispose();
             }
         }

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/SitemapSubscriptionService.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/SitemapSubscriptionService.java
@@ -113,7 +113,7 @@ public class SitemapSubscriptionService {
             // this was the only subscription listening on this page, so we can dispose the listener
             PageChangeListener listener = pageChangeListeners.get(sitemapPage);
             if (listener != null) {
-                pageChangeListeners.remove(listener);
+                pageChangeListeners.remove(sitemapPage);
                 listener.dispose();
             }
         }


### PR DESCRIPTION
At line 116 in `SitemapSubscriptionService` the `listener` is removed whereas I think it should remove the `sitemapPage`. The `.remove(..)` works on map keys, which should be the `sitemapPage`. Whereas the `listener` is the value of the map.

See #2322 for reproduction scenario.

Signed-off-by: Wouter Born <eclipse@maindrain.net>