### PR TITLE
prevent wrapping of safe method calls

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/common/SafeMethodCallerTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/common/SafeMethodCallerTest.groovy
@@ -18,8 +18,8 @@ import org.junit.Test
 
 
 /**
- * The SafeMethodCallerTest tests functionality of the SafeMethodCaller helper class.  
- * 
+ * The SafeMethodCallerTest tests functionality of the SafeMethodCaller helper class.
+ *
  * @author Dennis Nobel - Initial contribution
  */
 class SafeMethodCallerTest {
@@ -74,5 +74,19 @@ class SafeMethodCallerTest {
     void 'call just logs TimeoutException'() {
         def target = new Target();
         SafeMethodCaller.call({ target.methodWithTimeout() } as SafeMethodCaller.Action, 100)
+    }
+
+    @Test
+    void 'wrapped call executes directly'() {
+        String outerThreadName
+        String innerThreadName
+        SafeMethodCaller.call({
+            outerThreadName = Thread.currentThread().getName()
+            SafeMethodCaller.call({
+                innerThreadName = Thread.currentThread().getName()
+            } as SafeMethodCaller.ActionWithException)
+        } as SafeMethodCaller.ActionWithException)
+
+        assertThat innerThreadName, is(equalTo(outerThreadName))
     }
 }


### PR DESCRIPTION
...by checking if the current thread already is running
in a SafeMethodCaller context.

relates to #2986
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>