### PR TITLE
Fixed mistyped variable for Wemo binding OSGi tests

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoLightOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoLightOSGiTest.groovy
@@ -63,7 +63,7 @@ class GenericWemoLightOSGiTest extends GenericWemoOSGiTest {
                 .withConfiguration(configuration)
                 .build();
 
-        mangedThingProvider.add(bridge)
+        managedThingProvider.add(bridge)
     }
 
     protected void createDefaultThing(ThingTypeUID thingTypeUID) {
@@ -88,7 +88,7 @@ class GenericWemoLightOSGiTest extends GenericWemoOSGiTest {
                 .withBridge(bridgeUID)
                 .build();
 
-        mangedThingProvider.add(thing)
+        managedThingProvider.add(thing)
 
         createItem(channelUID,DEFAULT_TEST_ITEM_NAME,itemAcceptedType)
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoOSGiTest.groovy
@@ -77,7 +77,7 @@ public abstract class GenericWemoOSGiTest extends OSGiTest{
 
     def DEFAULT_TEST_ASSERTION_TIMEOUT = 1000;
 
-    ManagedThingProvider mangedThingProvider
+    ManagedThingProvider managedThingProvider
     static MockUpnpService mockUpnpService
     UpnpIOServiceImpl upnpIOService
     ThingRegistry thingRegistry
@@ -97,8 +97,8 @@ public abstract class GenericWemoOSGiTest extends OSGiTest{
         mockUpnpService.startup()
         registerService(mockUpnpService, UpnpService.class.getName())
 
-        mangedThingProvider = getService(ManagedThingProvider.class);
-        assertThat mangedThingProvider, is (notNullValue())
+        managedThingProvider = getService(ManagedThingProvider.class);
+        assertThat managedThingProvider, is (notNullValue())
 
         thingRegistry = getService(ThingRegistry.class)
         assertThat(thingRegistry, is (notNullValue()))
@@ -136,7 +136,7 @@ public abstract class GenericWemoOSGiTest extends OSGiTest{
                 .withChannel(channel)
                 .build();
 
-        mangedThingProvider.add(thing)
+        managedThingProvider.add(thing)
 
         createItem(channelUID,DEFAULT_TEST_ITEM_NAME,itemAcceptedType)
     }


### PR DESCRIPTION
`ManagedThingProvider managedThingProvider` was misspelled and said "mangedThingProvider". Successful builds of tests run after change applied.


Signed-off-by: Alexander Kostadinov <alexander.g.kostadinov@gmail.com>