### PR TITLE
Multiselect widget width issue inside md-dialog

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -1135,6 +1135,10 @@ background-color: green;
     color: rgba(0,0,0,0.72);
 }
 
+md-dialog-content .dropdown dt input {
+	width: 85%;
+}
+
 input[type=number].multiSel::-webkit-inner-spin-button, 
 input[type=number].multiSel::-webkit-outer-spin-button { 
     -webkit-appearance: none;


### PR DESCRIPTION
Before:
<img width="215" alt="screen shot 2017-01-12 at 12 11 12" src="https://cloud.githubusercontent.com/assets/5161937/21887495/67c34a7c-d8c0-11e6-9c92-d8a73bff2532.png">

After:
<img width="216" alt="screen shot 2017-01-12 at 12 10 55" src="https://cloud.githubusercontent.com/assets/5161937/21887500/7112be46-d8c0-11e6-8484-3f6b3fd286f8.png">

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>