### PR TITLE
run Maven in quiet mode on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,4 @@ before_install: echo "MAVEN_OPTS='-Xms1g -Xmx2g -XX:PermSize=512m -XX:MaxPermSiz
 #$ mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 #$ mvn test -B
 
-install: true
-script:
-  - mvn clean install -B -V
+install: travis_wait 60 mvn clean install -B -V -q


### PR DESCRIPTION
All Travis builds are failing now since the log exceeds 4MB.
This should be the quickest solution to the problem. If anyone has a good idea how to only partially reduce the logging, feel free to come up with something better!

Signed-off-by: Kai Kreuzer <kai@openhab.org>