### PR TITLE
Fix for the unclear error message when the module id does not match the regular expression (#3023)

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleEngine.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleEngine.java
@@ -326,8 +326,8 @@ public class RuleEngine implements RegistryChangeListener<ModuleType> {
         for (Module m : modules) {
             String mId = m.getId();
             if (mId == null || !mId.matches("[A-Za-z0-9_-]*")) {
-                throw new IllegalArgumentException("Invalid module uid: " + mId != null ? mId
-                        : "null" + ". It must not be null or not fit to the pattern: [A-Za-z0-9_-]*");
+                throw new IllegalArgumentException("Invalid module uid: " + (mId != null ? mId
+                        : "null") + ". It must not be null or not fit to the pattern: [A-Za-z0-9_-]*");
             }
         }
     }


### PR DESCRIPTION
Now the message is clear and correct.
The problem was in the evaluation of the expression:
`"Invalid module uid: " + mId != null ? mId
                        : "null" + ". It must not be null or not fit to the pattern: [A-Za-z0-9_-]*"`