### PR TITLE
[LIFX] Discover light labels, improve locking, optimize packet handling

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCommunicationHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCommunicationHandler.java
@@ -460,7 +460,7 @@ public class LifxLightCommunicationHandler {
             lock.lock();
 
             if (selectedKey == unicastKey) {
-                LifxNetworkThrottler.lock(macAsHex);
+                LifxNetworkThrottler.lock(macAddress);
             } else {
                 LifxNetworkThrottler.lock();
             }
@@ -509,7 +509,7 @@ public class LifxLightCommunicationHandler {
         } finally {
 
             if (selectedKey == unicastKey) {
-                LifxNetworkThrottler.unlock(macAsHex);
+                LifxNetworkThrottler.unlock(macAddress);
             } else {
                 LifxNetworkThrottler.unlock();
             }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
@@ -17,6 +17,7 @@ import java.net.SocketException;
 import java.net.StandardProtocolFamily;
 import java.net.StandardSocketOptions;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.DatagramChannel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
@@ -36,12 +37,14 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.binding.lifx.LifxBindingConstants;
 import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.GetLabelRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetServiceRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetVersionRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.Packet;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.PacketFactory;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.PacketHandler;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.Products;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.StateLabelResponse;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.StateServiceResponse;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.StateVersionResponse;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
@@ -59,10 +62,15 @@ import com.google.common.collect.Sets;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Karel Goderis - Rewrite for Firmware V2, and remove dependency on external libraries
+ * @author Wouter Born - Discover light labels, improve locking, optimize packet handling
  */
 public class LifxLightDiscovery extends AbstractDiscoveryService {
 
     private Logger logger = LoggerFactory.getLogger(LifxLightDiscovery.class);
+
+    private static final int SERVICE_REQUEST_SEQ_NO = 0;
+    private static final int VERSION_REQUEST_SEQ_NO = 1;
+    private static final int LABEL_REQUEST_SEQ_NO = 2;
 
     private List<InetSocketAddress> broadcastAddresses;
     private List<InetAddress> interfaceAddresses;
@@ -72,16 +80,35 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
     private static int SELECTOR_TIMEOUT = 10000;
     private int bufferSize = 0;
 
-    private HashMap<MACAddress, StateServiceResponse> serviceResponses = new HashMap<MACAddress, StateServiceResponse>();
-    private ArrayList<ConnectionSetupParameter> connectionsToSetUp;
     private Selector selector;
     private DatagramChannel broadcastChannel;
     private long source;
     private boolean isScanning = false;
 
     private ScheduledFuture<?> discoveryJob;
-
     private ScheduledFuture<?> networkJob;
+
+    private Map<MACAddress, DiscoveredLight> discoveredLights = new HashMap<MACAddress, DiscoveredLight>();
+
+    private class DiscoveredLight {
+
+        private MACAddress macAddress;
+        private InetSocketAddress ipAddress;
+        private String label;
+        private Products products;
+
+        private long lastRequestTimeMillis;
+
+        public DiscoveredLight(MACAddress macAddress, InetSocketAddress ipAddress) {
+            this.macAddress = macAddress;
+            this.ipAddress = ipAddress;
+        }
+
+        public boolean isDataComplete() {
+            return label != null && products != null;
+        }
+
+    }
 
     public LifxLightDiscovery() throws IllegalArgumentException {
         super(Sets.newHashSet(LifxBindingConstants.THING_TYPE_COLORLIGHT, LifxBindingConstants.THING_TYPE_COLORIRLIGHT,
@@ -99,7 +126,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
         try {
             networkInterfaces = NetworkInterface.getNetworkInterfaces();
         } catch (SocketException e) {
-            logger.debug("An exception occurred while discovering LIFX lights : '{}", e.getMessage());
+            logger.debug("An exception occurred while discovering LIFX lights : '{}'", e.getMessage());
         }
         if (networkInterfaces != null) {
             while (networkInterfaces.hasMoreElements()) {
@@ -123,7 +150,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
                         }
                     }
                 } catch (SocketException e) {
-                    logger.debug("An exception occurred while discovering LIFX lights : '{}", e.getMessage());
+                    logger.debug("An exception occurred while discovering LIFX lights : '{}'", e.getMessage());
                 }
             }
         }
@@ -207,22 +234,21 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
                         Long.toString(source, 16));
 
                 GetServiceRequest packet = new GetServiceRequest();
+                packet.setSequence(SERVICE_REQUEST_SEQ_NO);
+                packet.setSource(source);
+
                 broadcastPacket(packet, broadcastKey);
             } else {
                 logger.info("A discovery scan for LIFX light is already underway");
             }
 
         } catch (Exception e) {
-            logger.debug("An exception occurred while discovering LIFX lights : '{}", e.getMessage());
+            logger.debug("An exception occurred while discovering LIFX lights : '{}'", e.getMessage());
         }
 
     }
 
     private void broadcastPacket(Packet packet, SelectionKey broadcastKey) {
-
-        packet.setSequence(0);
-        packet.setSource(source);
-
         for (InetSocketAddress address : broadcastAddresses) {
             boolean result = false;
             while (!result) {
@@ -293,12 +319,11 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
             try {
 
                 long startStamp = System.currentTimeMillis();
+                discoveredLights.clear();
 
                 logger.trace("Entering read loop at {}", startStamp);
 
                 while (System.currentTimeMillis() - startStamp < SELECTOR_TIMEOUT) {
-
-                    connectionsToSetUp = new ArrayList<ConnectionSetupParameter>();
 
                     if (selector != null && selector.isOpen()) {
                         try {
@@ -383,31 +408,55 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
                             }
                         }
 
-                        // Iterate through the channels that have to be set up, and the packets that have to be sent
-                        // Workaround to avoid a ConcurrentModifictionException on the selector.SelectedKeys() Set
-                        for (ConnectionSetupParameter csp : connectionsToSetUp) {
-                            DatagramChannel unicastChannel = DatagramChannel.open(StandardProtocolFamily.INET)
-                                    .setOption(StandardSocketOptions.SO_REUSEADDR, true);
-                            unicastChannel.configureBlocking(false);
-                            SelectionKey unicastKey = unicastChannel.register(selector,
-                                    SelectionKey.OP_READ | SelectionKey.OP_WRITE);
-                            unicastChannel.connect(csp.ipaddress);
-                            logger.trace("Connected to a light via {}", unicastChannel.getLocalAddress().toString());
-
-                            GetVersionRequest versionPacket = new GetVersionRequest();
-                            versionPacket.setTarget(csp.target);
-                            versionPacket.setSequence(1);
-                            versionPacket.setSource(source);
-
-                            LifxNetworkThrottler.lock();
-                            sendPacket(versionPacket, csp.ipaddress, unicastKey);
-                            LifxNetworkThrottler.unlock();
-                        }
+                        requestAdditionalLightData();
                     }
                 }
                 isScanning = false;
             } catch (Exception e) {
-                logger.error("An exception orccurred while communicating with the light : '{}'", e.getMessage(), e);
+                logger.error("An exception occurred while communicating with the light : '{}'", e.getMessage(), e);
+            }
+        }
+
+        private void requestAdditionalLightData() throws IOException, ClosedChannelException {
+            // Iterate through the channels that have to be set up, and the packets that have to be sent
+            // Workaround to avoid a ConcurrentModifictionException on the selector.SelectedKeys() Set
+            for (DiscoveredLight light : discoveredLights.values()) {
+
+                boolean waitingForLightResponse = System.currentTimeMillis() - light.lastRequestTimeMillis < 200;
+
+                if (!light.isDataComplete() && !waitingForLightResponse) {
+                    DatagramChannel unicastChannel = DatagramChannel.open(StandardProtocolFamily.INET)
+                            .setOption(StandardSocketOptions.SO_REUSEADDR, true);
+                    unicastChannel.configureBlocking(false);
+                    SelectionKey unicastKey = unicastChannel.register(selector,
+                            SelectionKey.OP_READ | SelectionKey.OP_WRITE);
+                    unicastChannel.connect(light.ipAddress);
+                    logger.trace("Connected to a light via {}", unicastChannel.getLocalAddress().toString());
+
+                    if (light.products == null) {
+                        GetVersionRequest versionPacket = new GetVersionRequest();
+                        versionPacket.setTarget(light.macAddress);
+                        versionPacket.setSequence(VERSION_REQUEST_SEQ_NO);
+                        versionPacket.setSource(source);
+
+                        LifxNetworkThrottler.lock(light.macAddress);
+                        sendPacket(versionPacket, light.ipAddress, unicastKey);
+                        LifxNetworkThrottler.unlock(light.macAddress);
+                    }
+
+                    if (light.label == null) {
+                        GetLabelRequest labelPacket = new GetLabelRequest();
+                        labelPacket.setTarget(light.macAddress);
+                        labelPacket.setSequence(LABEL_REQUEST_SEQ_NO);
+                        labelPacket.setSource(source);
+
+                        LifxNetworkThrottler.lock(light.macAddress);
+                        sendPacket(labelPacket, light.ipAddress, unicastKey);
+                        LifxNetworkThrottler.unlock(light.macAddress);
+                    }
+
+                    light.lastRequestTimeMillis = System.currentTimeMillis();
+                }
             }
         }
     };
@@ -420,47 +469,43 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
 
         if (packet.getSource() == source || packet.getSource() == 0) {
 
-            if (packet instanceof StateServiceResponse) {
-                serviceResponses.put(packet.getTarget(), (StateServiceResponse) packet);
-                int port = (int) ((StateServiceResponse) packet).getPort();
+            DiscoveredLight light = discoveredLights.get(packet.getTarget());
 
+            if (packet instanceof StateServiceResponse) {
+                int port = (int) ((StateServiceResponse) packet).getPort();
                 if (port != 0) {
                     try {
-                        ConnectionSetupParameter connectionSetup = new ConnectionSetupParameter();
-                        connectionSetup.ipaddress = new InetSocketAddress(address.getAddress(), port);
-                        connectionSetup.target = packet.getTarget();
-                        connectionsToSetUp.add(connectionSetup);
+                        MACAddress macAddress = packet.getTarget();
+                        InetSocketAddress ipAddress = new InetSocketAddress(address.getAddress(), port);
+                        light = new DiscoveredLight(macAddress, ipAddress);
+                        discoveredLights.put(macAddress, light);
                     } catch (Exception e) {
                         logger.warn("An exception occurred while connecting to IP address : '{}'", e.getMessage());
                         return;
                     }
                 }
+            } else if (packet instanceof StateLabelResponse) {
+                light.label = ((StateLabelResponse) packet).getLabel().trim();
+            } else if (packet instanceof StateVersionResponse) {
+                light.products = Products.getProductFromProductID(((StateVersionResponse) packet).getProduct());
             }
 
-            if (packet instanceof StateVersionResponse) {
-                StateServiceResponse serviceResponse = serviceResponses.get(packet.getTarget());
-
-                if (serviceResponse != null) {
-                    DiscoveryResult discoveryResult = createDiscoveryResult(serviceResponse,
-                            (StateVersionResponse) packet);
-                    if (discoveryResult != null) {
-                        thingDiscovered(discoveryResult);
-                    }
+            if (light != null && light.isDataComplete()) {
+                DiscoveryResult discoveryResult = createDiscoveryResult(light);
+                if (discoveryResult != null) {
+                    thingDiscovered(discoveryResult);
                 }
             }
-
         }
     }
 
-    private DiscoveryResult createDiscoveryResult(StateServiceResponse packet, StateVersionResponse returnedPacket) {
-
-        MACAddress discoveredAddress = packet.getTarget();
+    private DiscoveryResult createDiscoveryResult(DiscoveredLight light) {
         try {
-            Products product = Products.getProductFromProductID(returnedPacket.getProduct());
-            ThingUID thingUID = getUID(discoveredAddress.getAsLabel(), product.isColor(), product.isInfrared());
+            String macAsLabel = light.macAddress.getAsLabel();
+            Products product = light.products;
+            ThingUID thingUID = getUID(macAsLabel, product.isColor(), product.isInfrared());
 
-            String label = "";
-
+            String label = light.label;
             if (StringUtils.isBlank(label)) {
                 label = product.getName();
             }
@@ -468,8 +513,8 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
             logger.trace("Discovered a LIFX light : {}", label);
 
             return DiscoveryResultBuilder.create(thingUID).withLabel(label)
-                    .withProperty(LifxBindingConstants.CONFIG_PROPERTY_DEVICE_ID, discoveredAddress.getAsLabel())
-                    .withRepresentationProperty(discoveredAddress.getAsLabel()).build();
+                    .withProperty(LifxBindingConstants.CONFIG_PROPERTY_DEVICE_ID, macAsLabel)
+                    .withRepresentationProperty(macAsLabel).build();
         } catch (IllegalArgumentException e) {
             logger.trace("Ignoring packet: {}", e);
             return null;
@@ -486,11 +531,6 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
         } else {
             return new ThingUID(LifxBindingConstants.THING_TYPE_WHITELIGHT, hex);
         }
-    }
-
-    private class ConnectionSetupParameter {
-        public MACAddress target;
-        public InetSocketAddress ipaddress;
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxNetworkThrottler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxNetworkThrottler.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,15 +67,15 @@ public class LifxNetworkThrottler {
      */
     private static List<LifxLightCommunicationTracker> trackers = new CopyOnWriteArrayList<>();
 
-    private static Map<String, LifxLightCommunicationTracker> macTrackerMapping = new ConcurrentHashMap<String, LifxLightCommunicationTracker>();
+    private static Map<MACAddress, LifxLightCommunicationTracker> macTrackerMapping = new ConcurrentHashMap<MACAddress, LifxLightCommunicationTracker>();
 
-    public static void lock(String mac) {
+    public static void lock(MACAddress mac) {
         LifxLightCommunicationTracker tracker = getOrCreateTracker(mac);
         tracker.lock();
         waitForNextPacketInterval(tracker.getTimestamp());
     }
 
-    private static LifxLightCommunicationTracker getOrCreateTracker(String mac) {
+    private static LifxLightCommunicationTracker getOrCreateTracker(MACAddress mac) {
         LifxLightCommunicationTracker tracker = macTrackerMapping.get(mac);
         if (tracker == null) {
             // for better performance only synchronize when necessary
@@ -102,7 +103,7 @@ public class LifxNetworkThrottler {
         }
     }
 
-    public static void unlock(String mac) {
+    public static void unlock(MACAddress mac) {
         if (macTrackerMapping.containsKey(mac)) {
             macTrackerMapping.get(mac).unlock();
         }


### PR DESCRIPTION
This PR adds light label discovery functionality based on the label used in the LIFX App. 
This improves the discovery user experience when working with a lot of lights.

Also the discovery process was further improved. Discovery now:
* only sends requests for missing light data
* waits 200ms before resending requests because it takes time for a response to arrive
* locks on one light only (and not all lights) when sending a packet to a specific light

With the above improvements I've seen the number of sent packets per `networkRunnable.run()` drop significantly. In my setup the number of sent packets per run has dropped by ~99% (from ~12538 to just ~177 packets, including the new label request packets).

Also the code has been reworked:
* it should be easier to add code for discovering additional light properties
* a `MACAddress` instead of a `String` is used to make sure all code is using the same light identifier when getting a lock