### PR TITLE
Bug fix: wrong item removal dialog template name

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.items.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.items.js
@@ -12,7 +12,7 @@ angular.module('PaperUI.controllers.configuration').controller('ItemSetupControl
         event.stopImmediatePropagation();
         $mdDialog.show({
             controller : 'ItemRemoveController',
-            templateUrl : 'partials/dialog.removeitem.html',
+            templateUrl : 'partials/dialog.remove.html',
             targetEvent : event,
             hasBackdrop : true,
             locals : {


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/2673
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>