### PR TITLE
removed maven nature from config.dispatch.test project

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/.project
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/.project
@@ -25,14 +25,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.groovy.core.groovyNature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>


### PR DESCRIPTION
...as our projects usually don't have the maven nature enabled.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>