### PR TITLE
correctly set itemRegistry in returned handler

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/factory/CoreModuleHandlerFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/factory/CoreModuleHandlerFactory.java
@@ -154,25 +154,21 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory {
             // Handle triggers
 
             if (GenericEventTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID)) {
-                return new GenericEventTriggerHandler((Trigger) module,
-                        this.bundleContext);
+                return new GenericEventTriggerHandler((Trigger) module, this.bundleContext);
             } else if (ItemCommandTriggerHandler.MODULE_TYPE_ID.equals(moduleTypeUID)) {
-                return new ItemCommandTriggerHandler((Trigger) module,
-                        this.bundleContext);
+                return new ItemCommandTriggerHandler((Trigger) module, this.bundleContext);
             } else if (ItemStateTriggerHandler.CHANGE_MODULE_TYPE_ID.equals(moduleTypeUID)
                     || ItemStateTriggerHandler.UPDATE_MODULE_TYPE_ID.equals(moduleTypeUID)) {
-                return new ItemStateTriggerHandler((Trigger) module,
-                        this.bundleContext);
+                return new ItemStateTriggerHandler((Trigger) module, this.bundleContext);
             }
         } else if (module instanceof Condition) {
             // Handle conditions
-
             if (ItemStateConditionHandler.ITEM_STATE_CONDITION.equals(moduleTypeUID)) {
-                new ItemStateConditionHandler((Condition) module).setItemRegistry(itemRegistry);
-                return new ItemStateConditionHandler((Condition) module);
+                ItemStateConditionHandler handler = new ItemStateConditionHandler((Condition) module);
+                handler.setItemRegistry(itemRegistry);
+                return handler;
             } else if (GenericEventConditionHandler.MODULETYPE_ID.equals(moduleTypeUID)) {
-                return new GenericEventConditionHandler(
-                        (Condition) module);
+                return new GenericEventConditionHandler((Condition) module);
             } else if (CompareConditionHandler.MODULE_TYPE.equals(moduleTypeUID)) {
                 return new CompareConditionHandler((Condition) module);
             }


### PR DESCRIPTION
I just tried a rule with an item state condition and came across
```
17:15:37.395 [ERROR] [re.handler.ItemStateConditionHandler] - The ItemRegistry is not available to evaluate the condition.
```
This PR fixes this (the relevant change is only in l. 167-169).

Signed-off-by: Kai Kreuzer <kai@openhab.org>