### PR TITLE
correctly handle hidden files

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.provider.file/src/main/java/org/eclipse/smarthome/automation/internal/provider/file/AbstractFileProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.provider.file/src/main/java/org/eclipse/smarthome/automation/internal/provider/file/AbstractFileProvider.java
@@ -135,7 +135,7 @@ public abstract class AbstractFileProvider<E> implements Provider<E> {
             File[] files = file.listFiles();
             if (files != null) {
                 for (File f : files) {
-                    if (!file.getName().startsWith(".")) {
+                    if (!file.isHidden()) {
                         importResources(f);
                     }
                 }


### PR DESCRIPTION
fixes #2854
#2855 didn't work in cases where a file was part of a subdirectory (since getName also returns the folders).

Signed-off-by: Kai Kreuzer <kai@openhab.org>