### PR TITLE
AudioFormat need to implement hashCode 

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioFormat.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioFormat.java
@@ -398,6 +398,19 @@ public class AudioFormat {
     }
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((bigEndian == null) ? 0 : bigEndian.hashCode());
+        result = prime * result + ((bitDepth == null) ? 0 : bitDepth.hashCode());
+        result = prime * result + ((bitRate == null) ? 0 : bitRate.hashCode());
+        result = prime * result + ((codec == null) ? 0 : codec.hashCode());
+        result = prime * result + ((container == null) ? 0 : container.hashCode());
+        result = prime * result + ((frequency == null) ? 0 : frequency.hashCode());
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "AudioFormat [" + (codec != null ? "codec=" + codec + ", " : "")
                 + (container != null ? "container=" + container + ", " : "")


### PR DESCRIPTION
Since AudioFormat implements equals(), it needs to implement hasCode() as well. It is used e.g. in SonosAudioSink in a HashMap. 

Signed-off-by: Andre Fuechsel <andre.fuechsel@telekom.de>