### PR TITLE
allow multiple ExtensionService implementations

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/extension/ExtensionService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/extension/ExtensionService.java
@@ -23,6 +23,9 @@ public interface ExtensionService {
     /**
      * Retrieves all extensions
      *
+     * It is expected that this method is rather cheap to call and will return quickly, i.e. some caching should be
+     * implemented if required.
+     *
      * @param locale the locale to use for the result
      * @return the localized extensions
      */
@@ -47,6 +50,7 @@ public interface ExtensionService {
 
     /**
      * Installs the given extension.
+     *
      * This can be a long running process. The framework makes sure that this is called within a separate thread and
      * ExtensionEvents will be sent upon its completion.
      *
@@ -56,6 +60,7 @@ public interface ExtensionService {
 
     /**
      * Uninstalls the given extension.
+     *
      * This can be a long running process. The framework makes sure that this is called within a separate thread and
      * ExtensionEvents will be sent upon its completion.
      *

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/extension/ExtensionType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/extension/ExtensionType.java
@@ -43,4 +43,34 @@ public class ExtensionType {
         return label;
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ExtensionType other = (ExtensionType) obj;
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/OSGI-INF/extensionresource.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/OSGI-INF/extensionresource.xml
@@ -14,6 +14,6 @@
       <provide interface="org.eclipse.smarthome.io.rest.RESTResource"/>
       <provide interface="org.eclipse.smarthome.io.rest.core.extensions.ExtensionResource"/>
    </service>
-   <reference bind="setExtensionService" cardinality="0..1" interface="org.eclipse.smarthome.core.extension.ExtensionService" name="ExtensionService" policy="dynamic" unbind="unsetExtensionService"/>
+   <reference bind="addExtensionService" cardinality="0..n" interface="org.eclipse.smarthome.core.extension.ExtensionService" name="ExtensionService" policy="dynamic" unbind="removeExtensionService"/>
    <reference bind="setEventPublisher" cardinality="0..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="dynamic" unbind="unsetEventPublisher"/>
 </scr:component>


### PR DESCRIPTION
...so that the REST resources consult all of them.

* ExtensionTypes are sorted alphabetically by their label
* The list of returned Extensions is stable but not sorted
* assumption: ExtensionTypes have a unique semantic (i.e. two ExtensionServices may
  provide ExtensionTypes with the same ID, but have to implicitly "agree" that they
  also have an identical meaning). Prefixing helps preventing undesired clashes.
* assumption: The list of extensions provided by each service is cheap to calculate,
  i.e. caching is implemented by the services if needed
* assumption: If two ExtensionServices provide Extensions with an identical ID, then
  it is also the same Extension and it does not matter which ExtensionService is used
  for installing/uninstalling the extension. Prefixing helps.

All of the above assumption might not hold true in future, but as long as we only have
a very limited, known set of ExtensionService providers I'd suggest to keep it simple
for now.

implements #2920
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>