### PR TITLE
set the Groovy compiler level for project to match the workspace level

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,2 @@
 eclipse.preferences.version=1
-groovy.compiler.level=23
+groovy.compiler.level=24


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/3011