### PR TITLE
[LIFX] Support 2016 product line-up and infrared functionality

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/thing-types.xml
@@ -102,7 +102,6 @@
         <item-type>Dimmer</item-type>
         <label>Infrared</label>
         <description>Sets the infrared of the light</description>
-        <category>Infrared</category>
     </channel-type>
 
     <!-- Brightness Channel -->

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/thing-types.xml
@@ -3,7 +3,7 @@
     xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
     xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <!-- LIFX Light -->
+    <!-- LIFX Color Light -->
     <thing-type id="colorlight">
         <label>LIFX Color Light</label>
 
@@ -25,7 +25,31 @@
         
     </thing-type>
 
-    <!-- LIFX Light -->
+    <!-- LIFX Color IR Light -->
+    <thing-type id="colorirlight">
+        <label>LIFX Color IR Light</label>
+
+        <channels>
+            <channel id="color" typeId="color" />
+            <channel id="temperature" typeId="temperature" />
+            <channel id="infrared" typeId="infrared" />
+        </channels>
+
+        <config-description>
+            <parameter name="deviceId" type="text" required="true">
+                <label>LIFX device ID</label>
+            </parameter>
+            <parameter name="fadetime" type="integer" required="false">
+                <label>Fade time</label>
+                <description>The time to fade to the new color value (in ms).</description>
+                <default>300</default>
+            </parameter>
+        </config-description>
+        
+    </thing-type>
+
+
+    <!-- LIFX White Light -->
     <thing-type id="whitelight">
         <label>LIFX White Light</label>
 
@@ -65,6 +89,7 @@
         </config-description>
     </channel-type>
     
+    <!-- Temperature Channel -->
     <channel-type id="temperature">
         <item-type>Dimmer</item-type>
         <label>Temperature</label>
@@ -72,6 +97,15 @@
         <category>Temperature</category>
     </channel-type>
 
+    <!-- Infrared Channel -->
+    <channel-type id="infrared">
+        <item-type>Dimmer</item-type>
+        <label>Infrared</label>
+        <description>Sets the infrared of the light</description>
+        <category>Infrared</category>
+    </channel-type>
+
+    <!-- Brightness Channel -->
     <channel-type id="brightness">
         <item-type>Dimmer</item-type>
         <label>Brightness</label>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
@@ -6,60 +6,135 @@ layout: documentation
 
 # LIFX Binding
 
-This binding integrates the [LIFX LED Bulb](http://www.lifx.com/). All LIFX bulbs are directly connected to the WLAN and the binding communicates with them over a UDP protocol.
+This binding integrates the [LIFX LED Lights](http://www.lifx.com/). All LIFX lights are directly connected to the WLAN and the binding communicates with them over a UDP protocol.
 
 ![LIFX E27](doc/lifx_e27.jpg)
 
 ## Supported Things
 
-The binding was mainly developed for the E27 original LIFX bulb. Other bulbs like the GU10 model are not tested, but should also be supported. 
+The following table lists the thing types of the supported LIFX devices:
+
+| Device Type                  | Thing Type   |
+|------------------------------|--------------|
+| Original 1000                | colorlight   |
+| Color 650                    | colorlight   |
+| Color 1000                   | colorlight   |
+| Color 1000 BR30              | colorlight   |
+| LIFX A19                     | colorlight   |
+| LIFX BR30                    | colorlight   |
+| LIFX Z                       | colorlight   |
+|                              |
+| LIFX+ A19                    | colorirlight |
+| LIFX+ BR30                   | colorirlight |
+|                              |              |
+| White 800 (Low Voltage)      | whitelight   |
+| White 800 (High Voltage)     | whitelight   |
+| White 900 BR30 (Low Voltage) | whitelight   |
+
+The thing type determines the capability of a device and with that the possible ways of interacting with it. The following matrix lists the capabilities (channels) for each type:
+
+| Thing Type   | On/Off | Brightness | Color | Color Temperature | Infrared |
+|--------------|:------:|:----------:|:-----:|:-----------------:|:--------:|
+| colorlight   | X      |            | X     | X                 |          |
+| colorirlight | X      |            | X     | X                 | X        |
+| whitelight   | X      | X          |       | X                 |          |
 
 ## Discovery
 
-The binding is able to auto-discover all bulbs in a network over the LIFX UDP protocol. Therefore all bulbs must be turned on.
+The binding is able to auto-discover all lights in a network over the LIFX UDP protocol. Therefore all lights must be turned on.
 
-*Note:* To get the binding working, all bulbs must be added to the WLAN network first with the help of the [LIFX smart phone applications](http://www.lifx.com/pages/go). The binding is NOT able to add or detect bulbs outside the network.
+*Note:* To get the binding working, all lights must be added to the WLAN network first with the help of the [LIFX smart phone applications](http://www.lifx.com/pages/go). The binding is NOT able to add or detect lights outside the network.
 
 ## Thing Configuration
 
-Each bulb needs the device ID as a configuration parameter. The device ID is printed as a serial number on the bulb and can also be found within the native LIFX Android or iOS application. But usually the discovery works quite reliably, so that a manual configuration is not needed.
+Each light needs the device ID as a configuration parameter. The device ID is printed as a serial number on the light and can also be found within the native LIFX Android or iOS application. But usually the discovery works quite reliably, so that a manual configuration is not needed.
 
 However, in the thing file, a manual configuration looks e.g. like
 
 ```
-Thing lifx:light:light1 [ deviceId="D073D5010E20" ]
+lifx:colorlight:living [ deviceId="D073D5A1A1A1", fadetime=200 ]
 ```
+
+The *fadetime* is an optional thing configuration parameter which configures the time to fade to a new color value (in ms). When the *fadetime* is not configured, the binding uses 300ms as default.
+
 
 ## Channels
 
-The bulb only supports the color channel:
+All devices support some of the following channels:
 
-| Channel Type ID | Item Type    | Description  |
-|-----------------|------------------------|--------------|----------------- |------------- |
-| color | Color       | This channel supports full color control with hue, saturation and brightness values. |
+| Channel Type ID | Item Type | Description                                                                          | Thing Types                          |
+|-----------------|-----------|--------------------------------------------------------------------------------------|--------------------------------------|
+| brightness      | Dimmer    | This channel supports adjusting the brightness value.                                | whitelight                           |
+| color           | Color     | This channel supports full color control with hue, saturation and brightness values. | colorlight, colorirlight             |
+| infrared        | Dimmer    | This channel supports adjusting the infrared value. *Note:* IR capable lights only activate their infrared LEDs when the brightness drops below a certain level. | colorirlight |
+| temperature     | Dimmer    | This channel supports adjusting the color temperature from cold (0%) to warm (100%).  | colorlight, colorirlight, whitelight |
 
+The *color* and *brightness* channels have a "Power on brightness" configuration option that is used to determine the brightness when a light is switched on. When it is left empty, the brightness of a light remains unchanged when a light is switched on or off.
 
 ## Full Example
 
-demo.things:
+In this example **living** is a Color 1000 light that has a *colorlight* thing type which supports *color* and *temperature* channels.
+
+The **porch** light is a LIFX+ BR30 that has a *colorirlight* thing type which supports *color*, *temperature* and *infrared* channels.
+
+Finally, **kitchen** is a White 800 (Low Voltage) light that has a *whitelight* thing type which supports *brightness* and *temperature* channels.
+
+### demo.things:
 
 ```
-Thing lifx:light:light1 [ deviceId="D073D5010E20" ]
+lifx:colorlight:living [ deviceId="D073D5A1A1A1" ]
+lifx:colorirlight:porch [ deviceId="D073D5B2B2B2", fadetime=0 ]
+lifx:whitelight:kitchen [ deviceId="D073D5C3C3C3", fadetime=150 ]
+
 ```
 
-demo.items:
+### demo.items:
 
 ```
-Color Light { channel="lifx:light:light1:color" }
+// Living
+Switch Living_Toggle { channel="lifx:colorlight:living:color" }
+Dimmer Living_Dimmer { channel="lifx:colorlight:living:color" }
+Color Living_Color { channel="lifx:colorlight:living:color" }
+Dimmer Living_Temperature { channel="lifx:colorlight:living:temperature" }
+
+// Porch
+Switch Porch_Toggle { channel="lifx:colorirlight:porch:color" }
+Dimmer Porch_Dimmer { channel="lifx:colorirlight:porch:color" }
+Color Porch_Color { channel="lifx:colorirlight:porch:color" }
+Dimmer Porch_Temperature { channel="lifx:colorirlight:porch:temperature" }
+Dimmer Porch_Infrared { channel="lifx:colorirlight:porch:infrared" }
+
+// Kitchen
+Switch Kitchen_Toggle { channel="lifx:whitelight:kichen:brightness" }
+Dimmer Kitchen_Brightness { channel="lifx:whitelight:kitchen:brightness" }
+Dimmer Kitchen_Temperature { channel="lifx:whitelight:kitchen:temperature" }
+
 ```
 
-demo.sitemap:
+### demo.sitemap:
 
 ```
 sitemap demo label="Main Menu"
 {
-	Frame {
-		Colorpicker item=Light
+	Frame label="Living" {
+		Switch item=Living_Toggle
+		Slider item=Living_Dimmer
+		Colorpicker item=Living_Color
+		Slider item=Living_Temperature
+	}
+
+	Frame label="Porch" {
+		Switch item=Porch_Toggle
+		Slider item=Porch_Dimmer
+		Colorpicker item=Porch_Color
+		Slider item=Porch_Temperature
+		Slider item=Porch_Infrared
+	}
+
+	Frame label="Kitchen" {
+		Switch item=Kitchen_Toggle
+		Slider item=Kitchen_Brightness
+		Slider item=Kitchen_Temperature
 	}
 }
 ```

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
@@ -36,6 +36,7 @@ public class LifxBindingConstants {
     public final static String CHANNEL_COLOR = "color";
     public final static String CHANNEL_TEMPERATURE = "temperature";
     public final static String CHANNEL_BRIGHTNESS = "brightness";
+    public final static String CHANNEL_INFRARED = "infrared";
 
     // config property for the LIFX device id
     public static final String CONFIG_PROPERTY_DEVICE_ID = "deviceId";
@@ -49,6 +50,7 @@ public class LifxBindingConstants {
 
     // List of all Thing Type UIDs
     public final static ThingTypeUID THING_TYPE_COLORLIGHT = new ThingTypeUID(BINDING_ID, "colorlight");
+    public final static ThingTypeUID THING_TYPE_COLORIRLIGHT = new ThingTypeUID(BINDING_ID, "colorirlight");
     public final static ThingTypeUID THING_TYPE_WHITELIGHT = new ThingTypeUID(BINDING_ID, "whitelight");
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxHandlerFactory.java
@@ -30,7 +30,7 @@ import com.google.common.collect.Lists;
 public class LifxHandlerFactory extends BaseThingHandlerFactory {
 
     public final static Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists.newArrayList(THING_TYPE_COLORLIGHT,
-            THING_TYPE_WHITELIGHT);
+            THING_TYPE_COLORIRLIGHT, THING_TYPE_WHITELIGHT);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -47,7 +47,8 @@ public class LifxHandlerFactory extends BaseThingHandlerFactory {
 
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(THING_TYPE_COLORLIGHT) || thingTypeUID.equals(THING_TYPE_WHITELIGHT)) {
+        if (thingTypeUID.equals(THING_TYPE_COLORLIGHT) || thingTypeUID.equals(THING_TYPE_COLORIRLIGHT)
+                || thingTypeUID.equals(THING_TYPE_WHITELIGHT)) {
             return new LifxLightHandler(thing);
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCommunicationHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCommunicationHandler.java
@@ -41,8 +41,6 @@ import org.eclipse.smarthome.binding.lifx.LifxBindingConstants;
 import org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler.CurrentLightState;
 import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
 import org.eclipse.smarthome.binding.lifx.internal.listener.LifxResponsePacketListener;
-import org.eclipse.smarthome.binding.lifx.internal.protocol.GetLightPowerRequest;
-import org.eclipse.smarthome.binding.lifx.internal.protocol.GetRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetServiceRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.Packet;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.PacketFactory;
@@ -383,13 +381,6 @@ public class LifxLightCommunicationHandler {
                             }
 
                             currentLightState.setOnline();
-
-                            // populate the current state variables
-                            GetLightPowerRequest powerPacket = new GetLightPowerRequest();
-                            sendPacket(powerPacket);
-
-                            GetRequest colorPacket = new GetRequest();
-                            sendPacket(colorPacket);
                         }
                     }
                 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCurrentStateUpdater.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCurrentStateUpdater.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.smarthome.binding.lifx.internal;
 
+import static org.eclipse.smarthome.binding.lifx.LifxBindingConstants.THING_TYPE_COLORIRLIGHT;
 import static org.eclipse.smarthome.binding.lifx.internal.LifxUtils.*;
 
 import java.util.concurrent.ScheduledExecutorService;
@@ -18,15 +19,18 @@ import org.eclipse.smarthome.binding.lifx.LifxBindingConstants;
 import org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler.CurrentLightState;
 import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
 import org.eclipse.smarthome.binding.lifx.internal.listener.LifxResponsePacketListener;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.GetLightInfraredRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetLightPowerRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.Packet;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.StateLightInfraredResponse;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.StatePowerResponse;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.StateResponse;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,11 +49,14 @@ public class LifxLightCurrentStateUpdater implements LifxResponsePacketListener 
     private final String macAsHex;
     private final CurrentLightState currentLightState;
     private final LifxLightCommunicationHandler communicationHandler;
+    private final ThingTypeUID thingTypeUID;
 
     private final ReentrantLock lock = new ReentrantLock();
 
     private ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(LifxBindingConstants.THREADPOOL_NAME);
+
+    private boolean wasOnline;
 
     private ScheduledFuture<?> statePollingJob;
 
@@ -61,15 +68,11 @@ public class LifxLightCurrentStateUpdater implements LifxResponsePacketListener 
                 lock.lock();
                 if (currentLightState.isOnline()) {
                     logger.trace("{} : Polling the state of the light", macAsHex);
-
-                    GetLightPowerRequest powerPacket = new GetLightPowerRequest();
-                    communicationHandler.sendPacket(powerPacket);
-
-                    GetRequest colorPacket = new GetRequest();
-                    communicationHandler.sendPacket(colorPacket);
+                    sendLightStateRequests();
                 } else {
                     logger.trace("{} : The light is not online, there is no point polling it", macAsHex);
                 }
+                wasOnline = currentLightState.isOnline();
             } catch (Exception e) {
                 logger.error("Error occured while polling light state", e);
             } finally {
@@ -79,10 +82,11 @@ public class LifxLightCurrentStateUpdater implements LifxResponsePacketListener 
     };
 
     public LifxLightCurrentStateUpdater(MACAddress macAddress, CurrentLightState currentLightState,
-            LifxLightCommunicationHandler communicationHandler) {
+            LifxLightCommunicationHandler communicationHandler, ThingTypeUID thingTypeUID) {
         this.macAsHex = macAddress.getHex();
         this.currentLightState = currentLightState;
         this.communicationHandler = communicationHandler;
+        this.thingTypeUID = thingTypeUID;
     }
 
     public void start() {
@@ -115,12 +119,33 @@ public class LifxLightCurrentStateUpdater implements LifxResponsePacketListener 
         }
     }
 
+    private void sendLightStateRequests() {
+        GetLightPowerRequest powerPacket = new GetLightPowerRequest();
+        communicationHandler.sendPacket(powerPacket);
+
+        GetRequest colorPacket = new GetRequest();
+        communicationHandler.sendPacket(colorPacket);
+
+        if (thingTypeUID.equals(THING_TYPE_COLORIRLIGHT)) {
+            GetLightInfraredRequest infraredPacket = new GetLightInfraredRequest();
+            communicationHandler.sendPacket(infraredPacket);
+        }
+    }
+
     @Override
     public void handleResponsePacket(Packet packet) {
         if (packet instanceof StateResponse) {
             handleLightStatus((StateResponse) packet);
         } else if (packet instanceof StatePowerResponse) {
             handlePowerStatus((StatePowerResponse) packet);
+        } else if (packet instanceof StateLightInfraredResponse) {
+            handleInfraredStatus((StateLightInfraredResponse) packet);
+        }
+
+        if (currentLightState.isOnline() && !wasOnline) {
+            wasOnline = true;
+            logger.trace("{} : The light just went online, immediately polling the state of the light", macAsHex);
+            sendLightStateRequests();
         }
     }
 
@@ -137,6 +162,12 @@ public class LifxLightCurrentStateUpdater implements LifxResponsePacketListener 
 
     public void handlePowerStatus(StatePowerResponse packet) {
         currentLightState.setPowerState(packet.getState());
+        currentLightState.setOnline();
+    }
+
+    public void handleInfraredStatus(StateLightInfraredResponse packet) {
+        PercentType infrared = infraredToPercentType(packet.getInfrared());
+        currentLightState.setInfrared(infrared);
         currentLightState.setOnline();
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
@@ -84,8 +84,8 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
     private ScheduledFuture<?> networkJob;
 
     public LifxLightDiscovery() throws IllegalArgumentException {
-        super(Sets.newHashSet(LifxBindingConstants.THING_TYPE_COLORLIGHT, LifxBindingConstants.THING_TYPE_WHITELIGHT),
-                1, true);
+        super(Sets.newHashSet(LifxBindingConstants.THING_TYPE_COLORLIGHT, LifxBindingConstants.THING_TYPE_COLORIRLIGHT,
+                LifxBindingConstants.THING_TYPE_WHITELIGHT), 1, true);
     }
 
     @Override
@@ -457,7 +457,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
         MACAddress discoveredAddress = packet.getTarget();
         try {
             Products product = Products.getProductFromProductID(returnedPacket.getProduct());
-            ThingUID thingUID = getUID(discoveredAddress.getAsLabel(), product.isColor());
+            ThingUID thingUID = getUID(discoveredAddress.getAsLabel(), product.isColor(), product.isInfrared());
 
             String label = "";
 
@@ -476,9 +476,13 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
         }
     }
 
-    private ThingUID getUID(String hex, boolean color) {
+    private ThingUID getUID(String hex, boolean color, boolean infrared) {
         if (color) {
-            return new ThingUID(LifxBindingConstants.THING_TYPE_COLORLIGHT, hex);
+            if (infrared) {
+                return new ThingUID(LifxBindingConstants.THING_TYPE_COLORIRLIGHT, hex);
+            } else {
+                return new ThingUID(LifxBindingConstants.THING_TYPE_COLORLIGHT, hex);
+            }
         } else {
             return new ThingUID(LifxBindingConstants.THING_TYPE_WHITELIGHT, hex);
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
@@ -26,6 +26,7 @@ public class LifxLightState {
     private PowerState powerState;
     private HSBType hsb;
     private PercentType temperature;
+    private PercentType infrared;
 
     private long lastChange;
 
@@ -35,6 +36,7 @@ public class LifxLightState {
         this.powerState = other.getPowerState();
         this.hsb = other.getHSB();
         this.temperature = other.getTemperature();
+        this.infrared = other.getInfrared();
     }
 
     public PowerState getPowerState() {
@@ -47,6 +49,10 @@ public class LifxLightState {
 
     public PercentType getTemperature() {
         return temperature;
+    }
+
+    public PercentType getInfrared() {
+        return infrared;
     }
 
     public void setHSB(HSBType newHSB) {
@@ -77,6 +83,15 @@ public class LifxLightState {
         updateLastChange();
         for (LifxLightStateListener listener : listeners) {
             listener.handleTemperatureChange(oldTemperature, newTemperature);
+        }
+    }
+
+    public void setInfrared(PercentType newInfrared) {
+        PercentType oldInfrared = this.infrared;
+        this.infrared = newInfrared;
+        updateLastChange();
+        for (LifxLightStateListener listener : listeners) {
+            listener.handleInfraredChange(oldInfrared, newInfrared);
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightStateChanger.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightStateChanger.java
@@ -23,11 +23,13 @@ import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
 import org.eclipse.smarthome.binding.lifx.internal.listener.LifxLightStateListener;
 import org.eclipse.smarthome.binding.lifx.internal.listener.LifxResponsePacketListener;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.AcknowledgementResponse;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.GetLightInfraredRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetLightPowerRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.Packet;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.PowerState;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SetColorRequest;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.SetLightInfraredRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SetLightPowerRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SetPowerRequest;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
@@ -224,6 +226,13 @@ public class LifxLightStateChanger implements LifxLightStateListener, LifxRespon
         addSetColorRequestToMap();
     }
 
+    @Override
+    public void handleInfraredChange(PercentType oldInfrared, PercentType newInfrared) {
+        int infrared = percentTypeToInfrared(pendingLightState.getInfrared());
+        SetLightInfraredRequest packet = new SetLightInfraredRequest(infrared);
+        addPacketToMap(packet);
+    }
+
     private void addSetColorRequestToMap() {
         HSBType hsb = pendingLightState.getHSB();
         if (hsb == null) {
@@ -272,6 +281,9 @@ public class LifxLightStateChanger implements LifxLightStateListener, LifxRespon
                 } else if (pendingPacket.packet instanceof SetColorRequest) {
                     GetRequest colorPacket = new GetRequest();
                     communicationHandler.sendPacket(colorPacket);
+                } else if (pendingPacket.packet instanceof SetLightInfraredRequest) {
+                    GetLightInfraredRequest infraredPacket = new GetLightInfraredRequest();
+                    communicationHandler.sendPacket(infraredPacket);
                 }
             } else {
                 logger.debug("{} : No pending packet found for ack with sequence number: {}", macAsHex,

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxUtils.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxUtils.java
@@ -49,6 +49,14 @@ public final class LifxUtils {
         }
     }
 
+    private static PercentType intToPercentType(int i) {
+        return new PercentType(Math.round((i / 65535.0f) * 100));
+    }
+
+    private static int percentTypeToInt(PercentType percentType) {
+        return (int) (percentType.floatValue() / 100 * 65535.0f);
+    }
+
     public static DecimalType hueToDecimalType(int hue) {
         return new DecimalType(hue * 360 / 65535.0f);
     }
@@ -58,19 +66,19 @@ public final class LifxUtils {
     }
 
     public static PercentType saturationToPercentType(int saturation) {
-        return new PercentType(Math.round((saturation / 65535.0f) * 100));
+        return intToPercentType(saturation);
     }
 
     public static int percentTypeToSaturation(PercentType saturation) {
-        return (int) (saturation.floatValue() / 100 * 65535.0f);
+        return percentTypeToInt(saturation);
     }
 
     public static PercentType brightnessToPercentType(int brightness) {
-        return new PercentType(Math.round((brightness / 65535.0f) * 100));
+        return intToPercentType(brightness);
     }
 
     public static int percentTypeToBrightness(PercentType brightness) {
-        return (int) (brightness.floatValue() / 100 * 65535.0f);
+        return percentTypeToInt(brightness);
     }
 
     public static PercentType kelvinToPercentType(int kelvin) {
@@ -82,4 +90,13 @@ public final class LifxUtils {
         // range is from 2500-9000K
         return 9000 - (temperature.intValue() * 65);
     }
+
+    public static PercentType infraredToPercentType(int infrared) {
+        return intToPercentType(infrared);
+    }
+
+    public static int percentTypeToInfrared(PercentType infrared) {
+        return percentTypeToInt(infrared);
+    }
+
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/listener/LifxLightStateListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/listener/LifxLightStateListener.java
@@ -43,4 +43,11 @@ public interface LifxLightStateListener {
      */
     void handleTemperatureChange(PercentType oldTemperature, PercentType newTemperature);
 
+    /**
+     * Called when the infrared property changes.
+     *
+     * @param oldInfrared the old infrared value
+     * @param newInfrared the new infrared value
+     */
+    void handleInfraredChange(PercentType oldInfrared, PercentType newInfrared);
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetLightInfraredRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetLightInfraredRequest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.lifx.internal.protocol;
+
+import java.nio.ByteBuffer;
+
+/**
+ * @author Wouter Born - Support LIFX 2016 product line-up and infrared functionality
+ */
+public class GetLightInfraredRequest extends Packet {
+
+    public static final int TYPE = 0x78;
+
+    public GetLightInfraredRequest() {
+        setTagged(false);
+        setAddressable(true);
+        setResponseRequired(true);
+    }
+
+    @Override
+    public int packetType() {
+        return TYPE;
+    }
+
+    @Override
+    protected int packetLength() {
+        return 0;
+    }
+
+    @Override
+    protected void parsePacket(ByteBuffer bytes) {
+        // do nothing
+    }
+
+    @Override
+    protected ByteBuffer packetBytes() {
+        return ByteBuffer.allocate(0);
+    }
+
+    @Override
+    public int[] expectedResponses() {
+        return new int[] { StateLightInfraredResponse.TYPE };
+    }
+
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/PacketFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/PacketFactory.java
@@ -18,6 +18,7 @@ import java.util.Map;
  *
  * @author Tim Buckley - Initial Contribution
  * @author Karel Goderis - Enhancement for the V2 LIFX Firmware and LAN Protocol Specification
+ * @author Wouter Born - Support LIFX 2016 product line-up and infrared functionality
  */
 public class PacketFactory {
 
@@ -44,6 +45,7 @@ public class PacketFactory {
         register(GetHostInfoRequest.class);
         register(GetInfoRequest.class);
         register(GetLabelRequest.class);
+        register(GetLightInfraredRequest.class);
         register(GetLightPowerRequest.class);
         register(GetLocationRequest.class);
         register(GetMeshFirmwareRequest.class);
@@ -59,6 +61,7 @@ public class PacketFactory {
         register(SetColorRequest.class);
         register(SetDimAbsoluteRequest.class);
         register(SetLabelRequest.class);
+        register(SetLightInfraredRequest.class);
         register(SetLightPowerRequest.class);
         register(SetPowerRequest.class);
         register(SetTagsRequest.class);
@@ -67,6 +70,7 @@ public class PacketFactory {
         register(StateHostInfoResponse.class);
         register(StateInfoResponse.class);
         register(StateLabelResponse.class);
+        register(StateLightInfraredResponse.class);
         register(StateLightPowerResponse.class);
         register(StateLocationResponse.class);
         register(StateMeshFirmwareResponse.class);

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Products.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Products.java
@@ -7,26 +7,42 @@
  */
 package org.eclipse.smarthome.binding.lifx.internal.protocol;
 
+/**
+ * Enumerates the LIFX products, their IDs and feature set.
+ *
+ * @see https://lan.developer.lifx.com/docs/lifx-products
+ *
+ * @author Wouter Born - Support LIFX 2016 product line-up and infrared functionality
+ */
 public enum Products {
 
-    OR1000(1, 1, "Original 1000", true),
-    C650(1, 3, "Color 650", true),
-    W800LV(1, 10, "White 800 (Low Voltage)", false),
-    W800HV(1, 11, "White 800 (High Voltage)", false),
-    W900LV(1, 18, "White 900 BR30 (Low Voltage)", false),
-    C900(1, 20, "Color 900 BR30", true),
-    C1000(1, 22, "Color 1000", true);
+    OR1000(1, 1, "Original 1000", true, false, false),
+    C650(1, 3, "Color 650", true, false, false),
+    W800LV(1, 10, "White 800 (Low Voltage)", false, false, false),
+    W800HV(1, 11, "White 800 (High Voltage)", false, false, false),
+    W900LV(1, 18, "White 900 BR30 (Low Voltage)", false, false, false),
+    C900(1, 20, "Color 900 BR30", true, false, false),
+    C1000(1, 22, "Color 1000", true, false, false),
+    LA19(1, 27, "LIFX A19", true, false, false),
+    LBR30(1, 28, "LIFX BR30", true, false, false),
+    LPA19(1, 29, "LIFX+ A19", true, true, false),
+    LPBR30(1, 30, "LIFX+ BR30", true, true, false),
+    LZ(1, 31, "LIFX Z", true, false, true);
 
     private final long vendorID;
     private final long productID;
     private final String name;
     private final boolean color;
+    private boolean infrared;
+    private boolean multiZone;
 
-    private Products(int vendorID, int productID, String name, boolean color) {
+    private Products(int vendorID, int productID, String name, boolean color, boolean infrared, boolean multiZone) {
         this.vendorID = vendorID;
         this.productID = productID;
         this.name = name;
         this.color = color;
+        this.infrared = infrared;
+        this.multiZone = multiZone;
     }
 
     @Override
@@ -48,6 +64,14 @@ public enum Products {
 
     public boolean isColor() {
         return color;
+    }
+
+    public boolean isInfrared() {
+        return infrared;
+    }
+
+    public boolean isMultiZone() {
+        return multiZone;
     }
 
     public static Products getProductFromProductID(long id) throws IllegalArgumentException {

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightInfraredRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightInfraredRequest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.lifx.internal.protocol;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.smarthome.binding.lifx.internal.fields.Field;
+import org.eclipse.smarthome.binding.lifx.internal.fields.UInt16Field;
+
+/**
+ * @author Wouter Born - Support LIFX 2016 product line-up and infrared functionality
+ */
+public class SetLightInfraredRequest extends Packet {
+
+    public static final int TYPE = 0x7A;
+
+    public static final Field<Integer> FIELD_STATE = new UInt16Field();
+
+    private int infrared;
+
+    public int getInfrared() {
+        return infrared;
+    }
+
+    public SetLightInfraredRequest() {
+        setTagged(false);
+        setAddressable(true);
+        setResponseRequired(true);
+    }
+
+    public SetLightInfraredRequest(int infrared) {
+        this();
+        this.infrared = infrared;
+    }
+
+    @Override
+    public int packetType() {
+        return TYPE;
+    }
+
+    @Override
+    protected int packetLength() {
+        return 2;
+    }
+
+    @Override
+    protected void parsePacket(ByteBuffer bytes) {
+        infrared = FIELD_STATE.value(bytes);
+    }
+
+    @Override
+    protected ByteBuffer packetBytes() {
+        return ByteBuffer.allocate(2).put(FIELD_STATE.bytes(infrared));
+    }
+
+    @Override
+    public int[] expectedResponses() {
+        return new int[] { StateLightInfraredResponse.TYPE };
+    }
+
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateLightInfraredResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateLightInfraredResponse.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.lifx.internal.protocol;
+
+import java.nio.ByteBuffer;
+
+import org.eclipse.smarthome.binding.lifx.internal.fields.Field;
+import org.eclipse.smarthome.binding.lifx.internal.fields.UInt16Field;
+
+/**
+ * @author Wouter Born - Support LIFX 2016 product line-up and infrared functionality
+ */
+public class StateLightInfraredResponse extends Packet {
+
+    public static final int TYPE = 0x79;
+
+    public static final Field<Integer> FIELD_STATE = new UInt16Field();
+
+    private int infrared;
+
+    public int getInfrared() {
+        return infrared;
+    }
+
+    @Override
+    public int packetType() {
+        return TYPE;
+    }
+
+    @Override
+    protected int packetLength() {
+        return 2;
+    }
+
+    @Override
+    protected void parsePacket(ByteBuffer bytes) {
+        infrared = FIELD_STATE.value(bytes);
+    }
+
+    @Override
+    protected ByteBuffer packetBytes() {
+        return ByteBuffer.allocate(packetLength()).put(FIELD_STATE.bytes(infrared));
+    }
+
+    @Override
+    public int[] expectedResponses() {
+        return new int[] {};
+    }
+
+}


### PR DESCRIPTION
Adds support for the following LIFX products:
* LIFX A19
* LIFX BR30
* LIFX+ A19
* LIFX+ BR30
* LIFX Z

Furthermore a `colorirlight` thing type has been introduced for the LIFX+ products. These things have an additional infrared channel. I've been testing with the new LIFX Z and LIFX+ A19 myself.