### PR TITLE
2578 Round values when converting brightness

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/LightStateConverterOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/LightStateConverterOSGiTest.groovy
@@ -1,0 +1,25 @@
+package org.eclipse.smarthome.binding.hue.test;
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+
+import org.eclipse.smarthome.binding.hue.handler.LightStateConverter
+import org.eclipse.smarthome.core.library.types.PercentType
+import org.junit.Test
+
+import nl.q42.jue.State
+import nl.q42.jue.StateUpdate
+
+class LightStateConverterOSGiTest extends AbstractHueOSGiTest {
+
+    @Test
+    void 'assert that LightStateConverter conversion is bijective'() {
+        int PERCENT_VALUE_67 = 67;
+        StateUpdate stateUpdate = LightStateConverter.toBrightnessLightState(new PercentType(PERCENT_VALUE_67));
+        assertThat(stateUpdate.commands.size, is(2))
+        assertThat(stateUpdate.commands[1].key, is("bri"))
+        State lightState = new State()
+        lightState.bri = stateUpdate.commands[1].value
+        assertThat(LightStateConverter.toBrightnessPercentType(lightState).intValue(), is(PERCENT_VALUE_67))
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/LightStateConverter.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/LightStateConverter.java
@@ -7,17 +7,17 @@
  */
 package org.eclipse.smarthome.binding.hue.handler;
 
-import nl.q42.jue.State;
-import nl.q42.jue.State.AlertMode;
-import nl.q42.jue.State.Effect;
-import nl.q42.jue.StateUpdate;
-
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StringType;
+
+import nl.q42.jue.State;
+import nl.q42.jue.State.AlertMode;
+import nl.q42.jue.State.Effect;
+import nl.q42.jue.StateUpdate;
 
 /**
  * The {@link LightStateConverter} is responsible for mapping Eclipse SmartHome
@@ -170,7 +170,8 @@ public class LightStateConverter {
      * @return percent type representing the color temperature
      */
     public static PercentType toColorTemperaturePercentType(State lightState) {
-        int percent = (int) Math.round(((lightState.getColorTemperature() - MIN_COLOR_TEMPERATURE) * 100.0 )/ COLOR_TEMPERATURE_RANGE);
+        int percent = (int) Math
+                .round(((lightState.getColorTemperature() - MIN_COLOR_TEMPERATURE) * 100.0) / COLOR_TEMPERATURE_RANGE);
         return new PercentType(restrictToBounds(percent));
     }
 
@@ -183,13 +184,13 @@ public class LightStateConverter {
      * @return percent type representing the brightness
      */
     public static PercentType toBrightnessPercentType(State lightState) {
-        int percent = (int) (lightState.getBrightness() / BRIGHTNESS_FACTOR);
+        int percent = (int) Math.round(lightState.getBrightness() / BRIGHTNESS_FACTOR);
         return new PercentType(restrictToBounds(percent));
     }
 
     /**
      * Transforms {@link State} into {@link StringType} representing the {@link AlertMode}.
-     * 
+     *
      * @param lightState
      *            light state.
      * @return string type representing the alert mode.


### PR DESCRIPTION
The conversion of brightness values between PercentType (0.100) and
native hue brightness value range (0..254) should be bijective.
E.g. 67 percent should be 67 percent after converting to hue value and
back to percent.

Signed-off-by: Markus Bösling <markus.boesling@telekom.de>