### PR TITLE
disable NTP tests until issue is solved

### DIFF
--- a/extensions/binding/pom.xml
+++ b/extensions/binding/pom.xml
@@ -22,7 +22,7 @@
     <module>org.eclipse.smarthome.binding.fsinternetradio</module>
     <module>org.eclipse.smarthome.binding.lifx</module>
     <module>org.eclipse.smarthome.binding.ntp</module>
-    <module>org.eclipse.smarthome.binding.ntp.test</module>
+    <!-- <module>org.eclipse.smarthome.binding.ntp.test</module> -->
     <module>org.eclipse.smarthome.binding.sonos</module>
     <module>org.eclipse.smarthome.binding.wemo</module>
     <module>org.eclipse.smarthome.binding.wemo.test</module>


### PR DESCRIPTION
As this should be only a temporary solution I prefer to remove the whole artifact from the reactor.

Related to: https://github.com/eclipse/smarthome/issues/2345
