### PR TITLE
prevent NPE on check for extension classloader

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/ScriptModuleActivator.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/src/main/java/org/eclipse/smarthome/automation/module/script/internal/ScriptModuleActivator.java
@@ -207,7 +207,7 @@ public class ScriptModuleActivator implements BundleActivator {
      * @param provider the provider holding the elements that should be added to the scope
      */
     private static void initializeNashornScope(ScriptEngine engine, ScriptScopeProvider provider) {
-        if (!AbstractScriptModuleHandler.class.getClassLoader().getParent().toString().contains("ExtClassLoader")) {
+        if (!checkForExtClassLoader()) {
             logger.warn(
                     "Found wrong classloader: To prevent class loading problems use this directive: -Dorg.osgi.framework.bundle.parent=ext");
         }
@@ -229,6 +229,15 @@ public class ScriptModuleActivator implements BundleActivator {
             engine.eval(scriptToEval);
         } catch (Exception e) {
             logger.error("Exception while importing scope: {}", e.getMessage());
+        }
+    }
+
+    private static boolean checkForExtClassLoader() {
+        final ClassLoader parentClassLoader = AbstractScriptModuleHandler.class.getClassLoader().getParent();
+        if (parentClassLoader == null) {
+            return false;
+        } else {
+            return parentClassLoader.toString().contains("ExtClassLoader");
         }
     }
 


### PR DESCRIPTION
Reference: https://docs.oracle.com/javase/7/docs/api/java/lang/ClassLoader.html#getParent()

Returns the parent class loader for delegation. Some implementations may use null to represent the bootstrap class loader. This method will return null in such implementations if this class loader's parent is the bootstrap class loader.
