### PR TITLE
Fix the voice label produced by the voice manager

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceManagerImpl.java
@@ -559,7 +559,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
                 List<ParameterOption> options = new ArrayList<>();
                 for (Voice voice : getAllVoices()) {
                     ParameterOption option = new ParameterOption(voice.getUID(),
-                            voice.getLabel() + " (" + voice.getLocale().getDisplayLanguage() + ")");
+                            voice.getLabel() + " " + voice.getLocale().getDisplayName());
                     options.add(option);
                 }
                 return options;


### PR DESCRIPTION
Signed-off-by: Laurent Garnier <lg.hc@free.fr>

With this fix, the label displayed by Paper UI for the default voice config setting will be like "VoiceRSS français (France)" for the voice attached to locale fr-FR.