### PR TITLE
Use CONTAINER_NONE in MP3 AudioFormat in URLAudioStream

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/URLAudioStream.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/URLAudioStream.java
@@ -46,7 +46,7 @@ public class URLAudioStream extends org.eclipse.smarthome.core.audio.AudioStream
             throw new IllegalArgumentException("url must not be null!");
         }
         this.url = url;
-        this.audioFormat = new AudioFormat(AudioFormat.CODEC_MP3, AudioFormat.CODEC_MP3, false, 16, null, null);
+        this.audioFormat = new AudioFormat(AudioFormat.CONTAINER_NONE, AudioFormat.CODEC_MP3, false, 16, null, null);
         this.inputStream = createInputStream();
     }
 


### PR DESCRIPTION
This fixes #2913 by changing the container on the MP3 AudioFormat created by URLAudioStream to "NONE".

Bug: https://github.com/eclipse/smarthome/issues/2913
Signed-off-by: Gregory Moyer <moyerg@syphr.com>