### PR TITLE
OSGi test: return implementation class

### DIFF
--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
@@ -91,8 +91,8 @@ abstract class OSGiTest {
      * @param filter
      * @return OSGi service or null if no service can be found for the given class
      */
-    protected <T> T getService(Class<T> clazz, Class<? extends T> implementationClass){
-        getService(clazz, { ServiceReference<?> serviceReference ->
+    protected <T,I extends T> I getService(Class<T> clazz, Class<I> implementationClass){
+        (I) getService(clazz, { ServiceReference<?> serviceReference ->
             implementationClass.isAssignableFrom(bundleContext.getService(serviceReference).getClass())
         })
     }


### PR DESCRIPTION
If we get a service class by filter on a specific implementation class an instance of the implementation class (so the more specified) should be returned.
This is what is currently done and used.
It seems Groovy ignores the types and does not warn / error if you assign the returned serice class to an instance of the implementation class.
If you use the Java compiler it errors as expected.