### PR TITLE
Refresh thing from remote

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -759,7 +759,7 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
             $scope.thing.configuration = $scope.configuration;
         }
     });
-    $scope.getThing(false);
+    $scope.getThing(true);
 }).controller('ChannelConfigController', function($scope, $mdDialog, toastService, thingRepository, thingService, configService, channelType, channelUID, thing) {
     $scope.parameters = configService.getRenderingModel(channelType.parameters, channelType.parameterGroups);
     $scope.thing = thing;


### PR DESCRIPTION
I was unable to reproduce the exact issue https://github.com/eclipse/smarthome/issues/3000. But this makes sure that thing is up to date on thing config page.
fixes https://github.com/eclipse/smarthome/issues/3000
Signed-off-by: Aoun Bukhari <bukhari@itemis.de>