### PR TITLE
correctly specify the parser format as DS properties

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/.project
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/.project
@@ -20,6 +20,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/OSGI-INF/ModuleTypeGSONParser.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/OSGI-INF/ModuleTypeGSONParser.xml
@@ -17,5 +17,6 @@
    </service>
    
    <property name="parser.type" type="String" value="parser.module.type"/>
+   <property name="format" type="String" value="json"/>
 
 </scr:component>

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/OSGI-INF/RuleGSONParser.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/OSGI-INF/RuleGSONParser.xml
@@ -17,5 +17,6 @@
    </service>
    
    <property name="parser.type" type="String" value="parser.rule"/>
+   <property name="format" type="String" value="json"/>
 
 </scr:component>

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/OSGI-INF/TemplateGSONParser.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/OSGI-INF/TemplateGSONParser.xml
@@ -17,5 +17,6 @@
    </service>
    
    <property name="parser.type" type="String" value="parser.template"/>
+   <property name="format" type="String" value="json"/>
 
 </scr:component>


### PR DESCRIPTION
According to the [parser JavaDoc](https://github.com/eclipse/smarthome/blob/master/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/parser/Parser.java#L38-L42) this property should be provided in DS.

Signed-off-by: Kai Kreuzer <kai@openhab.org>