### PR TITLE
fix indirect class reference

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/META-INF/MANIFEST.MF
@@ -22,4 +22,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
  org.junit,
- org.osgi.framework
+ org.osgi.framework,
+ org.osgi.service.component


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/2506

It fixes the error but I don't know why it is required at all.
The bundle is a fragment for the NTP binding bundle.
The NTP binding bundle is part of the classpath.
The NTP binding bundle has the OSGi compendium API in its classpath.

Perhaps it is a "bug" in the classpath resolution of the Eclipse IDE that we could workaround by manually specify the dependency using the manifest of the test bundle.
If someone could tell me the reason... Do it :wink: 