### PR TITLE
fix GenerericItem.getStateAs for non-Convertibles

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GenericItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GenericItemTest.groovy
@@ -15,7 +15,10 @@ import org.eclipse.smarthome.core.events.EventPublisher
 import org.eclipse.smarthome.core.items.events.ItemEventFactory
 import org.eclipse.smarthome.core.items.events.ItemStateChangedEvent
 import org.eclipse.smarthome.core.items.events.ItemStateEvent
+import org.eclipse.smarthome.core.library.types.OnOffType
+import org.eclipse.smarthome.core.library.types.PercentType
 import org.eclipse.smarthome.core.library.types.RawType
+import org.eclipse.smarthome.core.library.types.StringType
 import org.junit.Before
 import org.junit.Test
 
@@ -87,4 +90,34 @@ class GenericItemTest {
         def item = new TestItem("member1")
         item.removeGroupName(null)
     }
+
+    @Test
+    void 'assert that getStateAs works with the same type for a Convertible'() {
+        def item = new TestItem("member1")
+        item.setState(PercentType.HUNDRED)
+        assertThat item.getStateAs(PercentType), isA(PercentType)
+    }
+
+    @Test
+    void 'assert that getStateAs works with a different type for a Convertible'() {
+        def item = new TestItem("member1")
+        item.setState(PercentType.HUNDRED)
+        assertThat item.getStateAs(OnOffType), isA(OnOffType)
+    }
+
+    @Test
+    void 'assert that getStateAs works with the same type for a non-Convertible'() {
+        def item = new TestItem("member1")
+        item.setState(StringType.valueOf("Hello World"))
+        assertThat item.getStateAs(StringType), isA(StringType)
+    }
+
+    @Test
+    void 'assert that getStateAs works with null'() {
+        def item = new TestItem("member1")
+        item.setState(StringType.valueOf("Hello World"))
+        assertThat item.getStateAs(null), is(nullValue())
+    }
+
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.events.ItemEventFactory;
+import org.eclipse.smarthome.core.library.internal.StateConverterUtil;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.Convertible;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -94,7 +95,7 @@ abstract public class GenericItem implements ActiveItem {
         if (state instanceof Convertible) {
             return ((Convertible) state).as(typeClass);
         } else {
-            return null;
+            return StateConverterUtil.defaultConversion(state, typeClass);
         }
     }
 


### PR DESCRIPTION
When the target type is identical to the current state's
type, then the current state should be returned.

fixes #2334
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>