### PR TITLE
Prevent scriptarea from overlapping with outputs

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.config.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/include.config.html
@@ -101,8 +101,8 @@
 										<p ng-message="maxlength" class="customMessage">Maximum length is {{parameter.max}}</p>
 										<p ng-message="required" class="customMessage">Field is required</p>
 									</div>
-									<span ng-show="!focus">
-										<p class="hint noMargin">
+									<span>
+										<p class="hint noMargin" ng-class="{'invisible':focus}">
 											<small ng-bind-html="parameter.description"></small>
 										</p>
 									</span>


### PR DESCRIPTION
Fix: Script field overlaps with output field when focussed.
Before:
<img width="457" alt="screen shot 2016-10-20 at 12 08 26" src="https://cloud.githubusercontent.com/assets/5161937/19556287/af1b8480-96c0-11e6-9a20-ca2159273a85.png">
After:
<img width="465" alt="screen shot 2016-10-20 at 12 09 42" src="https://cloud.githubusercontent.com/assets/5161937/19556295/b901f560-96c0-11e6-87ba-1e355b4aad57.png">

Signed-off-by: Aoun Bukhari bukhari@itemis.de
