### PR TITLE
apply default configuration to channels in GenericThingProvider

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/OSGI-INF/HueConfigDescriptionProvider.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/OSGI-INF/HueConfigDescriptionProvider.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.eclipse.smarthome.model.thing.test.hue.TestHueConfigDescriptionProvider">
+   <implementation class="org.eclipse.smarthome.model.thing.test.hue.TestHueConfigDescriptionProvider"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.config.core.ConfigDescriptionProvider"/>
+   </service>
+</scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueConfigDescriptionProvider.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueConfigDescriptionProvider.groovy
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.model.thing.test.hue
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+import static org.junit.matchers.JUnitMatchers.*
+
+import org.eclipse.smarthome.config.core.ConfigDescription
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
+import org.eclipse.smarthome.config.core.ConfigDescriptionProvider
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type
+
+/**
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ *
+ */
+class TestHueConfigDescriptionProvider implements ConfigDescriptionProvider {
+
+    @Override
+    public Collection<ConfigDescription> getConfigDescriptions(Locale locale) {
+        return null
+    }
+
+    @Override
+    public ConfigDescription getConfigDescription(URI uri, Locale locale) {
+        if (uri.equals(new URI("hue:LCT001:color"))) {
+            ConfigDescriptionParameter configDescriptionParameter = [
+                getName: "defaultConfig",
+                getType: Type.TEXT,
+                getDefault: "defaultValue"
+            ] as ConfigDescriptionParameter
+            return new ConfigDescription(uri, Collections.singletonList(configDescriptionParameter))
+        }
+        return null
+    }
+}

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest.groovy
@@ -485,4 +485,26 @@ class GenericThingProviderTest extends OSGiTest {
         assertThat actualThings.size(), is(0)
     }
 
+    @Test
+    void 'assert that default configurations are applied to channels'() {
+        assertThat thingRegistry.getAll().size(), is(0)
+
+        String model =
+                '''
+            Bridge hue:bridge:myBridge @ "basement" [ ] {
+                LCT001 myBulb [ lightId = "1" ] {
+                    Type color : myChannel []
+                }
+            }
+            '''
+        modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.bytes))
+        def List<Thing> actualThings = thingRegistry.getAll()
+
+        // ensure a standard channel has its default values
+        assertThat actualThings.find {"hue:LCT001:myBridge:myBulb".equals(it.UID.toString())}.getChannel("color").getConfiguration().get("defaultConfig"), is(equalTo("defaultValue"))
+
+        // ensure a user-defined channel has its default values
+        assertThat actualThings.find {"hue:LCT001:myBridge:myBulb".equals(it.UID.toString())}.getChannel("myChannel").getConfiguration().get("defaultConfig"), is(equalTo("defaultValue"))
+    }
+
 }

--- a/bundles/model/org.eclipse.smarthome.model.thing/OSGI-INF/genericthingprovider.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing/OSGI-INF/genericthingprovider.xml
@@ -18,4 +18,5 @@
    <reference bind="addThingHandlerFactory" cardinality="0..n" interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory" name="ThingHandlerFactory" policy="dynamic" unbind="removeThingHandlerFactory"/>
    <reference bind="addBundleProcessor" cardinality="0..n" interface="org.eclipse.smarthome.config.core.BundleProcessor" name="BundleProcessor" policy="dynamic" unbind="removeBundleProcessor"/>
    <reference bind="setLocaleProvider" cardinality="1..1" interface="org.eclipse.smarthome.core.i18n.LocaleProvider" name="LocaleProvider" policy="static" unbind="unsetLocaleProvider"/>
+   <reference bind="setConfigDescriptionRegistry" cardinality="1..1" interface="org.eclipse.smarthome.config.core.ConfigDescriptionRegistry" name="ConfigDescriptionRegistry" policy="static" unbind="unsetConfigDescriptionRegistry"/>
 </scr:component>


### PR DESCRIPTION
So far, user-defined channels referencing an existing ChannelType did not
have the default configuration values set which were defined in the XML.
Now they do.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>