### PR TITLE
Bug fix: use channel type UID for comparison in channelGroups

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
@@ -579,7 +579,7 @@ angular.module('PaperUI.services', [ 'PaperUI.constants' ]).config(function($htt
                     var cg, cg_i, cg_l;
                     for (cg_i = 0, cg_l = thingType.channelGroups.length; cg_i < cg_l; ++cg_i) {
                         cg = thingType.channelGroups[cg_i];
-                        if (cg.id == cid_part[0]) {
+                        if (cg && cg.channels) {
                             for (c_i = 0, c_l = cg.channels.length; c_i < c_l; ++c_i) {
                                 c = cg.channels[c_i];
                                 if (c.typeUID == channelUID) {


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/eclipse/smarthome/pull/2949
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>