### PR TITLE
fix service injection into GenericItem

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/internal/ItemRegistryOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/internal/ItemRegistryOSGiTest.groovy
@@ -179,24 +179,24 @@ class ItemRegistryOSGiTest extends OSGiTest {
     @Test
     void 'assert getItemsByTag can filter by class and tag'() {
 
-      assertThat itemRegistry.getItemsByTag(SwitchItem.class, CAMERA_TAG).size(), is(0)
+        assertThat itemRegistry.getItemsByTag(SwitchItem.class, CAMERA_TAG).size(), is(0)
 
-      registerService itemProvider
+        registerService itemProvider
 
-      def items = itemRegistry.getItemsByTag(SwitchItem.class, CAMERA_TAG)
-      assertThat items.size(), is(2)
-      assertThat items.first().name, is(equalTo(CAMERA_ITEM_NAME1))
-      assertThat items.last().name, is(equalTo(CAMERA_ITEM_NAME2))
+        def items = itemRegistry.getItemsByTag(SwitchItem.class, CAMERA_TAG)
+        assertThat items.size(), is(2)
+        assertThat items.first().name, is(equalTo(CAMERA_ITEM_NAME1))
+        assertThat items.last().name, is(equalTo(CAMERA_ITEM_NAME2))
     }
 
     @Test
     void 'assert getItemsByTag can filter by class and tag with GenericItem'() {
 
-      assertThat itemRegistry.getItemsByTag(GenericItem.class, CAMERA_TAG).size(), is(0)
+        assertThat itemRegistry.getItemsByTag(GenericItem.class, CAMERA_TAG).size(), is(0)
 
-      registerService itemProvider
+        registerService itemProvider
 
-      assertThat itemRegistry.getItemsByTag(GenericItem.class, CAMERA_TAG).size(), is(3)
+        assertThat itemRegistry.getItemsByTag(GenericItem.class, CAMERA_TAG).size(), is(3)
     }
 
     @Test
@@ -353,6 +353,31 @@ class ItemRegistryOSGiTest extends OSGiTest {
         itemsChangeListener.removed(itemProvider, newItem)
         waitForAssert {assertThat receivedEvent, not(null)}
         assertThat receivedEvent, is(instanceOf(ItemRemovedEvent))
+    }
+
+    @Test
+    void 'assert that a changed item still has an event publisher'() {
+        registerService itemProvider
+
+        // add new item
+        def item = new SwitchItem("SomeSwitch")
+        assertThat item.eventPublisher, is(nullValue())
+        itemsChangeListener.added(itemProvider, item)
+        assertThat item.eventPublisher, is(notNullValue())
+
+        // update item
+        def oldItem = item;
+        def newItem = new SwitchItem("SomeSwitch")
+        assertThat oldItem.eventPublisher, is(notNullValue())
+        assertThat newItem.eventPublisher, is(nullValue())
+        itemsChangeListener.updated(itemProvider, oldItem, newItem)
+        assertThat oldItem.eventPublisher, is(nullValue())
+        assertThat newItem.eventPublisher, is(notNullValue())
+
+        // remove item
+        assertThat newItem.eventPublisher, is(notNullValue())
+        itemsChangeListener.removed(itemProvider, newItem)
+        assertThat newItem.eventPublisher, is(nullValue())
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -254,12 +254,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     private void initializeItem(Item item) throws IllegalArgumentException {
         ItemUtil.assertValidItemName(item.getName());
 
-        if (item instanceof GenericItem) {
-            GenericItem genericItem = (GenericItem) item;
-            genericItem.setEventPublisher(eventPublisher);
-            genericItem.setStateDescriptionProviders(stateDescriptionProviders);
-            genericItem.initialize();
-        }
+        injectServices(item);
 
         if (item instanceof GroupItem) {
             // fill group with its members
@@ -268,6 +263,22 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
         // add the item to all relevant groups
         addToGroupItems(item, item.getGroupNames());
+    }
+
+    private void injectServices(Item item) {
+        if (item instanceof GenericItem) {
+            GenericItem genericItem = (GenericItem) item;
+            genericItem.setEventPublisher(eventPublisher);
+            genericItem.setStateDescriptionProviders(stateDescriptionProviders);
+        }
+    }
+
+    private void clearServices(Item item) {
+        if (item instanceof GenericItem) {
+            GenericItem genericItem = (GenericItem) item;
+            genericItem.setEventPublisher(null);
+            genericItem.setStateDescriptionProviders(null);
+        }
     }
 
     private void addMembersToGroupItem(GroupItem groupItem) {
@@ -298,11 +309,14 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     @Override
     protected void onRemoveElement(Item element) {
+        clearServices(element);
         removeFromGroupItems(element, element.getGroupNames());
     }
 
     @Override
     protected void onUpdateElement(Item oldItem, Item item) {
+        clearServices(oldItem);
+        injectServices(item);
         removeFromGroupItems(oldItem, oldItem.getGroupNames());
         addToGroupItems(item, item.getGroupNames());
         if (item instanceof GroupItem) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -99,13 +99,6 @@ abstract public class GenericItem implements ActiveItem {
         }
     }
 
-    public void initialize() {
-    }
-
-    public void dispose() {
-        this.eventPublisher = null;
-    }
-
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
...as on item updates, the updated item did not get the event publisher
injected.

At the same time, I also fixed the cleanup of these references on
update (old item) and removal.

The initialize() (empty implementation) and dispose() (never called)
methods in GenericItem seem to be historic garbage. As far as I can
see they are completely useless (if called at all) and nowhere overridden.
Since they are not part if the Item interface, I simply removed them.

fixes #2846
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>