### PR TITLE
[LIFX] Refer to bulbs as lights

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
@@ -24,7 +24,7 @@ public class LifxBindingConstants {
     public static final String BINDING_ID = "lifx";
     public static final String THREADPOOL_NAME = "lifx";
 
-    // The LIFX LAN Protocol Specification states that bulbs can process up to 20 messages per second, not more.
+    // The LIFX LAN Protocol Specification states that lights can process up to 20 messages per second, not more.
     public final static long PACKET_INTERVAL = 50;
 
     // Fallback light state defaults

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
@@ -157,7 +157,7 @@ public class LifxLightHandler extends BaseThingHandler {
             macAddress = new MACAddress((String) getConfig().get(LifxBindingConstants.CONFIG_PROPERTY_DEVICE_ID), true);
             macAsHex = this.macAddress.getHex();
 
-            logger.debug("Initializing the LIFX handler for bulb '{}'.", macAsHex);
+            logger.debug("Initializing the LIFX handler for light '{}'.", macAsHex);
 
             fadeTime = getFadeTime();
             powerOnBrightness = getPowerOnBrightness();
@@ -276,7 +276,7 @@ public class LifxLightHandler extends BaseThingHandler {
                         break;
                 }
             } catch (Exception ex) {
-                logger.error("Error while refreshing a channel for the bulb: {}", ex.getMessage(), ex);
+                logger.error("Error while refreshing a channel for the light: {}", ex.getMessage(), ex);
             }
         } else {
             try {
@@ -320,7 +320,7 @@ public class LifxLightHandler extends BaseThingHandler {
                         break;
                 }
             } catch (Exception ex) {
-                logger.error("Error while updating bulb: {}", ex.getMessage(), ex);
+                logger.error("Error while updating light: {}", ex.getMessage(), ex);
             }
         }
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCommunicationHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCommunicationHandler.java
@@ -111,7 +111,7 @@ public class LifxLightCommunicationHandler {
 
             lock.lock();
 
-            logger.debug("Starting LIFX communication handler for bulb '{}'.", macAsHex);
+            logger.debug("Starting LIFX communication handler for light '{}'.", macAsHex);
 
             if (networkJob == null || networkJob.isCancelled()) {
                 networkJob = scheduler.scheduleWithFixedDelay(networkRunnable, 0, PACKET_INTERVAL,
@@ -324,7 +324,7 @@ public class LifxLightCommunicationHandler {
                     }
                 }
             } catch (Exception e) {
-                logger.error("An exception occurred while receiving a packet from the bulb : '{}'", e.getMessage());
+                logger.error("An exception occurred while receiving a packet from the light : '{}'", e.getMessage());
             } finally {
                 lock.unlock();
             }
@@ -372,9 +372,10 @@ public class LifxLightCommunicationHandler {
                                 unicastKey = unicastChannel.register(selector,
                                         SelectionKey.OP_READ | SelectionKey.OP_WRITE);
                                 unicastChannel.connect(ipAddress);
-                                logger.trace("Connected to a bulb via {}", unicastChannel.getLocalAddress().toString());
+                                logger.trace("Connected to a light via {}",
+                                        unicastChannel.getLocalAddress().toString());
                             } catch (Exception e) {
-                                logger.warn("An exception occurred while connecting to the bulb's IP address : '{}'",
+                                logger.warn("An exception occurred while connecting to the light's IP address : '{}'",
                                         e.getMessage());
                                 currentLightState.setOfflineByCommunicationError();
                                 return;
@@ -504,7 +505,7 @@ public class LifxLightCommunicationHandler {
                 }
             }
         } catch (Exception e) {
-            logger.error("An exception occurred while sending a packet to the bulb : '{}'", e.getMessage());
+            logger.error("An exception occurred while sending a packet to the light : '{}'", e.getMessage());
         } finally {
 
             if (selectedKey == unicastKey) {

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
@@ -280,7 +280,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
             }
 
         } catch (Exception e) {
-            logger.error("An exception occurred while communicating with the bulb : '{}'", e.getMessage());
+            logger.error("An exception occurred while communicating with the light : '{}'", e.getMessage());
         }
 
         return result;
@@ -392,7 +392,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
                             SelectionKey unicastKey = unicastChannel.register(selector,
                                     SelectionKey.OP_READ | SelectionKey.OP_WRITE);
                             unicastChannel.connect(csp.ipaddress);
-                            logger.trace("Connected to a bulb via {}", unicastChannel.getLocalAddress().toString());
+                            logger.trace("Connected to a light via {}", unicastChannel.getLocalAddress().toString());
 
                             GetVersionRequest versionPacket = new GetVersionRequest();
                             versionPacket.setTarget(csp.target);
@@ -407,7 +407,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
                 }
                 isScanning = false;
             } catch (Exception e) {
-                logger.error("An exception orccurred while communicating with the bulb : '{}'", e.getMessage(), e);
+                logger.error("An exception orccurred while communicating with the light : '{}'", e.getMessage(), e);
             }
         }
     };

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightOnlineStateUpdater.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightOnlineStateUpdater.java
@@ -80,7 +80,7 @@ public class LifxLightOnlineStateUpdater implements LifxResponsePacketListener {
                     }
                 } else {
                     // are we not configured? let's broadcast instead
-                    logger.trace("{} : The bulb is not online, let's broadcast instead", macAsHex);
+                    logger.trace("{} : The light is not online, let's broadcast instead", macAsHex);
                     GetServiceRequest packet = new GetServiceRequest();
                     communicationHandler.broadcastPacket(packet);
                 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxNetworkThrottler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxNetworkThrottler.java
@@ -20,7 +20,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * The {@link LifxNetworkThrottler} is a helper class that regulates the frequency at which messages/packets are sent to
- * LIFX bulbs. The LIFX LAN Protocol Specification states that bulbs can process up to 20 messages per second, not more.
+ * LIFX lights. The LIFX LAN Protocol Specification states that lights can process up to 20 messages per second, not
+ * more.
  *
  * @author Karel Goderis - Initial Contribution
  * @author Wouter Born - Deadlock fix
@@ -30,7 +31,7 @@ public class LifxNetworkThrottler {
     private static Logger logger = LoggerFactory.getLogger(LifxNetworkThrottler.class);
 
     /**
-     * Tracks when the last packet was sent to a LIFX bulb. The packet is sent after obtaining the lock and before
+     * Tracks when the last packet was sent to a LIFX light. The packet is sent after obtaining the lock and before
      * releasing the lock.
      */
     private static class LifxLightCommunicationTracker {

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Packet.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Packet.java
@@ -120,8 +120,8 @@ public abstract class Packet {
         return target;
     }
 
-    public void setTarget(MACAddress bulbAddress) {
-        this.target = bulbAddress;
+    public void setTarget(MACAddress lightAddress) {
+        this.target = lightAddress;
     }
 
     public ByteBuffer getReserved1() {
@@ -247,7 +247,7 @@ public abstract class Packet {
      * Certain fields are set to default values based on other class methods.
      * For example, the size and packet type fields will be set to the values
      * returned from {@link #length()} and {@link #packetType()}, respectively.
-     * Other defaults (such as the protocol, bulb address, site, and timestamp)
+     * Other defaults (such as the protocol, light address, site, and timestamp)
      * may be specified either by directly setting the relevant protected
      * variables or by overriding {@link #preambleDefaults()}.
      *

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/PowerState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/PowerState.java
@@ -8,7 +8,7 @@
 package org.eclipse.smarthome.binding.lifx.internal.protocol;
 
 /**
- * Represents bulb power states (on or off).
+ * Represents light power states (on or off).
  *
  * @author Tim Buckley - Initial Contribution
  * @author Karel Goderis - Enhancement for the V2 LIFX Firmware and LAN Protocol Specification


### PR DESCRIPTION
The LIFX binding uses the words *light* and *bulb* interchangeably. Now that the binding also supports LED strips (LIFX Z), the word *bulb* is sometimes unsuitable. This PR replaces occurrences of *bulb* with the more generic *light*.