### PR TITLE
Normalize configuration values when initializing thing handlers

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.config.core.BundleProcessorVetoManager;
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
+import org.eclipse.smarthome.config.core.ConfigUtil;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.common.SafeMethodCaller;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
@@ -638,6 +639,7 @@ public class ThingManager extends AbstractItemEventSubscriber implements ThingTr
                     synchronized (thing) {
                         if (!isInitializing(thing)) {
                             ThingType thingType = getThingType(thing);
+                            normalizeConfiguration(thing, thingType);
                             applyDefaultConfiguration(thing, thingType);
                             if (isInitializable(thing, thingType)) {
                                 setThingStatus(thing,
@@ -657,6 +659,17 @@ public class ThingManager extends AbstractItemEventSubscriber implements ThingTr
                     }
                 }
             });
+
+    private void normalizeConfiguration(Thing thing, ThingType thingType) {
+        Configuration configuration = thing.getConfiguration();
+        if (configuration != null && thingType != null) {
+            ConfigDescription configDesc = configDescriptionRegistry
+                    .getConfigDescription(thingType.getConfigDescriptionURI());
+            if (configDesc != null) {
+                configuration.setProperties(ConfigUtil.normalizeTypes(configuration.getProperties(), configDesc));
+            }
+        }
+    }
 
     private void applyDefaultConfiguration(Thing thing, ThingType thingType) {
         if (thingType != null) {


### PR DESCRIPTION
On startup stored integer configuration parameters are not normalized. As a result objects with decimals are returned when retrieving these `Configuration` values. This causes exceptions. 

E.g. with the LIFX binding the following warning is logged on startup:

```
18:52:28.940 [WARN ] [inding.lifx.handler.LifxLightHandler] - Invalid value '300.0' for transition time, using default instead.
```

The definition of this parameter is:

```
    <parameter name="fadetime" type="integer" required="false">
        <label>Fade time</label>
        <description>The time to fade to the new color value (in ms).</description>
        <default>300</default>
    </parameter>
```

In this case the code is expecting a Long and not a BigDecimal:

```
    try {
        return Long.parseLong(fadeCfg.toString());
    } catch (NumberFormatException e) {
        logger.warn("Invalid value '{}' for transition time, using default instead.", fadeCfg.toString());
        return FADE_TIME_DEFAULT;
    }
```

Other people have reported similar issues on the [openHAB community forums](https://community.openhab.org/t/replacement-of-mapdb-by-jsondb/17498/30). In PR #2633 a workaround is created for the digitalSTROM binding.

I also did a bit of [research](https://github.com/eclipse/smarthome/pull/2633#issuecomment-266820822) on this issue. The root cause I think is that `Gson` deserializes all integers in a Thing Configuration as a `BigDecimal`. Because this is done using reflection the configuration parameters are never validated/normalized.

This PR addresses the issue by normalizing the Configuration values at the same location where the Configuration defaults are also provided. I've tested it and for me it solves the issue with the LIFX binding. I think it should also fix the issues in other bindings.
