### PR TITLE
fix race condition which could leave a thing in INITIALIZING

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/BundleProcessorVetoManager.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/BundleProcessorVetoManager.java
@@ -94,9 +94,9 @@ public class BundleProcessorVetoManager<T> implements BundleProcessorListener {
      *
      * @param object the argument for the action
      */
-    public void applyActionFor(final T object) {
+    public void applyActionFor(final Class<?> classFromWatchedBundle, final T object) {
         boolean veto = false;
-        Bundle bundle = getBundle(object.getClass());
+        Bundle bundle = getBundle(classFromWatchedBundle);
         long bundleId = bundle.getBundleId();
         for (BundleProcessor proc : bundleProcessors) {
             if (!proc.hasFinishedLoading(bundle)) {
@@ -110,7 +110,7 @@ public class BundleProcessorVetoManager<T> implements BundleProcessorListener {
             }
         }
         if (veto) {
-            if (!queue.containsEntry(bundle, object)) {
+            if (!queue.containsEntry(bundleId, object)) {
                 logger.trace("Queueing '{}' in bundle '{}'", object, bundle.getSymbolicName());
                 queue.put(bundleId, object);
             }

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/org.eclipse.smarthome.model.thing.tests.launch.launch
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/org.eclipse.smarthome.model.thing.tests.launch.launch
@@ -26,7 +26,7 @@
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.model.thing.tests"/>

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest4.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest4.groovy
@@ -14,10 +14,16 @@ import static org.junit.matchers.JUnitMatchers.*
 import org.eclipse.smarthome.config.core.BundleProcessor
 import org.eclipse.smarthome.config.core.BundleProcessor.BundleProcessorListener
 import org.eclipse.smarthome.core.thing.Bridge
+import org.eclipse.smarthome.core.thing.ChannelUID
 import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingRegistry
+import org.eclipse.smarthome.core.thing.ThingStatus
 import org.eclipse.smarthome.core.thing.ThingUID
+import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler
+import org.eclipse.smarthome.core.thing.binding.ThingHandler
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory
+import org.eclipse.smarthome.core.types.Command
 import org.eclipse.smarthome.model.core.ModelRepository
 import org.eclipse.smarthome.model.thing.test.hue.TestHueThingHandlerFactoryX
 import org.eclipse.smarthome.model.thing.test.hue.TestHueThingTypeProvider
@@ -25,6 +31,9 @@ import org.eclipse.smarthome.test.OSGiTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
 import org.osgi.framework.Bundle
 import org.osgi.framework.FrameworkUtil
 import org.osgi.service.component.ComponentContext
@@ -38,18 +47,72 @@ import org.osgi.service.component.ComponentContext
  *
  * @author Simon Kaufmann - initial contribution and API.
  */
+@RunWith(Parameterized.class)
 class GenericThingProviderTest4 extends OSGiTest{
     private TestHueThingTypeProvider thingTypeProvider
     private BundleProcessor bundleProcessor
     private Bundle bundle
     private ThingHandlerFactory hueThingHandlerFactory
-    private BundleProcessorListener listener
+    private BundleProcessorListener listenerThingManager
+    private BundleProcessorListener listenerGenericProvider
     private boolean finished
+    private int bridgeInitializeCounter
+    private int thingInitializeCounter
+    final boolean thingManagerListenerFirst
+    final boolean slowInit
 
     private final static String TESTMODEL_NAME = "testModelX.things"
 
     ModelRepository modelRepository;
     ThingRegistry thingRegistry;
+
+    @Parameters(name = "{index}: thingManagerFirst={0}, slowInit={1}")
+    public static Collection<Object[]> data() {
+        return [
+            [
+                true,
+                false
+            ] as Object[],
+            [
+                false,
+                false
+            ] as Object[],
+            [
+                true,
+                true
+            ] as Object[],
+            [
+                false,
+                true
+            ] as Object[]
+        ]
+    }
+
+    public GenericThingProviderTest4(boolean thingManagerListenerFirst, boolean slowInit) {
+        this.thingManagerListenerFirst = thingManagerListenerFirst
+        this.slowInit = slowInit
+    }
+
+    class TestBridgeHandler extends BaseBridgeHandler {
+        public TestBridgeHandler(Bridge bridge) {
+            super(bridge)
+        }
+        @Override
+        public void handleCommand(ChannelUID channelUID, Command command) {
+        }
+        @Override
+        public void initialize() {
+            bridgeInitializeCounter++
+            if (slowInit) {
+                Thread.sleep(1000)
+            }
+            super.initialize()
+        }
+        @Override
+        public void dispose() {
+            super.dispose();
+        }
+    }
 
     @Before
     public void setUp() {
@@ -60,16 +123,42 @@ class GenericThingProviderTest4 extends OSGiTest{
         modelRepository.removeModel(TESTMODEL_NAME)
 
         def componentContextMock = [
-            getBundleContext: {getBundleContext()}
+            getBundleContext: { getBundleContext() }
         ] as ComponentContext
-        hueThingHandlerFactory = new TestHueThingHandlerFactoryX(componentContextMock)
+        hueThingHandlerFactory = new TestHueThingHandlerFactoryX(componentContextMock) {
+                    @Override
+                    protected ThingHandler createHandler(final Thing thing) {
+                        if (thing instanceof Bridge) {
+                            return new TestBridgeHandler((Bridge) thing)
+                        } else {
+                            return new BaseThingHandler(thing) {
+                                        void handleCommand(ChannelUID arg0, Command arg1) {};
+                                    }
+                        }
+                    }
+                }
 
         finished = false;
         bundle = FrameworkUtil.getBundle(TestHueThingHandlerFactoryX)
         bundleProcessor = [
             "hasFinishedLoading": { return finished },
-            "registerListener": {l -> listener = l},
-            "unregisterListener": {l -> listener = null}
+            "registerListener": { l ->
+                String actionClassName = l.action.getClass().getName()
+                if (actionClassName.contains("ThingManager")) {
+                    listenerThingManager = l
+                }
+                if (actionClassName.contains("GenericThingProvider")) {
+                    listenerGenericProvider = l
+                }
+            },
+            "unregisterListener": { l ->
+                if (l.action.getClass().getName().contains("ThingManager")) {
+                    listenerThingManager = null
+                }
+                if (l.action.getClass().getName().contains("GenericThingProvider")) {
+                    listenerGenericProvider = null
+                }
+            }
         ] as BundleProcessor
         registerService(bundleProcessor)
     }
@@ -82,6 +171,25 @@ class GenericThingProviderTest4 extends OSGiTest{
         }
     }
 
+    private void prepareThingWithShutDownBundle() {
+        updateModel()
+        registerThingTypeProvider()
+        finishLoading()
+        registerService(hueThingHandlerFactory, ThingHandlerFactory.class.name)
+        assertThatAllIsGood()
+        unload()
+        unregisterService(ThingHandlerFactory.class.name)
+        waitForAssert {
+            assertThat thingRegistry.getAll().size(), is(1)
+            assertThat thingRegistry.getAll().find{
+                it.getUID().getAsString().equals("Xhue:Xbridge:myBridge")
+            }.getStatus(), is(equalTo(ThingStatus.UNINITIALIZED))
+            assertThat thingRegistry.getAll().find{
+                it.getUID().getAsString().equals("Xhue:Xbridge:myBridge")
+            }.getHandler(), is(nullValue())
+        }
+    }
+
     private def updateModel() {
         String model =
                 '''
@@ -90,20 +198,38 @@ class GenericThingProviderTest4 extends OSGiTest{
         modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.bytes))
     }
 
-    private def finishLoading() {
+    private def registerThingTypeProvider() {
         thingTypeProvider = new TestHueThingTypeProvider()
         registerService(thingTypeProvider)
+    }
 
+    private def finishLoading() {
         finished = true;
-        listener.bundleFinished(bundleProcessor, bundle)
+        if (thingManagerListenerFirst) {
+            assertThat bridgeInitializeCounter, is(0)
+            listenerThingManager.bundleFinished(bundleProcessor, bundle)
+            listenerGenericProvider.bundleFinished(bundleProcessor, bundle)
+        } else {
+            assertThat bridgeInitializeCounter, is(0)
+            listenerGenericProvider.bundleFinished(bundleProcessor, bundle)
+            listenerThingManager.bundleFinished(bundleProcessor, bundle)
+        }
+    }
+
+    private def unload() {
+        unregisterService(thingTypeProvider)
+        finished = false;
     }
 
     private void assertThatAllIsGood() {
         assertThat thingRegistry.getAll().size(), is(1)
 
-        Thing bridge = thingRegistry.get(new ThingUID("Xhue:Xbridge:myBridge"))
-        assertThat bridge, is(notNullValue())
-        assertThat bridge, is(instanceOf(Bridge))
+        waitForAssert {
+            Thing bridge = thingRegistry.get(new ThingUID("Xhue:Xbridge:myBridge"))
+            assertThat bridge, is(notNullValue())
+            assertThat bridge, is(instanceOf(Bridge))
+            assertThat bridge.getStatus(), is(equalTo(ThingStatus.ONLINE))
+        }
     }
 
     @Test
@@ -113,6 +239,7 @@ class GenericThingProviderTest4 extends OSGiTest{
         assertThat thingRegistry.getAll().size(), is(0)
         registerService(hueThingHandlerFactory, ThingHandlerFactory.class.name)
         assertThat thingRegistry.getAll().size(), is(0)
+        registerThingTypeProvider()
         finishLoading()
         assertThatAllIsGood()
     }
@@ -124,6 +251,7 @@ class GenericThingProviderTest4 extends OSGiTest{
         assertThat thingRegistry.getAll().size(), is(0)
         updateModel()
         assertThat thingRegistry.getAll().size(), is(0)
+        registerThingTypeProvider()
         finishLoading()
         assertThatAllIsGood()
     }
@@ -131,6 +259,7 @@ class GenericThingProviderTest4 extends OSGiTest{
     @Test
     void 'assert that things are created only once the bundle finished loading with loaded_factory_update'() {
         assertThat thingRegistry.getAll().size(), is(0)
+        registerThingTypeProvider()
         finishLoading()
         assertThat thingRegistry.getAll().size(), is(0)
         registerService(hueThingHandlerFactory, ThingHandlerFactory.class.name)
@@ -142,6 +271,7 @@ class GenericThingProviderTest4 extends OSGiTest{
     @Test
     void 'assert that things are created only once the bundle finished loading with loaded_update_factory'() {
         assertThat thingRegistry.getAll().size(), is(0)
+        registerThingTypeProvider()
         finishLoading()
         assertThat thingRegistry.getAll().size(), is(0)
         updateModel()
@@ -155,6 +285,7 @@ class GenericThingProviderTest4 extends OSGiTest{
         assertThat thingRegistry.getAll().size(), is(0)
         registerService(hueThingHandlerFactory, ThingHandlerFactory.class.name)
         assertThat thingRegistry.getAll().size(), is(0)
+        registerThingTypeProvider()
         finishLoading()
         assertThat thingRegistry.getAll().size(), is(0)
         updateModel()
@@ -166,9 +297,25 @@ class GenericThingProviderTest4 extends OSGiTest{
         assertThat thingRegistry.getAll().size(), is(0)
         updateModel()
         assertThat thingRegistry.getAll().size(), is(0)
+        registerThingTypeProvider()
         finishLoading()
         assertThat thingRegistry.getAll().size(), is(0)
         registerService(hueThingHandlerFactory, ThingHandlerFactory.class.name)
+        assertThatAllIsGood()
+    }
+
+    @Test
+    void 'assert that thing handlers are managed correctly on update with factory_loaded'() {
+        prepareThingWithShutDownBundle()
+
+        bridgeInitializeCounter = 0
+        registerService(hueThingHandlerFactory, ThingHandlerFactory.class.name)
+        registerThingTypeProvider()
+        assertThat thingRegistry.get(new ThingUID("Xhue:Xbridge:myBridge")).getHandler(), is(nullValue())
+        finishLoading()
+        waitForAssert {
+            assertThat bridgeInitializeCounter >= 1, is(true)
+        }
         assertThatAllIsGood()
     }
 }

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
@@ -127,7 +127,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                 it != null
             ]?.toSet?.forEach[
                 // Execute for each unique ThingHandlerFactory
-                vetoManager.applyActionFor(it)
+                vetoManager.applyActionFor(it.getClass(), it)
             ]
         }
     }
@@ -519,7 +519,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
     }
 
     def private thingHandlerFactoryAdded(ThingHandlerFactory thingHandlerFactory) {
-        vetoManager.applyActionFor(thingHandlerFactory)
+        vetoManager.applyActionFor(thingHandlerFactory.getClass(), thingHandlerFactory)
     }
 
     def private createThingsFromModelForThingHandlerFactory(String modelName, ThingHandlerFactory factory) {


### PR DESCRIPTION
as we have seen in #2945 and #3015, there can be situations when a thing
is left in INITIALIZING state although the binding updated its state
correctly.

The root cause was a race condition between ThingManager and GenericThingProvider.
While the ThingManager was trying to initialize the Thing, the GenericThingProvider
tried to update the the existing thing (which already had a ThingHandler). As a
result, the existing ThingHandler updated the outdated thing, not knowing that
there actually was an update.

The key for fixing this was changing the point in time when a handler is created.
This will now also be postponed until the binding is fully loaded. Additionally,
bindings have to deal with thing updates while the thing still is in INITIALIZING
state. On the other hand, it is now technically prevented that ThingHandler.initialize()
can get called again when a thing already is ONLINE/OFFLINE/UNKNOWN.

fixes #2945
fixes #3015
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>