### PR TITLE
Fixed a typo inside the Javadoc for ItemThingLink class.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemThingLink.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemThingLink.java
@@ -8,10 +8,11 @@
 package org.eclipse.smarthome.core.thing.link;
 
 import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingUID;
 
 /**
- * {@link ItemThingLink} defines a link between an {@link Item} and a {@link Think}.
+ * {@link ItemThingLink} defines a link between an {@link Item} and a {@link Thing}.
  *
  * @author Dennis Nobel - Initial contribution
  */


### PR DESCRIPTION
Fixed a typo inside the Javadoc for ItemThingLink class.

Signed-off-by: Alexander Kostadinov <alexander.g.kostadinov@gmail.com>