### PR TITLE
Set category to null if input is empty

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.items.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.items.js
@@ -141,6 +141,9 @@ angular.module('PaperUI.controllers.configuration').controller('ItemSetupControl
             setItemToFunction();
         }
         if (JSON.stringify($scope.item) !== JSON.stringify(originalItem)) {
+            if ($scope.item.category == "") {
+                $scope.item.category = null;
+            }
             itemService.create({
                 itemName : $scope.item.name
             }, $scope.item).$promise.then(function() {


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/2828
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>