### PR TITLE
Extend the AudioSink infrastructure

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioManager.java
@@ -35,7 +35,7 @@ public interface AudioManager {
      * Plays the passed audio stream on the given sink.
      *
      * @param audioStream The audio stream to play
-     * @param sinkId The id of the audio sink to use or null
+     * @param sinkId The id of the audio sink or group of audio sinks to use, or null
      */
     void play(AudioStream audioStream, String sinkId);
 
@@ -47,7 +47,7 @@ public interface AudioManager {
     void playFile(String fileName) throws AudioException;
 
     /**
-     * Plays an audio file from the "sounds" folder using the given audio sink.
+     * Plays an audio file from the "sounds" folder using the given audio sink or group of audio sinks
      *
      * @throws AudioException in case the file does not exist or cannot be opened
      */
@@ -61,10 +61,10 @@ public interface AudioManager {
     void stream(String url) throws AudioException;
 
     /**
-     * Stream audio from the passed url to the given sink
+     * Stream audio from the passed url to the given sink or group of audio sinks
      *
      * @param url The url to stream from or null if streaming should be stopped
-     * @param sinkId The id of the audio sink to use or null
+     * @param sinkId The id of the audio sink or group of audio sinks to use or null
      * @throws AudioException in case the url stream cannot be opened
      */
     void stream(String url, String sinkId) throws AudioException;
@@ -78,10 +78,10 @@ public interface AudioManager {
     PercentType getVolume(String sinkId);
 
     /**
-     * Sets the volume for a sink.
+     * Sets the volume for a sink or group of audio sinks
      *
      * @param volume the volume to set as a value between 0 and 100
-     * @param sinkId the sink to set the volume
+     * @param sinkId the sink or group of audio sinks to set the volume
      */
     void setVolume(PercentType volume, String sinkId);
 
@@ -144,5 +144,61 @@ public interface AudioManager {
      * @return ids of matching sinks
      */
     Set<String> getSinks(String pattern);
+
+    /**
+     * Create a named (empty) group of Sinks
+     *
+     * @param groupId the id of the group to be created
+     * @return true if the creation was successful (e.g. no duplicate)
+     */
+    boolean createGroup(String groupId);
+
+    /**
+     * Remove the named group of Sinks
+     *
+     * @param groupId the id of the group to be removed
+     */
+    void removeGroup(String groupId);
+
+    /**
+     * Add a sink to a named group of Sinks
+     *
+     * @param sinkId the id of the group to be created
+     * @param groupId the id of the group to be created
+     * @return ids of sinks in the group
+     */
+    Set<String> addToGroup(String sinkId, String groupId);
+
+    /**
+     * Remove a sink to a named group of Sinks
+     *
+     * @param sinkId the id of the group to be created
+     * @param groupId the id of the group to be created
+     * @return ids of sinks in the group
+     */
+    Set<String> removeFromGroup(String sinkId, String groupId);
+
+    /**
+     * Get a list of sink ids that belong to a group
+     *
+     * @param groupId the id of the group to be queried
+     * @return ids of the sinks in the group
+     */
+    Set<String> getGroup(String groupId);
+
+    /**
+     * Get a list of groups
+     *
+     * @return ids of the groups
+     */
+    Set<String> getGroups();
+
+    /**
+     * Get a list of sink ids that match a given pattern
+     *
+     * @param pattern pattern to search, can include `*` and `?` placeholders
+     * @return ids of matching sinks
+     */
+    Set<String> getGroups(String pattern);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioServlet.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioServlet.java
@@ -173,9 +173,19 @@ public class AudioServlet extends HttpServlet implements AudioHTTPServer {
 
     @Override
     public String serve(FixedLengthAudioStream stream, int seconds) {
+        boolean found = false;
         String streamId = UUID.randomUUID().toString();
-        multiTimeStreams.put(streamId, stream);
-        streamTimeouts.put(streamId, System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds));
+        for (String aStreamId : multiTimeStreams.keySet()) {
+            if (multiTimeStreams.get(aStreamId) == stream) {
+                streamTimeouts.put(aStreamId, System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds));
+                streamId = aStreamId;
+                found = true;
+            }
+        }
+        if (!found) {
+            multiTimeStreams.put(streamId, stream);
+            streamTimeouts.put(streamId, System.nanoTime() + TimeUnit.SECONDS.toNanos(seconds));
+        }
         return getRelativeURL(streamId);
     }
 

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/actions/Audio.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/actions/Audio.java
@@ -126,4 +126,48 @@ public class Audio {
         setMasterVolume(newVolume);
     }
 
+    @ActionDoc(text = "creates an empty group of sinks")
+    public static void createSinkGroup(@ParamDoc(name = "group", text = "the id of the group") String group) {
+        try {
+            AudioActionService.audioManager.createGroup(group);
+        } catch (Exception e) {
+            logger.warn("Failed to create a group of sinks: {}", e.getMessage());
+        }
+    }
+
+    @ActionDoc(text = "clears a group of sinks")
+    public static void clearSinkGroup(@ParamDoc(name = "group", text = "the id of the group") String group) {
+        try {
+            AudioActionService.audioManager.removeGroup(group);
+        } catch (Exception e) {
+            logger.warn("Failed to clear a group of sinks: {}", e.getMessage());
+        }
+    }
+
+    @ActionDoc(text = "adds a sink to a group")
+    public static void addToSinkGroup(@ParamDoc(name = "group", text = "the id of the group") String group,
+            @ParamDoc(name = "sink", text = "the id of the sink") String sink) {
+        try {
+            AudioActionService.audioManager.addToGroup(sink, group);
+        } catch (Exception e) {
+            logger.warn("Failed to add a sink to a group of sinks: {}", e.getMessage());
+        }
+    }
+
+    @ActionDoc(text = "removes a sink to a group")
+    public static void removeFromSinkGroup(@ParamDoc(name = "group", text = "the id of the group") String group,
+            @ParamDoc(name = "sink", text = "the id of the sink") String sink) {
+        try {
+            AudioActionService.audioManager.removeFromGroup(sink, group);
+        } catch (Exception e) {
+            logger.warn("Failed to remove a sink to a group of sinks: {}", e.getMessage());
+        }
+    }
+
+    @ActionDoc(text = "sets the volume of a sink or group of sinks")
+    public static void setSinkVolume(@ParamDoc(name = "sink", text = "the id of the sink or group") String sink,
+            @ParamDoc(name = "percent") final PercentType percent) throws IOException {
+        AudioActionService.audioManager.setVolume(percent, sink);
+    }
+
 }


### PR DESCRIPTION
Extend the AudioSink infrastructure (ConsoleCommand, Rules) with the concept of “grouped” sinks that provide a multi-room audio functionality that goes beyond the boundary of a given hardware implementation (e.g. Sonos).

The Thread related code could be factored out if such a nee would arise. I have experimented with various Executor services, including the ones already implemented in the ESH core (e.g. SafeCall), but they proved not to be sufficient to let the AudioSinks play in a synchronised-lie way. Only the CachedThreadPool is fast enough to start up threads in sync, and thus play sounds correctly.


Signed-off-by: Karel Goderis <karel.goderis@me.com>