### PR TITLE
add a service to allow reuse of localized thing type creation

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlThingTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlThingTypeProvider.java
@@ -19,13 +19,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.smarthome.core.common.osgi.ServiceBinder.Bind;
 import org.eclipse.smarthome.core.common.osgi.ServiceBinder.Unbind;
-import org.eclipse.smarthome.core.i18n.I18nProvider;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
-import org.eclipse.smarthome.core.thing.i18n.ThingTypeI18nUtil;
-import org.eclipse.smarthome.core.thing.type.BridgeType;
-import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
-import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
+import org.eclipse.smarthome.core.thing.i18n.ThingTypeI18nLocalizationService;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.osgi.framework.Bundle;
 
@@ -103,7 +99,7 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
 
     private Map<Bundle, List<ThingType>> bundleThingTypesMap;
 
-    private ThingTypeI18nUtil thingTypeI18nUtil;
+    private ThingTypeI18nLocalizationService thingTypeI18nLocalizationService;
 
     public XmlThingTypeProvider() {
         this.bundleThingTypesMap = new ConcurrentHashMap<>(10);
@@ -149,57 +145,27 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
     }
 
     private ThingType createLocalizedThingType(Bundle bundle, ThingType thingType, Locale locale) {
+        // Create a localized thing type key (used for caching localized thing types).
+        final LocalizedThingTypeKey localizedThingTypeKey = getLocalizedThingTypeKey(thingType, locale);
 
-        LocalizedThingTypeKey localizedThingTypeKey = getLocalizedThingTypeKey(thingType, locale);
-
-        ThingType cacheEntry = localizedThingTypeCache.get(localizedThingTypeKey);
+        // Check if there is already an entry in our cache.
+        final ThingType cacheEntry = localizedThingTypeCache.get(localizedThingTypeKey);
         if (cacheEntry != null) {
             return cacheEntry;
         }
 
-        if (this.thingTypeI18nUtil != null) {
-            String label = this.thingTypeI18nUtil.getLabel(bundle, thingType.getUID(), thingType.getLabel(), locale);
-            String description = this.thingTypeI18nUtil.getDescription(bundle, thingType.getUID(),
-                    thingType.getDescription(), locale);
-
-            List<ChannelDefinition> localizedChannelDefinitions = new ArrayList<>(
-                    thingType.getChannelDefinitions().size());
-
-            for (ChannelDefinition channelDefinition : thingType.getChannelDefinitions()) {
-                String channelLabel = this.thingTypeI18nUtil.getChannelLabel(bundle,
-                        channelDefinition.getChannelTypeUID(), channelDefinition.getLabel(), locale);
-                String channelDescription = this.thingTypeI18nUtil.getChannelDescription(bundle,
-                        channelDefinition.getChannelTypeUID(), channelDefinition.getDescription(), locale);
-                localizedChannelDefinitions
-                        .add(new ChannelDefinition(channelDefinition.getId(), channelDefinition.getChannelTypeUID(),
-                                channelDefinition.getProperties(), channelLabel, channelDescription));
-            }
-
-            List<ChannelGroupDefinition> localizedChannelGroupDefinitions = new ArrayList<>(
-                    thingType.getChannelGroupDefinitions().size());
-            for (ChannelGroupDefinition channelGroupDefinition : thingType.getChannelGroupDefinitions()) {
-                localizedChannelGroupDefinitions.add(channelGroupDefinition);
-            }
-
-            if (thingType instanceof BridgeType) {
-                BridgeType bridgeType = (BridgeType) thingType;
-                BridgeType localizedBridgeType = new BridgeType(bridgeType.getUID(),
-                        bridgeType.getSupportedBridgeTypeUIDs(), label, description, thingType.isListed(),
-                        localizedChannelDefinitions, localizedChannelGroupDefinitions, thingType.getProperties(),
-                        bridgeType.getConfigDescriptionURI());
-                localizedThingTypeCache.put(localizedThingTypeKey, localizedBridgeType);
-                return localizedBridgeType;
-            } else {
-                ThingType localizedThingType = new ThingType(thingType.getUID(), thingType.getSupportedBridgeTypeUIDs(),
-                        label, description, thingType.isListed(), localizedChannelDefinitions,
-                        localizedChannelGroupDefinitions, thingType.getProperties(),
-                        thingType.getConfigDescriptionURI());
-                localizedThingTypeCache.put(localizedThingTypeKey, localizedThingType);
-                return localizedThingType;
-            }
-
+        // Check if there is a localization service available.
+        if (thingTypeI18nLocalizationService != null) {
+            // Fetch the localized thing type.
+            final ThingType localizedThingType = thingTypeI18nLocalizationService.createLocalizedThingType(bundle,
+                    thingType, locale);
+            // Put the localized thing type in our cache, so we could reuse it.
+            localizedThingTypeCache.put(localizedThingTypeKey, localizedThingType);
+            return localizedThingType;
+        } else {
+            // There is no localization service available, return the non-localized one.
+            return thingType;
         }
-        return thingType;
     }
 
     private LocalizedThingTypeKey getLocalizedThingTypeKey(ThingType thingType, Locale locale) {
@@ -281,12 +247,14 @@ public class XmlThingTypeProvider implements ThingTypeProvider {
     }
 
     @Bind
-    public void setI18nProvider(I18nProvider i18nProvider) {
-        this.thingTypeI18nUtil = new ThingTypeI18nUtil(i18nProvider);
+    public void setThingTypeI18nLocalizationService(
+            final ThingTypeI18nLocalizationService thingTypeI18nLocalizationService) {
+        this.thingTypeI18nLocalizationService = thingTypeI18nLocalizationService;
     }
 
     @Unbind
-    public void unsetI18nProvider(I18nProvider i18nProvider) {
-        this.thingTypeI18nUtil = null;
+    public void unsetThingTypeI18nLocalizationService(
+            final ThingTypeI18nLocalizationService thingTypeI18nLocalizationService) {
+        this.thingTypeI18nLocalizationService = null;
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingTypeI18nLocalizationService.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingTypeI18nLocalizationService.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2016 by the respective copyright holders.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.core.thing.i18n.thingtypei18nlocalizationservice">
+   <implementation class="org.eclipse.smarthome.core.thing.i18n.ThingTypeI18nLocalizationService"/>
+   <reference bind="setI18nProvider" cardinality="1..1" interface="org.eclipse.smarthome.core.i18n.I18nProvider" name="I18nProvider" policy="static" unbind="unsetI18nProvider"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.core.thing.i18n.ThingTypeI18nLocalizationService"/>
+   </service>
+</scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.i18n;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.smarthome.core.i18n.I18nProvider;
+import org.eclipse.smarthome.core.thing.type.BridgeType;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
+import org.eclipse.smarthome.core.thing.type.ThingType;
+import org.osgi.framework.Bundle;
+
+/**
+ * This OSGi service could be used to localize a thing type using the I18N mechanism of the Eclipse SmartHome
+ * framework.
+ *
+ * @author Markus Rathgeb - Move code from XML thing type provider to separate service
+ */
+public class ThingTypeI18nLocalizationService {
+
+    private ThingTypeI18nUtil thingTypeI18nUtil;
+
+    protected void setI18nProvider(I18nProvider i18nProvider) {
+        this.thingTypeI18nUtil = new ThingTypeI18nUtil(i18nProvider);
+    }
+
+    protected void unsetI18nProvider(I18nProvider i18nProvider) {
+        this.thingTypeI18nUtil = null;
+    }
+
+    public ThingType createLocalizedThingType(Bundle bundle, ThingType thingType, Locale locale) {
+        final String label = this.thingTypeI18nUtil.getLabel(bundle, thingType.getUID(), thingType.getLabel(), locale);
+        final String description = this.thingTypeI18nUtil.getDescription(bundle, thingType.getUID(),
+                thingType.getDescription(), locale);
+
+        final List<ChannelDefinition> localizedChannelDefinitions = new ArrayList<>(
+                thingType.getChannelDefinitions().size());
+
+        for (final ChannelDefinition channelDefinition : thingType.getChannelDefinitions()) {
+            final String channelLabel = this.thingTypeI18nUtil.getChannelLabel(bundle,
+                    channelDefinition.getChannelTypeUID(), channelDefinition.getLabel(), locale);
+            final String channelDescription = this.thingTypeI18nUtil.getChannelDescription(bundle,
+                    channelDefinition.getChannelTypeUID(), channelDefinition.getDescription(), locale);
+            localizedChannelDefinitions
+                    .add(new ChannelDefinition(channelDefinition.getId(), channelDefinition.getChannelTypeUID(),
+                            channelDefinition.getProperties(), channelLabel, channelDescription));
+        }
+
+        final List<ChannelGroupDefinition> localizedChannelGroupDefinitions = new ArrayList<>(
+                thingType.getChannelGroupDefinitions().size());
+        for (final ChannelGroupDefinition channelGroupDefinition : thingType.getChannelGroupDefinitions()) {
+            localizedChannelGroupDefinitions.add(channelGroupDefinition);
+        }
+
+        if (thingType instanceof BridgeType) {
+            final BridgeType bridgeType = (BridgeType) thingType;
+            return new BridgeType(bridgeType.getUID(), bridgeType.getSupportedBridgeTypeUIDs(), label, description,
+                    thingType.isListed(), localizedChannelDefinitions, localizedChannelGroupDefinitions,
+                    thingType.getProperties(), bridgeType.getConfigDescriptionURI());
+        } else {
+            return new ThingType(thingType.getUID(), thingType.getSupportedBridgeTypeUIDs(), label, description,
+                    thingType.isListed(), localizedChannelDefinitions, localizedChannelGroupDefinitions,
+                    thingType.getProperties(), thingType.getConfigDescriptionURI());
+        }
+    }
+
+}

--- a/features/karaf/esh-core/src/main/feature/feature.xml
+++ b/features/karaf/esh-core/src/main/feature/feature.xml
@@ -15,7 +15,12 @@
     <feature dependency="true">esh-tp</feature>
     <requirement>esh.tp;filter:="(&amp;(feature=xtext)(version&gt;=2.9.2)(!(version&gt;=2.9.3)))"</requirement>
     <requirement>esh.tp;filter:="(feature=jax-rs)"</requirement>
+
     <bundle>mvn:org.eclipse.smarthome.config/org.eclipse.smarthome.config.core/${project.version}</bundle>
+    <capability>
+      osgi.service;objectClass=org.eclipse.smarthome.config.core.i18n.ConfigI18nLocalizationService
+    </capability>
+
     <bundle>mvn:org.eclipse.smarthome.config/org.eclipse.smarthome.config.discovery/${project.version}</bundle>
     <bundle>mvn:org.eclipse.smarthome.config/org.eclipse.smarthome.config.dispatch/${project.version}</bundle>
     <bundle start-level="75">mvn:org.eclipse.smarthome.config/org.eclipse.smarthome.config.xml/${project.version}</bundle>

--- a/features/karaf/esh-core/src/main/feature/feature.xml
+++ b/features/karaf/esh-core/src/main/feature/feature.xml
@@ -44,6 +44,9 @@
       osgi.service;objectClass=org.eclipse.smarthome.core.thing.ThingRegistry
     </capability>
     <capability>
+      osgi.service;objectClass=org.eclipse.smarthome.core.thing.i18n.ThingTypeI18nLocalizationService
+    </capability>
+    <capability>
       osgi.service;objectClass=org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry
     </capability>
 


### PR DESCRIPTION
With this change the code that localize a thing type using the i18n stuff is moved from the XML implementation to a separate service so it could be reused by other code, too.