### PR TITLE
Changes in org.eclipse.smarthome.core.audio

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/URLAudioStream.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/URLAudioStream.java
@@ -90,7 +90,10 @@ public class URLAudioStream extends org.eclipse.smarthome.core.audio.AudioStream
                 os.write(req.getBytes());
                 is = shoutCastSocket.getInputStream();
             } else {
-                is = streamUrl.openStream();
+                // getInputStream() method is more error-proof than openStream(),
+                // because openStream() does openConnection().getInputStream(),
+                // which opens a new connection and does not reuse the old one.
+                is = connection.getInputStream();
             }
             return is;
         } catch (MalformedURLException e) {

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioManagerImpl.java
@@ -206,7 +206,7 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
         String regex = pattern.replace("?", ".?").replace("*", ".*?");
         Set<String> matchedSources = new HashSet<String>();
 
-        for (String aSource : audioSinks.keySet()) {
+        for (String aSource : audioSources.keySet()) {
             if (aSource.matches(regex)) {
                 matchedSources.add(aSource);
             }


### PR DESCRIPTION
I have written tests about the `org.eclipse.smarthome.core.audio` bundle: https://github.com/eclipse/smarthome/pull/2687. I have found the following problems:

1. `createInputStream()` in URLAudioStream does not reuse an already opened connection, but opens a new one:
`openStream()` method calls `openConnection().getInputStream()`, which opens an entirely new connection and does not reuse the old one. Also, `openStream()` initiates HTTP GET request: http://stackoverflow.com/questions/2778312/how-does-java-url-openstream-work. For example, this may cause a problem when we use `oneTimeStreams` in the `AudioServlet`, because `oneTimeStreams` can be requested only a single time.
This problem can be solved, if we use `getInputStream()` method on the currently opened connection.

2. `getSourceIds()` in `AudioManagerImpl` does not return the ids of the sources correctly:
The method `getSourceIds()` should be iterating through sources, not sinks.

Signed-off-by: Petar Valchev petar.valchev@musala.com