### PR TITLE
Added missing advanced field in channelTypeDTO

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/dto/ChannelTypeDTO.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/dto/ChannelTypeDTO.java
@@ -32,6 +32,7 @@ public class ChannelTypeDTO {
     public StateDescription stateDescription;
     public Set<String> tags;
     public String UID;
+    public boolean advanced;
 
     public ChannelTypeDTO() {
     }
@@ -39,7 +40,7 @@ public class ChannelTypeDTO {
     public ChannelTypeDTO(String UID, String label, String description, String category, String itemType,
             ChannelKind kind, List<ConfigDescriptionParameterDTO> parameters,
             List<ConfigDescriptionParameterGroupDTO> parameterGroups, StateDescription stateDescription,
-            Set<String> tags) {
+            Set<String> tags, boolean advanced) {
         this.UID = UID;
         this.label = label;
         this.description = description;
@@ -50,5 +51,6 @@ public class ChannelTypeDTO {
         this.tags = tags;
         this.kind = kind.toString();
         this.itemType = itemType;
+        this.advanced = advanced;
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/channel/ChannelTypeResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/channel/ChannelTypeResource.java
@@ -134,7 +134,7 @@ public class ChannelTypeResource implements SatisfiableRESTResource {
 
         return new ChannelTypeDTO(channelType.getUID().toString(), channelType.getLabel(), channelType.getDescription(),
                 channelType.getCategory(), channelType.getItemType(), channelType.getKind(), parameters,
-                parameterGroups, channelType.getState(), channelType.getTags());
+                parameterGroups, channelType.getState(), channelType.getTags(), channelType.isAdvanced());
     }
 
     private Set<ChannelTypeDTO> convertToChannelTypeDTOs(List<ChannelType> channelTypes, Locale locale) {


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/2911
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>