### PR TITLE
Fixes of some bugs found by the static analysis tool.

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.commands/src/main/java/org/eclipse/smarthome/automation/internal/commands/AbstractCommandProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.commands/src/main/java/org/eclipse/smarthome/automation/internal/commands/AbstractCommandProvider.java
@@ -157,16 +157,12 @@ public abstract class AbstractCommandProvider<E> implements ServiceTrackerCustom
      * @throws Exception is thrown when I/O operation has failed or has been interrupted or generating of the text fails
      *             for some reasons.
      */
-    @SuppressWarnings("resource")
     public String exportData(String parserType, Set<E> set, File file) throws Exception {
-        OutputStreamWriter oWriter = new OutputStreamWriter(new FileOutputStream(file));
         Parser<E> parser = parsers.get(parserType);
         if (parser != null) {
-            try {
+            try (OutputStreamWriter oWriter = new OutputStreamWriter(new FileOutputStream(file))) {
                 parser.serialize(set, oWriter);
                 return AutomationCommand.SUCCESS;
-            } finally {
-                oWriter.close();
             }
         } else {
             return String.format("%s! Parser \"%s\" not found!", AutomationCommand.FAIL, parserType);

--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/DialogProcessor.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/DialogProcessor.java
@@ -150,7 +150,7 @@ public class DialogProcessor implements KSListener, STTListener {
         try {
             Voice voice = null;
             for (Voice currentVoice : tts.getAvailableVoices()) {
-                if (this.locale.getLanguage() == currentVoice.getLocale().getLanguage()) {
+                if (this.locale.getLanguage().equals(currentVoice.getLocale().getLanguage())) {
                     voice = currentVoice;
                     break;
                 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/osgi/ResourceBundleClassLoader.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/osgi/ResourceBundleClassLoader.java
@@ -127,12 +127,13 @@ public class ResourceBundleClassLoader extends ClassLoader {
                     resourceStream = resourceURL.openStream();
                 }
                 if (resourceStream != null) {
-                    Reader resourceReader = new InputStreamReader(resourceStream, charset);
-                    Properties props = new Properties();
-                    props.load(resourceReader);
-                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                    props.store(baos, "converted");
-                    return new ByteArrayInputStream(baos.toByteArray());
+                    try (Reader resourceReader = new InputStreamReader(resourceStream, charset)) {
+                        Properties props = new Properties();
+                        props.load(resourceReader);
+                        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                        props.store(baos, "converted");
+                        return new ByteArrayInputStream(baos.toByteArray());
+                    }
                 }
             } catch (IOException e) {
             }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/DeviceStatusManagerImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/DeviceStatusManagerImpl.java
@@ -292,7 +292,7 @@ public class DeviceStatusManagerImpl implements DeviceStatusManager {
                 newAngle = device.getAnglePosition();
             }
             DeviceStateUpdate nextDeviceStateUpdate = device.getNextDeviceUpdateState();
-            while (nextDeviceStateUpdate != null && nextDeviceStateUpdate.getType() == stateUpdateType) {
+            while (nextDeviceStateUpdate != null && nextDeviceStateUpdate.getType().equals(stateUpdateType)) {
                 switch (stateUpdateType) {
                     case DeviceStateUpdate.UPDATE_BRIGHTNESS:
                         deviceStateUpdate = nextDeviceStateUpdate;

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/src/test/java/org/eclipse/smarthome/transform/map/internal/MapTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/src/test/java/org/eclipse/smarthome/transform/map/internal/MapTransformationServiceTest.java
@@ -64,10 +64,10 @@ public class MapTransformationServiceTest {
         Assert.assertEquals("zu", transformedResponse);
 
         Properties properties = new Properties();
-        try {
-            properties.load(new FileReader(USED_FILENAME));
+        try (FileReader reader = new FileReader(USED_FILENAME); FileWriter writer = new FileWriter(USED_FILENAME)) {
+            properties.load(reader);
             properties.setProperty(SOURCE_CLOSED, "changevalue");
-            properties.store(new FileWriter(USED_FILENAME), "");
+            properties.store(writer, "");
 
             // This tests that the requested transformation file has been removed from
             // the cache
@@ -81,7 +81,7 @@ public class MapTransformationServiceTest {
             }, 10000, 100);
 
             properties.setProperty(SOURCE_CLOSED, "zu");
-            properties.store(new FileWriter(USED_FILENAME), "");
+            properties.store(writer, "");
 
             waitForAssert(new Callable<Void>() {
                 @Override

--- a/extensions/transform/org.eclipse.smarthome.transform.map/src/main/java/org/eclipse/smarthome/transform/map/internal/MapTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/src/main/java/org/eclipse/smarthome/transform/map/internal/MapTransformationService.java
@@ -58,9 +58,9 @@ public class MapTransformationService extends AbstractFileTransformationService<
 
     @Override
     protected Properties internalLoadTransform(String filename) throws TransformationException {
-        try {
-            Properties result = new Properties();
-            result.load(new FileReader(filename));
+        Properties result = new Properties();
+        try (FileReader reader = new FileReader(filename)) {
+            result.load(reader);
             return result;
         } catch (IOException e) {
             throw new TransformationException("An error occured while opening file.", e);

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/ScaleTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/ScaleTransformationService.java
@@ -71,9 +71,9 @@ public class ScaleTransformationService extends AbstractFileTransformationServic
 
     @Override
     protected Map<Range, String> internalLoadTransform(String filename) throws TransformationException {
-        try {
+        try (FileReader reader = new FileReader(filename)) {
             final Properties properties = new Properties();
-            properties.load(new FileReader(filename));
+            properties.load(reader);
             final Map<Range, String> data = new HashMap<>();
 
             for (Entry<Object, Object> f : properties.entrySet()) {

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
@@ -9,5 +9,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.smarthome.core.audio,
  org.eclipse.smarthome.core.voice,
  org.hamcrest.core,
- org.junit;version="4.0.0"
+ org.junit;version="4.0.0",
+ org.apache.commons.io
 Bundle-ClassPath: .

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/src/test/java/org/eclipse/smarthome/voice/mactts/internal/MacTTSVoiceTest.java
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/src/test/java/org/eclipse/smarthome/voice/mactts/internal/MacTTSVoiceTest.java
@@ -14,6 +14,10 @@ import java.io.InputStreamReader;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.commons.io.IOUtils;
 
 /**
  * Test MacTTSVoice
@@ -21,24 +25,28 @@ import org.junit.Test;
  * @author Kelly Davis - Initial contribution and API
  */
 public class MacTTSVoiceTest {
+    
+    Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
      * Test MacTTSVoice(String) constructor
      */
     @Test
     public void testConstructor() {
-        Assume.assumeTrue("Mac OS X" == System.getProperty("os.name"));
-
+        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+        BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
             InputStreamReader inputStreamReader = new InputStreamReader(process.getInputStream());
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+            bufferedReader = new BufferedReader(inputStreamReader);
 
             String nextLine = bufferedReader.readLine();
             MacTTSVoice voiceMacOS = new MacTTSVoice(nextLine);
             Assert.assertNotNull("The MacTTSVoice(String) constructor failed", voiceMacOS);
         } catch (IOException e) {
             Assert.fail("testConstructor() failed with IOException: " + e.getMessage());
+        } finally {
+            IOUtils.closeQuietly(bufferedReader);
         }
     }
 
@@ -47,12 +55,12 @@ public class MacTTSVoiceTest {
      */
     @Test
     public void getUIDTest() {
-        Assume.assumeTrue("Mac OS X" == System.getProperty("os.name"));
-
+        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+        BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
             InputStreamReader inputStreamReader = new InputStreamReader(process.getInputStream());
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+            bufferedReader = new BufferedReader(inputStreamReader);
 
             String nextLine = bufferedReader.readLine();
             MacTTSVoice macTTSVoice = new MacTTSVoice(nextLine);
@@ -60,6 +68,8 @@ public class MacTTSVoiceTest {
                     (0 == macTTSVoice.getUID().indexOf("mactts:")));
         } catch (IOException e) {
             Assert.fail("getUIDTest() failed with IOException: " + e.getMessage());
+        } finally {
+        	IOUtils.closeQuietly(bufferedReader);
         }
     }
 
@@ -68,18 +78,20 @@ public class MacTTSVoiceTest {
      */
     @Test
     public void getLabelTest() {
-        Assume.assumeTrue("Mac OS X" == System.getProperty("os.name"));
-
+        Assume.assumeTrue("Mac OS X".equals(System.getProperty("os.name")));
+        BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
             InputStreamReader inputStreamReader = new InputStreamReader(process.getInputStream());
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+            bufferedReader = new BufferedReader(inputStreamReader);
 
             String nextLine = bufferedReader.readLine();
             MacTTSVoice voiceMacOS = new MacTTSVoice(nextLine);
             Assert.assertNotNull("The MacTTSVoice label has an incorrect format", voiceMacOS.getLabel());
         } catch (IOException e) {
             Assert.fail("getLabelTest() failed with IOException: " + e.getMessage());
+        } finally {
+            IOUtils.closeQuietly(bufferedReader);
         }
     }
 
@@ -89,17 +101,19 @@ public class MacTTSVoiceTest {
     @Test
     public void getLocaleTest() {
         Assume.assumeTrue("Mac OS X" == System.getProperty("os.name"));
-
+        BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
             InputStreamReader inputStreamReader = new InputStreamReader(process.getInputStream());
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+            bufferedReader = new BufferedReader(inputStreamReader);
 
             String nextLine = bufferedReader.readLine();
             MacTTSVoice voiceMacOS = new MacTTSVoice(nextLine);
             Assert.assertNotNull("The MacTTSVoice locale has an incorrect format", voiceMacOS.getLocale());
         } catch (IOException e) {
             Assert.fail("getLocaleTest() failed with IOException: " + e.getMessage());
+        } finally {
+            IOUtils.closeQuietly(bufferedReader);
         }
     }
 }

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .
 Import-Package: org.eclipse.smarthome.core.voice,
  org.eclipse.smarthome.core.audio,
+ org.apache.commons.io,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
 Bundle-ActivationPolicy: lazy

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/src/main/java/org/eclipse/smarthome/voice/mactts/internal/MacTTSService.java
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/src/main/java/org/eclipse/smarthome/voice/mactts/internal/MacTTSService.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
+import org.apache.commons.io.IOUtils;
 import org.eclipse.smarthome.core.audio.AudioException;
 import org.eclipse.smarthome.core.audio.AudioFormat;
 import org.eclipse.smarthome.core.audio.AudioStream;
@@ -89,10 +90,12 @@ public class MacTTSService implements TTSService {
      */
     private final Set<Voice> initVoices() {
         Set<Voice> voices = new HashSet<Voice>();
+        InputStreamReader inputStreamReader = null;
+        BufferedReader bufferedReader = null;
         try {
             Process process = Runtime.getRuntime().exec("say -v ?");
-            InputStreamReader inputStreamReader = new InputStreamReader(process.getInputStream());
-            BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+            inputStreamReader = new InputStreamReader(process.getInputStream());
+            bufferedReader = new BufferedReader(inputStreamReader);
 
             String nextLine;
             while ((nextLine = bufferedReader.readLine()) != null) {
@@ -100,6 +103,8 @@ public class MacTTSService implements TTSService {
             }
         } catch (IOException e) {
             logger.error("Error while executing the 'say -v ?' command: " + e.getMessage());
+        } finally {
+            IOUtils.closeQuietly(bufferedReader);
         }
         return voices;
     }


### PR DESCRIPTION
I've tried the static code analysis tool (https://github.com/eclipse/smarthome/pull/2440). 
Since my local build failed several times due to some bugs found by the tool, I decided to fix them.
The fixes are mainly related to closing opened streams and comparing Strings with the equals() method instead of the '==' operator.
In addition, I think that the UNUSED_PUBLIC_OR_PROTECTED_FIELD bug should have a lower  priority (it is defined in the rulesets\findbugs directory)

Signed-off-by: Mihaela Memova <mihaela.memova@musala.com>