### PR TITLE
Added documentation for audio sink support in Sonos

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/binding/binding.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/binding/binding.xml
@@ -15,7 +15,7 @@
 		</parameter>
         <parameter name="callbackUrl" type="text">
             <label>Callback URL</label>
-            <description>url to use for playing notification sounds, e.g. http://192.168.0.2:8080</description>
+            <description>URL to use for playing notification sounds, e.g. http://192.168.0.2:8080</description>
             <required>false</required>
         </parameter>
 	</config-description>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
@@ -90,7 +90,7 @@ All supported Sonos devices are registered as an audio sink in the framework.
 Audio streams are treated as notifications, i.e. they are fed into the `notificationsound` channel and changing the volume of the audio sink will change the `notificationvolume`, not the `volume`.
 Note that the Sonos binding has a limit of 20 seconds for notification sounds. Any sound that is longer than that will be cut off.
 
-An exception is done if an URL audio stream is passed (e.g. an Internet radio stream). This will be handled by the `playuri` channel.
+URL audio streams (e.g. an Internet radio stream) are an exception and do not get sent to the `notificationsound` channel. Instead, these will be sent to the `playuri` channel.
 
 ## Full Example
 

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
@@ -10,7 +10,7 @@ This binding integrates the [Sonos Multi-Room Audio system](http://www.sonos.com
 
 ## Supported Things
 
-All available Sonos (playback) devices are supported by this binding. This includes the Play:1, Play:3, Play:5, Connect, Connect:Amp, Playbar, and Sub. The Bridge and Boost are not supported, but these devices do only have an auxiliary role in the Sonos network and do not have any playback capability.
+All available Sonos (playback) devices are supported by this binding. This includes the Play:1, Play:3, Play:5, Connect, Connect:Amp, Playbar, and Sub. The Bridge and Boost are not supported, but these devices do only have an auxiliary role in the Sonos network and do not have any playback capability. All supported Sonos devices are registered as an audio sink in the framework.
 
 When being defined in a \*.things file, the specific thing types PLAY1, PLAY3, PLAY5, PLAYBAR, CONNECT and CONNECTAMP should be used.
 
@@ -22,7 +22,12 @@ The Sonos devices are discovered through UPnP in the local network and all devic
 
 ## Binding Configuration
 
-The binding does not require any special configuration
+The binding has the following configuration options, which can be set for "binding:sonos":
+
+| Parameter | Name    | Description  | Required |
+|-----------------|------------------------|--------------|------------ |
+| opmlUrl | OPML Service URL | URL for the OPML/tunein.com service | no |
+| callbackUrl | Callback URL | URL to use for playing notification sounds, e.g. http://192.168.0.2:8080 | no |
 
 ## Thing Configuration
 
@@ -78,6 +83,14 @@ The devices support the following channels:
 | zonegroup | String | XML formatted string with the current zonegroup configuration | all |
 | zonegroupid | String | Id of the Zone Group the Zone Player belongs to | all |
 | zonename | String | Name of the Zone Group the Zone Player belongs to | all |
+
+## Audio Support
+
+All supported Sonos devices are registered as an audio sink in the framework.
+Audio streams are treated as notifications, i.e. they are fed into the `notificationsound` channel and changing the volume of the audio sink will change the `notificationvolume`, not the `volume`.
+Note that the Sonos binding has a limit of 20 seconds for notification sounds. Any sound that is longer than that will be cut off.
+
+An exception is done if an URL audio stream is passed (e.g. an Internet radio stream). This will be handled by the `playuri` channel.
 
 ## Full Example
 


### PR DESCRIPTION
Fixes https://github.com/eclipse/smarthome/issues/2452

Signed-off-by: Kai Kreuzer <kai@openhab.org>