### PR TITLE
avoid NPE if no services are found

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/HttpServiceUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/HttpServiceUtil.java
@@ -39,6 +39,7 @@ public class HttpServiceUtil {
     }
 
     // Utility method that could be used for non-secure and secure port.
+    @SuppressWarnings("rawtypes")
     private static int getHttpServicePortProperty(final BundleContext bc, final String propertyName) {
         Object value;
         int port = -1;
@@ -47,27 +48,29 @@ public class HttpServiceUtil {
         try {
             int candidate = Integer.MIN_VALUE;
             final ServiceReference[] refs = bc.getAllServiceReferences("org.osgi.service.http.HttpService", null);
-            for (final ServiceReference ref : refs) {
-                value = ref.getProperty(propertyName);
-                if (value == null) {
-                    continue;
-                }
-                final int servicePort;
-                try {
-                    servicePort = Integer.parseInt(value.toString());
-                } catch (final NumberFormatException ex) {
-                    continue;
-                }
-                value = ref.getProperty(Constants.SERVICE_RANKING);
-                final int serviceRanking;
-                if (value == null || !(value instanceof Integer)) {
-                    serviceRanking = 0;
-                } else {
-                    serviceRanking = (Integer) value;
-                }
-                if (serviceRanking >= candidate) {
-                    candidate = serviceRanking;
-                    port = servicePort;
+            if (refs != null) {
+                for (final ServiceReference ref : refs) {
+                    value = ref.getProperty(propertyName);
+                    if (value == null) {
+                        continue;
+                    }
+                    final int servicePort;
+                    try {
+                        servicePort = Integer.parseInt(value.toString());
+                    } catch (final NumberFormatException ex) {
+                        continue;
+                    }
+                    value = ref.getProperty(Constants.SERVICE_RANKING);
+                    final int serviceRanking;
+                    if (value == null || !(value instanceof Integer)) {
+                        serviceRanking = 0;
+                    } else {
+                        serviceRanking = (Integer) value;
+                    }
+                    if (serviceRanking >= candidate) {
+                        candidate = serviceRanking;
+                        port = servicePort;
+                    }
                 }
             }
         } catch (final InvalidSyntaxException ex) {


### PR DESCRIPTION
Fixes https://github.com/eclipse/smarthome/issues/2372
Note that while this fixes the NPE, the result might not always be the expected behavior as it won't be able to return the port of http services that are registered later (after the call to HttpServiceUtil). If this is not what is expected, my suggestion is that the caller makes sure that the HttpService is already registered at time of the call, e.g. by having a dependency to it.

Signed-off-by: Kai Kreuzer <kai@openhab.org>