### PR TITLE
[RFC] introduce CREATED and DELETED events for Things and Items

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingCreatedEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingCreatedEvent.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.events;
+
+import org.eclipse.smarthome.core.thing.dto.ThingDTO;
+
+/**
+ * A {@link ThingCreatedEvent} notifies subscribers that a thing has been created.
+ * Thing created events must be created with the {@link ThingEventFactory}.
+ *
+ * @author Simon Kaufmann - Initial contribution and API
+ */
+public class ThingCreatedEvent extends AbstractThingRegistryEvent {
+
+    /**
+     * The thing added event type.
+     */
+    public final static String TYPE = ThingCreatedEvent.class.getSimpleName();
+
+    /**
+     * Constructs a new thing created event object.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param thing the thing data transfer object
+     */
+    protected ThingCreatedEvent(String topic, String payload, ThingDTO thing) {
+        super(topic, payload, null, thing);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return "Thing '" + getThing().UID + "' has been created.";
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingDeletedEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingDeletedEvent.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.events;
+
+import org.eclipse.smarthome.core.thing.dto.ThingDTO;
+
+/**
+ * A {@link ThingDeletedEvent} notifies subscribers that a thing has been deleted.
+ * Thing deleted events must be created with the {@link ThingEventFactory}.
+ *
+ * @author Simon Kaufmann - Initial contribution and API.
+ */
+public class ThingDeletedEvent extends AbstractThingRegistryEvent {
+
+    /**
+     * The thing removed event type.
+     */
+    public final static String TYPE = ThingDeletedEvent.class.getSimpleName();
+
+    /**
+     * Constructs a new thing deleted event object.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param thing the thing data transfer object
+     */
+    protected ThingDeletedEvent(String topic, String payload, ThingDTO thing) {
+        super(topic, payload, null, thing);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return "Thing '" + getThing().UID + "' has been deleted.";
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactory.java
@@ -8,6 +8,7 @@
 package org.eclipse.smarthome.core.thing.events;
 
 import java.util.List;
+
 import org.eclipse.smarthome.core.events.AbstractEventFactory;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -17,6 +18,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.dto.ThingDTO;
 import org.eclipse.smarthome.core.thing.dto.ThingDTOMapper;
 import org.eclipse.smarthome.core.types.Type;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -38,6 +40,10 @@ public class ThingEventFactory extends AbstractEventFactory {
 
     private static final String THING_UPDATED_EVENT_TOPIC = "smarthome/things/{thingUID}/updated";
 
+    private static final String THING_CREATED_EVENT_TOPIC = "smarthome/things/{thingUID}/created";
+
+    private static final String THING_DELETED_EVENT_TOPIC = "smarthome/things/{thingUID}/deleted";
+
     private static final String CHANNEL_TRIGGERED_EVENT_TOPIC = "smarthome/channels/{channelUID}/triggered";
 
     /**
@@ -45,7 +51,8 @@ public class ThingEventFactory extends AbstractEventFactory {
      */
     public ThingEventFactory() {
         super(Sets.newHashSet(ThingStatusInfoEvent.TYPE, ThingStatusInfoChangedEvent.TYPE, ThingAddedEvent.TYPE,
-                ThingRemovedEvent.TYPE, ThingUpdatedEvent.TYPE, ChannelTriggeredEvent.TYPE));
+                ThingRemovedEvent.TYPE, ThingUpdatedEvent.TYPE, ChannelTriggeredEvent.TYPE, ThingCreatedEvent.TYPE,
+                ThingDeletedEvent.TYPE));
     }
 
     @Override
@@ -57,8 +64,12 @@ public class ThingEventFactory extends AbstractEventFactory {
             event = createStatusInfoChangedEvent(topic, payload);
         } else if (eventType.equals(ThingAddedEvent.TYPE)) {
             event = createAddedEvent(topic, payload);
+        } else if (eventType.equals(ThingCreatedEvent.TYPE)) {
+            event = createCreatedEvent(topic, payload);
         } else if (eventType.equals(ThingRemovedEvent.TYPE)) {
             event = createRemovedEvent(topic, payload);
+        } else if (eventType.equals(ThingDeletedEvent.TYPE)) {
+            event = createDeletedEvent(topic, payload);
         } else if (eventType.equals(ThingUpdatedEvent.TYPE)) {
             event = createUpdatedEvent(topic, payload);
         } else if (eventType.equals(ChannelTriggeredEvent.TYPE)) {
@@ -145,6 +156,11 @@ public class ThingEventFactory extends AbstractEventFactory {
         return new ThingStatusInfoChangedEvent(topic, payload, thingUID, thingStatusInfo[0], thingStatusInfo[1]);
     }
 
+    private Event createCreatedEvent(String topic, String payload) throws Exception {
+        ThingDTO thingDTO = deserializePayload(payload, ThingDTO.class);
+        return new ThingCreatedEvent(topic, payload, thingDTO);
+    }
+
     private Event createAddedEvent(String topic, String payload) throws Exception {
         ThingDTO thingDTO = deserializePayload(payload, ThingDTO.class);
         return new ThingAddedEvent(topic, payload, thingDTO);
@@ -153,6 +169,11 @@ public class ThingEventFactory extends AbstractEventFactory {
     private Event createRemovedEvent(String topic, String payload) throws Exception {
         ThingDTO thingDTO = deserializePayload(payload, ThingDTO.class);
         return new ThingRemovedEvent(topic, payload, thingDTO);
+    }
+
+    private Event createDeletedEvent(String topic, String payload) throws Exception {
+        ThingDTO thingDTO = deserializePayload(payload, ThingDTO.class);
+        return new ThingDeletedEvent(topic, payload, thingDTO);
     }
 
     private Event createUpdatedEvent(String topic, String payload) throws Exception {
@@ -206,6 +227,23 @@ public class ThingEventFactory extends AbstractEventFactory {
     }
 
     /**
+     * Creates a thing created event.
+     *
+     * @param thing the thing
+     *
+     * @return the created thing created event
+     *
+     * @throws IllegalArgumentException if thing is null
+     */
+    public static ThingCreatedEvent createCreatedEvent(Thing thing) {
+        assertValidArgument(thing);
+        String topic = buildTopic(THING_CREATED_EVENT_TOPIC, thing.getUID());
+        ThingDTO thingDTO = map(thing);
+        String payload = serializePayload(thingDTO);
+        return new ThingCreatedEvent(topic, payload, thingDTO);
+    }
+
+    /**
      * Creates a thing added event.
      *
      * @param thing the thing
@@ -237,6 +275,23 @@ public class ThingEventFactory extends AbstractEventFactory {
         ThingDTO thingDTO = map(thing);
         String payload = serializePayload(thingDTO);
         return new ThingRemovedEvent(topic, payload, thingDTO);
+    }
+
+    /**
+     * Creates a thing deleted event.
+     *
+     * @param thing the thing
+     *
+     * @return the created thing deleted event
+     *
+     * @throws IllegalArgumentException if thing is null
+     */
+    public static ThingDeletedEvent createDeletedEvent(Thing thing) {
+        assertValidArgument(thing);
+        String topic = buildTopic(THING_DELETED_EVENT_TOPIC, thing.getUID());
+        ThingDTO thingDTO = map(thing);
+        String payload = serializePayload(thingDTO);
+        return new ThingDeletedEvent(topic, payload, thingDTO);
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -63,6 +65,8 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
             .synchronizedList(new ArrayList<StateDescriptionProvider>());
 
     private Map<String, Integer> stateDescriptionProviderRanking = new ConcurrentHashMap<>();
+
+    private Set<Provider<Item>> providersInLifecyclePhase = Collections.synchronizedSet(new HashSet<Provider<Item>>());
 
     public ItemRegistryImpl() {
         super(ItemProvider.class);
@@ -383,6 +387,9 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     @Override
     protected void notifyListenersAboutAddedElement(Item element) {
         super.notifyListenersAboutAddedElement(element);
+        if (!providersInLifecyclePhase.contains(getProvider(element))) {
+            postEvent(ItemEventFactory.createCreatedEvent(element));
+        }
         postEvent(ItemEventFactory.createAddedEvent(element));
     }
 
@@ -390,6 +397,9 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     protected void notifyListenersAboutRemovedElement(Item element) {
         super.notifyListenersAboutRemovedElement(element);
         postEvent(ItemEventFactory.createRemovedEvent(element));
+        if (!providersInLifecyclePhase.contains(getProvider(element))) {
+            postEvent(ItemEventFactory.createDeletedEvent(element));
+        }
     }
 
     @Override
@@ -456,6 +466,47 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
             for (Item item : getItems()) {
                 ((GenericItem) item).setStateDescriptionProviders(stateDescriptionProviders);
             }
+        }
+    }
+
+    private Provider<Item> getProvider(Item item) {
+        for (Entry<Provider<Item>, Collection<Item>> entry : elementMap.entrySet()) {
+            if (entry.getValue().contains(item)) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void added(Provider<Item> provider, Item element) {
+        synchronized (provider) {
+            super.added(provider, element);
+        }
+    }
+
+    @Override
+    public void removed(Provider<Item> provider, Item element) {
+        synchronized (provider) {
+            super.removed(provider, element);
+        }
+    }
+
+    @Override
+    protected void addProvider(Provider<Item> provider) {
+        synchronized (provider) {
+            providersInLifecyclePhase.add(provider);
+            super.addProvider(provider);
+            providersInLifecyclePhase.remove(provider);
+        }
+    }
+
+    @Override
+    protected void removeProvider(Provider<Item> provider) {
+        synchronized (provider) {
+            providersInLifecyclePhase.add(provider);
+            super.removeProvider(provider);
+            providersInLifecyclePhase.remove(provider);
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemCreatedEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemCreatedEvent.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.items.events;
+
+import org.eclipse.smarthome.core.items.dto.ItemDTO;
+
+/**
+ * An {@link ItemCreatedEvent} notifies subscribers that an item has been created.
+ * Item created events must be created with the {@link ItemEventFactory}.
+ *
+ * @author Simon Kaufmann - Initial contribution and API.
+ */
+public class ItemCreatedEvent extends AbstractItemRegistryEvent {
+
+    /**
+     * The item added event type.
+     */
+    public final static String TYPE = ItemCreatedEvent.class.getSimpleName();
+
+    /**
+     * Constructs a new item created event object.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param item the item data transfer object
+     */
+    protected ItemCreatedEvent(String topic, String payload, ItemDTO item) {
+        super(topic, payload, null, item);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return "Item '" + getItem().name + "' has been created.";
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemDeletedEvent.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemDeletedEvent.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.items.events;
+
+import org.eclipse.smarthome.core.items.dto.ItemDTO;
+
+/**
+ * An {@link ItemDeletedEvent} notifies subscribers that an item has been deleted.
+ * Item deleted events must be created with the {@link ItemEventFactory}.
+ *
+ * @author Simon Kaufmann - Initial contribution and API
+ */
+public class ItemDeletedEvent extends AbstractItemRegistryEvent {
+
+    /**
+     * The item removed event type.
+     */
+    public final static String TYPE = ItemDeletedEvent.class.getSimpleName();
+
+    /**
+     * Constructs a new item deleted event object.
+     *
+     * @param topic the topic
+     * @param payload the payload
+     * @param item the item data transfer object
+     */
+    protected ItemDeletedEvent(String topic, String payload, ItemDTO item) {
+        super(topic, payload, null, item);
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    @Override
+    public String toString() {
+        return "Item '" + getItem().name + "' has been deleted.";
+    }
+
+}

--- a/docs/documentation/features/events.md
+++ b/docs/documentation/features/events.md
@@ -31,28 +31,34 @@ The type of an event is represented by a string, usually the name of the concret
 
 The event source is optional and represents the name of the source identifying the sender.
 
+The actions generally are specific for the entity types. Nevertheless, it is worth mentioning that there is a subtle difference in the semantics of `created`/`deleted` vs. `added`/`removed` events. The `created`/`deleted` events occur whenever an entity is added to or removed from a provider. This happens e.g. whenever a user creates a new one or deletes it. An `added`/`removed` event will be sent out in addition to ensure backward compatibility. In contrast, the `added`/`removed` events are also triggered by providers which are (un-)registered from their registries. Hence the `added`/`removed` events might also get sent during startup/shutdown of the system. Therefore, whenever only a `removed` event is received for a specific entity (e.g. during shutdown), it's likely that this entity will reappear at a later point in time (e.g. at the next startup). On the other hand, if a `deleted` event is received for an entity, it really got deleted from the system and won't show up again, so e.g. further cleanup of additional related data would make sense.  
+
 #### Item Events
 
-| Event                 |Description                                      |Topic                                   |
-|-----------------------|-------------------------------------------------|----------------------------------------|
-| ItemAddedEvent        |An item has been added to the item registry.     |smarthome/items/{itemName}/added        |
-| ItemRemovedEvent      |An item has been removed from the item registry. |smarthome/items/{itemName}/removed      |
-| ItemUpdatedEvent      |An item has been updated in the item registry.   |smarthome/items/{itemName}/updated      |
-| ItemCommandEvent      |A command is sent to an item via a channel.      |smarthome/items/{itemName}/command      |
-| ItemStateEvent        |The state of an item is updated.                 |smarthome/items/{itemName}/state        |
-| ItemStateChangedEvent |The state of an item has changed.                |smarthome/items/{itemName}/statechanged |
+| Event                 |Description                                                        |Topic                                   |
+|-----------------------|-------------------------------------------------------------------|----------------------------------------|
+| ItemCreatedEvent      |An item has been newly created and was added to the item registry. |smarthome/items/{itemName}/created      |
+| ItemAddedEvent        |An item or its provider was added to the item registry.            |smarthome/items/{itemName}/added        |
+| ItemRemovedEvent      |An item or its provider was removed from the item registry.        |smarthome/items/{itemName}/removed      |
+| ItemDeletedEvent      |An item has been deleted from the item registry.                   |smarthome/items/{itemName}/deleted      |
+| ItemUpdatedEvent      |An item has been updated in the item registry.                     |smarthome/items/{itemName}/updated      |
+| ItemCommandEvent      |A command is sent to an item via a channel.                        |smarthome/items/{itemName}/command      |
+| ItemStateEvent        |The state of an item is updated.                                   |smarthome/items/{itemName}/state        |
+| ItemStateChangedEvent |The state of an item has changed.                                  |smarthome/items/{itemName}/statechanged |
 
 **Note:** The ItemStateEvent is always sent if the state of an item is updated, even if the state did not change. ItemStateChangedEvent is sent only if the state of an item was really changed. It contains the old and the new state of the item.
 
 #### Thing Events
 
-| Event                 |Description                                       |Topic                                   |
-|-----------------------|-------------------------------------------------|-----------------------------------|
-| ThingAddedEvent         |A thing has been added to the thing registry.    |smarthome/things/{thingUID}/added  |
-| ThingRemovedEvent      |A thing has been removed from the thing registry.|smarthome/things/{thingUID}/removed|
-| ThingUpdatedEvent     |A thing has been updated in the thing registry.  |smarthome/things/{thingUID}/updated|
-| ThingStatusInfoEvent    |The status of a thing is updated.                  |smarthome/things/{thingUID}/status |
-| ThingStatusInfoChangedEvent    |The status of a thing changed.                  |smarthome/things/{thingUID}/statuschanged |
+| Event                       |Description                                                         |Topic                                     |
+|-----------------------------|--------------------------------------------------------------------|------------------------------------------|
+| ThingCreatedEvent           |A thing has been newly created and was added to the thing registry. |smarthome/things/{thingUID}/created       |
+| ThingAddedEvent             |A thing or its provider was added to the thing registry.            |smarthome/things/{thingUID}/added         |
+| ThingRemovedEvent           |A thing or its provider was removed from the thing registry.        |smarthome/things/{thingUID}/removed       |
+| ThingDeletedEvent           |A thing has been deleted from the thing registry.                   |smarthome/things/{thingUID}/deleted       |
+| ThingUpdatedEvent           |A thing has been updated in the thing registry.                     |smarthome/things/{thingUID}/updated       |
+| ThingStatusInfoEvent        |The status of a thing is updated.                                   |smarthome/things/{thingUID}/status        |
+| ThingStatusInfoChangedEvent |The status of a thing changed.                                      |smarthome/things/{thingUID}/statuschanged |
 
 **Note:** The ThingStatusInfoEvent is always sent if the status info of a thing is updated, even if the status did not change. ThingStatusInfoChangedEvent is sent only if the status of a thing was really changed. It contains the old and the new status of the thing.
 


### PR DESCRIPTION
in order to allow distinguishing ADDED/REMOVED (which might also be caused by providers being added/removed , e.g. during startup/shutdown) from real CREATION and DELETION.

We had several discussions by now related to this topic (e.g. #1896). While in a dynamic system it is really hard to tell if startup/shudown is "finished", this PR is an attempt to ease the pain. I'm open for better suggestions, of course.

So, WDYT? 

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>