### PR TITLE
DBus bundle: allow usage of exported libraries in Eclipse IDE

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.dbus/.classpath
+++ b/bundles/io/org.eclipse.smarthome.io.transport.dbus/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="lib/unix-0.5.jar"/>
-	<classpathentry kind="lib" path="lib/libdbus-java-2.7.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/unix-0.5.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/libdbus-java-2.7.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/io/org.eclipse.smarthome.io.transport.dbus/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.dbus/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.smarthome.io.transport.dbus
 Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package:  org.freedesktop,
+Export-Package: org.freedesktop,
  org.freedesktop.dbus,
  org.freedesktop.dbus.exceptions,
  cx.ath.matthew.debug,
@@ -14,5 +14,7 @@ Export-Package:  org.freedesktop,
 Import-Package: 
  org.apache.commons.lang,
  org.slf4j
-Bundle-ClassPath: ., lib/unix-0.5.jar, lib/libdbus-java-2.7.jar
+Bundle-ClassPath: .,
+ lib/unix-0.5.jar,
+ lib/libdbus-java-2.7.jar
 


### PR DESCRIPTION
The content of 'lib/unix-0.5.jar' and 'lib/libdbus-java-2.7.jar' is already added to the bundle classpath and packages are already exported by OSGi.
The Eclipse IDE classpath settings does not mark that stuff of that files is exported. So access to e.g. org.freedesktop.dbus is not available in the Eclipse IDE.
