### PR TITLE
Use item label in image widget

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
@@ -213,7 +213,7 @@
 												<div layout-align="start center" layout="row">
 													<div flex="60">
 														<p class="ng-binding">
-															<i class="material-icons">camera_alt</i>Camera image
+															<i class="material-icons">camera_alt</i>{{getLabel(item.category,item.label,'Camera image')}}
 														</p>
 													</div>
 													<div layout="row" layout-align="end center" flex="40">


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/2839
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>