### PR TITLE
Fixes #2602. Refactor normalization of rule.

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/src/test/java/org/eclipse/smarthome/automation/core/internal/RuleEngineTest.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/src/test/java/org/eclipse/smarthome/automation/core/internal/RuleEngineTest.java
@@ -191,7 +191,7 @@ public class RuleEngineTest {
         List<ConfigDescriptionParameter> rule4cfgD = rule4Get.getConfigurationDescriptions();
         Assert.assertNotNull("Rule configuration is null", rule4cfg);
         Assert.assertTrue("Missing config property in rule copy", rule4cfg.containsKey("config1"));
-        Assert.assertEquals("Wrong config value", 5, rule4cfg.get("config1"));
+        Assert.assertEquals("Wrong config value", new BigDecimal(5), rule4cfg.get("config1"));
 
         Assert.assertNotNull("Rule configuration description is null", rule4cfgD);
         Assert.assertEquals("Missing config description in rule copy", 1, rule4cfgD.size());

--- a/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
@@ -5,6 +5,7 @@ Bundle-SymbolicName: org.eclipse.smarthome.automation.core
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Import-Package: 
+ com.google.gson,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.core.util,
  org.eclipse.smarthome.automation.events,


### PR DESCRIPTION
Remove double normalization of module's configuration data.
Add normalization of rule's configuration data (It is available when rule is added by template.)

Signed-off-by: Yordan Mihaylov <j.mihailov@prosyst.bg>