### PR TITLE
Add README.md files to transformations

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.exec/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/README.md
@@ -1,0 +1,19 @@
+# Exec Transformation Service
+
+Execute an external program, substituting the placeholder `%s` in the given command line with the input value, and returning the output of the external program.
+
+The external program must either be in the executable search path of the server process, or an absolute path can be used.
+
+## Example
+
+With the command line 
+
+```
+/bin/date -v1d -v+1m -v-1d -v-%s
+```
+
+return a string showing the last weekday of the month.
+
+| input | output |
+|-------|--------|
+| `fri` | `Fri 31 Mar 2017 13:58:47 IST` |

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/README.md
@@ -1,0 +1,19 @@
+# JavaScript Transformation Service
+
+Transform an input to an output using JavaScript. 
+
+It expects the transformation rule to be read from a file which is stored under the `transform` folder. 
+To organize the various transformations, one should use subfolders.
+
+## Example
+
+Let's assume we have received a string containing `foo bar baz` and we're looking for a length of the last word (`baz`).
+
+transform/getValue.js:
+
+```
+(function(i) {
+    var array = i.split(" ");
+    return array[array.length - 1].length;
+})(input)
+```

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/README.md
@@ -1,0 +1,19 @@
+# JsonPath Transformation Service
+
+Extract an element of a JSON string using a [JsonPath expression](https://github.com/jayway/JsonPath#jayway-jsonpath).
+
+Return `null` if the JsonPath expression could not be found.
+
+## Testing Tools
+
+* [http://jsonpath.com/](http://jsonpath.com/)
+* [http://www.jsonquerytool.com/](http://www.jsonquerytool.com/)
+
+## Example
+
+Given the JsonPath expression `$.device.status.temperature`:
+
+| input | output |
+|-------|--------|
+| `{ "device": { "status": { "temperature": 23.2 }}}` | `23.2` |
+

--- a/extensions/transform/org.eclipse.smarthome.transform.map/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/README.md
@@ -1,0 +1,25 @@
+# Map Transformation Service
+
+Transforms the input by mapping it to another string. It expects the mappings to be read from a file which is stored under the `transform` folder. 
+
+This file should be in property syntax, i.e. simple lines with "key=value" pairs. 
+The file format is documented [here](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-).
+To organize the various transformations one might use subfolders.
+
+## Example
+
+binary.map:
+
+```properties
+key=value
+1=ON
+0=OFF
+ON=1
+OFF=0
+```
+
+| input | output  |
+|-------|---------|
+| `1`   | `ON`    |
+| `OFF` | `0`     |
+| `key` | `value` |

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/README.md
@@ -1,0 +1,18 @@
+# RegEx Transformation Service
+
+Given a source string and a regular expression, use the regular expression to yield a transformed string.  
+
+If the regular expression is in the format `s/<regex>/result/g`, replace all occurrences of `<regex>` in the source string with `result` and return the result.
+
+If the regular expression is in the format `s/<regex>/result/`, replace the first occurrence of `<regex>` in the source string with `result` and return the result.
+
+If the regular expression contains a [capture group](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#cg), return the captured string.  The regular expression in this case is further restricted to isolate a complete line by adding `^` to the beginning and `$` to the end.
+
+## Examples
+
+With the input string `My network does not work.`:
+
+| regular expression | output |
+|--------------------|--------|
+| `s/work/cast/g`    | `My netcast does not cast.` |
+| `.*(\snot).*`      | ` not` |

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/README.md
@@ -1,0 +1,16 @@
+# Scale Transformation Service
+
+Transform the input by matching it between limits of ranges in a scale file.  The input string must be in numerical format.
+
+The file is expected to exist in the `transform` directory, and should follow the format given in the example below.
+
+## Example
+
+transform/temps.scale:
+
+```properties
+[12..23]=Temp between 12 or higher and 23 or lower
+]12..23[=Temp over 12 and below 23
+..23]=Any temp up to and including 23
+]12..=Any temp above 12
+```

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/README.md
@@ -1,0 +1,3 @@
+# XPath Transformation Service
+
+Transform XML input using an [XPath expression](https://www.w3.org/TR/xpath/#section-Expressions).

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/README.md
@@ -1,0 +1,37 @@
+# XSLT Transformation Service
+
+Transform input using the XML Stylesheet Language for Transformations (XSLT).
+
+It expects the transformation rule to be read from a file which is stored under the `transform` folder. 
+To organize the various transformations one should use subfolders.
+
+## Example
+
+(from [here](https://en.wikipedia.org/wiki/Java_API_for_XML_Processing#Example))
+
+input:
+
+```xml
+<?xml version='1.0' encoding='UTF-8'?>
+<root><node val='hello'/></root>
+```
+
+transform/helloworld.xsl:
+
+```xml
+<?xml version='1.0' encoding='UTF-8'?>
+<xsl:stylesheet version='2.0' xmlns:xsl='http://www.w3.org/1999/XSL/Transform'>
+   <xsl:output method='xml' indent='no'/>
+   <xsl:template match='/'>
+      <reRoot><reNode><xsl:value-of select='/root/node/@val' /> world</reNode></reRoot>
+   </xsl:template>
+</xsl:stylesheet>
+```
+
+output:
+
+```
+hello
+```
+
+Other examples may be found [here](https://en.wikipedia.org/wiki/XSLT#XSLT_examples).


### PR DESCRIPTION
The content comes from either my original work, the source code, or [the old wiki](https://github.com/openhab/openhab1-addons/wiki) where earlier versions of the transformations resided (at commit ecae0ce585a08b3a0342fbb9a59154360c71afc2.

Signed-off-by: John Cocula <john@cocula.com>