### PR TITLE
add a toString method to the configuration

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Configuration {
 
-    final private Map<String, Object> properties;
+    private final Map<String, Object> properties;
 
     private transient final Logger logger = LoggerFactory.getLogger(Configuration.class);
 
@@ -207,6 +207,24 @@ public class Configuration {
             return false;
         }
         return this.hashCode() == obj.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("Configuration[");
+        boolean first = true;
+        for (final Map.Entry<String, Object> prop : properties.entrySet()) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append(String.format("{key=%s; type=%s; value=%s}", prop.getKey(),
+                    prop.getValue().getClass().getSimpleName(), prop.getValue()));
+        }
+        sb.append("]");
+        return sb.toString();
     }
 
 }


### PR DESCRIPTION
This PR adds a toString method to the configuration to get a more readable representation of the internal state.

Imaging the following code:
```java
final Configuration config = new Configuration();
config.put("key1", Integer.valueOf(42));
config.put("key2", BigDecimal.valueOf(42));
config.put("key3", String.valueOf(42));
System.out.println(config);
```

Without this change the output will be similar to:
```text
org.eclipse.smarthome.config.core.Configuration@968207
```

After this change has been done the output will be:
```text
Configuration[{key=key1; type=Integer; value=42}, {key=key2; type=BigDecimal; value=42}, {key=key3; type=String; value=42}]
```