### PR TITLE
Wemo Tests back to default timeout.

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/discovery/test/WemoDiscoveryOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/discovery/test/WemoDiscoveryOSGiTest.groovy
@@ -51,7 +51,7 @@ class WemoDiscoveryOSGiTest extends GenericWemoOSGiTest{
         List<DiscoveryResult> results = inbox.getAll()
         assertThat "Inbox is not empty: ${Arrays.toString(results.toArray())}", results.size(), is(0)
     }
-    
+
     @Test
     public void 'assert supported thing is discovered'() {
         def thingType = WemoBindingConstants.THING_TYPE_INSIGHT
@@ -59,25 +59,25 @@ class WemoDiscoveryOSGiTest extends GenericWemoOSGiTest{
 
         addUpnpDevice(SERVICE_ID, SERVICE_NUMBER, model)
 
-        waitForAssert ({
+        waitForAssert {
             Collection<Device> devices =  mockUpnpService.getRegistry().getDevices()
             assertThat "Not exactly one UPnP device is  added to the UPnP Registry: ${devices}", devices.size(), is(1)
             Device device = devices.getAt(0)
             assertThat "UPnP device ${device} has incorrect model name:", device.getDetails().getModelDetails().getModelName(), is(model)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
         ThingUID thingUID = new ThingUID(thingType, DEVICE_UDN);
 
-        waitForAssert ({
+        waitForAssert {
             List<DiscoveryResult> results = inbox.get(new InboxFilterCriteria(thingUID, null))
             assertFalse "No Thing with UID " + thingUID.getAsString() + " in inbox", results.isEmpty()
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
         inbox.approve(thingUID, DEVICE_FRIENDLY_NAME)
 
-        waitForAssert ({
+        waitForAssert {
             Thing thing = thingRegistry.get(thingUID)
             assertThat "Thing is not created when approved.", thing, is(notNullValue())
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/discovery/test/WemoLinkDiscoveryServiceOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/discovery/test/WemoLinkDiscoveryServiceOSGiTest.groovy
@@ -40,14 +40,14 @@ class WemoLinkDiscoveryServiceOSGiTest extends GenericWemoLightOSGiTest{
     @Before
     void setUp() {
         setUpServices()
-        
+
         inbox = getService(Inbox.class)
         assertThat inbox, is(notNullValue())
-        
+
         servlet = new WemoLinkDiscoveryServlet(SERVICE_ID, SERVICE_NUMBER)
         registerServlet(SERVLET_URL, servlet)
     }
-    
+
     @After
     void tearDown() {
         unregisterServlet(SERVLET_URL)
@@ -64,8 +64,8 @@ class WemoLinkDiscoveryServiceOSGiTest extends GenericWemoLightOSGiTest{
         servlet.deviceId = DEVICE_UDN
 
         addUpnpDevice(SERVICE_ID, SERVICE_NUMBER, model)
-        
-        // This is needed, because the WemoLinkDiscovertSevice is registered from the
+
+        // This is needed, because the WemoLinkDiscoveryService is registered from the
         // WemoHandlerFactory, when a handler for a bridge is created
         createBridge(bridgeTypeUID)
 
@@ -75,14 +75,19 @@ class WemoLinkDiscoveryServiceOSGiTest extends GenericWemoLightOSGiTest{
         ThingUID bridgeUID = new ThingUID(bridgeTypeUID, WEMO_BRIDGE_ID);
         ThingUID thingUID = new ThingUID(thingTypeUID, bridgeUID, DEVICE_UDN);
 
-        waitForAssert ({
+        waitForAssert{
+            assertThat servlet.hasReceivedRequest, is(true)
+        }
+
+        waitForAssert {
             List<DiscoveryResult> results = inbox.get(new InboxFilterCriteria(thingUID, null))
             assertFalse "No Thing with UID " + thingUID.getAsString() + " in inbox. However found:" + Arrays.toString(results.toArray()), results.isEmpty()
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
     }
 
     class WemoLinkDiscoveryServlet extends GenericWemoHttpServlet {
+        def hasReceivedRequest = false
         def deviceIndex
         def deviceId
         def friendlyName
@@ -101,6 +106,8 @@ class WemoLinkDiscoveryServiceOSGiTest extends GenericWemoLightOSGiTest{
 
             if (endDevices.size() > 0) {
                 def endDeviceNode = endDevices.get(0);
+
+                hasReceivedRequest = true
 
                 // Add information about a single device
                 endDeviceNode.replaceNode {

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/handler/test/WemoHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/handler/test/WemoHandlerOSGiTest.groovy
@@ -8,7 +8,6 @@
 package org.eclipse.smarthome.binding.wemo.handler.test;
 
 import static org.hamcrest.CoreMatchers.*
-
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 import groovy.xml.XmlUtil
@@ -28,11 +27,10 @@ import org.eclipse.smarthome.core.thing.ThingStatus
 import org.eclipse.smarthome.core.thing.binding.ThingHandler
 import org.eclipse.smarthome.core.types.RefreshType
 import org.eclipse.smarthome.core.types.State
-import org.eclipse.smarthome.core.types.UnDefType;
+import org.eclipse.smarthome.core.types.UnDefType
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOServiceImpl
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -62,7 +60,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
         servlet = new WemoHttpServlet(SERVICE_ID, SERVICE_NUMBER);
         registerServlet(SERVLET_URL, servlet);
     }
-    
+
     @After
     public void tearDown() {
         removeThing()
@@ -83,17 +81,17 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
             assertThat handler, is(notNullValue())
             assertThat handler.getThing().getStatus(), is(ThingStatus.ONLINE)
         }
-        
+
         // The device is registered as UPnP Device after the initialization, this will ensure that the polling job will not start
         addUpnpDevice(SERVICE_ID, SERVICE_NUMBER, MODEL_NAME)
-        
+
         ChannelUID channelUID = new ChannelUID(thing.getUID(), DEFAULT_TEST_CHANNEL)
         thing.getHandler().handleCommand(channelUID, command)
 
-        waitForAssert({
+        waitForAssert{
             assertThat "Invalid SOAP action sent to the device: ${servlet.actions}", servlet.actions.contains(WemoHttpServlet.SET_ACTION) ,is (true)
             assertThat "The state of the device after the command ${command} was not updated with the expected value.", servlet.binaryState, is(exptectedBinaryState)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 
     @Test
@@ -102,7 +100,7 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
         // Binary state 0 is equivalent to OFF
         def expectedState = OnOffType.OFF
         def command = RefreshType.REFRESH;
-        
+
         createThing(THING_TYPE_UID, DEFAULT_TEST_CHANNEL, DEFAULT_TEST_CHANNEL_TYPE);
 
         waitForAssert {
@@ -111,28 +109,28 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
             assertThat handler.getThing().getStatus(), is(ThingStatus.ONLINE)
         }
 
-        waitForAssert({
+        waitForAssert{
             Item item = itemRegistry.get(DEFAULT_TEST_ITEM_NAME)
             assertThat "Item with name ${DEFAULT_TEST_ITEM_NAME} may not be created. Check the createItem() method.", item, is(notNullValue())
             assertThat "The state of the item ${DEFAULT_TEST_ITEM_NAME} was updated at start.", item.getState(), is(UnDefType.NULL)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
-        
+        }
+
         // The device is registered as UPnP Device after the initialization, this will ensure that the polling job will not start
         addUpnpDevice(SERVICE_ID, SERVICE_NUMBER, MODEL_NAME)
-        
+
         ChannelUID channelUID = new ChannelUID(thing.getUID(), DEFAULT_TEST_CHANNEL)
         thing.getHandler().handleCommand(channelUID, command)
-        
-        waitForAssert({
+
+        waitForAssert{
             assertThat "Invalid SOAP action sent to the device: ${servlet.actions}", servlet.actions.contains(WemoHttpServlet.GET_ACTION),is (true)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
-        
-        waitForAssert({
+        }
+
+        waitForAssert{
             Item item = itemRegistry.get(DEFAULT_TEST_ITEM_NAME)
             assertThat "Item with name ${DEFAULT_TEST_ITEM_NAME} may not be created. Check the createItem() method.", item, is(notNullValue())
             assertThat "The state of the item ${DEFAULT_TEST_ITEM_NAME} was not updated after command ${command}.", item.getState(), is(expectedState)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
-        
+        }
+
     }
 
     @Test
@@ -150,16 +148,16 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
             assertThat handler, is(notNullValue())
             assertThat handler.getThing().getStatus(), is(ThingStatus.ONLINE)
         }
-        
-        waitForAssert({
-            assertThat "Invalid SOAP action sent to the device: ${servlet.actions}", servlet.actions.contains(WemoHttpServlet.GET_ACTION), is(true)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
 
-        waitForAssert({
+        waitForAssert{
+            assertThat "Invalid SOAP action sent to the device: ${servlet.actions}", servlet.actions.contains(WemoHttpServlet.GET_ACTION), is(true)
+        }
+
+        waitForAssert{
             Item item = itemRegistry.get(DEFAULT_TEST_ITEM_NAME)
             assertThat "Item with name ${DEFAULT_TEST_ITEM_NAME} is not be created. Check the createItem() method.", item, is(notNullValue())
             assertThat "The state of the item ${DEFAULT_TEST_ITEM_NAME} was not updated at start.", item.getState(), is(expectedState)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 
     private void removeThing() {
@@ -173,21 +171,21 @@ public class WemoHandlerOSGiTest extends GenericWemoOSGiTest {
             assertThat thingHandler, is(nullValue())
         }
 
-        waitForAssert ({
+        waitForAssert {
             assertThat upnpIOService.participants.keySet().size(), is(0)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
         itemRegistry.remove(DEFAULT_TEST_ITEM_NAME)
-        waitForAssert ({
+        waitForAssert {
             assertThat itemRegistry.getAll().size(), is(0)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 }
 
 class WemoHttpServlet extends GenericWemoHttpServlet {
     final static def GET_ACTION = "GetBinaryState"
     final static def SET_ACTION = "SetBinaryState"
-    
+
     def actions = [] as Set
     def binaryState
 
@@ -196,13 +194,13 @@ class WemoHttpServlet extends GenericWemoHttpServlet {
     }
 
     protected String handleRequest (Node root) {
-        
+
         def getActions = root[soapNamespace.Body][uNamespace.GetBinaryState];
         if (getActions.size() > 0) {
             def getAction = getActions.get(0);
-            
+
             this.actions.add(getAction.name().getLocalPart())
-            
+
             getAction.replaceNode { BinaryState(this.binaryState) }
             return XmlUtil.serialize(root)
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/handler/test/WemoLightHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/handler/test/WemoLightHandlerOSGiTest.groovy
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.binding.wemo.handler.WemoLightHandler
 import org.eclipse.smarthome.binding.wemo.test.GenericWemoHttpServlet
 import org.eclipse.smarthome.binding.wemo.test.GenericWemoLightOSGiTest
 import org.eclipse.smarthome.core.items.Item
-import org.eclipse.smarthome.core.library.items.StringItem;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType
 import org.eclipse.smarthome.core.library.types.OnOffType
 import org.eclipse.smarthome.core.library.types.PercentType
@@ -29,12 +28,9 @@ import org.eclipse.smarthome.core.thing.ThingStatus
 import org.eclipse.smarthome.core.thing.ThingUID
 import org.eclipse.smarthome.core.thing.binding.ThingHandler
 import org.eclipse.smarthome.core.types.Command
-import org.eclipse.smarthome.core.types.RefreshType;
-import org.eclipse.smarthome.core.types.State
-import org.eclipse.smarthome.core.types.UnDefType
+import org.eclipse.smarthome.core.types.RefreshType
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -44,13 +40,14 @@ import org.junit.Test
  */
 class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
 
+    def BRIDGE_HANDLER_INITIALIZE_TIMEOUT = 1000;
+
     @Before
     public void setUp() {
         setUpServices()
         servlet = new WemoLightHttpServlet(SERVICE_ID, SERVICE_NUMBER);
         registerServlet(SERVLET_URL, servlet);
-        // FIXME The default timeout is 15 seconds, I am not sure if this timeout is hardware related. 
-        // For this test 1 second timeout is enough
+        // The default timeout is 15 seconds, for this test 1 second timeout is enough
         WemoLightHandler.DEFAULT_REFRESH_INITIAL_DELAY = 1
     }
 
@@ -71,33 +68,33 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
 
         createBridge(BRIDGE_TYPE_UID)
         //Without this sleep a NPE could occur in the WemoBridgeHandler#initialize() method
-        sleep(DEFAULT_TEST_ASSERTION_TIMEOUT)
+        sleep(BRIDGE_HANDLER_INITIALIZE_TIMEOUT)
         createDefaultThing(THING_TYPE_UID)
 
         WemoLightHandler handler
         WemoBridgeHandler bridgeHandler
 
-        waitForAssert ({
+        waitForAssert{
             bridgeHandler = getService(ThingHandler.class, WemoBridgeHandler.class)
             assertThat bridgeHandler, is(notNullValue())
             assertThat bridgeHandler.getThing().getStatus(), is(ThingStatus.ONLINE)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
-        waitForAssert ({
+        waitForAssert {
             handler = getService(ThingHandler.class, WemoLightHandler.class)
             assertThat handler, is(notNullValue())
             assertThat handler.getThing().getStatus(), is(ThingStatus.ONLINE)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
-        waitForAssert ({
+        waitForAssert {
             assertThat "Invalid SOAP action sent to the device: ${servlet.actions}", servlet.actions.contains(WemoLightHttpServlet.GET_ACTION), is(true)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT + 1000*WemoLightHandler.DEFAULT_REFRESH_INITIAL_DELAY)
-        
-        waitForAssert({
+        }
+
+        waitForAssert{
             Item item = itemRegistry.get(DEFAULT_TEST_ITEM_NAME)
             assertThat "Item with name ${DEFAULT_TEST_ITEM_NAME} may not be created. Check the createItem() method.", item, is(notNullValue())
             assertThat "The state of the item ${DEFAULT_TEST_ITEM_NAME} was not updated at start.", item.getState(), is(expectedState)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 
     @Test
@@ -118,7 +115,7 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
 
     @Test
     public void 'handle Percent command for BRIGHTNESS channel' () {
-        // Set brightness value to 20 Percent 
+        // Set brightness value to 20 Percent
         Command command = new PercentType(20);
         String channelID = WemoBindingConstants.CHANNEL_BRIGHTNESS
         String acceptedItemType = "Dimmer"
@@ -133,7 +130,7 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
 
     @Test
     public void 'handle Increase command for BRIGHTNESS channel' () {
-        // The value is increased by 5 Percents by default 
+        // The value is increased by 5 Percents by default
         Command command = IncreaseDecreaseType.INCREASE;
         String channelID = WemoBindingConstants.CHANNEL_BRIGHTNESS
         String acceptedItemType = "Dimmer"
@@ -182,31 +179,31 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
         def action = WemoLightHttpServlet.GET_ACTION
         def value= null
         def capitability = null
-        
+
         assertRequestForCommand(channelID, command, action, value, capitability)
-        
+
     }
 
     private assertRequestForCommand(String channelID, Command command, String action, String value, String capitability) {
         createBridge(BRIDGE_TYPE_UID)
         //Without this sleep a NPE could occur in the WemoBridgeHandler#initialize() method
-        sleep(DEFAULT_TEST_ASSERTION_TIMEOUT)
+        sleep(BRIDGE_HANDLER_INITIALIZE_TIMEOUT)
         createDefaultThing(THING_TYPE_UID)
 
         WemoLightHandler handler
         WemoBridgeHandler bridgeHandler
 
-        waitForAssert ({
+        waitForAssert {
             bridgeHandler = getService(ThingHandler.class, WemoBridgeHandler.class)
             assertThat bridgeHandler, is(notNullValue())
             assertThat bridgeHandler.getThing().getStatus(), is(ThingStatus.ONLINE)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
-        waitForAssert ({
+        waitForAssert {
             handler = getService(ThingHandler.class, WemoLightHandler.class)
             assertThat handler, is(notNullValue())
             assertThat handler.getThing().getStatus(), is(ThingStatus.ONLINE)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
         // The device is registered as UPnP Device after the initialization, this will ensure that the polling job will not start
         addUpnpDevice(SERVICE_ID, SERVICE_NUMBER, DEVICE_MODEL_NAME)
@@ -215,11 +212,11 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
         ChannelUID channelUID = new ChannelUID(thingUID, channelID)
         handler.handleCommand(channelUID, command)
 
-        waitForAssert ({
+        waitForAssert{
             assertThat "Invalid SOAP action sent to the device: ${servlet.actions}", servlet.actions.contains(action), is(true)
             assertThat "No request received for capitability: ${servlet.capitability}, after command ${command}", servlet.capitability, is(capitability)
             assertThat "Incorrect value recevied for capitability ${servlet.capitability} ", servlet.value, is(value)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 
     class WemoLightHttpServlet extends GenericWemoHttpServlet {
@@ -244,7 +241,7 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
             def getActions = root[soapNamespace.Body][uNamespace.GetDeviceStatus];
             def setActions = root[soapNamespace.Body][uNamespace.SetDeviceStatus];
             def getAllDevices = root[soapNamespace.Body][uNamespace.GetEndDevices];
-            
+
             if (getActions.size() > 0) {
                 super.setResponseStatus(HttpServletResponse.SC_OK)
 
@@ -260,7 +257,7 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
 
                 def setAction = setActions[0]
                 this.actions.add(setAction.name().getLocalPart())
-                
+
                 def innerXML = setAction.DeviceStatusList.text()
                 def innerRoot
                 synchronized(parser) {
@@ -268,7 +265,7 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
                 }
                 this.capitability = innerRoot.CapabilityID.text()
                 this.value  = innerRoot.CapabilityValue.text()
-            
+
                 return "";
             } else  if (getAllDevices.size() > 0) {
                 // Do not answer requests of the discovery service

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/handler/test/WemoMakerHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/handler/test/WemoMakerHandlerOSGiTest.groovy
@@ -28,7 +28,6 @@ import org.eclipse.smarthome.core.types.RefreshType
 import org.eclipse.smarthome.core.types.UnDefType
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -88,15 +87,15 @@ class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
             assertThat handler.getThing().getStatus(), is(ThingStatus.ONLINE)
         }
 
-        waitForAssert({
+        waitForAssert{
             assertThat "Invalid SOAP action sent to the device: ${deviceServlet.actions}", deviceServlet.actions.contains(WemoMakerHttpServlet.GET_ACTION), is (true)
-        })
+        }
 
-        waitForAssert({
+        waitForAssert{
             Item item = itemRegistry.getItem(DEFAULT_TEST_ITEM_NAME)
             assertThat "Item with name ${DEFAULT_TEST_ITEM_NAME} may not be created. Check the createItem() method.", item, is(notNullValue())
             assertThat "The state of the item ${DEFAULT_TEST_ITEM_NAME} was not updated at start.", item.getState(), is(expectedState)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 
     @Test
@@ -118,10 +117,10 @@ class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
         ChannelUID channelUID = new ChannelUID(thing.getUID(), DEFAULT_TEST_CHANNEL)
         thing.getHandler().handleCommand(channelUID, command)
 
-        waitForAssert({
+        waitForAssert {
             assertThat "Invalid SOAP action sent to the device: ${basicServlet.actions}", basicServlet.actions.contains(WemoMakerHttpServlet.SET_ACTION), is(true)
             assertThat "The state of the device after the command ${command} was not updated with the expected value.", basicServlet.binaryState, is(expectedState)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 
     @Test
@@ -139,11 +138,11 @@ class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
             assertThat handler.getThing().getStatus(), is(ThingStatus.ONLINE)
         }
 
-        waitForAssert({
+        waitForAssert{
             Item item = itemRegistry.get(DEFAULT_TEST_ITEM_NAME)
             assertThat "Item with name ${DEFAULT_TEST_ITEM_NAME} may not be created. Check the createItem() method.", item, is(notNullValue())
             assertThat "The state of the item ${DEFAULT_TEST_ITEM_NAME} was not updated at start.", item.getState(), is(UnDefType.NULL)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
         // The Device is registered as UPnP Device after the initialization, this will ensure that the polling job will not start
         addUpnpDevice(BASIC_EVENT_SERVICE_ID, SERVICE_NUMBER, MODEL)
@@ -151,15 +150,15 @@ class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
         ChannelUID channelUID = new ChannelUID(thing.getUID(), DEFAULT_TEST_CHANNEL)
         thing.getHandler().handleCommand(channelUID, command)
 
-        waitForAssert ({
+        waitForAssert {
             assertThat "Invalid SOAP action sent to the device:${deviceServlet.actions}", deviceServlet.actions.contains(WemoMakerHttpServlet.GET_ACTION), is(true)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
-        waitForAssert({
+        waitForAssert{
             Item item = itemRegistry.get(DEFAULT_TEST_ITEM_NAME)
             assertThat "Item with name ${DEFAULT_TEST_ITEM_NAME} may not be created. Check the createItem() method.", item, is(notNullValue())
             assertThat "The state of the item ${DEFAULT_TEST_ITEM_NAME} was not updated after command ${command}.", item.getState(), is(expectedState)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 
     private void removeThing() {
@@ -173,14 +172,14 @@ class WemoMakerHandlerOSGiTest extends GenericWemoOSGiTest {
             assertThat thingHandler, is(nullValue())
         }
 
-        waitForAssert ({
+        waitForAssert {
             assertThat "UPnP registry is not clear", upnpIOService.participants.keySet().size(), is(0)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
         itemRegistry.remove(DEFAULT_TEST_ITEM_NAME)
-        waitForAssert ({
+        waitForAssert {
             assertThat itemRegistry.getAll().size(), is(0)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 
     class WemoMakerHttpServlet extends GenericWemoHttpServlet {

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoLightOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoLightOSGiTest.groovy
@@ -100,29 +100,29 @@ class GenericWemoLightOSGiTest extends GenericWemoOSGiTest {
             assertThat("The thing ${thing.getUID()} cannot be deleted", removedThing, is(notNullValue()))
         }
 
-        waitForAssert ({
+        waitForAssert {
             ThingHandler thingHandler = getService(ThingHandler, WemoLightHandler)
             assertThat thingHandler, is(nullValue())
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
         if(bridge != null) {
             Bridge bridgeThing = thingRegistry.remove(bridge.getUID())
             assertThat "The bridge ${bridge.getUID()} cannot be deleted", bridgeThing, is(notNullValue())
         }
 
-        waitForAssert ({
+        waitForAssert {
             ThingHandler bridgeHandler = getService(ThingHandler, WemoBridgeHandler)
             assertThat bridgeHandler, is(nullValue())
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
-        waitForAssert ({
+        waitForAssert {
             Set<UpnpIOParticipant> participants  = upnpIOService.participants.keySet();
             assertThat "UPnP Registry is not clear: ${participants}", participants.size(), is(0)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
 
         itemRegistry.remove(DEFAULT_TEST_ITEM_NAME)
-        waitForAssert ({
+        waitForAssert {
             assertThat itemRegistry.getAll().size(), is(0)
-        }, DEFAULT_TEST_ASSERTION_TIMEOUT)
+        }
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoOSGiTest.groovy
@@ -21,7 +21,6 @@ import org.eclipse.smarthome.binding.wemo.handler.WemoHandler
 import org.eclipse.smarthome.config.core.Configuration
 import org.eclipse.smarthome.core.items.Item
 import org.eclipse.smarthome.core.items.ItemRegistry
-import org.eclipse.smarthome.core.library.items.StringItem
 import org.eclipse.smarthome.core.library.items.SwitchItem
 import org.eclipse.smarthome.core.thing.Channel
 import org.eclipse.smarthome.core.thing.ChannelUID
@@ -59,7 +58,7 @@ import org.osgi.service.http.HttpService
 public abstract class GenericWemoOSGiTest extends OSGiTest{
 
     static final def DEVICE_MANUFACTURER = "Belkin"
-    
+
     //This port is included in the run configuration
     def ORG_OSGI_SERVICE_HTTP_PORT = 8080
 
@@ -74,8 +73,6 @@ public abstract class GenericWemoOSGiTest extends OSGiTest{
     def DEVICE_URL = "http://127.0.0.1:${ORG_OSGI_SERVICE_HTTP_PORT}"
     def DEVICE_DESCRIPTION_PATH = "/setup.xml"
     def DEVICE_CONTROL_PATH = '/upnp/control/'
-
-    def DEFAULT_TEST_ASSERTION_TIMEOUT = 1000;
 
     ManagedThingProvider managedThingProvider
     static MockUpnpService mockUpnpService
@@ -146,7 +143,7 @@ public abstract class GenericWemoOSGiTest extends OSGiTest{
             testItem = new SwitchItem(itemName)
         }
         // If a new test is implemented with different Item Type testItem from this Type must be created here
-        
+
         itemRegistry.add(testItem)
 
         def ManagedItemChannelLinkProvider itemChannelLinkProvider = getService(ManagedItemChannelLinkProvider)
@@ -155,7 +152,7 @@ public abstract class GenericWemoOSGiTest extends OSGiTest{
         ThingUID thingUID = thing.getUID()
         itemChannelLinkProvider.add(new ItemChannelLink(itemName, channelUID))
     }
-    
+
 
     protected addUpnpDevice(def serviceTypeID, def serviceNumber, def modelName) {
         UDN udn = new UDN(DEVICE_UDN);
@@ -187,7 +184,7 @@ public abstract class GenericWemoOSGiTest extends OSGiTest{
 abstract class GenericWemoHttpServlet extends HttpServlet{
     final static def parser = new XmlParser()
     final static def CONTENT_TYPE = "text/xml; charset=utf-8"
-    
+
     def soapNamespace
     def uNamespace
     def responseStatus
@@ -212,16 +209,16 @@ abstract class GenericWemoHttpServlet extends HttpServlet{
 
         response.setStatus(responseStatus);
         response.setContentType(CONTENT_TYPE)
-        
+
         if(responseStatus == HttpServletResponse.SC_OK) {
             response.getOutputStream().print(responseContent)
-        } 
+        }
     }
 
     protected void setResponseStatus(int status) {
         responseStatus = status
     }
-    
+
     abstract protected String handleRequest (Node root);
 }
 


### PR DESCRIPTION
Wemo tests now use the default timeout in waitForAssert statements to
prevent test failures on slower machines.

Fixes #2392.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>