### PR TITLE
fix transformation in empty label

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -330,7 +330,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                     }
                 }
 
-                label = label.trim().substring(0, label.indexOf("[") + 1) + formatPattern + "]";
+                label = label.trim();
+                label = label.substring(0, label.indexOf("[") + 1) + formatPattern + "]";
             }
         }
 


### PR DESCRIPTION
issue #2371

Comment: The problem seems to be that label.indexOf is evaluated before label.trim() has been executed. In case of an empty label a space might occur before the opening square bracket. That is trimmed, but the index is 1 where it should be 0. This has been fixed by moving the .trim() to a seperate statement.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>