### PR TITLE
remove Maven Nature from fsinternetradio test

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/.project
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/.project
@@ -20,14 +20,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.groovy.core.groovyNature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+groovy.compiler.level=-1


### PR DESCRIPTION
This will remove this error shown in the Eclipse IDE:
Description: Plugin execution not covered by lifecycle configuration:
  org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
  (execution: default, phase: compile)
Resource: pom.xml
Path: /org.eclipse.smarthome.binding.fsinternetradio.test
Location: line 4
Type: Maven Project Build Lifecycle Mapping Problem
