### PR TITLE
reduce severity in io.upnp

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/src/main/java/org/eclipse/smarthome/io/transport/upnp/UpnpIOServiceImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/src/main/java/org/eclipse/smarthome/io/transport/upnp/UpnpIOServiceImpl.java
@@ -297,7 +297,7 @@ public class UpnpIOServiceImpl implements UpnpIOService {
                                 }
                             }
 
-                            logger.debug("Invoking Action '{}' of service '{}' for participant '{}'",
+                            logger.trace("Invoking Action '{}' of service '{}' for participant '{}'",
                                     new Object[] { actionID, serviceID, participant.getUDN() });
                             new ActionCallback.Default(invocation, upnpService.getControlPoint()).run();
 


### PR DESCRIPTION
in order to avoid flooding the logs with "Invoking Action [...]" messages.

They are pretty much spamming the logs with messages like this, e.g. when using sonos:

```
Invoking Action 'GetRunningAlarmProperties' of service 'AVTransport' for participant 'RINCON_[...]'
```

Unless anybody has a good reason to keep them on DEBUG level, I would suggest to reduce them to TRACE, so if we need them we can specifically enable them.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>