### PR TITLE
Changed PersistentInbox to remove only results created by the same discovery service

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceRegistryOSGITest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceRegistryOSGITest.groovy
@@ -58,6 +58,12 @@ class DiscoveryServiceRegistryOSGITest extends OSGiTest {
     def EXTENDED_BINDING_ID = 'extendedBindingId'
     def EXTENDED_THING_TYPE = 'extendedThingType'
 
+    class AnotherDiscoveryService extends DiscoveryServiceMock {
+        public AnotherDiscoveryService(Object thingType, int timeout) {
+            super(thingType, timeout);
+        }
+    }
+
     DiscoveryService discoveryServiceMockForBinding1
     DiscoveryService discoveryServiceMockForBinding2
     DiscoveryService discoveryServiceFaultyMock
@@ -256,6 +262,62 @@ class DiscoveryServiceRegistryOSGITest extends OSGiTest {
         discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan())
         assertThat inbox.getAll().size(), is(2)
     }
+
+    @Test
+    void 'assert that removeOlderResults removes only the entries of the same discovery service' () {
+        AsyncResultWrapper<Boolean> scanListenerResult1 = new AsyncResultWrapper<Boolean>()
+        AsyncResultWrapper<DiscoveryResult> discoveryListenerResult = new AsyncResultWrapper<Boolean>()
+        DiscoveryListener discoveryListenerMock = [
+            thingDiscovered: { DiscoveryService source, DiscoveryResult result ->
+                discoveryListenerResult.set result
+            },
+            removeOlderThings: { DiscoveryService source, long timestamp, Collection<ThingTypeUID> thingTypeUIDs ->
+                []
+            }
+        ] as DiscoveryListener
+
+        discoveryServiceRegistry.addDiscoveryListener(discoveryListenerMock);
+        discoveryServiceRegistry.startScan(new ThingTypeUID(ANY_BINDING_ID_1, ANY_THING_TYPE_1), [
+            onFinished: {
+                scanListenerResult1.set(Void.TYPE)
+            },
+            onErrorOccurred: {
+            }
+        ] as ScanListener)
+
+        waitForAssert({ assertTrue scanListenerResult1.isSet }, 2000)
+        assertTrue discoveryListenerResult.isSet
+
+        Inbox inbox = getService(Inbox)
+        assertThat inbox.getAll().size(), is(1)
+
+        // register another discovery service for the same thing type
+        AnotherDiscoveryService anotherDiscoveryServiceMockForBinding1 = new AnotherDiscoveryService(
+                new ThingTypeUID(ANY_BINDING_ID_1,ANY_THING_TYPE_1), 1)
+        serviceRegs.add(registerService(anotherDiscoveryServiceMockForBinding1, DiscoveryService.class.name))
+
+        // start discovery again
+        discoveryServiceRegistry.startScan(new ThingTypeUID(ANY_BINDING_ID_1, ANY_THING_TYPE_1), [
+            onFinished: {scanListenerResult1.set(Void.TYPE)},
+            onErrorOccurred: {
+            }
+        ] as ScanListener)
+        waitForAssert({ assertTrue scanListenerResult1.isSet }, 2000)
+        assertTrue discoveryListenerResult.isSet
+
+        assertThat inbox.getAll().size(), is(3)
+
+        // should remove no entry, as there is no older entry discovery of this specific discovery service
+        anotherDiscoveryServiceMockForBinding1.removeOlderResults(anotherDiscoveryServiceMockForBinding1.getTimestampOfLastScan())
+        assertThat inbox.getAll().size(), is(3)
+
+        // should remove only one entry
+        discoveryServiceMockForBinding1.removeOlderResults(discoveryServiceMockForBinding1.getTimestampOfLastScan())
+        assertThat inbox.getAll().size(), is(2)
+
+        anotherDiscoveryServiceMockForBinding1.abortScan()
+    }
+
 
     @Test
     void 'assert that a removed listener is not notified about DiscoveryResults anymore' () {

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/InboxOSGITest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/InboxOSGITest.groovy
@@ -836,6 +836,17 @@ class InboxOSGITest extends OSGiTest {
         assertThat inbox.getAll().size(), is(0)
     }
 
+    @Test
+    void 'assert that removeOlderResults removes results without a source'() {
+        inbox.add testDiscoveryResult
+        long now = new Date().getTime() + 1
+        assertThat inbox.getAll().size(), is(1)
+
+        // should remove a result
+        inbox.removeOlderResults(discoveryService2, now, [testThingType.getUID()])
+        assertThat inbox.getAll().size(), is(0)
+    }
+
     class DummyThingHandlerFactory extends BaseThingHandlerFactory {
 
         public DummyThingHandlerFactory(ComponentContext context) {

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/InboxOSGITest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/inbox/InboxOSGITest.groovy
@@ -10,20 +10,14 @@ package org.eclipse.smarthome.config.setup.test.inbox
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 
-import java.net.URI;
-import java.util.List
-import java.util.Map;
-
-import javax.xml.ws.Response
-import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory
-import org.eclipse.smarthome.core.thing.binding.ThingFactory;
-import org.eclipse.smarthome.core.thing.binding.ThingHandler;
-import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder
 import org.eclipse.smarthome.config.core.ConfigDescription
-import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry
-import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.config.core.Configuration
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type
+import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService
 import org.eclipse.smarthome.config.discovery.DiscoveryResult
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder
 import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag
 import org.eclipse.smarthome.config.discovery.DiscoveryServiceRegistry
 import org.eclipse.smarthome.config.discovery.inbox.Inbox
@@ -33,15 +27,16 @@ import org.eclipse.smarthome.config.discovery.inbox.events.InboxAddedEvent
 import org.eclipse.smarthome.config.discovery.inbox.events.InboxRemovedEvent
 import org.eclipse.smarthome.config.discovery.inbox.events.InboxUpdatedEvent
 import org.eclipse.smarthome.config.discovery.internal.DiscoveryResultImpl
-import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type
-import org.eclipse.smarthome.config.discovery.internal.PersistentInbox;
-import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder
+import org.eclipse.smarthome.config.discovery.internal.PersistentInbox
 import org.eclipse.smarthome.core.events.EventSubscriber
 import org.eclipse.smarthome.core.thing.ManagedThingProvider
 import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingRegistry
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory
+import org.eclipse.smarthome.core.thing.binding.ThingHandler
+import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
 import org.eclipse.smarthome.core.thing.type.ThingType
 import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry
@@ -50,15 +45,37 @@ import org.eclipse.smarthome.test.OSGiTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.ComponentContext
 
 import com.google.common.collect.Sets
 
-
 class InboxOSGITest extends OSGiTest {
+
+    class DiscoveryService1 extends AbstractDiscoveryService {
+        public DiscoveryService1() {
+            super(5)
+        }
+
+        @Override
+        protected void startScan() {
+        }
+    }
+    class DiscoveryService2 extends AbstractDiscoveryService {
+        public DiscoveryService2() {
+            super(5)
+        }
+
+        @Override
+        protected void startScan() {
+        }
+    }
+
+    def discoveryService1 = [] as DiscoveryService1
+    def discoveryService2 = [] as DiscoveryService2
 
     def DEFAULT_TTL = 60
     def BRIDGE_ID = new ThingUID("bindingId:bridge:bridgeId")
+
     DiscoveryResult BRIDGE = new DiscoveryResultImpl(BRIDGE_ID, null, null,"Bridge", "bridge", DEFAULT_TTL)
     DiscoveryResult THING1_WITH_BRIDGE = new DiscoveryResultImpl(new ThingUID("bindingId:thing:id1"), BRIDGE_ID, null,"Thing1", "thing1", DEFAULT_TTL)
     DiscoveryResult THING2_WITH_BRIDGE = new DiscoveryResultImpl(new ThingUID("bindingId:thing:id2"), BRIDGE_ID, null,"Thing2", "thing2", DEFAULT_TTL)
@@ -109,7 +126,7 @@ class InboxOSGITest extends OSGiTest {
         typeRegistry = getService ThingTypeRegistry
         descriptionRegistry = getService ConfigDescriptionRegistry
         def componentContextMock = [
-            getBundleContext: {getBundleContext()}
+            getBundleContext: { getBundleContext() }
         ] as ComponentContext
         ((PersistentInbox)inbox).addThingHandlerFactory(new DummyThingHandlerFactory(componentContextMock))
     }
@@ -802,6 +819,21 @@ class InboxOSGITest extends OSGiTest {
             assertFalse descResultParam == null
             assertTrue thingProperty.equals(descResultParam)
         }
+    }
+
+    @Test
+    void 'assert that removeOlderResults only removes results from the same discovery service'() {
+        inbox.thingDiscovered discoveryService1, testDiscoveryResult
+        long now = new Date().getTime() + 1
+        assertThat inbox.getAll().size(), is(1)
+
+        // should not remove a result
+        inbox.removeOlderResults(discoveryService2, now, [testThingType.getUID()])
+        assertThat inbox.getAll().size(), is(1)
+
+        // should remove a result
+        inbox.removeOlderResults(discoveryService1, now, [testThingType.getUID()])
+        assertThat inbox.getAll().size(), is(0)
     }
 
     class DummyThingHandlerFactory extends BaseThingHandlerFactory {

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
@@ -307,7 +307,7 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
         for (DiscoveryResult discoveryResult : getAll()) {
             String discovererName = resultDiscovererMap.get(discoveryResult); 
             if (thingTypeUIDs.contains(discoveryResult.getThingTypeUID()) && discoveryResult.getTimestamp() < timestamp
-                    && sourceName.equals(discovererName)) {
+                    && (discovererName == null || sourceName.equals(discovererName))) {
                 ThingUID thingUID = discoveryResult.getThingUID();
                 removedThings.add(thingUID);
                 remove(thingUID);


### PR DESCRIPTION
Also extended PersistentInbox#removeOlderResults to remove only the results from the source DiscoveryService

Signed-off-by: Andre Fuechsel andre.fuechsel@telekom.de
