### PR TITLE
Allow changing of unmanaged Things

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
@@ -35,6 +35,7 @@ import org.eclipse.smarthome.core.thing.Channel
 import org.eclipse.smarthome.core.thing.ChannelUID
 import org.eclipse.smarthome.core.thing.ManagedThingProvider
 import org.eclipse.smarthome.core.thing.Thing
+import org.eclipse.smarthome.core.thing.ThingProvider
 import org.eclipse.smarthome.core.thing.ThingRegistry
 import org.eclipse.smarthome.core.thing.ThingStatus
 import org.eclipse.smarthome.core.thing.ThingStatusDetail
@@ -320,7 +321,7 @@ class ThingManagerOSGiTest extends OSGiTest {
             initialize: {
                 def shouldFail = testThing.getConfiguration().get("shouldFail") as boolean
                 if(shouldFail) {
-                    throw new Exception("Invalid config!")
+                    throw new RuntimeException("Invalid config!")
                 } else {
                     callback.statusUpdated(testThing, ThingStatusInfoBuilder.create(ThingStatus.ONLINE).build())
                 }
@@ -342,7 +343,7 @@ class ThingManagerOSGiTest extends OSGiTest {
         assertThat testThing.getStatusInfo(), is(statusInfo)
 
         managedThingProvider.add(testThing)
-        statusInfo = ThingStatusInfoBuilder.create(ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_INITIALIZING_ERROR).build()
+        statusInfo = ThingStatusInfoBuilder.create(ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_INITIALIZING_ERROR).withDescription("Invalid config!").build()
         waitForAssert { assertThat testThing.getStatusInfo(), is(statusInfo) }
 
         testThing.getConfiguration().put("shouldFail", false)
@@ -799,43 +800,26 @@ class ThingManagerOSGiTest extends OSGiTest {
         }
     }
 
-    @Test(expected=IllegalStateException.class)
-    void 'ThingManager complains if the managed thing provider cannot handle thing updates'() {
+    void 'ThingManager allows changes to unmanaged things'() {
+        ThingManager thingManager = getService(ThingManager)
+        assertThat thingManager, is(notNullValue())
 
         def itemName = "name"
         ThingHandlerCallback callback;
 
-        managedThingProvider.add(THING)
-        managedItemChannelLinkProvider.add(new ItemChannelLink(itemName, CHANNEL_UID))
-        def thingHandler = [
-            setCallback: {callbackArg -> callback = callbackArg },
-            initialize: {},
-            dispose: {},
-            getThing: { return THING },
-            thingUpdated: {
-            }
-        ] as ThingHandler
-
-        def thingHandlerFactory = [
-            supportsThingType: {ThingTypeUID thingTypeUID -> true},
-            registerHandler: {thing -> thingHandler },
-            unregisterHandler: {thing -> },
-            removeThing: {thingUID ->
-            }
-        ] as ThingHandlerFactory
-        registerService(thingHandlerFactory)
+        def customThingProvider = [
+            getAll: {[THING]}
+        ] as ThingProvider
+        registerService(customThingProvider)
 
         boolean thingUpdated = false
 
         ThingRegistry thingRegistry = getService(ThingRegistry)
         def registryChangeListener = [ updated: {old, updated -> thingUpdated = true} ] as RegistryChangeListener
 
-        ThingHandlerCallback storedCallback = callback
-        managedThingProvider.remove(THING.getUID())
-
         try {
             thingRegistry.addRegistryChangeListener(registryChangeListener)
-            storedCallback.thingUpdated(THING)
+            thingManager.thingHandlerCallback.thingUpdated(THING)
             assertThat thingUpdated, is(true)
         } finally {
             thingRegistry.removeRegistryChangeListener(registryChangeListener)

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingManager.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingManager.xml
@@ -19,7 +19,6 @@
    <reference bind="setEventPublisher" cardinality="1..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="static" unbind="unsetEventPublisher"/>
    <reference bind="setItemChannelLinkRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry" name="ItemChannelLinkRegistry" policy="static" unbind="unsetItemChannelLinkRegistry"/>
    <reference bind="setConfigDescriptionRegistry" cardinality="1..1" interface="org.eclipse.smarthome.config.core.ConfigDescriptionRegistry" name="ConfigDescriptionRegistry" policy="static" unbind="unsetConfigDescriptionRegistry"/>
-   <reference bind="setManagedThingProvider" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ManagedThingProvider" name="ManagedThingProvider" policy="static" unbind="unsetManagedThingProvider"/>
    <reference bind="setThingTypeRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.type.ThingTypeRegistry" name="ThingTypeRegistry" policy="static" unbind="unsetThingTypeRegistry"/>
    <reference bind="setBundleProcessor" cardinality="0..n" interface="org.eclipse.smarthome.config.core.BundleProcessor" name="BundleProcessor" policy="dynamic" unbind="unsetBundleProcessor"/>
 </scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -10,6 +10,7 @@ package org.eclipse.smarthome.core.thing.internal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.smarthome.config.core.Configuration;
@@ -269,6 +270,15 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
 
     protected void removeThingHandlerFactory(ThingHandlerFactory thingHandlerFactory) {
         this.thingHandlerFactories.remove(thingHandlerFactory);
+    }
+
+    public Provider<Thing> getProvider(Thing thing) {
+        for (Entry<Provider<Thing>, Collection<Thing>> entry : elementMap.entrySet()) {
+            if (entry.getValue().contains(thing)) {
+                return entry.getKey();
+            }
+        }
+        return null;
     }
 
 }

--- a/docs/documentation/development/bindings/thing-handler.md
+++ b/docs/documentation/development/bindings/thing-handler.md
@@ -222,6 +222,8 @@ If configuration needs to be sent to devices, this method should be overridden a
 
 It can happen that the binding wants to update the configuration or even the whole structure of a thing. If the `BaseThingHandler` class is used, it provides some helper methods for modifying the thing.
 
+Please note that not all thing providers are writable. Therefore bindings must not rely on any thing changes to be persisted. 
+
 ### Updating the Configuration
 
 Usually the configuration is maintained by the user and the binding is informed about the updated configuration. But if the configuration can also be changed in the external system, the binding should reflect this change and notify the framework about it.
@@ -268,8 +270,6 @@ protected void thingStructureChanged() {
     updateThing(thingBuilder.build());
 }
 ```
-
-As the builder does not support removing a channel, the developer has top copy the existing channels into a modifiable list and remove the channel in this list. The list can be passed as an argument to the `withChannels()` method of the `ThingBuilder`, which overrides the complete list of channels.
 
 ## Handling Thing Removal
 


### PR DESCRIPTION
So far, changes were allowed only to Things coming from
the ManagedThingProvider. With this change it is now allowed
to change all Things structurally, no matter where they are
from. They will simply not be persisted if its provider is not
managed.

fixes #1977
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>