### PR TITLE
Stop blaming handlers for being queued

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeMethodCaller.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeMethodCaller.java
@@ -199,10 +199,11 @@ public class SafeMethodCaller {
                 getLogger().debug("Timeout of {}ms exceeded, thread {} ({}) in state {} is at {}.{}({}:{}).", timeout,
                         thread.getName(), thread.getId(), thread.getState().toString(), element.getClassName(),
                         element.getMethodName(), element.getFileName(), element.getLineNumber());
+                throw e;
             } else {
-                getLogger().debug("Timeout of {}ms exceeded with no thread info available.", timeout);
+                getLogger().debug("Timeout of {}ms exceeded but the task was still queued.", timeout);
             }
-            throw e;
+            return null;
         }
     }
 


### PR DESCRIPTION
..as so far it could happen that a ThingHandler call through the SafeMethodCaller
timed out because it was still queued, so the Handler is not to "blame".

Now the SafeMethodCall returns silently in such a case, not re-throwing the TimeoutException anymore.

relates to #2986
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>