### PR TITLE
#2485 Sonos notification sound: restore the same volume …

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
@@ -2248,7 +2248,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
      * @param coordinator - {@link ZonePlayerHandler} coordinator for the SONOS device(s)
      */
     private void handleNotificationSound(Command notificationURL, ZonePlayerHandler coordinator) {
-        String originalVolume = coordinator.getVolume();
+        String originalVolume = (isAdHocGroup() || isStandalonePlayer()) ? getVolume() : coordinator.getVolume();
         coordinator.stop();
         applyNotificationSoundVolume();
         int notificationPosition = coordinator.getQueue().size() + 1;


### PR DESCRIPTION
… for all group members

When saving the current volume - retrieve the data from current player handler and not from the coordinator

Signed-off-by: Ivaylo Ivanov <ivivanov.bg@gmail.com>