### PR TITLE
Fixed jquery-ui ‘define’ error

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -62,10 +62,11 @@ var paths = {
     ],
     JQUI: [{
         'src' : [
-             './node_modules/jquery-ui/ui/core.js',
+             './node_modules/jquery-ui/ui/data.js',
+             './node_modules/jquery-ui/ui/scroll-parent.js',
              './node_modules/jquery-ui/ui/widget.js',
-             './node_modules/jquery-ui/ui/mouse.js',
-             './node_modules/jquery-ui/ui/sortable.js',
+             './node_modules/jquery-ui/ui/widgets/mouse.js',
+             './node_modules/jquery-ui/ui/widgets/sortable.js',
         ],
         'name': 'jquery-ui.js'
     }],


### PR DESCRIPTION
Fixes broken modules drag-drop feature and error below:
<img width="374" alt="screen shot 2017-02-08 at 16 40 27" src="https://cloud.githubusercontent.com/assets/5161937/22744364/7f3e2a24-ee1d-11e6-9c3c-782dc9b1f44b.png">


Signed-off-by: Aoun Bukhari <bukhari@itemis.de>