### PR TITLE
fixed DayOfWeekConditionHandlerTest when running on non-english systems

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/src/test/groovy/org/eclipse/smarthome/automation/module/timer/internal/DayOfWeekConditionHandlerTest.groovy
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/src/test/groovy/org/eclipse/smarthome/automation/module/timer/internal/DayOfWeekConditionHandlerTest.groovy
@@ -48,7 +48,7 @@ class DayOfWeekConditionHandlerTest extends OSGiTest{
     VolatileStorageService volatileStorageService = new VolatileStorageService()
     def RuleRegistry ruleRegistry
     Calendar cal = Calendar.getInstance();
-    SimpleDateFormat sdf = new SimpleDateFormat("EEE");
+    SimpleDateFormat sdf = new SimpleDateFormat("EEE", Locale.ENGLISH);
     String dayOfWeek = sdf.format(cal.getTime()).toUpperCase();
 
     @Before

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/src/test/groovy/org/eclipse/smarthome/automation/module/timer/internal/TimeOfDayTriggerHandlerTest.groovy
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/src/test/groovy/org/eclipse/smarthome/automation/module/timer/internal/TimeOfDayTriggerHandlerTest.groovy
@@ -11,8 +11,6 @@ import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
-import java.text.SimpleDateFormat
-
 import org.eclipse.smarthome.automation.RuleRegistry
 import org.eclipse.smarthome.automation.module.timer.handler.TimeOfDayTriggerHandler
 import org.eclipse.smarthome.automation.type.ModuleTypeRegistry
@@ -34,9 +32,6 @@ class TimeOfDayTriggerHandlerTest extends OSGiTest{
     final Logger logger = LoggerFactory.getLogger(RuntimeRuleTest.class)
     VolatileStorageService volatileStorageService = new VolatileStorageService()
     def RuleRegistry ruleRegistry
-    Calendar cal = Calendar.getInstance();
-    SimpleDateFormat sdf = new SimpleDateFormat("EEE");
-    String dayOfWeek = sdf.format(cal.getTime()).toUpperCase();
 
     @Before
     void before() {


### PR DESCRIPTION
...as for preparation of the configuration parameters a different locale
will create different output for the days (e.g. FR instead of FRI with
german locale).

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>