### PR TITLE
[LIFX] give the framework a chance to detect failed initialization

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
@@ -165,8 +165,9 @@ public class LifxLightHandler extends BaseThingHandler {
             currentStateUpdater.start();
             onlineStateUpdater.start();
             lightStateChanger.start();
-        } catch (Exception ex) {
-            logger.error("Error occured while initializing LIFX handler: " + ex.getMessage(), ex);
+        } catch (Exception e) {
+            logger.debug("Error occured while initializing LIFX handler: " + e.getMessage(), e);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
         } finally {
             lock.unlock();
         }


### PR DESCRIPTION
...as otherwise the Thing will stay in `INITIALIZING` forever as the framework waits for the handler to set it to either `ONLINE` or `OFFLINE`.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>