### PR TITLE
"ü" is not correctly displayed in the browser

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/ESH-INF/i18n/configstatus_de.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/ESH-INF/i18n/configstatus_de.properties
@@ -1,1 +1,1 @@
-config-status.error.location-not-found=Der Ort für die WOEID {0} konnte nicht gefunden werden.
+config-status.error.location-not-found=Der Ort f\u00FCr die WOEID {0} konnte nicht gefunden werden.

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/ESH-INF/i18n/yahooweather_de.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/ESH-INF/i18n/yahooweather_de.properties
@@ -1,6 +1,6 @@
 # binding
 binding.yahooweather.name = Yahoo Wetter Binding
-binding.yahooweather.description = Das Yahoo Wetter Binding stellt verschiedene Wetterdaten wie die Temperatur, die Luftfeuchtigkeit und den Luftdruck für konfigurierbare Orte vom yahoo Wetterdienst bereit
+binding.yahooweather.description = Das Yahoo Wetter Binding stellt verschiedene Wetterdaten wie die Temperatur, die Luftfeuchtigkeit und den Luftdruck f\u00FCr konfigurierbare Orte vom yahoo Wetterdienst bereit
 
 # thing types
 thing-type.yahooweather.weather.label = Wetterinformation


### PR DESCRIPTION
Therefore it was replaced by the equivalent UTF-8 constant.

Fixes #2639

Signed-off-by: Martin Herbst <mail@mherbst.de>