### PR TITLE
fixed inconsistent caching behavior in rule module handler factories

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/handler/BaseModuleHandlerFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/handler/BaseModuleHandlerFactory.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.smarthome.automation.handler;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,7 +22,7 @@ import org.osgi.framework.BundleContext;
  */
 abstract public class BaseModuleHandlerFactory implements ModuleHandlerFactory {
 
-    protected Map<String, ModuleHandler> handlers = new HashMap<String, ModuleHandler>();
+    private Map<String, ModuleHandler> handlers = new HashMap<String, ModuleHandler>();
     protected BundleContext bundleContext;
 
     public void activate(BundleContext bundleContext) {
@@ -35,15 +36,29 @@ abstract public class BaseModuleHandlerFactory implements ModuleHandlerFactory {
         dispose();
     }
 
+    protected Map<String, ModuleHandler> getHandlers() {
+        return Collections.unmodifiableMap(handlers);
+    }
+
     @Override
     public ModuleHandler getHandler(Module module, String ruleUID) {
-        ModuleHandler handler = internalCreate(module, ruleUID);
-        if (handler != null) {
-            handlers.put(ruleUID + module.getId(), handler);
+        ModuleHandler handler = handlers.get(ruleUID + module.getId());
+        if (handler == null) {
+            handler = internalCreate(module, ruleUID);
+            if (handler != null) {
+                handlers.put(ruleUID + module.getId(), handler);
+            }
         }
         return handler;
     }
 
+    /**
+     * Create a new handler for the given module.
+     *
+     * @param module the {@link Module} for which a handler shoult be created
+     * @param ruleUID the id of the rule for which the handler should be created
+     * @return A {@link ModuleHandler} instance or <code>null</code> if thins module type is not supported
+     */
     abstract protected ModuleHandler internalCreate(Module module, String ruleUID);
 
     public void dispose() {

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/composite/CompositeModuleHandlerFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/composite/CompositeModuleHandlerFactory.java
@@ -79,7 +79,7 @@ public class CompositeModuleHandlerFactory extends BaseModuleHandlerFactory impl
     @SuppressWarnings({ "unchecked" })
     @Override
     public void ungetHandler(Module module, String childModulePrefix, ModuleHandler handler) {
-        ModuleHandler handlerOfModule = handlers.get(childModulePrefix + module.getId());
+        ModuleHandler handlerOfModule = getHandlers().get(childModulePrefix + module.getId());
         if (handlerOfModule instanceof AbstractCompositeModuleHandler) {
             AbstractCompositeModuleHandler<Module, ?, ?> h = (AbstractCompositeModuleHandler<Module, ?, ?>) handlerOfModule;
             Set<Module> modules = h.moduleHandlerMap.keySet();

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/factory/CoreModuleHandlerFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/factory/CoreModuleHandlerFactory.java
@@ -82,7 +82,7 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory {
      */
     protected void setItemRegistry(ItemRegistry itemRegistry) {
         this.itemRegistry = itemRegistry;
-        for (ModuleHandler handler : handlers.values()) {
+        for (ModuleHandler handler : getHandlers().values()) {
             if (handler instanceof ItemStateConditionHandler) {
                 ((ItemStateConditionHandler) handler).setItemRegistry(this.itemRegistry);
             } else if (handler instanceof ItemCommandActionHandler) {
@@ -97,7 +97,7 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory {
      * @param itemRegistry
      */
     protected void unsetItemRegistry(ItemRegistry itemRegistry) {
-        for (ModuleHandler handler : handlers.values()) {
+        for (ModuleHandler handler : getHandlers().values()) {
             if (handler instanceof ItemStateConditionHandler) {
                 ((ItemStateConditionHandler) handler).unsetItemRegistry(this.itemRegistry);
             } else if (handler instanceof ItemCommandActionHandler) {
@@ -114,7 +114,7 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory {
      */
     protected void setEventPublisher(EventPublisher eventPublisher) {
         this.eventPublisher = eventPublisher;
-        for (ModuleHandler handler : handlers.values()) {
+        for (ModuleHandler handler : getHandlers().values()) {
             if (handler instanceof ItemCommandActionHandler) {
                 ((ItemCommandActionHandler) handler).setEventPublisher(eventPublisher);
             }
@@ -128,7 +128,7 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory {
      */
     protected void unsetEventPublisher(EventPublisher eventPublisher) {
         this.eventPublisher = null;
-        for (ModuleHandler handler : handlers.values()) {
+        for (ModuleHandler handler : getHandlers().values()) {
             if (handler instanceof ItemCommandActionHandler) {
                 ((ItemCommandActionHandler) handler).unsetEventPublisher(eventPublisher);
             }
@@ -149,81 +149,41 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory {
     @Override
     protected synchronized ModuleHandler internalCreate(final Module module, final String ruleUID) {
         logger.trace("create {} -> {} : {}", module.getId(), module.getTypeUID(), ruleUID);
-
-        final ModuleHandler handler = handlers.get(ruleUID + module.getId());
         final String moduleTypeUID = module.getTypeUID();
-
         if (module instanceof Trigger) {
             // Handle triggers
 
             if (GenericEventTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID)) {
-                if (handler != null && handler instanceof GenericEventTriggerHandler) {
-                    return handler;
-                } else {
-                    final GenericEventTriggerHandler triggerHandler = new GenericEventTriggerHandler((Trigger) module,
-                            this.bundleContext);
-                    return triggerHandler;
-                }
+                return new GenericEventTriggerHandler((Trigger) module,
+                        this.bundleContext);
             } else if (ItemCommandTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID)) {
-                if (handler != null && handler instanceof ItemCommandTriggerHandler) {
-                    return handler;
-                } else {
-                    final ItemCommandTriggerHandler triggerHandler = new ItemCommandTriggerHandler((Trigger) module,
-                            this.bundleContext);
-                    return triggerHandler;
-                }
+                return new ItemCommandTriggerHandler((Trigger) module,
+                        this.bundleContext);
             } else if (ItemStateTriggerHandler.CHANGE_MODULE_TYPE_ID.equals(moduleTypeUID)
                     || ItemStateTriggerHandler.UPDATE_MODULE_TYPE_ID.equals(moduleTypeUID)) {
-                if (handler != null && handler instanceof ItemStateTriggerHandler) {
-                    return handler;
-                } else {
-                    final ItemStateTriggerHandler triggerHandler = new ItemStateTriggerHandler((Trigger) module,
-                            this.bundleContext);
-                    return triggerHandler;
-                }
+                return new ItemStateTriggerHandler((Trigger) module,
+                        this.bundleContext);
             }
         } else if (module instanceof Condition) {
             // Handle conditions
 
             if (ItemStateConditionHandler.ITEM_STATE_CONDITION.equals(moduleTypeUID)) {
-                if (handler != null && handler instanceof ItemStateConditionHandler) {
-                    return handler;
-                } else {
-                    final ItemStateConditionHandler conditionHandler = new ItemStateConditionHandler(
-                            (Condition) module);
-                    conditionHandler.setItemRegistry(itemRegistry);
-                    return conditionHandler;
-                }
+                new ItemStateConditionHandler((Condition) module).setItemRegistry(itemRegistry);
+                return new ItemStateConditionHandler((Condition) module);
             } else if (GenericEventConditionHandler.MODULETYPE_ID.equals(moduleTypeUID)) {
-                if (handler != null && handler instanceof GenericEventConditionHandler) {
-                    return handler;
-                } else {
-                    final GenericEventConditionHandler eventConditionHandler = new GenericEventConditionHandler(
-                            (Condition) module);
-                    return eventConditionHandler;
-                }
+                return new GenericEventConditionHandler(
+                        (Condition) module);
             } else if (CompareConditionHandler.MODULE_TYPE.equals(moduleTypeUID)) {
-                if (handler != null && handler instanceof CompareConditionHandler) {
-                    return handler;
-                } else {
-                    final CompareConditionHandler compareConditionHandler = new CompareConditionHandler(
-                            (Condition) module);
-                    return compareConditionHandler;
-                }
+                return new CompareConditionHandler((Condition) module);
             }
         } else if (module instanceof Action) {
             // Handle actions
 
             if (ItemCommandActionHandler.ITEM_COMMAND_ACTION.equals(moduleTypeUID)) {
-                if (handler != null && handler instanceof ItemCommandActionHandler) {
-                    return handler;
-                } else {
-                    final ItemCommandActionHandler postCommandActionHandler = new ItemCommandActionHandler(
-                            (Action) module);
-                    postCommandActionHandler.setEventPublisher(eventPublisher);
-                    postCommandActionHandler.setItemRegistry(itemRegistry);
-                    return postCommandActionHandler;
-                }
+                final ItemCommandActionHandler postCommandActionHandler = new ItemCommandActionHandler((Action) module);
+                postCommandActionHandler.setEventPublisher(eventPublisher);
+                postCommandActionHandler.setItemRegistry(itemRegistry);
+                return postCommandActionHandler;
             } else if (RuleEnableHandler.UID.equals(moduleTypeUID)) {
                 return new RuleEnableHandler((Action) module, ruleRegistry);
             }

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/src/main/java/org/eclipse/smarthome/automation/module/timer/factory/TimerModuleHandlerFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/src/main/java/org/eclipse/smarthome/automation/module/timer/factory/TimerModuleHandlerFactory.java
@@ -52,33 +52,13 @@ public class TimerModuleHandlerFactory extends BaseModuleHandlerFactory {
     @Override
     protected ModuleHandler internalCreate(Module module, String ruleUID) {
         logger.trace("create {} -> {}", module.getId(), module.getTypeUID());
-        ModuleHandler handler = handlers.get(ruleUID + module.getId());
         String moduleTypeUID = module.getTypeUID();
-
         if (GenericCronTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID) && module instanceof Trigger) {
-            GenericCronTriggerHandler timerTriggerHandler = handler != null
-                    && handler instanceof GenericCronTriggerHandler ? (GenericCronTriggerHandler) handler : null;
-            if (timerTriggerHandler == null) {
-                timerTriggerHandler = new GenericCronTriggerHandler((Trigger) module);
-                handlers.put(ruleUID + module.getId(), timerTriggerHandler);
-            }
-            return timerTriggerHandler;
+            return new GenericCronTriggerHandler((Trigger) module);
         } else if (TimeOfDayTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID) && module instanceof Trigger) {
-            TimeOfDayTriggerHandler timeTriggerHandler = handler != null && handler instanceof TimeOfDayTriggerHandler
-                    ? (TimeOfDayTriggerHandler) handler : null;
-            if (timeTriggerHandler == null) {
-                timeTriggerHandler = new TimeOfDayTriggerHandler((Trigger) module);
-                handlers.put(ruleUID + module.getId(), timeTriggerHandler);
-            }
-            return timeTriggerHandler;
+            return new TimeOfDayTriggerHandler((Trigger) module);
         } else if (DayOfWeekConditionHandler.MODULE_TYPE_ID.equals(moduleTypeUID) && module instanceof Condition) {
-            DayOfWeekConditionHandler dowConditionHandler = handler != null
-                    && handler instanceof DayOfWeekConditionHandler ? (DayOfWeekConditionHandler) handler : null;
-            if (dowConditionHandler == null) {
-                dowConditionHandler = new DayOfWeekConditionHandler((Condition) module);
-                handlers.put(ruleUID + module.getId(), dowConditionHandler);
-            }
-            return dowConditionHandler;
+            return new DayOfWeekConditionHandler((Condition) module);
         } else {
             logger.error("The module handler type '{}' is not supported.", moduleTypeUID);
         }

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/src/main/java/org/eclipse/smarthome/automation/internal/sample/json/handler/SampleHandlerFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/src/main/java/org/eclipse/smarthome/automation/internal/sample/json/handler/SampleHandlerFactory.java
@@ -78,10 +78,6 @@ public class SampleHandlerFactory extends BaseModuleHandlerFactory {
         } else {
             logger.error(MODULE_HANDLER_FACTORY_NAME + "Not supported moduleHandler: {}", module.getTypeUID());
         }
-        if (moduleHandler != null) {
-            handlers.put(ruleUID + module.getId(), moduleHandler);
-        }
-
         return moduleHandler;
     }
 


### PR DESCRIPTION
...as I noticed some differences in the implemenations of internalCreate().
* some factories  where first trying to access the cache, some didn't
* some factories were writing to the cache, some didn't

Therefore I moved the cache access completely to the abstract base class,
allowing derived classes only to access it for read-only purposes.
By doing that, the cache is managed completely within the abstract
base class and this concern does not leak.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>