### PR TITLE
NTP Binding Tests Localization Fix

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/src/test/groovy/org/eclipse/smarthome/binding/ntp/test/NtpOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/src/test/groovy/org/eclipse/smarthome/binding/ntp/test/NtpOSGiTest.groovy
@@ -58,6 +58,7 @@ import org.junit.Test
  */
 class NtpOSGiTest extends OSGiTest {
     private static TimeZone systemTimeZone
+    private static Locale locale
 
     private EventSubscriberMock eventSubscriberMock
 
@@ -97,13 +98,15 @@ class NtpOSGiTest extends OSGiTest {
 
     @BeforeClass
     public static void setUpClass(){
-        /* Store the initial system time zone value,
-         so that we can restore it at the test end.*/
+        /* Store the initial system time zone and locale value,
+         so that we can restore them at the test end.*/
         systemTimeZone = TimeZone.getDefault()
+        locale = Locale.getDefault()
 
-        /* Set new default time zone,
+        /* Set new default time zone and locale,
          which will be used during the tests execution.*/
         TimeZone.setDefault(TimeZone.getTimeZone(DEFAULT_TIME_ZONE_ID))
+        Locale.setDefault(Locale.US)
     }
 
     @Before
@@ -143,8 +146,9 @@ class NtpOSGiTest extends OSGiTest {
 
     @AfterClass
     public static void tearDownClass(){
-        // Set the default time zone to its initial value.
+        // Set the default time zone and locale to their initial value.
         TimeZone.setDefault(systemTimeZone)
+        Locale.setDefault(locale)
     }
 
     @Test


### PR DESCRIPTION
Fixed the bug in the NTP Binding Tests, related to returning a different time zone in different locales: https://github.com/eclipse/smarthome/issues/2376