### PR TITLE
moved extension event classes from rest to core

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Eclipse SmartHome Sample Extension Service
 Bundle-SymbolicName: org.eclipse.smarthome.core.extension.sample
 Bundle-Version: 0.9.0.qualifier
 Import-Package: org.apache.commons.lang,
+ org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.extension
 Bundle-Vendor: Eclipse.org/SmartHome
 Service-Component: OSGI-INF/*.xml

--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/OSGI-INF/sampleextensionservice.xml
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/OSGI-INF/sampleextensionservice.xml
@@ -13,4 +13,5 @@
    <service>
       <provide interface="org.eclipse.smarthome.core.extension.ExtensionService"/>
    </service>
+   <reference bind="setEventPublisher" cardinality="1..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="static" unbind="unsetEventPublisher"/>
 </scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/src/main/java/org/eclipse/smarthome/core/extension/sample/internal/SampleExtensionService.java
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/src/main/java/org/eclipse/smarthome/core/extension/sample/internal/SampleExtensionService.java
@@ -15,7 +15,10 @@ import java.util.Map;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.smarthome.core.events.Event;
+import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.extension.Extension;
+import org.eclipse.smarthome.core.extension.ExtensionEventFactory;
 import org.eclipse.smarthome.core.extension.ExtensionService;
 import org.eclipse.smarthome.core.extension.ExtensionType;
 
@@ -29,8 +32,18 @@ import org.eclipse.smarthome.core.extension.ExtensionType;
  */
 public class SampleExtensionService implements ExtensionService {
 
+    private EventPublisher eventPublisher;
+
     List<ExtensionType> types = new ArrayList<>(3);
     Map<String, Extension> extensions = new HashMap<>(30);
+
+    protected void setEventPublisher(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    protected void unsetEventPublisher(EventPublisher eventPublisher) {
+        this.eventPublisher = null;
+    }
 
     protected void activate() {
         types.add(new ExtensionType("binding", "Bindings"));
@@ -61,6 +74,7 @@ public class SampleExtensionService implements ExtensionService {
             Thread.sleep((long) (Math.random() * 10000));
             Extension extension = getExtension(id, null);
             extension.setInstalled(true);
+            postInstalledEvent(id);
         } catch (InterruptedException e) {
         }
     }
@@ -71,6 +85,7 @@ public class SampleExtensionService implements ExtensionService {
             Thread.sleep((long) (Math.random() * 5000));
             Extension extension = getExtension(id, null);
             extension.setInstalled(false);
+            postUninstalledEvent(id);
         } catch (InterruptedException e) {
         }
     }
@@ -90,4 +105,17 @@ public class SampleExtensionService implements ExtensionService {
         return types;
     }
 
+    private void postInstalledEvent(String extensionId) {
+        if (eventPublisher != null) {
+            Event event = ExtensionEventFactory.createExtensionInstalledEvent(extensionId);
+            eventPublisher.post(event);
+        }
+    }
+
+    private void postUninstalledEvent(String extensionId) {
+        if (eventPublisher != null) {
+            Event event = ExtensionEventFactory.createExtensionUninstalledEvent(extensionId);
+            eventPublisher.post(event);
+        }
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/OSGI-INF/extensioneventfactory.xml
+++ b/bundles/core/org.eclipse.smarthome.core/OSGI-INF/extensioneventfactory.xml
@@ -8,8 +8,8 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.io.rest.core.binding.ExtensionEventFactory">
-   <implementation class="org.eclipse.smarthome.io.rest.core.extensions.ExtensionEventFactory"/>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.core.extension.ExtensionEventFactory">
+   <implementation class="org.eclipse.smarthome.core.extension.ExtensionEventFactory"/>
    <service>
       <provide interface="org.eclipse.smarthome.core.events.EventFactory"/>
    </service>

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/extension/ExtensionEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/extension/ExtensionEvent.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.io.rest.core.extensions;
+package org.eclipse.smarthome.core.extension;
 
 import org.eclipse.smarthome.core.events.AbstractEvent;
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/extension/ExtensionEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/extension/ExtensionEventFactory.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.io.rest.core.extensions;
+package org.eclipse.smarthome.core.extension;
 
 import org.eclipse.smarthome.core.events.AbstractEventFactory;
 import org.eclipse.smarthome.core.events.Event;

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/extensions/ExtensionResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/extensions/ExtensionResource.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.extension.Extension;
+import org.eclipse.smarthome.core.extension.ExtensionEventFactory;
 import org.eclipse.smarthome.core.extension.ExtensionService;
 import org.eclipse.smarthome.core.extension.ExtensionType;
 import org.eclipse.smarthome.io.rest.LocaleUtil;
@@ -125,7 +126,6 @@ public class ExtensionResource implements SatisfiableRESTResource {
             public void run() {
                 try {
                     extensionService.install(extensionId);
-                    postInstalledEvent(extensionId);
                 } catch (Exception e) {
                     logger.error("Exception while installing extension: {}", e.getMessage());
                     postFailureEvent(extensionId, e.getMessage());
@@ -145,7 +145,6 @@ public class ExtensionResource implements SatisfiableRESTResource {
             public void run() {
                 try {
                     extensionService.uninstall(extensionId);
-                    postUninstalledEvent(extensionId);
                 } catch (Exception e) {
                     logger.error("Exception while uninstalling extension: {}", e.getMessage());
                     postFailureEvent(extensionId, e.getMessage());
@@ -153,20 +152,6 @@ public class ExtensionResource implements SatisfiableRESTResource {
             }
         });
         return Response.ok().build();
-    }
-
-    private void postInstalledEvent(String extensionId) {
-        if (eventPublisher != null) {
-            Event event = ExtensionEventFactory.createExtensionInstalledEvent(extensionId);
-            eventPublisher.post(event);
-        }
-    }
-
-    private void postUninstalledEvent(String extensionId) {
-        if (eventPublisher != null) {
-            Event event = ExtensionEventFactory.createExtensionUninstalledEvent(extensionId);
-            eventPublisher.post(event);
-        }
     }
 
     private void postFailureEvent(String extensionId, String msg) {


### PR DESCRIPTION
moved responsibility of sending a success event to the extension service

So far the Extension REST resource itself sent the "installed" events itself, once the extension service returned from the call. This prevented the extension service from doing launching installations asynchronously (and delegating this task).
This is now changed to have the installed events being sent by the extension service itself. Through this, we also have such events if installation is triggered e.g. through the console or other mechanisms than the REST API.

Signed-off-by: Kai Kreuzer <kai@openhab.org>