### PR TITLE
Unifying syntax for references in Module Configurations & CompositeCh…

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/src/test/java/org/eclipse/smarthome/automation/core/internal/ReferenceResolverUtilTest.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/src/test/java/org/eclipse/smarthome/automation/core/internal/ReferenceResolverUtilTest.java
@@ -33,7 +33,7 @@ public class ReferenceResolverUtilTest {
         context.put(CONTEXT_PROPERTY4, 12345);
 
         // module configuration with references
-        moduleConfiguration.put("simpleReference", "$" + CONTEXT_PROPERTY4);
+        moduleConfiguration.put("simpleReference", String.format("${%s}", CONTEXT_PROPERTY4));
         moduleConfiguration.put("complexReference",
                 String.format("Hello ${%s} ${%s}", CONTEXT_PROPERTY1, CONTEXT_PROPERTY4));
         moduleConfiguration.put("complexReferenceWithMissing",
@@ -63,9 +63,9 @@ public class ReferenceResolverUtilTest {
                 String.format("{key1: ${UNKNOWN}, key2: %s, key3: ${UNKNOWN2}}", context.get(CONTEXT_PROPERTY2)));
 
         // composite child module input with references
-        compositeChildModuleInputsReferences.put("moduleInput", "$" + CONTEXT_PROPERTY1);
-        compositeChildModuleInputsReferences.put("moduleInputMissing", "$UNKNOWN");
-        compositeChildModuleInputsReferences.put("moduleInput2", "$" + CONTEXT_PROPERTY2);
+        compositeChildModuleInputsReferences.put("moduleInput", String.format("${%s}", CONTEXT_PROPERTY1));
+        compositeChildModuleInputsReferences.put("moduleInputMissing", "${UNKNOWN}");
+        compositeChildModuleInputsReferences.put("moduleInput2", String.format("${%s}", CONTEXT_PROPERTY2));
         // expected resolved child module context
         expectedCompositeChildModuleContext.put("moduleInput", context.get(CONTEXT_PROPERTY1));
         expectedCompositeChildModuleContext.put("moduleInputMissing", context.get("UNKNOWN"));

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/ESH-INF/automation/moduletypes/CustomTriggersTypeDefinition.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/ESH-INF/automation/moduletypes/CustomTriggersTypeDefinition.json
@@ -10,7 +10,7 @@
                "label":"CustomTriggerOutput1 label",
                "description":"Custom trigger output.",
                "defaultValue":true,
-               "reference":"$event"
+               "reference":"${event}"
             }
          ]
       },
@@ -24,7 +24,7 @@
                "label":"CustomTriggerOutput2 label",
                "description":"Custom trigger output.",
                "defaultValue":"event",
-               "reference":"$event"
+               "reference":"${event}"
             }
          ]
       }

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/ESH-INF/automation/templates/SimpleTestTemplate.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/ESH-INF/automation/templates/SimpleTestTemplate.json
@@ -39,7 +39,7 @@
             "id":"ItemUpdateTrigger_1",
             "type":"GenericEventTrigger",
             "configuration":{  
-               "eventSource":"$onItem",
+               "eventSource":"${onItem}",
                "eventTopic":"smarthome/items/*",
                "eventTypes":"ItemStateEvent"
             }
@@ -51,8 +51,8 @@
             "type":"ItemStateEventCondition",
             "configuration":{  
                "operator":"=",
-               "itemName":"$onItem",
-               "state":"$ifState"
+               "itemName":"${onItem}",
+               "state":"${ifState}"
             },
 			"inputs":{
 				"event":"ItemUpdateTrigger_1.event"
@@ -64,8 +64,8 @@
             "id":"ItemPostCommandActionID_1",
             "type":"ItemPostCommandAction",
             "configuration":{  
-               "itemName":"$updateItem",
-               "command":"$updateCommand"
+               "itemName":"${updateItem}",
+               "command":"${updateCommand}"
             }
          }
       ]

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/ESH-INF/automation/templates/TestTemplateRuleWithReferences.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/ESH-INF/automation/templates/TestTemplateRuleWithReferences.json
@@ -29,7 +29,7 @@
         "id": "ItemStateChangeTriggerID",
         "type": "GenericEventTrigger",
 		"configuration":{
-			"eventSource":"$triggerItem",
+			"eventSource":"${triggerItem}",
 			"eventTopic":"smarthome/items/*",
 			"eventTypes":"ItemStateEvent"
 		}
@@ -53,7 +53,7 @@
         "id": "ItemPostCommandActionID",
         "type": "ItemPostCommandAction",
         "configuration": {  
-          "itemName": "$actionItem",
+          "itemName": "${actionItem}",
 		  "command": "ON"
         }
       }

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/ESH-INF/automation/templates/TestTemplateWithCompositeModules.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/ESH-INF/automation/templates/TestTemplateWithCompositeModules.json
@@ -39,7 +39,7 @@
             "id":"ItemUpdateTrigger_2",
             "type":"ItemStateChangeTrigger",
             "configuration":{  
-               "itemName":"$onItem"
+               "itemName":"${onItem}"
             }
          }
       ],
@@ -48,8 +48,8 @@
             "id":"ItemStateConditionID_2",
             "type":"ItemStateEventCompareCondition",
             "configuration":{  
-               "itemName":"$onItem",
-               "state":"$ifState"
+               "itemName":"${onItem}",
+               "state":"${ifState}"
             },
 			"inputs":{
 				"event":"ItemUpdateTrigger_2.event"
@@ -61,8 +61,8 @@
             "id":"ItemPostCommandActionID_1",
             "type":"ItemPostCommandAction",
             "configuration":{  
-               "itemName":"$updateItem",
-               "command":"$updateCommand"
+               "itemName":"${updateItem}",
+               "command":"${updateCommand}"
             }
          }
       ]

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/EventTriggersTypeDefinition.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/EventTriggersTypeDefinition.json
@@ -60,7 +60,7 @@
                "id":"itemStateUpdateTriggerID",
                "type":"GenericEventTrigger",
                "configuration":{
-                  "eventSource":"$itemName",
+                  "eventSource":"${itemName}",
                   "eventTopic":"smarthome/items/*",
                   "eventTypes":"ItemStateEvent"
                }
@@ -95,7 +95,7 @@
                "id":"itemStateChangeTriggerID",
                "type":"GenericEventTrigger",
                "configuration":{
-                  "eventSource":"$itemName",
+                  "eventSource":"${itemName}",
                   "eventTopic":"smarthome/items/${itemName}/state",
                   "eventTypes":"ItemStateChangedEvent"
                }
@@ -130,7 +130,7 @@
                "id":"channelEventTriggerId",
                "type":"GenericEventTrigger",
                "configuration":{
-                  "eventSource":"$channelUID",
+                  "eventSource":"${channelUID}",
                   "eventTopic":"smarthome/channels/*/triggered",
                   "eventTypes":"ChannelTriggeredEvent"
                }

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/GenericCondition.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/GenericCondition.json
@@ -75,10 +75,10 @@
           "configuration":{
             "inputproperty":"itemName",
             "operator":"=",
-            "right":"$itemName"
+            "right":"${itemName}"
           },
           "inputs":{
-                "input":"$event"
+                "input":"${event}"
           }
         },
         {
@@ -87,10 +87,10 @@
           "configuration":{
             "inputproperty":"payload",
             "operator":"matches",
-            "right":"$state"
+            "right":"${state}"
           },
           "inputs":{
-                "input":"$event"
+                "input":"${event}"
           }
         }
       ]

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/ItemEventConditionModuleTypeDefinition.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/ItemEventConditionModuleTypeDefinition.json
@@ -36,13 +36,13 @@
                "id":"itemStateEventConditionID",
                "type":"EventCondition",
                "configuration":{  
-                  "eventSource":"$itemName",
+                  "eventSource":"${itemName}",
                   "eventTopic":"smarthome/items/*",
                   "eventTypes":"ItemStateEvent",
-                  "payload":"$state"
+                  "payload":"${state}"
                },
                "inputs":{  
-                  "event":"$event"
+                  "event":"${event}"
                }
             }
          ]
@@ -76,11 +76,11 @@
                "id":"itemStateEventONConditionID",
                "type":"ItemStateEventCondition",
                "configuration":{  
-                  "itemName":"$itemName",
+                  "itemName":"${itemName}",
                   "state":"ON"
                },
                "inputs":{  
-                  "event":"$event"
+                  "event":"${event}"
                }
             }
          ]
@@ -114,11 +114,11 @@
                "id":"itemStateEventOFFConditionID",
                "type":"ItemStateEventCondition",
                "configuration":{  
-                  "itemName":"$itemName",
+                  "itemName":"${itemName}",
                   "state":"OFF"
                },
                "inputs":{  
-                  "event":"$event"
+                  "event":"${event}"
                }
             }
          ]

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/ESH-INF/automation/moduletypes/SampleModuleTypeDefinition.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/ESH-INF/automation/moduletypes/SampleModuleTypeDefinition.json
@@ -108,14 +108,14 @@
                "id":"SampleAction2",
                "type":"SampleAction",
                "inputs":{
-                  "message":"$compositeMessage"
+                  "message":"${compositeMessage}"
                }
             },
             {  
                "id":"SampleAction1",
                "type":"SampleAction",
                "inputs":{  
-                  "message":"$compositeActionInput"
+                  "message":"${compositeActionInput}"
                }
             }
          ]

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/ESH-INF/automation/templates/SampleTemplateDefinitions.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/ESH-INF/automation/templates/SampleTemplateDefinitions.json
@@ -36,8 +36,8 @@
         "label": "Sample Condition",
         "description": "This is a sample condition",
         "configuration": {
-          "operator": "$condition_operator",
-          "constraint": "$condition_constraint"
+          "operator": "${condition_operator}",
+          "constraint": "${condition_constraint}"
         },
         "inputs": {
           "conditionInput": "CompositeSampleTriggerTemplateID.compositeTriggerOutput"


### PR DESCRIPTION
…ild Inputs):

1. Whole value: '${reference}' - (was just '$reference')
2. Part of value: '{key: ${reference}}'

Related to:     #2477 

Signed-off-by: Vasil Ilchev <v.ilchev@prosyst.bg>