### PR TITLE
adapted label to be identical on console as in the UI

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceConsoleCommandExtension.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceConsoleCommandExtension.java
@@ -71,7 +71,8 @@ public class VoiceConsoleCommandExtension extends AbstractConsoleCommandExtensio
                     return;
                 case SUBCMD_VOICES:
                     for (Voice voice : voiceManager.getAllVoices()) {
-                        console.println(voice.getUID() + " " + voice.getLabel() + " (" + voice.getLocale() + ")");
+                        console.println(
+                                voice.getUID() + " " + voice.getLabel() + " - " + voice.getLocale().getDisplayName());
                     }
                     return;
                 default:


### PR DESCRIPTION
See also https://github.com/eclipse/smarthome/commit/70ff83d03071508839b164aef1f1011de747dd92

Signed-off-by: Kai Kreuzer <kai@openhab.org>