### PR TITLE
Set min width/height of text control

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -1191,6 +1191,8 @@ input[type=number].multiSel::-webkit-outer-spin-button {
 .textControl .state {
 	font-size: 30px;
 	font-weight: 300;
+	min-height: 40px;
+	min-width: 140px;
 }
 
 .searchBox {


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/2736
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>