### PR TITLE
DiscoveryResults not updated on DiscoveryService change

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/ExtendedDiscoveryServiceMock.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/ExtendedDiscoveryServiceMock.groovy
@@ -23,9 +23,11 @@ import org.eclipse.smarthome.core.thing.ThingUID
 class ExtendedDiscoveryServiceMock extends DiscoveryServiceMock implements ExtendedDiscoveryService {
 
     public DiscoveryServiceCallback discoveryServiceCallback
+    public Map<String, Object> discoveryProperties;
 
     public ExtendedDiscoveryServiceMock(thingType, timeout, faulty = false) {
         super(thingType, timeout)
+        this.discoveryProperties = null;
     }
 
     @Override
@@ -35,6 +37,11 @@ class ExtendedDiscoveryServiceMock extends DiscoveryServiceMock implements Exten
 
     @Override
     public void startScan() {
-        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, "foo"), null, null, null, null, DEFAULT_TTL))
+        thingDiscovered(new DiscoveryResultImpl(new ThingUID(thingType, "foo"), null, discoveryProperties, null, null, DEFAULT_TTL))
     }
+    
+    public void setDiscoveryProperties(Map<String, Object> discoveryProperties) {
+        this.discoveryProperties = discoveryProperties;
+    }
+    
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -258,6 +258,7 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
     @Override
     public synchronized void thingDiscovered(final DiscoveryService source, final DiscoveryResult result) {
         synchronized (cachedResults) {
+            cachedResults.remove(source, result);
             cachedResults.put(source, result);
         }
         for (final DiscoveryListener listener : this.listeners) {


### PR DESCRIPTION
When particular DiscoveryService is changed (eg. there are new properties added to the discovery results) the already discovered things are not been updated.

This is due to the cache used in DiscoveryServiceRegistryImpl:

`private HashMultimap<DiscoveryService, DiscoveryResult> cachedResults = HashMultimap.create();`

Javadoc of `HashMultimap` says: 
`Adding a new key-value pair equal to an existing key-value pair has no effect.`

Possible solution is - each time an entry is put to the map - already existing entry to be first removed from the map