### PR TITLE
remove wrong deprecation and ItemThingLinkRegistry references

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/link/LinkEventOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/link/LinkEventOSGiTest.groovy
@@ -22,7 +22,7 @@ import org.junit.Test
 import com.google.common.collect.Sets
 
 /**
- * Event Tests for {@link ItemChannelLinkRegistry} and {@link ItemThingLinkRegistry}.
+ * Event Tests for {@link ItemChannelLinkRegistry}.
  *
  * @author Dennis Nobel - Initial contribution
  */

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
@@ -41,8 +41,7 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
     /**
      * Returns a set of bound channels for the given item name.
      *
-     * @param itemName
-     *            item name
+     * @param itemName item name
      * @return set of bound channels for the given item name
      */
     public Set<ChannelUID> getBoundChannels(String itemName) {
@@ -93,15 +92,10 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
     /**
      * Returns a set of bound things for the given item name.
      *
-     * @deprecated Will be removed soon. Use {@link ItemThingLinkRegistry#getLinkedThings(String)} instead.
-     *
-     * @param itemName
-     *            item name
+     * @param itemName item name
      * @return set of bound things for the given item name
      */
-    @Deprecated
     public Set<Thing> getBoundThings(String itemName) {
-
         Set<Thing> things = new HashSet<>();
         Collection<ChannelUID> boundChannels = getBoundChannels(itemName);
 


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/2357