### PR TITLE
[LIFX] Power state bug fixes and code cleanup

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/binding/binding.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/binding/binding.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
     <name>LIFX Binding</name>
-    <description>This is the binding for LIFX bulbs.</description>
+    <description>This is the binding for LIFX lights.</description>
     <author>Karel Goderis</author>
 
 </binding:binding>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
@@ -64,8 +64,8 @@ public class LifxLightState {
         }
     }
 
-    public void setPowerState(OnOffType onOffType) {
-        setPowerState(onOffType == OnOffType.ON ? PowerState.ON : PowerState.OFF);
+    public void setPowerState(OnOffType newOnOff) {
+        setPowerState(PowerState.fromOnOffType(newOnOff));
     }
 
     public void setPowerState(PowerState newPowerState) {

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/AcknowledgementResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/AcknowledgementResponse.java
@@ -42,9 +42,7 @@ public class AcknowledgementResponse extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] {
-                // PowerStateResponse.TYPE // apparently not expected?
-        };
+        return new int[] {};
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/EchoRequestResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/EchoRequestResponse.java
@@ -57,9 +57,7 @@ public class EchoRequestResponse extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] {
-                // PowerStateResponse.TYPE // apparently not expected?
-        };
+        return new int[] {};
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetLabelRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetLabelRequest.java
@@ -45,7 +45,7 @@ public class GetLabelRequest extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] {}; // ?
+        return new int[] { StateLabelResponse.TYPE };
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetPowerRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetPowerRequest.java
@@ -45,9 +45,7 @@ public class GetPowerRequest extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] {
-                // PowerStateResponse.TYPE // apparently not expected?
-        };
+        return new int[] { StatePowerResponse.TYPE };
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetServiceRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetServiceRequest.java
@@ -17,8 +17,6 @@ public class GetServiceRequest extends Packet {
 
     public static final int TYPE = 0x02;
 
-    // public static final int PROTOCOL_DEFAULT = 21504; // ??
-
     public GetServiceRequest() {
         setTagged(true);
         setAddressable(true);
@@ -46,7 +44,7 @@ public class GetServiceRequest extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] { StateServiceResponse.TYPE }; // UDP packets cannot have responses
+        return new int[] { StateServiceResponse.TYPE };
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetTagLabelsRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetTagLabelsRequest.java
@@ -57,7 +57,7 @@ public class GetTagLabelsRequest extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] {};
+        return new int[] { TagLabelsResponse.TYPE };
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetTagsRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetTagsRequest.java
@@ -39,7 +39,7 @@ public class GetTagsRequest extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] {};
+        return new int[] { TagsResponse.TYPE };
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetWifiInfoRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetWifiInfoRequest.java
@@ -45,7 +45,7 @@ public class GetWifiInfoRequest extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] {};
+        return new int[] { StateWifiInfoResponse.TYPE };
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/PowerState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/PowerState.java
@@ -7,11 +7,14 @@
  */
 package org.eclipse.smarthome.binding.lifx.internal.protocol;
 
+import org.eclipse.smarthome.core.library.types.OnOffType;
+
 /**
  * Represents light power states (on or off).
  *
  * @author Tim Buckley - Initial Contribution
  * @author Karel Goderis - Enhancement for the V2 LIFX Firmware and LAN Protocol Specification
+ * @author Wouter Born - Added OnOffType conversion methods
  */
 public enum PowerState {
 
@@ -41,6 +44,14 @@ public enum PowerState {
         }
 
         return null;
+    }
+
+    public static PowerState fromOnOffType(OnOffType onOff) {
+        return onOff == OnOffType.ON ? ON : OFF;
+    }
+
+    public OnOffType toOnOffType() {
+        return this == ON ? OnOffType.ON : OnOffType.OFF;
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLabelRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLabelRequest.java
@@ -60,7 +60,7 @@ public class SetLabelRequest extends Packet {
 
     @Override
     public int[] expectedResponses() {
-        return new int[] {}; // ?
+        return new int[] {};
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightPowerRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightPowerRequest.java
@@ -44,7 +44,7 @@ public class SetLightPowerRequest extends Packet {
         this.duration = 0;
         setTagged(false);
         setAddressable(true);
-        // setResponseRequired(true);
+        setResponseRequired(true);
     }
 
     public SetLightPowerRequest(PowerState state) {
@@ -52,7 +52,7 @@ public class SetLightPowerRequest extends Packet {
         this.duration = 0;
         setTagged(false);
         setAddressable(true);
-        // setResponseRequired(true);
+        setResponseRequired(true);
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetPowerRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetPowerRequest.java
@@ -33,7 +33,6 @@ public class SetPowerRequest extends Packet {
         setTagged(false);
         setAddressable(true);
         setResponseRequired(true);
-        // protocol = 0x1400;
     }
 
     public SetPowerRequest(PowerState state) {
@@ -41,7 +40,6 @@ public class SetPowerRequest extends Packet {
         setTagged(false);
         setAddressable(true);
         setResponseRequired(true);
-        // protocol = 0x1400;
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateResponse.java
@@ -36,7 +36,7 @@ public class StateResponse extends Packet {
     private int brightness;
     private int kelvin;
     private int dim;
-    private PowerState power; // PowerState?
+    private PowerState power;
     private String label;
     private long tags;
 
@@ -104,7 +104,7 @@ public class StateResponse extends Packet {
     protected ByteBuffer packetBytes() {
         return ByteBuffer.allocate(packetLength()).put(FIELD_HUE.bytes(hue)).put(FIELD_SATURATION.bytes(saturation))
                 .put(FIELD_BRIGHTNESS.bytes(brightness)).put(FIELD_KELVIN.bytes(kelvin)).put(FIELD_DIM.bytes(dim))
-                .put(FIELD_POWER.bytes(hue)).put(FIELD_LABEL.bytes(label)).put(FIELD_TAGS.bytes(tags));
+                .put(FIELD_POWER.bytes(power.getValue())).put(FIELD_LABEL.bytes(label)).put(FIELD_TAGS.bytes(tags));
     }
 
     @Override


### PR DESCRIPTION
### Power state bug fixes
* "Power on brightness" was not properly applied when switching ON/OFF White lights. There actually is no difference between switching ON/OFF Color and White lights.
* When switching ON/OFF a light, the brightness should not be changed with `handleHSBCommand` because it always switches a light ON when it is already OFF. I.e. a light that is OFF, and switched OFF again, could go ON and immediately OFF again.
* Power state polling of lights did not work properly. A `GetLightPowerRequest` was sent which results in a `StateLightPowerResponse` and not the `StatePowerResponse` that was used for updating the `PowerState`. Because the power state is also part of the `StateResponse` it is unnecessary to poll for it with a second packet.
* Because power state polling now works properly, issues in the `CurrentLightState` showed up, hence the reworked logic.
* `MAX_STATE_CHANGE_DURATION` has been increased because sometimes power state change packets are not received within this interval. As a result lights were not properly switched ON/OFF because the `CurrentLightState` still contained an old value.
* Because of the above, `Switch`-es and `Dimmer`s bound to the `color`/`brightness` channels now update properly. Also when changing the state of a light via other means such as the LIFX App or a second ESH instance.

### Code cleanup
* Parameters/variables have been renamed for more clarity/consistency.
* Commented code in protocol objects has been cleaned up.
* Missing `expectedResponses` have been added in protocol objects.
