### PR TITLE
state that null is an allowed return value

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/handler/ActionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/handler/ActionHandler.java
@@ -28,7 +28,7 @@ public interface ActionHandler extends ModuleHandler {
      *
      * @param context contains action input values and snapshot of all module output values. The output ids are defined
      *            in form: ModuleId.outputId
-     * @return values map of values which must be set to outputs of the {@link Action}.
+     * @return values map of values which must be set to outputs of the {@link Action} (may be null).
      */
     public Map<String, Object> execute(Map<String, ?> context);
 


### PR DESCRIPTION
The current JavaDoc states, that a map of values should be returned.
The current implementations of that interfaces use null as a return
value, too.
Also the rule engine checks the return value and checks for null.

I personally prefer to state that the function must not return a null
value and should return an empty map instead of adding a null check in
the handling of the return value.
But if we don't want to break third party action implementations we
should at least state, that null is an allowed return value.