### PR TITLE
added missing mock method in ThingManagerOSGiTest

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
@@ -635,7 +635,8 @@ class ThingManagerOSGiTest extends OSGiTest {
             setCallback: {callbackArg -> callback = callbackArg },
             initialize: {},
             dispose: {
-            }
+            },
+            getThing: {return THING}
         ] as ThingHandler
 
         def thingHandlerFactory = [


### PR DESCRIPTION
...which caused an UnsupportedOperationException.
It is just cosmetical though because it happend during tear down only.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>