### PR TITLE
remove error shown in the Eclipse IDE

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.core.test/.project
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/.project
@@ -20,14 +20,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.groovy.core.groovyNature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/bundles/model/org.eclipse.smarthome.model.core.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+groovy.compiler.level=-1


### PR DESCRIPTION
Description: Plugin execution not covered by lifecycle configuration:
  org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
  (execution: default, phase: compile)
Resource: pom.xml
Path: /org.eclipse.smarthome.model.core.test
Location: line 4
Type: Maven Project Build Lifecycle Mapping Problem