### PR TITLE
remove rest.auth from base feature

### DIFF
--- a/features/karaf-tp/src/main/feature/feature.xml
+++ b/features/karaf-tp/src/main/feature/feature.xml
@@ -48,7 +48,6 @@
   <feature name="esh-tp-jax-rs" version="${project.version}">
     <capability>esh.tp;feature=jax-rs;version=5.3.1</capability>
     <feature>esh-tp-jax-rs-min</feature>
-    <feature>esh-tp-jax-rs-provider-security</feature>
     <feature>esh-tp-jax-rs-provider-gson</feature>
   </feature>
 

--- a/features/karaf/src/main/feature/feature.xml
+++ b/features/karaf/src/main/feature/feature.xml
@@ -55,7 +55,6 @@
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.monitor/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.net/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest/${project.version}</bundle>
-    <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest.auth/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest.core/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest.sse/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.model/org.eclipse.smarthome.model.core/${project.version}</bundle>
@@ -68,8 +67,15 @@
     <bundle>mvn:org.eclipse.smarthome.auth/org.eclipse.smarthome.auth.jaas/${project.version}</bundle>
   </feature>
 
+  <feature name="esh-rest-auth" version="${project.version}">
+    <feature>esh-base</feature>
+    <feature>esh-tp-jax-rs-provider-security</feature>
+    <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest.auth/${project.version}</bundle>
+  </feature>
+
   <feature name="esh-rest-auth-basic" version="${project.version}">
     <feature>esh-base</feature>
+    <feature>esh-rest-auth</feature>
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest.auth.basic/${project.version}</bundle>
   </feature>
 


### PR DESCRIPTION
There is not need to add the rest.auth bundle to the base feature as we can also run fine without it.