### PR TITLE
fix triggers for itemName vs. itemNameExtended

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemCommandTriggerHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemCommandTriggerHandler.java
@@ -41,6 +41,8 @@ public class ItemCommandTriggerHandler extends BaseTriggerModuleHandler implemen
 
     private String itemName;
     private String command;
+    private String topic;
+
     private Set<String> types;
     private BundleContext bundleContext;
 
@@ -59,7 +61,8 @@ public class ItemCommandTriggerHandler extends BaseTriggerModuleHandler implemen
         this.types = Collections.singleton(ItemCommandEvent.TYPE);
         this.bundleContext = bundleContext;
         Dictionary<String, Object> properties = new Hashtable<String, Object>();
-        properties.put("event.topics", "smarthome/items/*");
+        this.topic = "smarthome/items/" + itemName + "/command";
+        properties.put("event.topics", topic);
         eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,
                 properties);
     }
@@ -105,7 +108,7 @@ public class ItemCommandTriggerHandler extends BaseTriggerModuleHandler implemen
     @Override
     public boolean apply(Event event) {
         logger.trace("->FILTER: {}:{}", event.getTopic(), itemName);
-        return event.getTopic().contains(itemName);
+        return event.getTopic().equals(topic);
     }
 
 }

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemStateTriggerHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemStateTriggerHandler.java
@@ -62,7 +62,7 @@ public class ItemStateTriggerHandler extends BaseTriggerModuleHandler implements
                 UPDATE_MODULE_TYPE_ID.equals(module.getTypeUID()) ? ItemStateEvent.TYPE : ItemStateChangedEvent.TYPE);
         this.bundleContext = bundleContext;
         Dictionary<String, Object> properties = new Hashtable<String, Object>();
-        properties.put("event.topics", "smarthome/items/*");
+        properties.put("event.topics", "smarthome/items/" + itemName + "/*");
         eventSubscriberRegistration = this.bundleContext.registerService(EventSubscriber.class.getName(), this,
                 properties);
     }
@@ -116,7 +116,7 @@ public class ItemStateTriggerHandler extends BaseTriggerModuleHandler implements
     @Override
     public boolean apply(Event event) {
         logger.trace("->FILTER: {}:{}", event.getTopic(), itemName);
-        return event.getTopic().contains(itemName);
+        return event.getTopic().contains("/" + itemName + "/");
     }
 
 }


### PR DESCRIPTION
If there are two items: itemName and itemNameExtended, the wrong trigger can be triggered.

If one adds a rule with a trigger to "itemName" and the state of itemNameExtended changes, the trigger to "itemName" will be triggered. The following PR fixes that.

Signed-off-by: Simon Merschjohann <smerschjo@gmail.com>