### PR TITLE
Create default icon for Number type items from Text icon, fixes #2994

### DIFF
--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/icons/_iconcopy
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/icons/_iconcopy
@@ -9,6 +9,7 @@
 cp -f house.png             group.png
 cp -f house.svg             group.svg
 
+cp -f number.svg            text.svg
 
 # Alternative Types
 

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/icons/_iconcopy
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/icons/_iconcopy
@@ -9,7 +9,7 @@
 cp -f house.png             group.png
 cp -f house.svg             group.svg
 
-cp -f number.svg            text.svg
+cp -f text.svg              number.svg
 
 # Alternative Types
 


### PR DESCRIPTION
Fixes #2994: Broken image in basic ui for number items without explicit icon

Any Number type item without an explicitly defined icon (in a text based .items file) will show a broken image in Basic UI. Until a final choice has been made what to do with these (missing) icons, create an alias for the number icon from the text icon.

Signed-off-by: Robert van Bregt <robert@robertvanbregt.nl>