### PR TITLE
removed dependency="true" from features

### DIFF
--- a/features/karaf/esh-ext/src/main/feature/feature.xml
+++ b/features/karaf/esh-ext/src/main/feature/feature.xml
@@ -68,9 +68,9 @@
   <feature name="esh-transform-jsonpath" description="JSONPath Transformation" version="${project.version}">
     <feature>esh-base</feature>
     <bundle start-level="75">mvn:org.eclipse.smarthome.transform/org.eclipse.smarthome.transform.jsonpath/${project.version}</bundle>
-    <bundle dependency="true">mvn:com.jayway.jsonpath/json-path/2.0.0</bundle>
-    <bundle dependency="true">mvn:net.minidev/asm/1.0.2</bundle>
-    <bundle dependency="true">mvn:net.minidev/json-smart/2.1.1</bundle>
+    <bundle>mvn:com.jayway.jsonpath/json-path/2.0.0</bundle>
+    <bundle>mvn:net.minidev/asm/1.0.2</bundle>
+    <bundle>mvn:net.minidev/json-smart/2.1.1</bundle>
   </feature>
 
   <feature name="esh-transform-map" description="Map Transformation" version="${project.version}">
@@ -101,7 +101,7 @@
   <feature name="esh-ui-basic" version="${project.version}">
     <feature>esh-base</feature>
     <feature>esh-ui</feature>
-    <feature dependency="true">esh-io-rest-sitemap</feature>
+    <feature>esh-io-rest-sitemap</feature>
     <bundle>mvn:org.eclipse.smarthome.extension.ui/org.eclipse.smarthome.ui.basic/${project.version}</bundle>
   </feature>
 


### PR DESCRIPTION
This setting caused the bundles not being added to KAR files, but we should not expect these bundles being available to Karaf-based solutions, so they need to be a part of our features.

Signed-off-by: Kai Kreuzer <kai@openhab.org>