### PR TITLE
fix state conversion between HSBType and DecimalType

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/ColorItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/ColorItemTest.java
@@ -36,6 +36,13 @@ public class ColorItemTest {
     }
 
     @Test
+    public void testSetStateWithDecimalType() {
+        ColorItem item = new ColorItem("test");
+        item.setState(new DecimalType("0.5"));
+        assertEquals(new HSBType("0,0,50"), item.getState());
+    }
+
+    @Test
     public void testUpdateStateWithPercentType() {
         ColorItem item = new ColorItem("test");
         item.setState(new HSBType(new DecimalType(75), new PercentType(75), new PercentType(75)));

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
@@ -105,4 +105,11 @@ public class DecimalTypeTest {
         assertEquals(UnDefType.UNDEF, new DecimalType("0.5").as(OpenClosedType.class));
     }
 
+    @Test
+    public void testConversionToHSBType() {
+        assertEquals(new HSBType("0,0,0"), new DecimalType("0.0").as(HSBType.class));
+        assertEquals(new HSBType("0,0,100"), new DecimalType("1.0").as(HSBType.class));
+        assertEquals(new HSBType("0,0,50"), new DecimalType("0.5").as(HSBType.class));
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PercentTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PercentTypeTest.java
@@ -79,4 +79,11 @@ public class PercentTypeTest {
         assertEquals(UnDefType.UNDEF, new PercentType("50.0").as(OpenClosedType.class));
     }
 
+    @Test
+    public void testConversionToHSBType() {
+        assertEquals(new HSBType("0,0,0"), new PercentType("0.0").as(HSBType.class));
+        assertEquals(new HSBType("0,0,100"), new PercentType("100.0").as(HSBType.class));
+        assertEquals(new HSBType("0,0,50"), new PercentType("50.0").as(HSBType.class));
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.smarthome.core.library.items;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -82,6 +83,9 @@ public class ColorItem extends DimmerItem {
                 applyState(new HSBType(hue, saturation, PercentType.HUNDRED));
             } else if (state instanceof PercentType && !(state instanceof HSBType)) {
                 applyState(new HSBType(hue, saturation, (PercentType) state));
+            } else if (state instanceof DecimalType && !(state instanceof HSBType)) {
+                applyState(new HSBType(hue, saturation,
+                        new PercentType(((DecimalType) state).toBigDecimal().multiply(new BigDecimal(100)))));
             } else {
                 applyState(state);
             }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
@@ -85,7 +85,7 @@ public class ColorItem extends DimmerItem {
                 applyState(new HSBType(hue, saturation, (PercentType) state));
             } else if (state instanceof DecimalType && !(state instanceof HSBType)) {
                 applyState(new HSBType(hue, saturation,
-                        new PercentType(((DecimalType) state).toBigDecimal().multiply(new BigDecimal(100)))));
+                        new PercentType(((DecimalType) state).toBigDecimal().multiply(BigDecimal.valueOf(100)))));
             } else {
                 applyState(state);
             }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunction.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunction.java
@@ -232,7 +232,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
                 }
             }
             if (count > 0) {
-                return new DecimalType(sum.divide(new BigDecimal(count), RoundingMode.HALF_UP));
+                return new DecimalType(sum.divide(BigDecimal.valueOf(count), RoundingMode.HALF_UP));
             } else {
                 return UnDefType.UNDEF;
             }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -165,6 +165,9 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
             } else {
                 return UnDefType.UNDEF;
             }
+        } else if (target == HSBType.class) {
+            return new HSBType(DecimalType.ZERO, PercentType.ZERO,
+                    new PercentType(this.toBigDecimal().multiply(new BigDecimal(100))));
         } else {
             return StateConverterUtil.defaultConversion(this, target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -41,7 +41,7 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
     }
 
     public DecimalType(long value) {
-        this.value = new BigDecimal(value);
+        this.value = BigDecimal.valueOf(value);
     }
 
     public DecimalType(double value) {
@@ -148,11 +148,11 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         if (target == OnOffType.class) {
             return equals(ZERO) ? OnOffType.OFF : OnOffType.ON;
         } else if (target == PercentType.class) {
-            return new PercentType(toBigDecimal().multiply(new BigDecimal(100)));
+            return new PercentType(toBigDecimal().multiply(BigDecimal.valueOf(100)));
         } else if (target == UpDownType.class) {
             if (equals(ZERO)) {
                 return UpDownType.UP;
-            } else if (toBigDecimal().compareTo(new BigDecimal(1)) == 0) {
+            } else if (toBigDecimal().compareTo(BigDecimal.valueOf(1)) == 0) {
                 return UpDownType.DOWN;
             } else {
                 return UnDefType.UNDEF;
@@ -160,14 +160,14 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         } else if (target == OpenClosedType.class) {
             if (equals(ZERO)) {
                 return OpenClosedType.CLOSED;
-            } else if (toBigDecimal().compareTo(new BigDecimal(1)) == 0) {
+            } else if (toBigDecimal().compareTo(BigDecimal.valueOf(1)) == 0) {
                 return OpenClosedType.OPEN;
             } else {
                 return UnDefType.UNDEF;
             }
         } else if (target == HSBType.class) {
             return new HSBType(DecimalType.ZERO, PercentType.ZERO,
-                    new PercentType(this.toBigDecimal().multiply(new BigDecimal(100))));
+                    new PercentType(this.toBigDecimal().multiply(BigDecimal.valueOf(100))));
         } else {
             return StateConverterUtil.defaultConversion(this, target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -212,11 +212,12 @@ public class HSBType extends PercentType implements ComplexType, State, Command,
         PercentType green = null;
         PercentType blue = null;
 
-        BigDecimal h = hue.divide(new BigDecimal(100), 10, BigDecimal.ROUND_HALF_UP);
-        BigDecimal s = saturation.divide(new BigDecimal(100));
+        BigDecimal h = hue.divide(BigDecimal.valueOf(100), 10, BigDecimal.ROUND_HALF_UP);
+        BigDecimal s = saturation.divide(BigDecimal.valueOf(100));
 
-        int h_int = h.multiply(new BigDecimal(5)).divide(new BigDecimal(3), 10, BigDecimal.ROUND_HALF_UP).intValue();
-        BigDecimal f = h.multiply(new BigDecimal(5)).divide(new BigDecimal(3), 10, BigDecimal.ROUND_HALF_UP)
+        int h_int = h.multiply(BigDecimal.valueOf(5)).divide(BigDecimal.valueOf(3), 10, BigDecimal.ROUND_HALF_UP)
+                .intValue();
+        BigDecimal f = h.multiply(BigDecimal.valueOf(5)).divide(BigDecimal.valueOf(3), 10, BigDecimal.ROUND_HALF_UP)
                 .remainder(BigDecimal.ONE);
         PercentType a = new PercentType(value.multiply(BigDecimal.ONE.subtract(s)));
         PercentType b = new PercentType(value.multiply(BigDecimal.ONE.subtract(s.multiply(f))));
@@ -264,7 +265,7 @@ public class HSBType extends PercentType implements ComplexType, State, Command,
             // if brightness is not completely off, we consider the state to be on
             return getBrightness().equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON;
         } else if (target == DecimalType.class) {
-            return new DecimalType(getBrightness().toBigDecimal().divide(new BigDecimal(100), 8, RoundingMode.UP));
+            return new DecimalType(getBrightness().toBigDecimal().divide(BigDecimal.valueOf(100), 8, RoundingMode.UP));
         } else if (target == PercentType.class) {
             return new PercentType(getBrightness().toBigDecimal());
         } else {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
@@ -47,7 +47,7 @@ public class PercentType extends DecimalType {
     }
 
     private void validateValue(BigDecimal value) {
-        if (BigDecimal.ZERO.compareTo(value) > 0 || new BigDecimal(100).compareTo(value) < 0) {
+        if (BigDecimal.ZERO.compareTo(value) > 0 || BigDecimal.valueOf(100).compareTo(value) < 0) {
             throw new IllegalArgumentException("Value must be between 0 and 100");
         }
     }
@@ -61,7 +61,7 @@ public class PercentType extends DecimalType {
         if (target == OnOffType.class) {
             return equals(ZERO) ? OnOffType.OFF : OnOffType.ON;
         } else if (target == DecimalType.class) {
-            return new DecimalType(toBigDecimal().divide(new BigDecimal(100), 8, RoundingMode.UP));
+            return new DecimalType(toBigDecimal().divide(BigDecimal.valueOf(100), 8, RoundingMode.UP));
         } else if (target == UpDownType.class) {
             if (equals(ZERO)) {
                 return UpDownType.UP;


### PR DESCRIPTION
It looks like #2471 was caused by the missing conversion from DecimalType to HSBType. It got lost in #2334 because it was very well hidden in the super classes (i.e. PercentType/DimmerItem).

fixes #2471
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>