### PR TITLE
make outputs available to scripts and provide access to the full context

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/ESH-INF/automation/rules/DemoScriptRule.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/ESH-INF/automation/rules/DemoScriptRule.json
@@ -20,7 +20,7 @@
         "type": "script.ScriptCondition",
         "configuration": {  
           "type": "application/javascript",
-          "script": "trigger.event.itemState==ON"
+          "script": "event.itemState==ON"
         }
       }
     ],
@@ -30,7 +30,7 @@
         "type": "script.ScriptAction",
         "configuration": {  
           "type": "application/javascript",
-          "script": "print(items.MyTrigger), print(things.getAll()), print(trigger.event), events.sendCommand('ScriptItem', 'ON')"
+          "script": "print(items.MyTrigger), print(things.getAll()), print(context.get('trigger.event')), events.sendCommand('ScriptItem', 'ON')"
         }
       }
     ]

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/src/main/groovy/org/eclipse/smarthome/automation/module/script/ScriptRuleTest.groovy
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/src/main/groovy/org/eclipse/smarthome/automation/module/script/ScriptRuleTest.groovy
@@ -113,12 +113,12 @@ class ScriptRuleTest extends OSGiTest {
         assertThat condition1, is(notNullValue())
         assertThat condition1.typeUID, is("script.ScriptCondition")
         assertThat condition1.configuration.get("type"), is("application/javascript")
-        assertThat condition1.configuration.get("script"), is("trigger.event.itemState==ON")
+        assertThat condition1.configuration.get("script"), is("event.itemState==ON")
         def action = rule.actions.find{it.id.equals("action")} as Action
         assertThat action, is(notNullValue())
         assertThat action.typeUID, is("script.ScriptAction")
         assertThat action.configuration.get("type"), is("application/javascript")
-        assertThat action.configuration.get("script"), is("print(items.MyTrigger), print(things.getAll()), print(trigger.event), events.sendCommand('ScriptItem', 'ON')")
+        assertThat action.configuration.get("script"), is("print(items.MyTrigger), print(things.getAll()), print(context.get('trigger.event')), events.sendCommand('ScriptItem', 'ON')")
         def ruleStatus = ruleRegistry.getStatusInfo(rule.uid) as RuleStatusInfo
         assertThat ruleStatus.getStatus(), is(RuleStatus.IDLE)
 

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/ESH-INF/automation/moduletypes/ScriptTypes.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/ESH-INF/automation/moduletypes/ScriptTypes.json
@@ -43,7 +43,8 @@
                         "label": "Javascript",
                         "value": "application/javascript"
                     }
-                ]
+                ],
+                "defaultValue":"application/javascript"
             },
             {  
                "name":"script",

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/handler/AbstractScriptModuleHandler.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.smarthome.automation.module.script.internal.handler;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -51,21 +50,19 @@ abstract public class AbstractScriptModuleHandler<T extends Module> extends Base
         if (executionContext == null) {
             executionContext = engine.getContext();
         }
-        // add the rule context to the script engine (only for this execution)
-        for (Entry<String, ?> entry : context.entrySet()) {
 
-            final HashMap<String, Object> jsonObj = new HashMap<String, Object>();
+        // make the whole context available as "context"
+        executionContext.setAttribute("context", context, ScriptContext.ENGINE_SCOPE);
+
+        // add the single context entries without their prefix to the scope
+        for (Entry<String, ?> entry : context.entrySet()) {
             Object value = entry.getValue();
             String key = entry.getKey();
             int dotIndex = key.indexOf('.');
             if (dotIndex != -1) {
-                String jsonKey = key.substring(dotIndex + 1);
-                key = key.substring(0, dotIndex);
-                jsonObj.put(jsonKey, value);
-                executionContext.setAttribute(key, jsonObj, ScriptContext.ENGINE_SCOPE);
-            } else {
-                executionContext.setAttribute(key, value, ScriptContext.ENGINE_SCOPE);
+                key = key.substring(dotIndex + 1);
             }
+            executionContext.setAttribute(key, value, ScriptContext.ENGINE_SCOPE);
         }
         return executionContext;
     }


### PR DESCRIPTION
outputs are now available with their unprefixed id. As this can be a problem if there are multiple modules with the same output ids, the full rule context is additionally made available. This makes the following options available:
```
print(newState)
print(context.get('1.newState'))
```

fixes #2849

Signed-off-by: Kai Kreuzer <kai@openhab.org>