### PR TITLE
Allow injection of timestamp into AbstractDiscoveryService

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/discovery/inbox/events/InboxEventFactoryTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/discovery/inbox/events/InboxEventFactoryTest.groovy
@@ -29,7 +29,7 @@ class InboxEventFactoryTest {
 
     def THING_UID = new ThingUID("binding:type:id")
 
-    def DISCOVERY_RESULT = new DiscoveryResultImpl(THING_UID, null, null, null, null, 60)
+    def DISCOVERY_RESULT = new DiscoveryResultImpl(THING_UID, null, null, null, null, 60, null)
 
     def INBOX_ADDED_EVENT_TYPE = InboxAddedEvent.TYPE
 

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryResultImplTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryResultImplTest.groovy
@@ -10,6 +10,7 @@ package org.eclipse.smarthome.config.setup.test.discovery;
 import static org.junit.Assert.*
 
 import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag
+import org.eclipse.smarthome.config.discovery.DiscoveryService
 import org.eclipse.smarthome.config.discovery.internal.DiscoveryResultImpl
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
@@ -19,7 +20,7 @@ import org.junit.Test
 /**
  * The {@link DiscoveryResultTest} checks if any invalid input parameters
  * and the synchronization of {@link DiscoveryResult}s work in a correct way.
- * 
+ *
  * @author Michael Grammling - Initial Contribution
  * @author Thomas Höfer - Added representation
  */
@@ -30,7 +31,7 @@ class DiscoveryResultImplTest {
     @Test
     public void testInvalidConstructorForThingType() {
         try {
-            new DiscoveryResultImpl(new ThingUID("aa"), null, null, null, null, DEFAULT_TTL)
+            new DiscoveryResultImpl(new ThingUID("aa"), null, null, null, null, DEFAULT_TTL, null)
             fail "The constructor must throw an IllegalArgumentException if null is used"
             + " as Thing type!"
         } catch (IllegalArgumentException expected) {
@@ -43,7 +44,7 @@ class DiscoveryResultImplTest {
             def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
 
             DiscoveryResultImpl discoveryResult =
-                    new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, null, null, null, -2)
+                    new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, null, null, null, -2, null)
             fail "The constructor must throw an IllegalArgumentException if negative value is used"
             + " as ttl!"
         } catch (IllegalArgumentException expected) {
@@ -53,15 +54,17 @@ class DiscoveryResultImplTest {
     @Test
     public void testValidConstructor() {
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
+        def discoveryService = "discoveryService" as DiscoveryService
 
         DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, null, null, null, DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, null, null, null, DEFAULT_TTL, discoveryService)
 
         assertEquals("bindingId:thingType", discoveryResult.getThingTypeUID().toString())
         assertEquals("bindingId:thingType:thingId", discoveryResult.getThingUID().toString())
         assertEquals("bindingId", discoveryResult.getBindingId())
         assertEquals("", discoveryResult.getLabel())
         assertEquals(DiscoveryResultFlag.NEW, discoveryResult.getFlag())
+        assertEquals(discoveryService, discoveryResult.isDiscoveredBy())
 
         assertNotNull("The properties must never be null!", discoveryResult.getProperties())
         assertNull(discoveryResult.getRepresentationProperty())
@@ -73,7 +76,7 @@ class DiscoveryResultImplTest {
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
         def discoveryResultSourceMap = [ "ipAddress" : "127.0.0.1" ]
         DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL, null)
 
         discoveryResult.setFlag(DiscoveryResultFlag.IGNORED)
 
@@ -91,12 +94,12 @@ class DiscoveryResultImplTest {
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
         def discoveryResultSourceMap = [ "ipAddress" : "127.0.0.1" ]
         DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL, null)
 
         discoveryResult.setFlag(DiscoveryResultFlag.IGNORED)
 
         DiscoveryResultImpl discoveryResultSource =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "anotherThingId"), null, null, null, null, DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "anotherThingId"), null, null, null, null, DEFAULT_TTL, null)
 
 
         discoveryResult.synchronize(discoveryResultSource)
@@ -113,13 +116,13 @@ class DiscoveryResultImplTest {
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
         def discoveryResultSourceMap = [ "ipAddress" : "127.0.0.1" ]
         DiscoveryResultImpl discoveryResult =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultSourceMap, "ipAddress", "TARGET", DEFAULT_TTL, null)
 
         discoveryResult.setFlag(DiscoveryResultFlag.IGNORED)
 
         def discoveryResultMap = [ "ipAddress" : "192.168.178.1", "macAddress" : "AA:BB:CC:DD:EE:FF" ]
         DiscoveryResultImpl discoveryResultSource =
-                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultMap, "macAddress", "SOURCE", DEFAULT_TTL)
+                new DiscoveryResultImpl(new ThingUID(thingTypeUID, "thingId"), null, discoveryResultMap, "macAddress", "SOURCE", DEFAULT_TTL, null)
 
 
         discoveryResultSource.setFlag(DiscoveryResultFlag.NEW)
@@ -136,7 +139,7 @@ class DiscoveryResultImplTest {
     @Test
     public void testThingTypeCompatibility() {
         def thingTypeUID = new ThingTypeUID("bindingId", "thingType")
-        DiscoveryResultImpl discoveryResult = new DiscoveryResultImpl(null, new ThingUID(thingTypeUID, "thingId"), null, null, "nothing", "label", DEFAULT_TTL)
+        DiscoveryResultImpl discoveryResult = new DiscoveryResultImpl(null, new ThingUID(thingTypeUID, "thingId"), null, null, "nothing", "label", DEFAULT_TTL, null)
         assertNotNull(discoveryResult.getThingTypeUID())
         assertEquals(discoveryResult.getThingTypeUID(), thingTypeUID)
     }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceMock.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceMock.groovy
@@ -47,6 +47,6 @@ class DiscoveryServiceMock extends AbstractDiscoveryService {
         if (faulty) {
             throw new Exception()
         }
-        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, generator((('A'..'Z')+('0'..'9')).join(), 9)), null, null, null, null, DEFAULT_TTL))
+        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, generator((('A'..'Z')+('0'..'9')).join(), 9)), null, null, null, null, DEFAULT_TTL, this))
     }
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/ExtendedDiscoveryServiceMock.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/ExtendedDiscoveryServiceMock.groovy
@@ -35,6 +35,6 @@ class ExtendedDiscoveryServiceMock extends DiscoveryServiceMock implements Exten
 
     @Override
     public void startScan() {
-        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, "foo"), null, null, null, null, DEFAULT_TTL))
+        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, "foo"), null, null, null, null, DEFAULT_TTL, this))
     }
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/DynamicThingUpdateOSGITest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/DynamicThingUpdateOSGITest.groovy
@@ -151,7 +151,7 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
 
         final Map<String, Object> discoveryResultProps = new HashMap<>();
         discoveryResultProps.put(CFG_IP_ADDRESS_KEY, CFG_IP_ADDRESS_VALUE);
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_UID, null, discoveryResultProps, "DummyRepr", "DummyLabel1", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_UID, null, discoveryResultProps, "DummyRepr", "DummyLabel1", DEFAULT_TTL, null)
 
         inbox.add discoveryResult
 
@@ -172,7 +172,7 @@ class DynamicThingUpdateOSGITest extends OSGiTest {
 
         managedThingProvider.add ThingBuilder.create(THING_TYPE_UID, THING_ID).build()
 
-        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_UID, null, [:], null, "DummyLabel", DEFAULT_TTL)
+        DiscoveryResult discoveryResult = new DiscoveryResultImpl(THING_UID, null, [:], null, "DummyLabel", DEFAULT_TTL, null)
 
         inbox.add discoveryResult
 

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
@@ -248,6 +248,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *            Holds the information needed to identify the discovered device.
      */
     protected void thingDiscovered(DiscoveryResult discoveryResult) {
+        discoveryResult.discoveredBy(this);
         for (DiscoveryListener discoveryListener : discoveryListeners) {
             try {
                 discoveryListener.thingDiscovered(this, discoveryResult);

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryResult.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryResult.java
@@ -80,7 +80,7 @@ public interface DiscoveryResult {
      * discovered. Its actual value can be retrieved from the {@link DiscoveryResult#getProperties()} map. Such unique
      * identifiers are typically the <code>ipAddress</code>, the <code>macAddress</code> or the
      * <code>serialNumber</code> of the discovered thing.
-     * 
+     *
      * @return the representation property of this result object (could be null)
      */
     public String getRepresentationProperty();
@@ -112,15 +112,29 @@ public interface DiscoveryResult {
 
     /**
      * Get the timestamp of this {@link DiscoveryResult}.
-     * 
+     *
      * @return timestamp as long
      */
     public long getTimestamp();
 
     /**
      * Get the time to live in seconds for this entry.
-     * 
+     *
      * @return time to live in seconds
      */
     public long getTimeToLive();
+
+    /**
+     * Stores a reference to the discoveryService, that created this result.
+     *
+     * @param discoveryService {@link DiscoveryService}
+     */
+    public void discoveredBy(DiscoveryService discoveryService);
+
+    /**
+     * Get the {@link DiscoveryService}, that created this {@link DiscoveryResult}.
+     *
+     * @return service that created that result, may be null
+     */
+    public DiscoveryService isDiscoveredBy();
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryResultBuilder.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/DiscoveryResultBuilder.java
@@ -33,6 +33,7 @@ public class DiscoveryResultBuilder {
     private String label;
     private long ttl = DiscoveryResult.TTL_UNLIMITED;
     private ThingTypeUID thingTypeUID;
+    private DiscoveryService discoveredBy;
 
     private DiscoveryResultBuilder(ThingUID thingUID) {
         this.thingTypeUID = thingUID.getThingTypeUID();
@@ -128,13 +129,24 @@ public class DiscoveryResultBuilder {
     }
 
     /**
+     * Sets the {@link DiscoveryService} that has discovered this {@link DiscoveryResult}.
+     *
+     * @param service discovery service
+     * @return the updated builder
+     */
+    public DiscoveryResultBuilder withDiscoveryService(DiscoveryService service) {
+        this.discoveredBy = service;
+        return this;
+    }
+
+    /**
      * Builds a result with the settings of this builder.
      *
      * @return the desired result
      */
     public DiscoveryResult build() {
         return new DiscoveryResultImpl(thingTypeUID, thingUID, bridgeUID, properties, representationProperty, label,
-                ttl);
+                ttl, discoveredBy);
     }
 
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryResultImpl.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryResultImpl.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 
@@ -23,6 +24,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     private ThingUID thingUID;
     private ThingTypeUID thingTypeUID;
 
+    private DiscoveryService discoveredBy;
     private Map<String, Object> properties;
     private String representationProperty;
     private DiscoveryResultFlag flag;
@@ -49,6 +51,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      * @param label the human readable label to set (could be null or empty)
      * @param bridgeUID the unique bridge ID to be set
      * @param timeToLive time to live in seconds
+     * @param discoveredBy {@link DiscoveryService}, that created this result
      *
      * @throws IllegalArgumentException
      *             if the Thing type UID or the Thing UID is null
@@ -57,8 +60,10 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      */
     @Deprecated
     public DiscoveryResultImpl(ThingUID thingUID, ThingUID bridgeUID, Map<String, Object> properties,
-            String representationProperty, String label, long timeToLive) throws IllegalArgumentException {
-        this(thingUID.getThingTypeUID(), thingUID, bridgeUID, properties, representationProperty, label, timeToLive);
+            String representationProperty, String label, long timeToLive, DiscoveryService discoveredBy)
+            throws IllegalArgumentException {
+        this(thingUID.getThingTypeUID(), thingUID, bridgeUID, properties, representationProperty, label, timeToLive,
+                discoveredBy);
     }
 
     /**
@@ -73,13 +78,14 @@ public class DiscoveryResultImpl implements DiscoveryResult {
      * @param label the human readable label to set (could be null or empty)
      * @param bridgeUID the unique bridge ID to be set
      * @param timeToLive time to live in seconds
+     * @param discoveredBy {@link DiscoveryService}, that created this result
      *
      * @throws IllegalArgumentException
      *             if the Thing type UID or the Thing UID is null
      */
     public DiscoveryResultImpl(ThingTypeUID thingTypeUID, ThingUID thingUID, ThingUID bridgeUID,
-            Map<String, Object> properties, String representationProperty, String label, long timeToLive)
-                    throws IllegalArgumentException {
+            Map<String, Object> properties, String representationProperty, String label, long timeToLive,
+            DiscoveryService discoveredBy) throws IllegalArgumentException {
         if (thingUID == null) {
             throw new IllegalArgumentException("The thing UID must not be null!");
         }
@@ -97,6 +103,7 @@ public class DiscoveryResultImpl implements DiscoveryResult {
 
         this.timestamp = new Date().getTime();
         this.timeToLive = timeToLive;
+        this.discoveredBy = discoveredBy;
 
         this.flag = DiscoveryResultFlag.NEW;
     }
@@ -196,25 +203,31 @@ public class DiscoveryResultImpl implements DiscoveryResult {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj)
+        if (this == obj) {
             return true;
-        if (obj == null)
+        }
+        if (obj == null) {
             return false;
-        if (getClass() != obj.getClass())
+        }
+        if (getClass() != obj.getClass()) {
             return false;
+        }
         DiscoveryResultImpl other = (DiscoveryResultImpl) obj;
         if (thingUID == null) {
-            if (other.thingUID != null)
+            if (other.thingUID != null) {
                 return false;
-        } else if (!thingUID.equals(other.thingUID))
+            }
+        } else if (!thingUID.equals(other.thingUID)) {
             return false;
+        }
         return true;
     }
 
     @Override
     public String toString() {
         return "DiscoveryResult [thingUID=" + thingUID + ", properties=" + properties + ", flag=" + flag + ", label="
-                + label + ", bridgeUID=" + bridgeUID + ", ttl=" + timeToLive + ", timestamp=" + timestamp + "]";
+                + label + ", bridgeUID=" + bridgeUID + ", ttl=" + timeToLive + ", timestamp=" + timestamp
+                + ", discoveredBy = " + (discoveredBy != null ? discoveredBy.getClass().getSimpleName() : "") + "]";
     }
 
     @Override
@@ -225,5 +238,15 @@ public class DiscoveryResultImpl implements DiscoveryResult {
     @Override
     public long getTimeToLive() {
         return timeToLive;
+    }
+
+    @Override
+    public void discoveredBy(DiscoveryService discoveryService) {
+        this.discoveredBy = discoveryService;
+    }
+
+    @Override
+    public DiscoveryService isDiscoveredBy() {
+        return discoveredBy;
     }
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
@@ -299,8 +299,8 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
             Collection<ThingTypeUID> thingTypeUIDs) {
         HashSet<ThingUID> removedThings = new HashSet<>();
         for (DiscoveryResult discoveryResult : getAll()) {
-            if (thingTypeUIDs.contains(discoveryResult.getThingTypeUID())
-                    && discoveryResult.getTimestamp() < timestamp) {
+            if (thingTypeUIDs.contains(discoveryResult.getThingTypeUID()) && discoveryResult.getTimestamp() < timestamp
+                    && (discoveryResult.isDiscoveredBy() == null || discoveryResult.isDiscoveredBy() == source)) {
                 ThingUID thingUID = discoveryResult.getThingUID();
                 removedThings.add(thingUID);
                 remove(thingUID);

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/UpnpDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/UpnpDiscoveryService.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This is a {@link DiscoveryService} implementation, which can find UPnP devices in the network.
  * Support for further devices can be added by implementing and registering a {@link UpnpDiscoveryParticipant}.
- * 
+ *
  * @author Kai Kreuzer - Initial contribution
  * @author Andre Fuechsel - Added call of removeOlderResults
  *
@@ -67,7 +67,10 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService implements Re
         if (upnpService != null) {
             Collection<RemoteDevice> devices = upnpService.getRegistry().getRemoteDevices();
             for (RemoteDevice device : devices) {
-                participant.createResult(device);
+                DiscoveryResult result = participant.createResult(device);
+                if (result != null) {
+                    thingDiscovered(result);
+                }
             }
         }
     }


### PR DESCRIPTION
When starting several discovery services for the same thing types at once, each service is started some milliseconds after the other and storing its own timestamp. When calling removeOlderResults it could happen, that discovery results discovered the service that has been started first will be removed by one of the other services started later. Therefore DiscoveryService#startScan now allows to specify the starting timestamp giving the DiscoveryServiceRegistry a chance, to inject the same timestamp into all started discovery services. 

Signed-off-by: Andre Fuechsel <andre.fuechsel@telekom.de>