### PR TITLE
Dropdown height fix on systems page

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -908,7 +908,7 @@ md-dialog-content .dayParameter {
 	min-height: 48px;
 }
 
-.container.itemConfig .md-select-value {
+.container.itemConfig .md-select-value, .container .includeConfig .md-select-value {
 	padding: 2px 2px 1px 2px;
 }
 


### PR DESCRIPTION
Before:
<img width="906" alt="screen shot 2016-11-15 at 16 22 17" src="https://cloud.githubusercontent.com/assets/5161937/20311393/f0059f6e-ab4f-11e6-8771-78def5f5516f.png">

After:
<img width="903" alt="screen shot 2016-11-15 at 16 20 12" src="https://cloud.githubusercontent.com/assets/5161937/20311403/f8a5fc4a-ab4f-11e6-8923-c3594d65b7a1.png">

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>