### PR TITLE
Allow to define channel labels in the DSL

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest.groovy
@@ -293,10 +293,12 @@ class GenericThingProviderTest extends OSGiTest {
                         LCT001 bulb_custom [] {
                             Channels:
                                 Type color : manual []
+                                Type color : manualWithLabel "With Label" []
                         }
                         LCT001 bulb_broken [] {
                             Channels:
                                 Type broken : manual []
+                                Type broken : manualWithLabel "With Label" []
                         }
                     }
 
@@ -311,14 +313,18 @@ class GenericThingProviderTest extends OSGiTest {
         assertThat thingDefault.getChannels().size(), is(2)
 
         Thing thingCustom = actualThings.find { it.getUID().getId().equals("bulb_custom") }
-        assertThat thingCustom.getChannels().size(), is(3)
+        assertThat thingCustom.getChannels().size(), is(4)
         assertThat thingCustom.getChannel("manual").getChannelTypeUID(), is(equalTo(new ChannelTypeUID("hue", "color")))
+        assertThat thingCustom.getChannel("manual").getLabel(), is("colorLabel") // default from thing type
+        assertThat thingCustom.getChannel("manualWithLabel").getLabel(), is("With Label") // manual overrides default
 
         Thing thingBroken = actualThings.find { it.getUID().getId().equals("bulb_broken") }
-        assertThat thingBroken.getChannels().size(), is(3)
+        assertThat thingBroken.getChannels().size(), is(4)
         assertThat thingBroken.getChannel("manual").getChannelTypeUID(), is(equalTo(new ChannelTypeUID("hue", "broken")))
         assertThat thingBroken.getChannel("manual").getKind(), is(ChannelKind.STATE)
         assertThat thingBroken.getChannel("manual").getAcceptedItemType(), is(nullValue())
+        assertThat thingBroken.getChannel("manual").getLabel(), is(nullValue())
+        assertThat thingBroken.getChannel("manualWithLabel").getLabel(), is("With Label")
 
     }
 

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/Thing.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/Thing.xtext
@@ -50,6 +50,7 @@ ModelThing:
 
 ModelChannel:
 	(((channelKind= ('State' | 'Trigger'))? type=ModelItemType) | 'Type' channelType=UID_SEGMENT) ':' id=UID_SEGMENT
+    (label=STRING)?
 	('['
 		properties+=ModelProperty (',' properties+=ModelProperty)*
 	']')?

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
@@ -280,12 +280,16 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                 
                 var ChannelTypeUID channelTypeUID
                 var String itemType
+                var label = it.label
                 if (it.channelType != null) {
                     channelTypeUID = new ChannelTypeUID(thingUID.bindingId, it.channelType)
                     val resolvedChannelType = TypeResolver.resolve(channelTypeUID)
                     if (resolvedChannelType != null) {
                         itemType = resolvedChannelType.itemType
                         parsedKind = resolvedChannelType.kind
+                        if (label == null) {
+                            label = resolvedChannelType.label
+                        }
                     } else {
                         logger.error("Channel type {} could not be resolved.",  channelTypeUID.asString)
                     }
@@ -300,6 +304,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                     .withKind(parsedKind)
                     .withConfiguration(createConfiguration)
                     .withType(channelTypeUID)
+                    .withLabel(label)
                 channels += channel.build()
             }
         ]

--- a/docs/documentation/features/dsl.md
+++ b/docs/documentation/features/dsl.md
@@ -67,7 +67,7 @@ It is also possible to manually define channels in the DSL. Usually this is not 
 ```
 Thing yahooweather:weather:losangeles [ location=2442047, unit="us", refresh=120 ] {
 	Channels:
-		State String : customChannel1 [
+		State String : customChannel1 "My Custom Channel" [
 			configParameter="Value"
 		]
 		State Number : customChannel2 []
@@ -81,12 +81,15 @@ As state channels are the default channels, you can omit the `State` keyword, th
 ```
 Thing yahooweather:weather:losangeles [ location=2442047, unit="us", refresh=120 ] {
 	Channels:
-		String : customChannel1 [
+		String : customChannel1 "My Custom Channel" [
 			configParameter="Value"
 		]
 		Number : customChannel2 []
 }
 ```
+
+You may optionally give the channel a proper label (like "My Custom Channel" in the example above) so you can distinguish the channels easily. 
+
 
 ### Trigger channels
 
@@ -124,10 +127,10 @@ They can be referenced within a thing's channel definition, so that they need to
 ```
 Thing yahooweather:weather:losangeles [ location=2442047, unit="us", refresh=120 ] {
     Channels:
-        Type temperature : my_yesterday_temperature
+        Type temperature : my_yesterday_temperature "Yesterday's Temperature"
 }
 ``` 
 
 The `Type` keyword indicates a reference to an existing channel definition. The channel kind and accepted item types of course are takes from the channel definition, therefore they don't need to be specified here again. 
 
-
+You may optionally give the channel a proper label (like "Yesterday's Temperature" in the example above) so you can distinguish the channels easily. If you decide not to, then the label from the referenced channel type definition will be used.


### PR DESCRIPTION
...as we discovered in [#2343](https://github.com/eclipse/smarthome/pull/2343#issuecomment-256919779) that this was not possible so far.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>