### PR TITLE
git status: cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,12 @@ distribution/smarthome/*.zip
 distribution/smarthome/runtime/etc/mapdb/storage.mapdb
 distribution/smarthome/runtime/etc/mapdb/storage.mapdb.p
 distribution/smarthome/runtime/etc/mapdb/storage.mapdb.t
+distribution/smarthome/userdata/
 bundles/core/org.eclipse.smarthome.core.id.test/userdata/
 bundles/model/antlr-generator-3.2.0-patch.jar
+bundles/storage/org.eclipse.smarthome.storage.json.test/userdata/
 bundles/storage/org.eclipse.smarthome.storage.mapdb.test/userdata/mapdb/storage.mapdb
 bundles/storage/org.eclipse.smarthome.storage.mapdb.test/userdata/mapdb/storage.mapdb.p
 bundles/storage/org.eclipse.smarthome.storage.mapdb.test/userdata/mapdb/storage.mapdb.t
 features/karaf/*/src/main/history
+

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+groovy.compiler.level=23


### PR DESCRIPTION
* `bundles/storage/org.eclipse.smarthome.storage.json.test/userdata/` is created on build process
* `distribution/smarthome/userdata/` is created if you use the SmartHome launch configuration of the Eclipse IDE
* the `org.eclipse.smarthome.config.dispatch.test/.settings` directory is created while using the Eclipse IDE