### PR TITLE
removed not recommended items in lifx README

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
@@ -23,7 +23,7 @@ The following table lists the thing types of the supported LIFX devices:
 | LIFX A19                     | colorlight   |
 | LIFX BR30                    | colorlight   |
 | LIFX Z                       | colorlight   |
-|                              |
+|                              |              |
 | LIFX+ A19                    | colorirlight |
 | LIFX+ BR30                   | colorirlight |
 |                              |              |
@@ -79,6 +79,9 @@ The **porch** light is a LIFX+ BR30 that has a *colorirlight* thing type which s
 
 Finally, **kitchen** is a White 800 (Low Voltage) light that has a *whitelight* thing type which supports *brightness* and *temperature* channels.
 
+It is possible to link *Switch* and *Dimmer* items to the *color* channel. However it is not recommended.
+Instead simply use *Switch* and *Slider* in addition to the *Colorpicker* entry for the *Color* item in the sitemap.
+
 ### demo.things:
 
 ```
@@ -100,17 +103,13 @@ Thing lifx:whitelight:kitchen [ deviceId="D073D5C3C3C3", fadetime=150 ]
 
 ```
 // Living
-Switch Living_Toggle { channel="lifx:colorlight:living:color" }
-Dimmer Living_Dimmer { channel="lifx:colorlight:living:color" }
 Color Living_Color { channel="lifx:colorlight:living:color" }
 Dimmer Living_Temperature { channel="lifx:colorlight:living:temperature" }
 
 // Porch
-Switch Porch_Toggle { channel="lifx:colorirlight:porch:color" }
-Dimmer Porch_Dimmer { channel="lifx:colorirlight:porch:color" }
 Color Porch_Color { channel="lifx:colorirlight:porch:color" }
-Dimmer Porch_Temperature { channel="lifx:colorirlight:porch:temperature" }
 Dimmer Porch_Infrared { channel="lifx:colorirlight:porch:infrared" }
+Dimmer Porch_Temperature { channel="lifx:colorirlight:porch:temperature" }
 
 // Kitchen
 Switch Kitchen_Toggle { channel="lifx:whitelight:kichen:brightness" }
@@ -125,15 +124,15 @@ Dimmer Kitchen_Temperature { channel="lifx:whitelight:kitchen:temperature" }
 sitemap demo label="Main Menu"
 {
 	Frame label="Living" {
-		Switch item=Living_Toggle
-		Slider item=Living_Dimmer
+		Switch item=Living_Color
+		Slider item=Living_Color
 		Colorpicker item=Living_Color
 		Slider item=Living_Temperature
 	}
 
 	Frame label="Porch" {
-		Switch item=Porch_Toggle
-		Slider item=Porch_Dimmer
+		Switch item=Porch_Color
+		Slider item=Porch_Color
 		Colorpicker item=Porch_Color
 		Slider item=Porch_Temperature
 		Slider item=Porch_Infrared

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
@@ -79,13 +79,19 @@ The **porch** light is a LIFX+ BR30 that has a *colorirlight* thing type which s
 
 Finally, **kitchen** is a White 800 (Low Voltage) light that has a *whitelight* thing type which supports *brightness* and *temperature* channels.
 
-It is possible to link *Switch* and *Dimmer* items to the *color* channel. However it is not recommended.
-Instead simply use *Switch* and *Slider* in addition to the *Colorpicker* entry for the *Color* item in the sitemap.
+Either create a single *Color* item linked to the *color* channel and define *Switch*, *Slider* and *Colorpicker* entries with this item in the sitemap.
+Or create items for each type (*Color*, *Switch*, *Dimmer*) and define the correspondent entries in the sitemap.
+
 
 ### demo.things:
 
 ```
 Thing lifx:colorlight:living [ deviceId="D073D5A1A1A1" ] {
+	Channels:
+		Type color : color [ powerOnBrightness= ]
+}
+
+Thing lifx:colorlight:living2 [ deviceId="D073D5A2A2A2" ] {
 	Channels:
 		Type color : color [ powerOnBrightness= ]
 }
@@ -105,6 +111,12 @@ Thing lifx:whitelight:kitchen [ deviceId="D073D5C3C3C3", fadetime=150 ]
 // Living
 Color Living_Color { channel="lifx:colorlight:living:color" }
 Dimmer Living_Temperature { channel="lifx:colorlight:living:temperature" }
+
+// Living2 (alternative approach)
+Color Living2_Color { channel="lifx:colorlight:living2:color" }
+Switch Living2_Switch { channel="lifx:colorlight:living2:color" }
+Dimmer Living2_Dimmer { channel="lifx:colorlight:living2:color" }
+Dimmer Living2_Temperature { channel="lifx:colorlight:living2:temperature" }
 
 // Porch
 Color Porch_Color { channel="lifx:colorirlight:porch:color" }
@@ -129,6 +141,13 @@ sitemap demo label="Main Menu"
 		Colorpicker item=Living_Color
 		Slider item=Living_Temperature
 	}
+
+	Frame label="Living2" {
+        	Switch item=Living2_Toggle
+        	Slider item=Living2_Dimmer
+        	Colorpicker item=Living2_Color
+        	Slider item=Living2_Temperature
+    }
 
 	Frame label="Porch" {
 		Switch item=Porch_Color


### PR DESCRIPTION
according to @kaikreuzer, the items Switch and Dimmer are not recommended.
https://github.com/eclipse/smarthome/issues/3014#issuecomment-279943751

Signed-off-by: Christoph Wempe <cw-git@wempe.net> (github: CWempe)