### PR TITLE
use endtime for last datapoint in boundary query

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/persistence/PersistenceResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/persistence/PersistenceResource.java
@@ -303,7 +303,7 @@ public class PersistenceResource implements SatisfiableRESTResource {
             filter.setOrdering(Ordering.ASCENDING);
             result = qService.query(filter);
             if (result != null && result.iterator().hasNext()) {
-                dto.addData(result.iterator().next().getTimestamp().getTime(), result.iterator().next().getState());
+                dto.addData(dateTimeEnd.getTime(), result.iterator().next().getState());
                 quantity++;
             }
         }


### PR DESCRIPTION
Fixes #2538 

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>