### PR TITLE
Fixes #2332 Selection sitemap item does not show current selection after Basic UI page (re)load

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.basic/snippets/selection.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/snippets/selection.html
@@ -6,7 +6,7 @@
 		%label_header%
 	</span>
 	<span class="mdl-form__value">
-        %value%
+        %value_header%
     </span>
 	<div
 		class="mdl-form__control mdl-form__selection"

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SelectionRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SelectionRenderer.java
@@ -83,7 +83,7 @@ public class SelectionRenderer extends AbstractWidgetRenderer {
             rowSB.append(rowSnippet);
         }
         snippet = StringUtils.replace(snippet, "%rows%", rowSB.toString());
-        snippet = StringUtils.replace(snippet, "%value%", mappingLabel != null ? mappingLabel : "");
+        snippet = StringUtils.replace(snippet, "%value_header%", mappingLabel != null ? mappingLabel : "");
 
         // Process the color tags
         snippet = processColor(w, snippet);


### PR DESCRIPTION
This issue is that `preprocessSnippet` in `SelectionRenderer.java` already substitutes `%value%` so I've changed the name of the substituted value.

Signed-off-by: Wouter Born <eclipse@maindrain.net>