### PR TITLE
Json storage BigDecimal scaling

### DIFF
--- a/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/PropertiesTypeAdapter.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/PropertiesTypeAdapter.java
@@ -52,7 +52,7 @@ public class PropertiesTypeAdapter extends TypeAdapter<Map<String, Object>> {
         valueAdapter = gson.getAdapter(Object.class);
 
         // obtain default gson objects
-        constructor = new ConstructorConstructor(Collections.<Type, InstanceCreator<?>> emptyMap());
+        constructor = new ConstructorConstructor(Collections.<Type, InstanceCreator<?>>emptyMap());
         delegate = new MapTypeAdapterFactory(constructor, false).create(new Gson(), TOKEN);
     }
 
@@ -114,7 +114,12 @@ public class PropertiesTypeAdapter extends TypeAdapter<Map<String, Object>> {
         // if the next json token is a number we read it as a BigDecimal,
         // otherwise use the default adapter to read it
         if (JsonToken.NUMBER.equals(in.peek())) {
-            value = new BigDecimal(in.nextString());
+            String inString = in.nextString();
+            if (inString.endsWith(".0")) {
+                value = new BigDecimal(inString).setScale(0);
+            } else {
+                value = new BigDecimal(inString);
+            }
         } else {
             value = valueAdapter.read(in);
         }


### PR DESCRIPTION
As discussed in #2665 Gson doesn't provide access to the raw data - in the TypeAdapter class, the string value that is available has already been altered from what is in the file - so a value in the file of 50 is already 50.0. Therefore there is no way to reliably resolve a BigDecimal with scale 1, and a BigDecimal with scale 0.

This currently appears to be the best compromise.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>