### PR TITLE
print possible values for enums

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.console/src/main/java/org/eclipse/smarthome/io/console/internal/extension/SendConsoleCommandExtension.java
+++ b/bundles/io/org.eclipse.smarthome.io.console/src/main/java/org/eclipse/smarthome/io/console/internal/extension/SendConsoleCommandExtension.java
@@ -28,7 +28,7 @@ import org.eclipse.smarthome.io.console.extensions.AbstractConsoleCommandExtensi
  * @author Markus Rathgeb - Create DS for command extension
  * @author Dennis Nobel - Changed service references to be injected via DS
  * @author Stefan Bußweiler - Migration to new ESH event concept
- * 
+ *
  */
 public class SendConsoleCommandExtension extends AbstractConsoleCommandExtension {
 
@@ -57,12 +57,19 @@ public class SendConsoleCommandExtension extends AbstractConsoleCommandExtension
                         eventPublisher.post(ItemEventFactory.createCommandEvent(itemName, command));
                         console.println("Command has been sent successfully.");
                     } else {
-                        console.println("Error: Command '" + commandName + "' is not valid for item '" + itemName + "'");
-                        console.print("Valid command types are: ( ");
+                        console.println(
+                                "Error: Command '" + commandName + "' is not valid for item '" + itemName + "'");
+                        console.println("Valid command types are:");
                         for (Class<? extends Command> acceptedType : item.getAcceptedCommandTypes()) {
-                            console.print(acceptedType.getSimpleName() + " ");
+                            console.print("  " + acceptedType.getSimpleName());
+                            if (acceptedType.isEnum()) {
+                                console.print(": ");
+                                for (Object e : acceptedType.getEnumConstants()) {
+                                    console.print(e + " ");
+                                }
+                            }
+                            console.println("");
                         }
-                        console.println(")");
                     }
                 } else {
                     printUsage(console);


### PR DESCRIPTION
...in the "send" console command in case the given
command cannot be parsed successfully.

So instead of

```
Error: Command 'hallo' is not valid for item 'my_switch'
Valid command types are: ( OnOffType  RefreshType )
```

it would now print 

```
Error: Command 'hallo' is not valid for item 'my_switch'
Valid command types are:  
  OnOffType: ON OFF 
  RefreshType: REFRESH 
```

However, with this change non-enum types would continue showing as their type only, leaving it to the creativity of the users to figure out what e.g. a valid String or Decimal would be. But I assume that's not so much of a big deal.

fixes #2787
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>