### PR TITLE
Preference page UI changes

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -479,7 +479,6 @@ md-progress-circular.md-default-theme .md-inner .md-left .md-half-circle
 }
 
 .container .md-select-value {
-	text-align: center;
 	padding: 16px 2px 1px;
 	border-bottom-style: none;
 	font-size: 18px;

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/preferences.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/preferences.html
@@ -16,7 +16,7 @@
 			<p>Configure your UI preferences.</p>
 
 			<form class="form" role="form">
-				<div class="form-group">
+				<div class="form-group col-sm-6 col-xs-12 language">
 					<md-select placeholder="Language" ng-model="language"> <md-option value="en">English</md-option> <md-option value="de">German</md-option> </md-select>
 					<p class="hint">
 						<small>Configure language for Binding texts (UI is not localized yet)</small>


### PR DESCRIPTION
1) Changed width of dropdown.
2) Aligned dropdown text to left.

Before:
<img width="1018" alt="screen shot 2016-11-03 at 17 14 22" src="https://cloud.githubusercontent.com/assets/5161937/19974511/088a7a70-a1e9-11e6-90c1-3016d9c50823.png">

After:
<img width="1013" alt="screen shot 2016-11-03 at 17 13 55" src="https://cloud.githubusercontent.com/assets/5161937/19974519/0f46d0a2-a1e9-11e6-9574-b6864bb8cb87.png">

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>