### PR TITLE
Fix #2551 LIFX throws NPE

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
@@ -7,6 +7,9 @@
  */
 package org.eclipse.smarthome.binding.lifx;
 
+import org.eclipse.smarthome.binding.lifx.internal.LifxUtils;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -23,6 +26,11 @@ public class LifxBindingConstants {
 
     // The LIFX LAN Protocol Specification states that bulbs can process up to 20 messages per second, not more.
     public final static long PACKET_INTERVAL = 50;
+
+    // Fallback light state defaults
+    public final static HSBType DEFAULT_COLOR = HSBType.WHITE;
+    public final static PercentType DEFAULT_TEMPERATURE = LifxUtils.kelvinToPercentType(3000);
+    public final static PercentType DEFAULT_BRIGHTNESS = PercentType.HUNDRED;
 
     // List of all Channel IDs
     public final static String CHANNEL_COLOR = "color";

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
@@ -119,8 +119,8 @@ public class LifxLightHandler extends BaseThingHandler {
                     updateState(CHANNEL_COLOR, getHSB());
                     updateState(CHANNEL_BRIGHTNESS, getHSB().getBrightness());
                 } else {
-                    updateState(CHANNEL_COLOR, HSBType.WHITE);
-                    updateState(CHANNEL_BRIGHTNESS, PercentType.HUNDRED);
+                    updateState(CHANNEL_COLOR, LifxBindingConstants.DEFAULT_COLOR);
+                    updateState(CHANNEL_BRIGHTNESS, LifxBindingConstants.DEFAULT_BRIGHTNESS);
                 }
             }
             super.setPowerState(powerState);

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightStateChanger.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightStateChanger.java
@@ -226,10 +226,23 @@ public class LifxLightStateChanger implements LifxLightStateListener, LifxRespon
 
     private void addSetColorRequestToMap() {
         HSBType hsb = pendingLightState.getHSB();
+        if (hsb == null) {
+            // use default color when temperature is changed while color is unknown
+            hsb = LifxBindingConstants.DEFAULT_COLOR;
+        }
+
         PercentType temperature = pendingLightState.getTemperature();
-        SetColorRequest packet = new SetColorRequest(decimalTypeToHue(hsb.getHue()),
-                percentTypeToSaturation(hsb.getSaturation()), percentTypeToBrightness(hsb.getBrightness()),
-                percentTypeToKelvin(temperature), fadeTime);
+        if (temperature == null) {
+            // use default temperature when color is changed while temperature is unknown
+            temperature = LifxBindingConstants.DEFAULT_TEMPERATURE;
+        }
+
+        int hue = decimalTypeToHue(hsb.getHue());
+        int saturation = percentTypeToSaturation(hsb.getSaturation());
+        int brightness = percentTypeToBrightness(hsb.getBrightness());
+        int kelvin = percentTypeToKelvin(temperature);
+
+        SetColorRequest packet = new SetColorRequest(hue, saturation, brightness, kelvin, fadeTime);
         addPacketToMap(packet);
     }
 


### PR DESCRIPTION
The binding will now use the defaults as discussed in #2551 when the current light state is unknown.