### PR TITLE
allow overriding of channel configurations within channel groups

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueChannelTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueChannelTypeProvider.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
@@ -34,7 +35,10 @@ public class TestHueChannelTypeProvider implements ChannelTypeProvider {
     public static final ChannelTypeUID COLOR_TEMP_CHANNEL_TYPE_UID = new ChannelTypeUID("hue:color_temperature");
     public static final ChannelTypeUID COLOR_CHANNEL_TYPE_UID = new ChannelTypeUID("hue:color");
 
+    public static final ChannelGroupTypeUID GROUP_CHANNEL_GROUP_TYPE_UID = new ChannelGroupTypeUID("hue", "group");
+
     private List<ChannelType> channelTypes;
+    private List<ChannelGroupType> channelGroupTypes;
 
     public TestHueChannelTypeProvider() {
         try {
@@ -49,6 +53,13 @@ public class TestHueChannelTypeProvider implements ChannelTypeProvider {
                     "colorTemperatureLabel", "description", null, null, null,
                     new URI("Xhue", "XLCT001:Xcolor_temperature", null));
             channelTypes = Lists.newArrayList(ctColor, ctColorTemperature, ctColorX, ctColorTemperatureX);
+
+            ChannelGroupType groupX = new ChannelGroupType(GROUP_CHANNEL_GROUP_TYPE_UID, false, "Channel Group",
+                    "Channel Group",
+                    Lists.newArrayList(new ChannelDefinition("foo", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID),
+                            new ChannelDefinition("bar", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID)));
+            channelGroupTypes = Lists.newArrayList(groupX);
+
         } catch (Exception willNeverBeThrown) {
         }
     }
@@ -70,12 +81,17 @@ public class TestHueChannelTypeProvider implements ChannelTypeProvider {
 
     @Override
     public ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID, Locale locale) {
+        for (ChannelGroupType channelGroupType : channelGroupTypes) {
+            if (channelGroupType.getUID().equals(channelGroupTypeUID)) {
+                return channelGroupType;
+            }
+        }
         return null;
     }
 
     @Override
     public Collection<ChannelGroupType> getChannelGroupTypes(Locale locale) {
-        return Lists.newArrayList();
+        return channelGroupTypes;
     }
 
 }

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueConfigDescriptionProvider.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueConfigDescriptionProvider.groovy
@@ -16,6 +16,8 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
 import org.eclipse.smarthome.config.core.ConfigDescriptionProvider
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type
 
+import com.google.common.collect.Lists
+
 /**
  *
  * @author Simon Kaufmann - initial contribution and API
@@ -30,13 +32,19 @@ class TestHueConfigDescriptionProvider implements ConfigDescriptionProvider {
 
     @Override
     public ConfigDescription getConfigDescription(URI uri, Locale locale) {
+        System.err.println(uri)
         if (uri.equals(new URI("hue:LCT001:color"))) {
-            ConfigDescriptionParameter configDescriptionParameter = new ConfigDescriptionParameter("defaultConfig", Type.TEXT) {
+            ConfigDescriptionParameter paramDefault = new ConfigDescriptionParameter("defaultConfig", Type.TEXT) {
                         String getDefault() {
                             return "defaultValue"
                         };
                     }
-            return new ConfigDescription(uri, Collections.singletonList(configDescriptionParameter))
+            ConfigDescriptionParameter paramCustom = new ConfigDescriptionParameter("customConfig", Type.TEXT) {
+                        String getDefault() {
+                            return "none"
+                        };
+                    }
+            return new ConfigDescription(uri, Lists.newArrayList(paramDefault, paramCustom));
         }
         return null
     }

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactory.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactory.java
@@ -10,10 +10,12 @@ package org.eclipse.smarthome.model.thing.test.hue;
 import java.util.Set;
 
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
@@ -33,12 +35,13 @@ public class TestHueThingHandlerFactory extends BaseThingHandlerFactory {
     public final static ThingTypeUID THING_TYPE_BRIDGE = new ThingTypeUID(BINDING_ID, "bridge");
     public final static ThingTypeUID THING_TYPE_LCT001 = new ThingTypeUID(BINDING_ID, "LCT001");
     public final static ThingTypeUID THING_TYPE_TEST = new ThingTypeUID(BINDING_ID, "TEST");
+    public final static ThingTypeUID THING_TYPE_GROUPED = new ThingTypeUID(BINDING_ID, "grouped");
     public final static ThingTypeUID THING_TYPE_LONG_NAME = new ThingTypeUID(BINDING_ID,
             "1-thing-id-with-5-dashes_and_3_underscores");
 
     public final static Set<ThingTypeUID> SUPPORTED_BRIDGE_TYPES = Sets.newHashSet(THING_TYPE_BRIDGE);
     public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES = Sets.newHashSet(THING_TYPE_LCT001, THING_TYPE_TEST,
-            THING_TYPE_LONG_NAME);
+            THING_TYPE_LONG_NAME, THING_TYPE_GROUPED);
     public final static Set<ThingTypeUID> SUPPORTED_TYPES = Sets.union(SUPPORTED_BRIDGE_TYPES, SUPPORTED_THING_TYPES);
 
     // List all channels
@@ -93,11 +96,20 @@ public class TestHueThingHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     protected ThingHandler createHandler(Thing thing) {
-        return new BaseThingHandler(thing) {
-            @Override
-            public void handleCommand(ChannelUID channelUID, Command command) {
-            }
-        };
+        if (thing instanceof Bridge) {
+            return new BaseBridgeHandler((Bridge) thing) {
+                @Override
+                public void handleCommand(ChannelUID channelUID, Command command) {
+                }
+            };
+        } else {
+            return new BaseThingHandler(thing) {
+                @Override
+                public void handleCommand(ChannelUID channelUID, Command command) {
+                }
+            };
+        }
+
     }
 
     @Override

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingTypeProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.type.BridgeType;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +69,15 @@ public class TestHueThingTypeProvider implements ThingTypeProvider {
                             Lists.newArrayList(TestHueThingHandlerFactoryX.THING_TYPE_BRIDGE.toString()), "XLCT001",
                             "Hue LAMP", false, Lists.newArrayList(colorX, colorTempX), null, null,
                             new URI("Xhue", "XLCT001", null)));
+
+            ChannelGroupDefinition groupDefinition = new ChannelGroupDefinition("group",
+                    TestHueChannelTypeProvider.GROUP_CHANNEL_GROUP_TYPE_UID);
+            thingTypes.put(TestHueThingHandlerFactory.THING_TYPE_GROUPED,
+                    new ThingType(TestHueThingHandlerFactory.THING_TYPE_GROUPED,
+                            Lists.newArrayList(TestHueThingHandlerFactory.THING_TYPE_BRIDGE.toString()), "grouped",
+                            "Grouped Lamp", null, Lists.newArrayList(groupDefinition), null,
+                            new URI("hue", "grouped", null)));
+
         } catch (Exception e) {
             logger.error(e.getMessage());
         }

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/Thing.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/Thing.xtext
@@ -49,7 +49,7 @@ ModelThing:
 ;
 
 ModelChannel:
-	(((channelKind= ('State' | 'Trigger'))? type=ModelItemType) | 'Type' channelType=UID_SEGMENT) ':' id=UID_SEGMENT
+	(((channelKind= ('State' | 'Trigger'))? type=ModelItemType) | 'Type' channelType=UID_SEGMENT) ':' id=CHANNEL_ID
     (label=STRING)?
 	('['
 		properties+=ModelProperty (',' properties+=ModelProperty)*
@@ -62,6 +62,10 @@ ModelItemType :
 
 ModelProperty:
 	key=ID '=' value=ValueType
+;
+
+CHANNEL_ID:
+    UID_SEGMENT ('#' UID_SEGMENT)?
 ;
 
 UID:


### PR DESCRIPTION
...as so far such channels could not be referenced in the DSL
('#' was not allowed as part of the channel id)

fixes openhab/openhab2-addons#1264
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>