### PR TITLE
Fix averageSince calculation

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
@@ -132,7 +132,7 @@ public class PersistenceExtensionsTest {
         long recentInterval = DateTime.now().getMillis() - endStored.getMillis();
         double expected = (2007.4994 * storedInterval + 2518.5 * recentInterval) / (storedInterval + recentInterval);
         DecimalType average = PersistenceExtensions.averageSince(item, startStored, "test");
-        assertEquals(expected, average.doubleValue(), 0.001);
+        assertEquals(expected, average.doubleValue(), 0.01);
     }
 
     @Test

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
@@ -125,8 +125,13 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageSince() {
         item.setState(new DecimalType(3025));
-        DecimalType average = PersistenceExtensions.averageSince(item, new DateMidnight(2003, 1, 1), "test");
-        assertEquals(2007.4994, average.doubleValue(), 0.0001);
+        DateMidnight startStored = new DateMidnight(2003, 1, 1);
+        DateMidnight endStored = new DateMidnight(2012, 1, 1);
+        long storedInterval = endStored.getMillis() - startStored.getMillis();
+        long recentInterval = DateTime.now().getMillis() - endStored.getMillis();
+        double expected = (2007.4994 * storedInterval + 2518.5 * recentInterval) / (storedInterval + recentInterval);
+        DecimalType average = PersistenceExtensions.averageSince(item, startStored, "test");
+        assertEquals(expected, average.doubleValue(), 0.001);
     }
 
     @Test

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
@@ -125,7 +125,7 @@ public class PersistenceExtensionsTest {
     public void testAverageSince() {
         item.setState(new DecimalType(3025));
         DecimalType average = PersistenceExtensions.averageSince(item, new DateMidnight(2003, 1, 1), "test");
-        assertEquals("2100", average.toString());
+        assertEquals("2007.5", average.toString());
     }
 
     @Test

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
@@ -21,6 +21,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.model.persistence.tests.TestPersistenceService;
 import org.joda.time.DateMidnight;
+import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
@@ -125,7 +125,7 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageSince() {
         item.setState(new DecimalType(3025));
-        DecimalType average = PersistenceExtensions.averageSince(item, new DateMidnight(2003, 1, 1), false, "test");
+        DecimalType average = PersistenceExtensions.averageSince(item, new DateMidnight(2003, 1, 1), "test");
         assertEquals(2007.4994, average.doubleValue(), 0.0001);
     }
 

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/src/test/java/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensionsTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 /**
  * @author Kai Kreuzer - Initial contribution and API
  * @author Chris Jackson
+ * @author Jan N. Klug
  */
 @SuppressWarnings("deprecation")
 public class PersistenceExtensionsTest {
@@ -124,8 +125,8 @@ public class PersistenceExtensionsTest {
     @Test
     public void testAverageSince() {
         item.setState(new DecimalType(3025));
-        DecimalType average = PersistenceExtensions.averageSince(item, new DateMidnight(2003, 1, 1), "test");
-        assertEquals("2007.5", average.toString());
+        DecimalType average = PersistenceExtensions.averageSince(item, new DateMidnight(2003, 1, 1), false, "test");
+        assertEquals(2007.4994, average.doubleValue(), 0.0001);
     }
 
     @Test

--- a/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensions.java
@@ -77,7 +77,8 @@ public class PersistenceExtensions {
                         .warn("There is no default persistence service configured!");
             }
         } else {
-            LoggerFactory.getLogger(PersistenceExtensions.class).warn("PersistenceServiceRegistryImpl is not available!");
+            LoggerFactory.getLogger(PersistenceExtensions.class)
+                    .warn("PersistenceServiceRegistryImpl is not available!");
         }
         return null;
     }
@@ -400,13 +401,10 @@ public class PersistenceExtensions {
         Iterable<HistoricItem> result = getAllStatesSince(item, timestamp, serviceId);
         Iterator<HistoricItem> it = result.iterator();
 
-        DecimalType value = (DecimalType) item.getStateAs(DecimalType.class);
-        if (value == null) {
-            value = DecimalType.ZERO;
-        }
+        DecimalType value = DecimalType.ZERO;
 
         BigDecimal total = value.toBigDecimal();
-        int quantity = 1;
+        int quantity = 0;
         while (it.hasNext()) {
             State state = it.next().getState();
             if (state instanceof DecimalType) {
@@ -415,6 +413,16 @@ public class PersistenceExtensions {
                 quantity++;
             }
         }
+
+        if (quantity == 0) {
+            quantity = 1;
+            value = (DecimalType) item.getStateAs(DecimalType.class);
+            if (value == null) {
+                value = DecimalType.ZERO;
+            }
+            total = value.toBigDecimal();
+        }
+
         BigDecimal average = total.divide(BigDecimal.valueOf(quantity), MathContext.DECIMAL64);
 
         return new DecimalType(average);

--- a/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensions.java
@@ -377,7 +377,6 @@ public class PersistenceExtensions {
      *
      * @param item the item to get the average state value for
      * @param timestamp the point in time from which to search for the average state value
-     * @param includeCurrentValue include the current value in the calculation
      * @return the average state values since <code>timestamp</code>, <code>null</code> if the default persistence
      *         service is not available, or the state of the given <code>item</code> if no previous states could be
      *         found or if the default persistence service does not refer to an available
@@ -423,7 +422,6 @@ public class PersistenceExtensions {
                             MathContext.DECIMAL64);
                     timeSpan = thisTimestamp.subtract(lastTimestamp);
                     total = total.add(avgValue.multiply(timeSpan, MathContext.DECIMAL64));
-
                 }
                 lastTimestamp = thisTimestamp;
                 lastState = thisState;

--- a/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensions.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/extensions/PersistenceExtensions.java
@@ -377,21 +377,6 @@ public class PersistenceExtensions {
      *
      * @param item the item to get the average state value for
      * @param timestamp the point in time from which to search for the average state value
-     * @return the average state values since <code>timestamp</code>, <code>null</code> if the default persistence
-     *         service is not available, or the state of the given <code>item</code> if no previous states could be
-     *         found or if the default persistence service does not refer to an available
-     *         {@link QueryablePersistenceService}
-     */
-    public static DecimalType averageSince(Item item, AbstractInstant timestamp, boolean includeCurrentValue) {
-        return averageSince(item, timestamp, includeCurrentValue, getDefaultServiceId());
-    }
-
-    /**
-     * Gets the average value of the state of a given <code>item</code> since a certain point in time.
-     * The default persistence service is used.
-     *
-     * @param item the item to get the average state value for
-     * @param timestamp the point in time from which to search for the average state value
      * @param includeCurrentValue include the current value in the calculation
      * @return the average state values since <code>timestamp</code>, <code>null</code> if the default persistence
      *         service is not available, or the state of the given <code>item</code> if no previous states could be
@@ -399,7 +384,7 @@ public class PersistenceExtensions {
      *         {@link QueryablePersistenceService}
      */
     public static DecimalType averageSince(Item item, AbstractInstant timestamp) {
-        return averageSince(item, timestamp, true, getDefaultServiceId());
+        return averageSince(item, timestamp, getDefaultServiceId());
     }
 
     /**
@@ -414,23 +399,6 @@ public class PersistenceExtensions {
      *         refer to an available {@link QueryablePersistenceService}
      */
     public static DecimalType averageSince(Item item, AbstractInstant timestamp, String serviceId) {
-        return averageSince(item, timestamp, true, serviceId);
-    }
-
-    /**
-     * Gets the average value of the state of a given <code>item</code> since a certain point in time.
-     * The {@link PersistenceService} identified by the <code>serviceId</code> is used.
-     *
-     * @param item the item to get the average state value for
-     * @param timestamp the point in time from which to search for the average state value
-     * @param includeCurrentValue include the current value in the calculation
-     * @param serviceId the name of the {@link PersistenceService} to use
-     * @return the average state values since <code>timestamp</code>, or the state of the given <code>item</code> if no
-     *         previous states could be found or if the persistence service given by <code>serviceId</code> does not
-     *         refer to an available {@link QueryablePersistenceService}
-     */
-    public static DecimalType averageSince(Item item, AbstractInstant timestamp, boolean includeCurrentValue,
-            String serviceId) {
         Iterable<HistoricItem> result = getAllStatesSince(item, timestamp, serviceId);
         Iterator<HistoricItem> it = result.iterator();
 
@@ -462,7 +430,7 @@ public class PersistenceExtensions {
             }
         }
 
-        if ((lastState != null) && includeCurrentValue) {
+        if (lastState != null) {
             thisState = (DecimalType) item.getStateAs(DecimalType.class);
             thisTimestamp = BigDecimal.valueOf((new DateTime()).getMillis());
             avgValue = (thisState.toBigDecimal().add(lastState.toBigDecimal())).divide(BigDecimal.valueOf(2),
@@ -475,7 +443,6 @@ public class PersistenceExtensions {
             timeSpan = thisTimestamp.subtract(firstTimestamp, MathContext.DECIMAL64);
 
             BigDecimal average = total.divide(timeSpan, MathContext.DECIMAL64);
-            System.out.println(String.valueOf(timeSpan) + ":" + String.valueOf(total));
             return new DecimalType(average);
         } else {
             return null;


### PR DESCRIPTION
Average since is calculated over persisted values AND the actual value.
The description describes that it is calculated over persisted values OR
the actual value (if no persisted values are found). The description is
desribes the correct behaviour, while the implementation was wrong. This
is fixed with this PR.

Bug: https://github.com/eclipse/smarthome/issues/2404
Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>