### PR TITLE
updated unit-api on target platform

### DIFF
--- a/targetplatform/smarthome.target
+++ b/targetplatform/smarthome.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="SmartHome" sequenceNumber="104">
+<?pde version="3.8"?><target name="SmartHome" sequenceNumber="105">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.inject" version="3.0.0.v201312141243"/>
@@ -138,8 +138,7 @@
 <unit id="com.jayway.jsonpath.json-path" version="2.0.0"/>
 <unit id="org.mapdb.mapdb" version="1.0.9"/>
 <unit id="net.minidev.json-smart" version="2.1.1"/>
-<unit id="javax.measure.unit-api" version="0.8.0"/>
-<unit id="tec.units.unit-ri" version="0.8.0"/>
+<unit id="javax.measure.unit-api" version="1.0.0"/>
 <unit id="org.h2" version="1.3.176"/>
 <unit id="org.osgi.service.jdbc" version="1.0.0.201505202023"/>
 <repository location="http://eclipse.github.io/smarthome/third-party/target/repository"/>


### PR DESCRIPTION
Replaced the unit-api 0.8 and unit-ri 0.8 bundles by unit-api 1.0 and uom-se 1.0.2 by https://github.com/eclipse/smarthome/commit/9f23b63a16fbd10ac86ab87acf39859617a09882.

This PR updates the smarthome.target to use the unit-api 1.0 now.
Unfortunately, we cannot yet add uom-se to the tp, since it has a dependency on javax.annotation 1.3.0, which is not available on Orbit. I guess we will need another CQ for it.

Signed-off-by: Kai Kreuzer <kai@openhab.org>