### PR TITLE
Improvements in startup behavior for cron rules

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/ModelRepositoryImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/ModelRepositoryImpl.java
@@ -12,10 +12,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.emf.common.util.URI;
@@ -46,8 +44,6 @@ public class ModelRepositoryImpl implements ModelRepository {
     private final ResourceSet resourceSet;
 
     private final List<ModelRepositoryChangeListener> listeners = new CopyOnWriteArrayList<>();
-
-    private Set<String> ignoredResources = new HashSet<>();
 
     public ModelRepositoryImpl() {
         XtextResourceSet xtextResourceSet = new SynchronizedXtextResourceSet();
@@ -183,6 +179,7 @@ public class ModelRepositoryImpl implements ModelRepository {
                         // It's not sufficient to discard the derived state.
                         // The quick & dirts solution is to reparse the whole resource.
                         // We trigger this by dummy updating the resource.
+                        logger.debug("Refreshing resource '{}'", resource.getURI().lastSegment());
                         xtextResource.update(1, 0, "");
                         notifyListeners(resource.getURI().lastSegment(), EventType.MODIFIED);
                     }

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/ruleengine.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/ruleengine.xml
@@ -14,7 +14,7 @@
       <provide interface="org.eclipse.smarthome.core.events.EventSubscriber"/>
       <provide interface="org.eclipse.smarthome.model.rule.runtime.RuleEngine"/>
    </service>
-   <reference bind="setItemRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.items.ItemRegistry" name="ItemRegistry" policy="dynamic" unbind="unsetItemRegistry"/>
+   <reference bind="setItemRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.items.ItemRegistry" name="ItemRegistry" policy="static" unbind="unsetItemRegistry"/>
    <reference bind="setModelRepository" cardinality="1..1" interface="org.eclipse.smarthome.model.core.ModelRepository" name="ModelRepository" policy="static" unbind="unsetModelRepository"/>
    <reference bind="setScriptEngine" cardinality="1..1" interface="org.eclipse.smarthome.model.script.engine.ScriptEngine" name="ScriptEngine" policy="static" unbind="unsetScriptEngine"/>
 </scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTriggerManager.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTriggerManager.java
@@ -10,6 +10,7 @@ package org.eclipse.smarthome.model.rule.runtime.internal.engine;
 import static org.eclipse.smarthome.model.rule.runtime.internal.engine.RuleTriggerManager.TriggerTypes.*;
 import static org.quartz.JobBuilder.newJob;
 import static org.quartz.TriggerBuilder.newTrigger;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.types.Command;
@@ -45,6 +47,7 @@ import org.quartz.impl.StdSchedulerFactory;
 import org.quartz.impl.matchers.GroupMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -92,6 +95,9 @@ public class RuleTriggerManager {
         try {
             scheduler = StdSchedulerFactory.getDefaultScheduler();
             scheduler.setJobFactory(injector.getInstance(GuiceAwareJobFactory.class));
+
+            // we want to defer timer rule execution until after the startup rules have been executed.
+            scheduler.standby();
         } catch (SchedulerException e) {
             logger.error("initializing scheduler throws exception", e);
         }
@@ -319,6 +325,8 @@ public class RuleTriggerManager {
                     }
                 }
                 break;
+            default:
+                break;
         }
         return result;
     }
@@ -538,6 +546,9 @@ public class RuleTriggerManager {
      * @throws SchedulerException if there is an internal Scheduler error.
      */
     private void createTimer(Rule rule, TimerTrigger trigger) throws SchedulerException {
+        synchronized (rule) {
+
+        }
         String cronExpression = trigger.getCron();
         if (trigger.getTime() != null) {
             if (trigger.getTime().equals("noon")) {
@@ -545,8 +556,7 @@ public class RuleTriggerManager {
             } else if (trigger.getTime().equals("midnight")) {
                 cronExpression = "0 0 0 * * ?";
             } else {
-                logger.warn("Unrecognized time expression '{}' in rule '{}'",
-                        new String[] { trigger.getTime(), rule.getName() });
+                logger.warn("Unrecognized time expression '{}' in rule '{}'", trigger.getTime(), rule.getName());
                 return;
             }
         }
@@ -558,9 +568,9 @@ public class RuleTriggerManager {
                     .usingJobData(ExecuteRuleJob.JOB_DATA_RULEMODEL, rule.eResource().getURI().path())
                     .usingJobData(ExecuteRuleJob.JOB_DATA_RULENAME, rule.getName()).withIdentity(jobIdentity).build();
             Trigger quartzTrigger = newTrigger().withSchedule(CronScheduleBuilder.cronSchedule(cronExpression)).build();
-            scheduler.scheduleJob(job, quartzTrigger);
+            scheduler.scheduleJob(job, Collections.singleton(quartzTrigger), true);
 
-            logger.debug("Scheduled rule {} with cron expression {}", new String[] { rule.getName(), cronExpression });
+            logger.debug("Scheduled rule '{}' with cron expression '{}'", rule.getName(), cronExpression);
         } catch (RuntimeException e) {
             throw new SchedulerException(e.getMessage());
         }
@@ -596,5 +606,13 @@ public class RuleTriggerManager {
             }
         }
         return jobIdentity;
+    }
+
+    public void startTimerRuleExecution() {
+        try {
+            scheduler.start();
+        } catch (SchedulerException e) {
+            logger.error("Error while starting the scheduler service: {}", e.getMessage());
+        }
     }
 }

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTriggerManager.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTriggerManager.java
@@ -546,9 +546,6 @@ public class RuleTriggerManager {
      * @throws SchedulerException if there is an internal Scheduler error.
      */
     private void createTimer(Rule rule, TimerTrigger trigger) throws SchedulerException {
-        synchronized (rule) {
-
-        }
         String cronExpression = trigger.getCron();
         if (trigger.getTime() != null) {
             if (trigger.getTime().equals("noon")) {

--- a/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/jvmmodel/RulesItemRefresher.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/jvmmodel/RulesItemRefresher.java
@@ -30,6 +30,9 @@ import org.slf4j.LoggerFactory;
  */
 public class RulesItemRefresher implements ItemRegistryChangeListener {
 
+    // delay before rule resources are refreshed after items or services have changed
+    private static final long REFRESH_DELAY = 2000;
+
     private final Logger logger = LoggerFactory.getLogger(RulesItemRefresher.class);
 
     ModelRepository modelRepository;
@@ -87,7 +90,7 @@ public class RulesItemRefresher implements ItemRegistryChangeListener {
         if (job != null && !job.isDone()) {
             job.cancel(false);
         }
-        job = scheduler.schedule(runnable, 1000, TimeUnit.MILLISECONDS);
+        job = scheduler.schedule(runnable, REFRESH_DELAY, TimeUnit.MILLISECONDS);
     }
 
     Runnable runnable = new Runnable() {

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/internal/actions/TimerImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/internal/actions/TimerImpl.java
@@ -65,8 +65,7 @@ public class TimerImpl implements Timer {
                 cancelled = true;
             }
         } catch (SchedulerException e) {
-            logger.warn("An error occured while cancelling the job '{}': {}",
-                    new String[] { jobKey.toString(), e.getMessage() });
+            logger.warn("An error occured while cancelling the job '{}': {}", jobKey.toString(), e.getMessage());
         }
         return cancelled;
     }
@@ -81,8 +80,7 @@ public class TimerImpl implements Timer {
             this.terminated = false;
             return true;
         } catch (SchedulerException e) {
-            logger.warn("An error occured while rescheduling the job '{}': {}",
-                    new String[] { jobKey.toString(), e.getMessage() });
+            logger.warn("An error occured while rescheduling the job '{}': {}", jobKey.toString(), e.getMessage());
             return false;
         }
     }

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/jvmmodel/ScriptItemRefresher.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/jvmmodel/ScriptItemRefresher.java
@@ -32,6 +32,9 @@ public class ScriptItemRefresher implements ItemRegistryChangeListener {
 
     private final Logger logger = LoggerFactory.getLogger(ScriptItemRefresher.class);
 
+    // delay before rule resources are refreshed after items or services have changed
+    private static final long REFRESH_DELAY = 2000;
+
     ModelRepository modelRepository;
     private ItemRegistry itemRegistry;
     private ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -87,7 +90,7 @@ public class ScriptItemRefresher implements ItemRegistryChangeListener {
         if (job != null && !job.isDone()) {
             job.cancel(false);
         }
-        job = scheduler.schedule(runnable, 1, TimeUnit.SECONDS);
+        job = scheduler.schedule(runnable, REFRESH_DELAY, TimeUnit.MILLISECONDS);
     }
 
     Runnable runnable = new Runnable() {


### PR DESCRIPTION
* delay cron job execution until after startup rules have been processed
* only register the rule engine as a listener on other services in activate(), which avoids concurrent execution of addRule()
* if a job already exists for whatever reason, simply replace it instead of failing with an error
* cleaned some javadoc and logging statements

See issues reported at https://community.openhab.org/t/startup-error-for-all-cron-based-rules/14405

Signed-off-by: Kai Kreuzer <kai@openhab.org>