### PR TITLE
run Eclipse formatter rules on Hue binding

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
@@ -23,7 +23,17 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.smarthome.binding.hue.internal.Config;
+import org.eclipse.smarthome.binding.hue.internal.FullConfig;
+import org.eclipse.smarthome.binding.hue.internal.FullLight;
+import org.eclipse.smarthome.binding.hue.internal.HueBridge;
 import org.eclipse.smarthome.binding.hue.internal.HueConfigStatusMessage;
+import org.eclipse.smarthome.binding.hue.internal.State;
+import org.eclipse.smarthome.binding.hue.internal.StateUpdate;
+import org.eclipse.smarthome.binding.hue.internal.exceptions.ApiException;
+import org.eclipse.smarthome.binding.hue.internal.exceptions.DeviceOffException;
+import org.eclipse.smarthome.binding.hue.internal.exceptions.LinkButtonException;
+import org.eclipse.smarthome.binding.hue.internal.exceptions.UnauthorizedException;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.status.ConfigStatusMessage;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -37,17 +47,6 @@ import org.eclipse.smarthome.core.thing.binding.ConfigStatusBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.eclipse.smarthome.binding.hue.internal.Config;
-import org.eclipse.smarthome.binding.hue.internal.FullConfig;
-import org.eclipse.smarthome.binding.hue.internal.FullLight;
-import org.eclipse.smarthome.binding.hue.internal.HueBridge;
-import org.eclipse.smarthome.binding.hue.internal.State;
-import org.eclipse.smarthome.binding.hue.internal.StateUpdate;
-import org.eclipse.smarthome.binding.hue.internal.exceptions.ApiException;
-import org.eclipse.smarthome.binding.hue.internal.exceptions.DeviceOffException;
-import org.eclipse.smarthome.binding.hue.internal.exceptions.LinkButtonException;
-import org.eclipse.smarthome.binding.hue.internal.exceptions.UnauthorizedException;
 
 /**
  * {@link HueBridgeHandler} is the handler for a hue bridge and connects it to
@@ -156,7 +155,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler {
                 logger.error("An unexpected error occurred: {}", t.getMessage(), t);
             }
         }
-        
+
         private boolean isReachable(String ipAddress) {
             try {
                 // note that InetAddress.isReachable is unreliable, see

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
@@ -15,6 +15,10 @@ import java.util.Set;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.smarthome.binding.hue.internal.FullLight;
+import org.eclipse.smarthome.binding.hue.internal.HueBridge;
+import org.eclipse.smarthome.binding.hue.internal.State;
+import org.eclipse.smarthome.binding.hue.internal.StateUpdate;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
@@ -35,11 +39,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
-import org.eclipse.smarthome.binding.hue.internal.FullLight;
-import org.eclipse.smarthome.binding.hue.internal.HueBridge;
-import org.eclipse.smarthome.binding.hue.internal.State;
-import org.eclipse.smarthome.binding.hue.internal.StateUpdate;
 
 /**
  * {@link HueLightHandler} is the handler for a hue light. It uses the {@link HueBridgeHandler} to execute the actual

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/LightStateConverter.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/LightStateConverter.java
@@ -7,17 +7,16 @@
  */
 package org.eclipse.smarthome.binding.hue.handler;
 
+import org.eclipse.smarthome.binding.hue.internal.State;
+import org.eclipse.smarthome.binding.hue.internal.State.AlertMode;
+import org.eclipse.smarthome.binding.hue.internal.State.Effect;
+import org.eclipse.smarthome.binding.hue.internal.StateUpdate;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.StringType;
-
-import org.eclipse.smarthome.binding.hue.internal.State;
-import org.eclipse.smarthome.binding.hue.internal.State.AlertMode;
-import org.eclipse.smarthome.binding.hue.internal.State.Effect;
-import org.eclipse.smarthome.binding.hue.internal.StateUpdate;
 
 /**
  * The {@link LightStateConverter} is responsible for mapping Eclipse SmartHome
@@ -215,8 +214,7 @@ public class LightStateConverter {
         saturationInPercent = restrictToBounds(saturationInPercent);
         brightnessInPercent = restrictToBounds(brightnessInPercent);
 
-        return new HSBType(new DecimalType(hue / HUE_FACTOR),
-                new PercentType(saturationInPercent),
+        return new HSBType(new DecimalType(hue / HUE_FACTOR), new PercentType(saturationInPercent),
                 new PercentType(brightnessInPercent));
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/LightStatusListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/LightStatusListener.java
@@ -22,7 +22,7 @@ public interface LightStatusListener {
     /**
      * This method is called whenever the state of the given light has changed. The new state can be obtained by
      * {@link FullLight#getState()}.
-     * 
+     *
      * @param bridge The bridge the changed light is connected to.
      * @param light The light which received the state update.
      */
@@ -30,7 +30,7 @@ public interface LightStatusListener {
 
     /**
      * This method us called whenever a light is removed.
-     * 
+     *
      * @param bridge The bridge the removed light was connected to.
      * @param light The light which is removed.
      */
@@ -38,7 +38,7 @@ public interface LightStatusListener {
 
     /**
      * This method us called whenever a light is added.
-     * 
+     *
      * @param bridge The bridge the added light was connected to.
      * @param light The light which is added.
      */

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/BridgeDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/BridgeDiscovery.java
@@ -30,118 +30,126 @@ import com.google.gson.Gson;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding, minor code cleanup
  */
 public class BridgeDiscovery {
-	private BridgeDiscovery() {}
-	
-	/**
-	 * Search for bridges on the local network using UPnP, and
-	 * more specifically the SSDP protocol.
-	 * 
-	 * It usually takes a while for devices to respond, so a
-	 * typical timeout would be 30 seconds. This function will
-	 * only return bridge objects with the IP address set, you
-	 * still need to authenticate manually.
-	 * 
-	 * You can optionally specify a callback to get bridges as
-	 * they're being discovered. Pass null if you don't need that.
-	 * @param timeout time to search in milliseconds
-	 * @param callback function to call when a new bridge is discovered (can be null)
-	 * @return list of bridges discovered
-	 */
-	public static List<HueBridge> searchUPnP(int timeout, BridgeDiscoveryCallback callback) throws IOException {
-		// Send out SSDP discovery broadcast
-		String ssdpBroadcast = "M-SEARCH * HTTP/1.1\nHOST: 239.255.255.250:1900\nMAN: ssdp:discover\nMX: 8\nST:SsdpSearch:all";
-		DatagramSocket upnpSock = new DatagramSocket();
-		upnpSock.setSoTimeout(100);
-		upnpSock.send(new DatagramPacket(ssdpBroadcast.getBytes(), ssdpBroadcast.length(), new InetSocketAddress("239.255.255.250", 1900)));
-		
-		// Start waiting
-		HashSet<String> ips = new HashSet<>();
-		ArrayList<HueBridge> bridges = new ArrayList<>();
-		
-		long start = System.currentTimeMillis();
-		long nextBroadcast = start + 5000;
-		
-		while (System.currentTimeMillis() - start < timeout) {
-			// Send a new discovery broadcast every 5 seconds just in case
-			if (System.currentTimeMillis() > nextBroadcast) {
-				upnpSock.send(new DatagramPacket(ssdpBroadcast.getBytes(), ssdpBroadcast.length(), new InetSocketAddress("239.255.255.250", 1900)));
-				nextBroadcast = System.currentTimeMillis() + 5000;
-			}
-			
-			byte[] responseBuffer = new byte[1024];
-			
-			DatagramPacket responsePacket = new DatagramPacket(responseBuffer, responseBuffer.length);
-			
-			try {
-				upnpSock.receive(responsePacket);
-			} catch (SocketTimeoutException e) {
-				if (System.currentTimeMillis() - start > timeout) {
-					break;
-				} else {
-					continue;
-				}
-			}
-			
-			final String ip = responsePacket.getAddress().getHostAddress();
-			final String response = new String(responsePacket.getData());
-			
-			if (!ips.contains(ip)) {
-				Matcher m = Pattern.compile("LOCATION: (.*)", Pattern.CASE_INSENSITIVE).matcher(response);
-				
-				if (m.find()) {
-					final String description = new HttpClient().get(m.group(1)).getBody();
-					
-					// Parsing with RegEx allowed here because the output format is fairly strict
-					final String modelName = Util.quickMatch("<modelName>(.*?)</modelName>", description);
-													
-					// Check from description if we're dealing with a hue bridge or some other device
-					if (modelName.toLowerCase().contains("philips hue bridge")) {
-						try {
-							final HueBridge bridgeToBe = new HueBridge(ip);
-							bridgeToBe.getConfig();
-							
-							bridges.add(bridgeToBe);
-							
-							if (callback != null) callback.onBridgeDiscovered(bridgeToBe);
-						} catch (ApiException e) {
-							// Do nothing, this basically serves as an extra check to see if it's really a hue bridge
-						}
-					}
-				}
-				
-				// Ignore subsequent packets
-				ips.add(ip);
-			}
-		}
-		
-		return bridges;
-	}
-	
-	/**
-	 * Search for local bridges using the portal API.
-	 * See: http://developers.meethue.com/5_portalapi.html
-	 * @return list of bridges
-	 */
-	public static List<HueBridge> searchPortal() throws IOException {
-		Result result = new HttpClient().get("http://www.meethue.com/api/nupnp");
-		
-		if (result.getResponseCode() == 200) {
-			return new Gson().fromJson(result.getBody(), PortalDiscoveryResult.gsonType);
-		} else {
-			throw new IOException();
-		}
-	}
-	
-	/**
-	 * Callback for intermediary bridge search results.
-	 */
-	public interface BridgeDiscoveryCallback {
-		/**
-		 * Called when a new bridge has been discovered by UPnP.
-		 * No attempt to authenticate will be made, so you'll
-		 * have to call authenticate() on the object manually.
-		 * @param bridge Object representing found bridge
-		 */
-		void onBridgeDiscovered(HueBridge bridge);
-	}
+    private BridgeDiscovery() {
+    }
+
+    /**
+     * Search for bridges on the local network using UPnP, and
+     * more specifically the SSDP protocol.
+     *
+     * It usually takes a while for devices to respond, so a
+     * typical timeout would be 30 seconds. This function will
+     * only return bridge objects with the IP address set, you
+     * still need to authenticate manually.
+     *
+     * You can optionally specify a callback to get bridges as
+     * they're being discovered. Pass null if you don't need that.
+     *
+     * @param timeout time to search in milliseconds
+     * @param callback function to call when a new bridge is discovered (can be null)
+     * @return list of bridges discovered
+     */
+    public static List<HueBridge> searchUPnP(int timeout, BridgeDiscoveryCallback callback) throws IOException {
+        // Send out SSDP discovery broadcast
+        String ssdpBroadcast = "M-SEARCH * HTTP/1.1\nHOST: 239.255.255.250:1900\nMAN: ssdp:discover\nMX: 8\nST:SsdpSearch:all";
+        DatagramSocket upnpSock = new DatagramSocket();
+        upnpSock.setSoTimeout(100);
+        upnpSock.send(new DatagramPacket(ssdpBroadcast.getBytes(), ssdpBroadcast.length(),
+                new InetSocketAddress("239.255.255.250", 1900)));
+
+        // Start waiting
+        HashSet<String> ips = new HashSet<>();
+        ArrayList<HueBridge> bridges = new ArrayList<>();
+
+        long start = System.currentTimeMillis();
+        long nextBroadcast = start + 5000;
+
+        while (System.currentTimeMillis() - start < timeout) {
+            // Send a new discovery broadcast every 5 seconds just in case
+            if (System.currentTimeMillis() > nextBroadcast) {
+                upnpSock.send(new DatagramPacket(ssdpBroadcast.getBytes(), ssdpBroadcast.length(),
+                        new InetSocketAddress("239.255.255.250", 1900)));
+                nextBroadcast = System.currentTimeMillis() + 5000;
+            }
+
+            byte[] responseBuffer = new byte[1024];
+
+            DatagramPacket responsePacket = new DatagramPacket(responseBuffer, responseBuffer.length);
+
+            try {
+                upnpSock.receive(responsePacket);
+            } catch (SocketTimeoutException e) {
+                if (System.currentTimeMillis() - start > timeout) {
+                    break;
+                } else {
+                    continue;
+                }
+            }
+
+            final String ip = responsePacket.getAddress().getHostAddress();
+            final String response = new String(responsePacket.getData());
+
+            if (!ips.contains(ip)) {
+                Matcher m = Pattern.compile("LOCATION: (.*)", Pattern.CASE_INSENSITIVE).matcher(response);
+
+                if (m.find()) {
+                    final String description = new HttpClient().get(m.group(1)).getBody();
+
+                    // Parsing with RegEx allowed here because the output format is fairly strict
+                    final String modelName = Util.quickMatch("<modelName>(.*?)</modelName>", description);
+
+                    // Check from description if we're dealing with a hue bridge or some other device
+                    if (modelName.toLowerCase().contains("philips hue bridge")) {
+                        try {
+                            final HueBridge bridgeToBe = new HueBridge(ip);
+                            bridgeToBe.getConfig();
+
+                            bridges.add(bridgeToBe);
+
+                            if (callback != null) {
+                                callback.onBridgeDiscovered(bridgeToBe);
+                            }
+                        } catch (ApiException e) {
+                            // Do nothing, this basically serves as an extra check to see if it's really a hue bridge
+                        }
+                    }
+                }
+
+                // Ignore subsequent packets
+                ips.add(ip);
+            }
+        }
+
+        return bridges;
+    }
+
+    /**
+     * Search for local bridges using the portal API.
+     * See: http://developers.meethue.com/5_portalapi.html
+     *
+     * @return list of bridges
+     */
+    public static List<HueBridge> searchPortal() throws IOException {
+        Result result = new HttpClient().get("http://www.meethue.com/api/nupnp");
+
+        if (result.getResponseCode() == 200) {
+            return new Gson().fromJson(result.getBody(), PortalDiscoveryResult.gsonType);
+        } else {
+            throw new IOException();
+        }
+    }
+
+    /**
+     * Callback for intermediary bridge search results.
+     */
+    public interface BridgeDiscoveryCallback {
+        /**
+         * Called when a new bridge has been discovered by UPnP.
+         * No attempt to authenticate will be made, so you'll
+         * have to call authenticate() on the object manually.
+         *
+         * @param bridge Object representing found bridge
+         */
+        void onBridgeDiscovered(HueBridge bridge);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Command.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Command.java
@@ -15,15 +15,15 @@ import com.google.gson.Gson;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 class Command {
-	private String key;
-	private Object value;
-	
-	public Command(String key, Object value) {
-		this.key = key;
-		this.value = value;
-	}
-	
-	String toJson() {
-		return "\"" + key + "\":" + new Gson().toJson(value);
-	}
+    private String key;
+    private Object value;
+
+    public Command(String key, Object value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    String toJson() {
+        return "\"" + key + "\":" + new Gson().toJson(value);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Config.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Config.java
@@ -19,127 +19,141 @@ import java.util.Map;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding, minor code cleanup
  */
 public class Config {
-	private String name;
-	private String swversion;
-	private String mac;
-	private boolean dhcp;
-	private String ipaddress;
-	private String netmask;
-	private String gateway;
-	private String proxyaddress;
-	private int proxyport;
-	private Date UTC;
-	private boolean linkbutton;
-	private Map<String, User> whitelist;
-	private SoftwareUpdate swupdate;
-	
-	Config() {}
-	
-	/**
-	 * Returns the name.
-	 * @return name of the bridge
-	 */
-	public String getName() {
-		return name;
-	}
-	
-	/**
-	 * Returns the version of the software.
-	 * @return version of software on the bridge
-	 */
-	public String getSoftwareVersion() {
-		return swversion;
-	}
-	
-	/**
-	 * Returns the MAC address.
-	 * @return mac address of bridge
-	 */
-	public String getMACAddress() {
-		return mac;
-	}
-	
-	/**
-	 * Returns if the current IP address was obtained with DHCP.
-	 * @return true if the current IP address was obtained with DHCP, false otherwise.
-	 */
-	public boolean isDHCPEnabled() {
-		return dhcp;
-	}
-	
-	/**
-	 * Returns the IP address.
-	 * @return ip address of bridge
-	 */
-	public String getIPAddress() {
-		return ipaddress;
-	}
-	
-	/**
-	 * Returns the network mask.
-	 * @return network mask
-	 */
-	public String getNetworkMask() {
-		return netmask;
-	}
-	
-	/**
-	 * Returns the IP address of the gateway. 
-	 * @return ip address of gateway
-	 */
-	public String getGateway() {
-		return gateway;
-	}
-	
-	/**
-	 * Returns the IP address of the proxy or null if there is none.
-	 * @return ip address of proxy or null
-	 */
-	public String getProxyAddress() {
-		return proxyaddress.equals("none") ? null : proxyaddress;
-	}
-	
-	/**
-	 * Returns the port of the proxy or null if there is none.
-	 * @return port of proxy or null
-	 */
-	public Integer getProxyPort() {
-		return proxyaddress.equals("none") ? null : proxyport;
-	}
-	
-	/**
-	 * Returns the time on the bridge.
-	 * @return time on the bridge
-	 */
-	public Date getUTCTime() {
-		return UTC;
-	}
-	
-	/**
-	 * Returns if the link button has been pressed within the last 30 seconds.
-	 * @return true if the link button has been pressed within the last 30 seconds, false otherwise
-	 */
-	public boolean isLinkButtonPressed() {
-		return linkbutton;
-	}
-	
-	/**
-	 * Returns the list of whitelisted users.
-	 * @return list of whitelisted users
-	 */
-	public List<User> getWhitelist() {
-		ArrayList<User> usersList = new ArrayList<>();
-		
-		usersList.addAll(whitelist.values());
-		
-		return usersList;
-	}
-	
-	/**
-	 * Returns information about a bridge firmware update.
-	 * @return bridge firmware update info
-	 */
-	public SoftwareUpdate getSoftwareUpdate() {
-		return swupdate;
-	}
+    private String name;
+    private String swversion;
+    private String mac;
+    private boolean dhcp;
+    private String ipaddress;
+    private String netmask;
+    private String gateway;
+    private String proxyaddress;
+    private int proxyport;
+    private Date UTC;
+    private boolean linkbutton;
+    private Map<String, User> whitelist;
+    private SoftwareUpdate swupdate;
+
+    Config() {
+    }
+
+    /**
+     * Returns the name.
+     *
+     * @return name of the bridge
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the version of the software.
+     *
+     * @return version of software on the bridge
+     */
+    public String getSoftwareVersion() {
+        return swversion;
+    }
+
+    /**
+     * Returns the MAC address.
+     *
+     * @return mac address of bridge
+     */
+    public String getMACAddress() {
+        return mac;
+    }
+
+    /**
+     * Returns if the current IP address was obtained with DHCP.
+     *
+     * @return true if the current IP address was obtained with DHCP, false otherwise.
+     */
+    public boolean isDHCPEnabled() {
+        return dhcp;
+    }
+
+    /**
+     * Returns the IP address.
+     *
+     * @return ip address of bridge
+     */
+    public String getIPAddress() {
+        return ipaddress;
+    }
+
+    /**
+     * Returns the network mask.
+     *
+     * @return network mask
+     */
+    public String getNetworkMask() {
+        return netmask;
+    }
+
+    /**
+     * Returns the IP address of the gateway.
+     *
+     * @return ip address of gateway
+     */
+    public String getGateway() {
+        return gateway;
+    }
+
+    /**
+     * Returns the IP address of the proxy or null if there is none.
+     *
+     * @return ip address of proxy or null
+     */
+    public String getProxyAddress() {
+        return proxyaddress.equals("none") ? null : proxyaddress;
+    }
+
+    /**
+     * Returns the port of the proxy or null if there is none.
+     *
+     * @return port of proxy or null
+     */
+    public Integer getProxyPort() {
+        return proxyaddress.equals("none") ? null : proxyport;
+    }
+
+    /**
+     * Returns the time on the bridge.
+     *
+     * @return time on the bridge
+     */
+    public Date getUTCTime() {
+        return UTC;
+    }
+
+    /**
+     * Returns if the link button has been pressed within the last 30 seconds.
+     *
+     * @return true if the link button has been pressed within the last 30 seconds, false otherwise
+     */
+    public boolean isLinkButtonPressed() {
+        return linkbutton;
+    }
+
+    /**
+     * Returns the list of whitelisted users.
+     *
+     * @return list of whitelisted users
+     */
+    public List<User> getWhitelist() {
+        ArrayList<User> usersList = new ArrayList<>();
+
+        usersList.addAll(whitelist.values());
+
+        return usersList;
+    }
+
+    /**
+     * Returns information about a bridge firmware update.
+     *
+     * @return bridge firmware update info
+     */
+    public SoftwareUpdate getSoftwareUpdate() {
+        return swupdate;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/ConfigUpdate.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/ConfigUpdate.java
@@ -16,110 +16,120 @@ import java.util.ArrayList;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding, minor code cleanup
  */
 public class ConfigUpdate {
-	private ArrayList<Command> commands = new ArrayList<>();
-	
-	String toJson() {
-		StringBuilder json = new StringBuilder("{");
-		
-		for (int i = 0; i < commands.size(); i++) {
-			json.append(commands.get(i).toJson());
-			if (i < commands.size() - 1) json.append(",");
-		}
-		
-		json.append("}");
-		
-		return json.toString();
-	}
-	
-	/**
-	 * Set the port of the proxy or null if there is no proxy.
-	 * @param port port for proxy
-	 * @return this object for chaining calls
-	 */
-	public ConfigUpdate setProxyPort(Integer port) {
-		if (port != null && port < 0) {
-			throw new IllegalArgumentException("Invalid value for port");
-		}
-		
-		commands.add(new Command("proxyport", port == null ? 0 : port));
-		return this;
-	}
-	
-	/**
-	 * Set the name of the bridge, which also functions as the UPnP name.
-	 * @param name new name [4..16]
-	 * @return this object for chaining calls
-	 */
-	public ConfigUpdate setName(String name) {
-		if (Util.stringSize(name) < 4 || Util.stringSize(name) > 16) {
-			throw new IllegalArgumentException("Bridge name must be between 4 and 16 characters long");
-		}
-		
-		commands.add(new Command("name", name));
-		return this;
-	}
-	
-	/**
-	 * Set the address of the proxy or null if there is no proxy.
-	 * @param ip ip of proxy
-	 * @return this object for chaining calls
-	 */
-	public ConfigUpdate setProxyAddress(String ip) {
-		if (ip != null && Util.stringSize(ip) > 40) {
-			throw new IllegalArgumentException("Bridge proxy address can be at most 40 characters long");
-		}
-		
-		commands.add(new Command("proxyaddress", ip == null ? "none" : ip));
-		return this;
-	}
-	
-	/**
-	 * Set whether the link button has been pressed within the last 30 seconds or not.
-	 * @param pressed true for pressed, false for not pressed
-	 * @return this object for chaining calls
-	 */
-	public ConfigUpdate setLinkButton(boolean pressed) {
-		commands.add(new Command("linkbutton", pressed));
-		return this;
-	}
-	
-	/**
-	 * Set the IP address of the bridge.
-	 * @param ip ip address of bridge
-	 * @return this object for chaining calls
-	 */
-	public ConfigUpdate setIPAddress(String ip) {
-		commands.add(new Command("ipaddress", ip));
-		return this;
-	}
-	
-	/**
-	 * Set the network mask of the bridge.
-	 * @param netmask network mask
-	 * @return this object for chaining calls
-	 */
-	public ConfigUpdate setNetworkMask(String netmask) {
-		commands.add(new Command("netmask", netmask));
-		return this;
-	}
-	
-	/**
-	 * Set the gateway address of the bridge.
-	 * @param ip gateway address
-	 * @return this object for chaining calls
-	 */
-	public ConfigUpdate setGateway(String ip) {
-		commands.add(new Command("gateway", ip));
-		return this;
-	}
-	
-	/**
-	 * Set whether the bridge uses DHCP to get an ip address or not.
-	 * @param enabled dhcp enabled
-	 * @return this object for chaining calls
-	 */
-	public ConfigUpdate setDHCP(boolean enabled) {
-		commands.add(new Command("dhcp", enabled));
-		return this;
-	}
+    private ArrayList<Command> commands = new ArrayList<>();
+
+    String toJson() {
+        StringBuilder json = new StringBuilder("{");
+
+        for (int i = 0; i < commands.size(); i++) {
+            json.append(commands.get(i).toJson());
+            if (i < commands.size() - 1) {
+                json.append(",");
+            }
+        }
+
+        json.append("}");
+
+        return json.toString();
+    }
+
+    /**
+     * Set the port of the proxy or null if there is no proxy.
+     *
+     * @param port port for proxy
+     * @return this object for chaining calls
+     */
+    public ConfigUpdate setProxyPort(Integer port) {
+        if (port != null && port < 0) {
+            throw new IllegalArgumentException("Invalid value for port");
+        }
+
+        commands.add(new Command("proxyport", port == null ? 0 : port));
+        return this;
+    }
+
+    /**
+     * Set the name of the bridge, which also functions as the UPnP name.
+     *
+     * @param name new name [4..16]
+     * @return this object for chaining calls
+     */
+    public ConfigUpdate setName(String name) {
+        if (Util.stringSize(name) < 4 || Util.stringSize(name) > 16) {
+            throw new IllegalArgumentException("Bridge name must be between 4 and 16 characters long");
+        }
+
+        commands.add(new Command("name", name));
+        return this;
+    }
+
+    /**
+     * Set the address of the proxy or null if there is no proxy.
+     *
+     * @param ip ip of proxy
+     * @return this object for chaining calls
+     */
+    public ConfigUpdate setProxyAddress(String ip) {
+        if (ip != null && Util.stringSize(ip) > 40) {
+            throw new IllegalArgumentException("Bridge proxy address can be at most 40 characters long");
+        }
+
+        commands.add(new Command("proxyaddress", ip == null ? "none" : ip));
+        return this;
+    }
+
+    /**
+     * Set whether the link button has been pressed within the last 30 seconds or not.
+     *
+     * @param pressed true for pressed, false for not pressed
+     * @return this object for chaining calls
+     */
+    public ConfigUpdate setLinkButton(boolean pressed) {
+        commands.add(new Command("linkbutton", pressed));
+        return this;
+    }
+
+    /**
+     * Set the IP address of the bridge.
+     *
+     * @param ip ip address of bridge
+     * @return this object for chaining calls
+     */
+    public ConfigUpdate setIPAddress(String ip) {
+        commands.add(new Command("ipaddress", ip));
+        return this;
+    }
+
+    /**
+     * Set the network mask of the bridge.
+     *
+     * @param netmask network mask
+     * @return this object for chaining calls
+     */
+    public ConfigUpdate setNetworkMask(String netmask) {
+        commands.add(new Command("netmask", netmask));
+        return this;
+    }
+
+    /**
+     * Set the gateway address of the bridge.
+     *
+     * @param ip gateway address
+     * @return this object for chaining calls
+     */
+    public ConfigUpdate setGateway(String ip) {
+        commands.add(new Command("gateway", ip));
+        return this;
+    }
+
+    /**
+     * Set whether the bridge uses DHCP to get an ip address or not.
+     *
+     * @param enabled dhcp enabled
+     * @return this object for chaining calls
+     */
+    public ConfigUpdate setDHCP(boolean enabled) {
+        commands.add(new Command("dhcp", enabled));
+        return this;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/CreateScheduleRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/CreateScheduleRequest.java
@@ -16,27 +16,27 @@ import java.util.Date;
  */
 @SuppressWarnings("unused")
 class CreateScheduleRequest {
-	private String name;
-	private String description;
-	private ScheduleCommand command;
-	private Date time;
-	
-	public CreateScheduleRequest(String name, String description, ScheduleCommand command, Date time) {
-		if (name != null && Util.stringSize(name) > 32) {
-			throw new IllegalArgumentException("Schedule name can be at most 32 characters long");
-		}
-		
-		if (description != null && Util.stringSize(description) > 64) {
-			throw new IllegalArgumentException("Schedule description can be at most 64 characters long");
-		}
-		
-		if (command == null) {
-			throw new IllegalArgumentException("No schedule command specified");
-		}
-		
-		this.name = name;
-		this.description = description;
-		this.command = command;
-		this.time = time;
-	}
+    private String name;
+    private String description;
+    private ScheduleCommand command;
+    private Date time;
+
+    public CreateScheduleRequest(String name, String description, ScheduleCommand command, Date time) {
+        if (name != null && Util.stringSize(name) > 32) {
+            throw new IllegalArgumentException("Schedule name can be at most 32 characters long");
+        }
+
+        if (description != null && Util.stringSize(description) > 64) {
+            throw new IllegalArgumentException("Schedule description can be at most 64 characters long");
+        }
+
+        if (command == null) {
+            throw new IllegalArgumentException("No schedule command specified");
+        }
+
+        this.name = name;
+        this.description = description;
+        this.command = command;
+        this.time = time;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/CreateUserRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/CreateUserRequest.java
@@ -14,27 +14,27 @@ package org.eclipse.smarthome.binding.hue.internal;
  */
 @SuppressWarnings("unused")
 class CreateUserRequest {
-	private String username;
-	private String devicetype;
-	
-	public CreateUserRequest(String username, String devicetype) {
-		if (Util.stringSize(devicetype) > 40) {
-			throw new IllegalArgumentException("Device type can be at most 40 characters long");
-		}
-		
-		if (Util.stringSize(username) < 10 || Util.stringSize(username) > 40) {
-			throw new IllegalArgumentException("Username must be between 10 and 40 characters long");
-		}
-		
-		this.username = username;
-		this.devicetype = devicetype;
-	}
-	
-	public CreateUserRequest(String devicetype) {
-		if (Util.stringSize(devicetype) > 40) {
-			throw new IllegalArgumentException("Device type can be at most 40 characters long");
-		}
-		
-		this.devicetype = devicetype;
-	}
+    private String username;
+    private String devicetype;
+
+    public CreateUserRequest(String username, String devicetype) {
+        if (Util.stringSize(devicetype) > 40) {
+            throw new IllegalArgumentException("Device type can be at most 40 characters long");
+        }
+
+        if (Util.stringSize(username) < 10 || Util.stringSize(username) > 40) {
+            throw new IllegalArgumentException("Username must be between 10 and 40 characters long");
+        }
+
+        this.username = username;
+        this.devicetype = devicetype;
+    }
+
+    public CreateUserRequest(String devicetype) {
+        if (Util.stringSize(devicetype) > 40) {
+            throw new IllegalArgumentException("Device type can be at most 40 characters long");
+        }
+
+        this.devicetype = devicetype;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/ErrorResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/ErrorResponse.java
@@ -18,25 +18,26 @@ import com.google.gson.reflect.TypeToken;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 class ErrorResponse {
-	public final static Type gsonType = new TypeToken<List<ErrorResponse>>(){}.getType();
-	
-	public class Error {
-		private Integer type;
-		private String address;
-		private String description;
-	}
-	
-	private Error error;
-	
-	public Integer getType() {
-		return error.type;
-	}
-	
-	public String getAddress() {
-		return error.address;
-	}
-	
-	public String getDescription() {
-		return error.description;
-	}
+    public final static Type gsonType = new TypeToken<List<ErrorResponse>>() {
+    }.getType();
+
+    public class Error {
+        private Integer type;
+        private String address;
+        private String description;
+    }
+
+    private Error error;
+
+    public Integer getType() {
+        return error.type;
+    }
+
+    public String getAddress() {
+        return error.address;
+    }
+
+    public String getDescription() {
+        return error.description;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullConfig.java
@@ -18,48 +18,51 @@ import java.util.Map;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class FullConfig {
-	private Map<String, FullLight> lights;
-	private Map<String, FullGroup> groups;
-	private Config config;
-	
-	/**
-	 * Returns detailed information about all lights known to the bridge.
-	 * @return detailed lights list
-	 */
-	public List<FullLight> getLights() {
-		ArrayList<FullLight> lightsList = new ArrayList<FullLight>();
-		
-		for (String id : lights.keySet()) {
-			FullLight light = lights.get(id);
-			light.setId(id);
-			lightsList.add(light);
-		}
-		
-		return lightsList;
-	}
-	
-	/**
-	 * Returns detailed information about all groups on the bridge.
-	 * @return detailed groups list
-	 */
-	public List<FullGroup> getGroups() {		
-		ArrayList<FullGroup> groupsList = new ArrayList<FullGroup>();
-		
-		for (String id : groups.keySet()) {
-			FullGroup group = groups.get(id);
-			group.setId(id);
-			groupsList.add(group);
-		}
-		
-		return groupsList;
-	}
-	
-	/**
-	 * Returns bridge configuration.
-	 * Use HueBridge.getConfig() if you only need this.
-	 * @return bridge configuration
-	 */
-	public Config getConfig() {
-		return config;
-	}
+    private Map<String, FullLight> lights;
+    private Map<String, FullGroup> groups;
+    private Config config;
+
+    /**
+     * Returns detailed information about all lights known to the bridge.
+     *
+     * @return detailed lights list
+     */
+    public List<FullLight> getLights() {
+        ArrayList<FullLight> lightsList = new ArrayList<>();
+
+        for (String id : lights.keySet()) {
+            FullLight light = lights.get(id);
+            light.setId(id);
+            lightsList.add(light);
+        }
+
+        return lightsList;
+    }
+
+    /**
+     * Returns detailed information about all groups on the bridge.
+     *
+     * @return detailed groups list
+     */
+    public List<FullGroup> getGroups() {
+        ArrayList<FullGroup> groupsList = new ArrayList<>();
+
+        for (String id : groups.keySet()) {
+            FullGroup group = groups.get(id);
+            group.setId(id);
+            groupsList.add(group);
+        }
+
+        return groupsList;
+    }
+
+    /**
+     * Returns bridge configuration.
+     * Use HueBridge.getConfig() if you only need this.
+     *
+     * @return bridge configuration
+     */
+    public Config getConfig() {
+        return config;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullGroup.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullGroup.java
@@ -16,25 +16,28 @@ import java.util.List;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class FullGroup extends Group {
-	private State action;
-	private List<String> lights;
-	
-	FullGroup() {}
-	
-	/**
-	 * Returns the last sent state update to the group.
-	 * This does not have to reflect the current state of the group.
-	 * @return last state update
-	 */
-	public State getAction() {
-		return action;
-	}
-	
-	/**
-	 * Returns a list of the lights in the group.
-	 * @return lights in the group
-	 */
-	public List<Light> getLights() {
-		return Util.idsToLights(lights);
-	}
+    private State action;
+    private List<String> lights;
+
+    FullGroup() {
+    }
+
+    /**
+     * Returns the last sent state update to the group.
+     * This does not have to reflect the current state of the group.
+     *
+     * @return last state update
+     */
+    public State getAction() {
+        return action;
+    }
+
+    /**
+     * Returns a list of the lights in the group.
+     *
+     * @return lights in the group
+     */
+    public List<Light> getLights() {
+        return Util.idsToLights(lights);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullLight.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullLight.java
@@ -15,50 +15,55 @@ package org.eclipse.smarthome.binding.hue.internal;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class FullLight extends Light {
-	private State state;
-	private String type;
-	private String modelid;
-	private String swversion;
-	private String uniqueid;
-	
-	FullLight() {}
-	
-	/**
-	 * Returns the current state of the light.
-	 * @return current state
-	 */
-	public State getState() {
-		return state;
-	}
-	
-	/**
-	 * Returns the type of the light.
-	 * @return type
-	 */
-	public String getType() {
-		return type;
-	}
-	
-	/**
-	 * Returns the model ID of the light.
-	 * @return model id
-	 */
-	public String getModelID() {
-		return modelid;
-	}
-	
-	/**
-	 * Returns the software version of the light.
-	 * @return software version
-	 */
-	public String getSoftwareVersion() {
-		return swversion;
-	}
-	
+    private State state;
+    private String type;
+    private String modelid;
+    private String swversion;
+    private String uniqueid;
+
+    FullLight() {
+    }
+
+    /**
+     * Returns the current state of the light.
+     *
+     * @return current state
+     */
+    public State getState() {
+        return state;
+    }
+
+    /**
+     * Returns the type of the light.
+     *
+     * @return type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Returns the model ID of the light.
+     *
+     * @return model id
+     */
+    public String getModelID() {
+        return modelid;
+    }
+
+    /**
+     * Returns the software version of the light.
+     *
+     * @return software version
+     */
+    public String getSoftwareVersion() {
+        return swversion;
+    }
+
     /**
      * Returns the unique id of the light. The unique is the MAC address of the device with a unique endpoint id in the
      * form: AA:BB:CC:DD:EE:FF:00:11-XX
-     * 
+     *
      * @return the unique id
      */
     public String getUniqueID() {

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullSchedule.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullSchedule.java
@@ -16,31 +16,34 @@ import java.util.Date;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class FullSchedule extends Schedule {
-	private String description;
-	private ScheduleCommand command; // Not really appropriate for exposure
-	private Date time;
-	
-	/**
-	 * Returns the description of the schedule.
-	 * @return description
-	 */
-	public String getDescription() {
-		return description;
-	}
-	
-	/**
-	 * Returns the scheduled command.
-	 * @return command
-	 */
-	public ScheduleCommand getCommand() {
-		return command;
-	}
-	
-	/**
-	 * Returns the time for which the command is scheduled to be ran.
-	 * @return scheduled time
-	 */
-	public Date getTime() {
-		return time;
-	}
+    private String description;
+    private ScheduleCommand command; // Not really appropriate for exposure
+    private Date time;
+
+    /**
+     * Returns the description of the schedule.
+     *
+     * @return description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * Returns the scheduled command.
+     *
+     * @return command
+     */
+    public ScheduleCommand getCommand() {
+        return command;
+    }
+
+    /**
+     * Returns the time for which the command is scheduled to be ran.
+     *
+     * @return scheduled time
+     */
+    public Date getTime() {
+        return time;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Group.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Group.java
@@ -19,46 +19,50 @@ import com.google.gson.reflect.TypeToken;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class Group {
-	public final static Type gsonType = new TypeToken<Map<String, Group>>(){}.getType();
-	
-	private String id;
-	private String name;
-	
-	Group() {
-		this.id = "0";
-		this.name = "Lightset 0";
-	}
-	
-	void setName(String name) {
-		this.name = name;
-	}
-	
-	void setId(String id) {
-		this.id = id;
-	}
-	
-	/**
-	 * Returns if the group can be modified.
-	 * Currently only returns false for the all lights pseudo group.
-	 * @return modifiability of group
-	 */
-	public boolean isModifiable() {
-		return !id.equals("0");
-	}
-	
-	/**
-	 * Returns the id of the group.
-	 * @return id
-	 */
-	public String getId() {
-		return id;
-	}
-	
-	/**
-	 * Returns the name of the group.
-	 * @return name
-	 */
-	public String getName() {
-		return name;
-	}
+    public final static Type gsonType = new TypeToken<Map<String, Group>>() {
+    }.getType();
+
+    private String id;
+    private String name;
+
+    Group() {
+        this.id = "0";
+        this.name = "Lightset 0";
+    }
+
+    void setName(String name) {
+        this.name = name;
+    }
+
+    void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns if the group can be modified.
+     * Currently only returns false for the all lights pseudo group.
+     *
+     * @return modifiability of group
+     */
+    public boolean isModifiable() {
+        return !id.equals("0");
+    }
+
+    /**
+     * Returns the id of the group.
+     *
+     * @return id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the name of the group.
+     *
+     * @return name
+     */
+    public String getName() {
+        return name;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HttpClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HttpClient.java
@@ -22,74 +22,74 @@ import java.util.Scanner;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 class HttpClient {
-	private int timeout = 1000;
-	
-	public void setTimeout(int timeout) {
-		this.timeout = timeout;
-	}
-	
-	public Result get(String address) throws IOException {
-		return doNetwork(address, "GET", "");
-	}
-	
-	public Result post(String address, String body) throws IOException {
-		return doNetwork(address, "POST", body);
-	}
-	
-	public Result put(String address, String body) throws IOException {
-		return doNetwork(address, "PUT", body);
-	}
-	
-	public Result delete(String address) throws IOException {
-		return doNetwork(address, "DELETE", "");
-	}
-	
-	protected Result doNetwork(String address, String requestMethod, String body) throws IOException {
-		HttpURLConnection conn = (HttpURLConnection) new URL(address).openConnection();
-		try {
-			conn.setRequestMethod(requestMethod);
-			conn.setRequestProperty("Content-Type", "application/json");
-			conn.setConnectTimeout(timeout);
-			conn.setReadTimeout(timeout);
-			
-			if (body != null && !body.equals("")) {
-				conn.setDoOutput(true);
-				OutputStreamWriter out = new OutputStreamWriter(conn.getOutputStream());
-				out.write(body);
-				out.close();
-			}
-			
-			InputStream in = new BufferedInputStream(conn.getInputStream());
-			String output = convertStreamToString(in);
-			return new Result(output, conn.getResponseCode());
-		} finally {
-			conn.disconnect();
-		}
-	}
-	
-	private static String convertStreamToString(InputStream is) {
-	    try {
-	        return new Scanner(is).useDelimiter("\\A").next();
-	    } catch (NoSuchElementException e) {
-	        return "";
-	    }
-	}
-	
-	public static class Result {
-		private String body;
-		private int responseCode;
-		
-		public Result(String body, int responseCode) {
-			this.body = body;
-			this.responseCode = responseCode;
-		}
-		
-		public String getBody() {
-			return body;
-		}
-		
-		public int getResponseCode() {
-			return responseCode;
-		}
-	}
+    private int timeout = 1000;
+
+    public void setTimeout(int timeout) {
+        this.timeout = timeout;
+    }
+
+    public Result get(String address) throws IOException {
+        return doNetwork(address, "GET", "");
+    }
+
+    public Result post(String address, String body) throws IOException {
+        return doNetwork(address, "POST", body);
+    }
+
+    public Result put(String address, String body) throws IOException {
+        return doNetwork(address, "PUT", body);
+    }
+
+    public Result delete(String address) throws IOException {
+        return doNetwork(address, "DELETE", "");
+    }
+
+    protected Result doNetwork(String address, String requestMethod, String body) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) new URL(address).openConnection();
+        try {
+            conn.setRequestMethod(requestMethod);
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setConnectTimeout(timeout);
+            conn.setReadTimeout(timeout);
+
+            if (body != null && !body.equals("")) {
+                conn.setDoOutput(true);
+                OutputStreamWriter out = new OutputStreamWriter(conn.getOutputStream());
+                out.write(body);
+                out.close();
+            }
+
+            InputStream in = new BufferedInputStream(conn.getInputStream());
+            String output = convertStreamToString(in);
+            return new Result(output, conn.getResponseCode());
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private static String convertStreamToString(InputStream is) {
+        try {
+            return new Scanner(is).useDelimiter("\\A").next();
+        } catch (NoSuchElementException e) {
+            return "";
+        }
+    }
+
+    public static class Result {
+        private String body;
+        private int responseCode;
+
+        public Result(String body, int responseCode) {
+            this.body = body;
+            this.responseCode = responseCode;
+        }
+
+        public String getBody() {
+            return body;
+        }
+
+        public int getResponseCode() {
+            return responseCode;
+        }
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
@@ -41,108 +41,116 @@ import com.google.gson.JsonParser;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding, minor code cleanup
  */
 public class HueBridge {
-	private final static String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
-	
-	private String ip;
-	private String username;
-	
-	private Gson gson = new GsonBuilder().setDateFormat(DATE_FORMAT).create();
-	private HttpClient http = new HttpClient();
-	
-	/**
-	 * Connect with a bridge as a new user.
-	 * @param ip ip address of bridge
-	 */
-	public HueBridge(String ip) {
-		this.ip = ip;
-	}
-	
-	/**
-	 * Connect with a bridge as an existing user.
-	 * 
-	 * The username is verified by requesting the list of lights.
-	 * Use the ip only constructor and authenticate() function if
-	 * you don't want to connect right now.
-	 * @param ip ip address of bridge
-	 * @param username username to authenticate with
-	 */
-	public HueBridge(String ip, String username) throws IOException, ApiException {
-		this.ip = ip;
-		authenticate(username);
-	}
-	
-	/**
-	 * Set the connect and read timeout for HTTP requests.
-	 * @param timeout timeout in milliseconds or 0 for indefinitely
-	 */
-	public void setTimeout(int timeout) {
-		http.setTimeout(timeout);
-	}
-	
-	/**
-	 * Returns the IP address of the bridge.
-	 * @return ip address of bridge
-	 */
-	public String getIPAddress() {
-		return ip;
-	}
-	
-	/**
-	 * Returns the username currently authenticated with or null if there isn't one.
-	 * @return username or null
-	 */
-	public String getUsername() {
-		return username;
-	}
-	
-	/**
-	 * Returns if authentication was successful on the bridge.
-	 * @return true if authenticated on the bridge, false otherwise
-	 */
-	public boolean isAuthenticated() {
-		return getUsername() != null;
-	}
-	
-	/**
-	 * Returns a list of lights known to the bridge.
-	 * @return list of known lights 
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public List<Light> getLights() throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL("lights"));
-		
-		handleErrors(result);
-			
-		Map<String, Light> lightMap = safeFromJson(result.getBody(), Light.gsonType);
-		
-		ArrayList<Light> lightList = new ArrayList<>();
-		
-		for (String id : lightMap.keySet()) {
-			Light light = lightMap.get(id);
-			light.setId(id);
-			lightList.add(light);
-		}
-		
-		return lightList;
-	}
-	
-	/**
-	 * Returns the last time a search for new lights was started.
-	 * If a search is currently running, the current time will be
-	 * returned or null if a search has never been started.
-	 * @return last search time
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public Date getLastSearch() throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL("lights/new"));
-		
-		handleErrors(result);
-		
-		String lastScan = safeFromJson(result.getBody(), NewLightsResponse.class).lastscan;
+    private final static String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+
+    private String ip;
+    private String username;
+
+    private Gson gson = new GsonBuilder().setDateFormat(DATE_FORMAT).create();
+    private HttpClient http = new HttpClient();
+
+    /**
+     * Connect with a bridge as a new user.
+     *
+     * @param ip ip address of bridge
+     */
+    public HueBridge(String ip) {
+        this.ip = ip;
+    }
+
+    /**
+     * Connect with a bridge as an existing user.
+     *
+     * The username is verified by requesting the list of lights.
+     * Use the ip only constructor and authenticate() function if
+     * you don't want to connect right now.
+     *
+     * @param ip ip address of bridge
+     * @param username username to authenticate with
+     */
+    public HueBridge(String ip, String username) throws IOException, ApiException {
+        this.ip = ip;
+        authenticate(username);
+    }
+
+    /**
+     * Set the connect and read timeout for HTTP requests.
+     *
+     * @param timeout timeout in milliseconds or 0 for indefinitely
+     */
+    public void setTimeout(int timeout) {
+        http.setTimeout(timeout);
+    }
+
+    /**
+     * Returns the IP address of the bridge.
+     *
+     * @return ip address of bridge
+     */
+    public String getIPAddress() {
+        return ip;
+    }
+
+    /**
+     * Returns the username currently authenticated with or null if there isn't one.
+     *
+     * @return username or null
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Returns if authentication was successful on the bridge.
+     *
+     * @return true if authenticated on the bridge, false otherwise
+     */
+    public boolean isAuthenticated() {
+        return getUsername() != null;
+    }
+
+    /**
+     * Returns a list of lights known to the bridge.
+     *
+     * @return list of known lights
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public List<Light> getLights() throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.get(getRelativeURL("lights"));
+
+        handleErrors(result);
+
+        Map<String, Light> lightMap = safeFromJson(result.getBody(), Light.gsonType);
+
+        ArrayList<Light> lightList = new ArrayList<>();
+
+        for (String id : lightMap.keySet()) {
+            Light light = lightMap.get(id);
+            light.setId(id);
+            lightList.add(light);
+        }
+
+        return lightList;
+    }
+
+    /**
+     * Returns the last time a search for new lights was started.
+     * If a search is currently running, the current time will be
+     * returned or null if a search has never been started.
+     *
+     * @return last search time
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public Date getLastSearch() throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.get(getRelativeURL("lights/new"));
+
+        handleErrors(result);
+
+        String lastScan = safeFromJson(result.getBody(), NewLightsResponse.class).lastscan;
 
         switch (lastScan) {
             case "none":
@@ -156,24 +164,26 @@ public class HueBridge {
                     return null;
                 }
         }
-	}
-	
-	/**
-	 * Start searching for new lights for 1 minute.
-	 * A maximum amount of 15 new lights will be added.
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public void startSearch() throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.post(getRelativeURL("lights"), "");
-		
-		handleErrors(result);
-	}
+    }
+
+    /**
+     * Start searching for new lights for 1 minute.
+     * A maximum amount of 15 new lights will be added.
+     *
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public void startSearch() throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.post(getRelativeURL("lights"), "");
+
+        handleErrors(result);
+    }
 
     /**
      * Start searching for new lights with given serial numbers for 1 minute.
      * A maximum amount of 15 new lights will be added.
+     *
      * @param serialNumbers list of serial numbers
      * @throws UnauthorizedException thrown if the user no longer exists
      */
@@ -186,684 +196,717 @@ public class HueBridge {
         handleErrors(result);
     }
 
-	
-	/**
-	 * Returns detailed information for the given light.
-	 * @param light light
-	 * @return detailed light information
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if a light with the given id doesn't exist 
-	 */
-	public FullLight getLight(Light light) throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL("lights/" + enc(light.getId())));
-		
-		handleErrors(result);
-		
-		FullLight fullLight = safeFromJson(result.getBody(), FullLight.class);
-		fullLight.setId(light.getId());
-		return fullLight;
-	}
-	
-	/**
-	 * Changes the name of the light and returns the new name.
-	 * A number will be appended to duplicate names, which may result in a new name exceeding 32 characters.
-	 * @param light light
-	 * @param name new name [0..32]
-	 * @return new name
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the specified light no longer exists
-	 */
-	public String setLightName(Light light, String name) throws IOException, ApiException {
-		requireAuthentication();
-		
-		String body = gson.toJson(new SetAttributesRequest(name));
-		Result result = http.put(getRelativeURL("lights/" + enc(light.getId())), body);
-		
-		handleErrors(result);
-		
-		List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
-		SuccessResponse response = entries.get(0);
-		
-		return (String) response.success.get("/lights/" + enc(light.getId()) + "/name");
-	}
-	
-	/**
-	 * Changes the state of a light.
-	 * @param light light
-	 * @param update changes to the state
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the specified light no longer exists
-	 * @throws DeviceOffException thrown if the specified light is turned off
-	 */
-	public void setLightState(Light light, StateUpdate update) throws IOException, ApiException {
-		requireAuthentication();
-		
-		String body = update.toJson();
-		Result result = http.put(getRelativeURL("lights/" + enc(light.getId()) + "/state"), body);
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Returns a group object representing all lights.
-	 * @return all lights pseudo group
-	 */
-	public Group getAllGroup() {
-		requireAuthentication();
-		
-		return new Group();
-	}
-	
-	/**
-	 * Returns the list of groups, including the unmodifiable all lights group.
-	 * @return list of groups
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public List<Group> getGroups() throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL("groups"));
-		
-		handleErrors(result);
-		
-		Map<String, Group> groupMap = safeFromJson(result.getBody(), Group.gsonType);
-		ArrayList<Group> groupList = new ArrayList<>();
-		
-		groupList.add(new Group());
-		
-		for (String id : groupMap.keySet()) {
-			Group group = groupMap.get(id);
-			group.setId(id);
-			groupList.add(group);
-		}
-		
-		return groupList;
-	}
-	
-	/**
-	 * Creates a new group and returns it.
-	 * Due to API limitations, the name of the returned object
-	 * will simply be "Group". The bridge will append a number to this
-	 * name if it's a duplicate. To get the final name, call getGroup
-	 * with the returned object.
-	 * @param lights lights in group
-	 * @return object representing new group
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws GroupTableFullException thrown if the group limit has been reached
-	 */
-	public Group createGroup(List<Light> lights) throws IOException, ApiException {
-		requireAuthentication();
-		
-		String body = gson.toJson(new SetAttributesRequest(lights));
-		Result result = http.post(getRelativeURL("groups"), body);
-		
-		handleErrors(result);
-		
-		List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
-		SuccessResponse response = entries.get(0);
-		
-		Group group = new Group();
-		group.setName("Group");
-		group.setId(Util.quickMatch("^/groups/([0-9]+)$", (String) response.success.values().toArray()[0]));
-		return group;
-	}
-	
-	/**
-	 * Creates a new group and returns it.
-	 * Due to API limitations, the name of the returned object
-	 * will simply be the same as the name parameter. The bridge will
-	 * append a number to the name if it's a duplicate. To get the final
-	 * name, call getGroup with the returned object.
-	 * @param name new group name
-	 * @param lights lights in group
-	 * @return object representing new group
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws GroupTableFullException thrown if the group limit has been reached
-	 */
-	public Group createGroup(String name, List<Light> lights) throws IOException, ApiException {
-		requireAuthentication();
-		
-		String body = gson.toJson(new SetAttributesRequest(name, lights));
-		Result result = http.post(getRelativeURL("groups"), body);
-		
-		handleErrors(result);
-		
-		List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
-		SuccessResponse response = entries.get(0);
-		
-		Group group = new Group();
-		group.setName(name);
-		group.setId(Util.quickMatch("^/groups/([0-9]+)$", (String) response.success.values().toArray()[0]));
-		return group;
-	}
-	
-	/**
-	 * Returns detailed information for the given group.
-	 * @param group group
-	 * @return detailed group information
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if a group with the given id doesn't exist
-	 */
-	public FullGroup getGroup(Group group) throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL("groups/" + enc(group.getId())));
-		
-		handleErrors(result);
-		
-		FullGroup fullGroup = safeFromJson(result.getBody(), FullGroup.class);
-		fullGroup.setId(group.getId());
-		return fullGroup;
-	}
-	
-	/**
-	 * Changes the name of the group and returns the new name.
-	 * A number will be appended to duplicate names, which may result in a new name exceeding 32 characters.
-	 * @param group group
-	 * @param name new name [0..32]
-	 * @return new name
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the specified group no longer exists
-	 */
-	public String setGroupName(Group group, String name) throws IOException, ApiException {
-		requireAuthentication();
-		
-		if (!group.isModifiable()) {
-			throw new IllegalArgumentException("Group cannot be modified");
-		}
-		
-		String body = gson.toJson(new SetAttributesRequest(name));
-		Result result = http.put(getRelativeURL("groups/" + enc(group.getId())), body);
-		
-		handleErrors(result);
-		
-		List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
-		SuccessResponse response = entries.get(0);
-		
-		return (String) response.success.get("/groups/" + enc(group.getId()) + "/name");
-	}
-	
-	/**
-	 * Changes the lights in the group.
-	 * @param group group
-	 * @param lights new lights [1..16]
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the specified group no longer exists
-	 */
-	public void setGroupLights(Group group, List<Light> lights) throws IOException, ApiException {
-		requireAuthentication();
-		
-		if (!group.isModifiable()) {
-			throw new IllegalArgumentException("Group cannot be modified");
-		}
-		
-		String body = gson.toJson(new SetAttributesRequest(lights));
-		Result result = http.put(getRelativeURL("groups/" + enc(group.getId())), body);
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Changes the name and the lights of a group and returns the new name.
-	 * @param group group
-	 * @param name new name [0..32]
-	 * @param lights [1..16]
-	 * @return new name
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the specified group no longer exists
-	 */
-	public String setGroupAttributes(Group group, String name, List<Light> lights) throws IOException, ApiException {
-		requireAuthentication();
-		
-		if (!group.isModifiable()) {
-			throw new IllegalArgumentException("Group cannot be modified");
-		}
-		
-		String body = gson.toJson(new SetAttributesRequest(name, lights));
-		Result result = http.put(getRelativeURL("groups/" + enc(group.getId())), body);
-		
-		handleErrors(result);
-		
-		List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
-		SuccessResponse response = entries.get(0);
-		
-		return (String) response.success.get("/groups/" + enc(group.getId()) + "/name");
-	}
-	
-	/**
-	 * Changes the state of a group.
-	 * @param group group
-	 * @param update changes to the state
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the specified group no longer exists
-	 */
-	public void setGroupState(Group group, StateUpdate update) throws IOException, ApiException {
-		requireAuthentication();
-		
-		String body = update.toJson();
-		Result result = http.put(getRelativeURL("groups/" + enc(group.getId()) + "/action"), body);
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Delete a group.
-	 * @param group group
- 	 * @throws UnauthorizedException thrown if the user no longer exists
- 	 * @throws EntityNotAvailableException thrown if the specified group no longer exists
-	 */
-	public void deleteGroup(Group group) throws IOException, ApiException {
-		requireAuthentication();
-		
-		if (!group.isModifiable()) {
-			throw new IllegalArgumentException("Group cannot be modified");
-		}
-		
-		Result result = http.delete(getRelativeURL("groups/" + enc(group.getId())));
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Returns a list of schedules on the bridge.
-	 * @return schedules
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public List<Schedule> getSchedules() throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL("schedules"));
-		
-		handleErrors(result);
-		
-		Map<String, Schedule> scheduleMap = safeFromJson(result.getBody(), Schedule.gsonType);
-		
-		ArrayList<Schedule> scheduleList = new ArrayList<>();
-		
-		for (String id : scheduleMap.keySet()) {
-			Schedule schedule = scheduleMap.get(id);
-			schedule.setId(id);
-			scheduleList.add(schedule);
-		}
-		
-		return scheduleList;
-	}
-	
-	/**
-	 * Schedules a new command to be run at the specified time.
-	 * To select the command for the new schedule, simply run it
-	 * as you normally would in the callback. Instead of it running
-	 * immediately, it will be scheduled to run at the specified time.
-	 * It will automatically fail with an IOException, because there
-	 * will be no response. Note that GET methods cannot be scheduled,
-	 * so those will still run and return results immediately.
-	 * @param time time to run command
-	 * @param callback callback in which the command is specified
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws InvalidCommandException thrown if the scheduled command is larger than 90 bytes or otherwise invalid 
-	 */
-	public void createSchedule(Date time, ScheduleCallback callback) throws IOException, ApiException {
-		createSchedule(null, null, time, callback);
-	}
-	
-	/**
-	 * Schedules a new command to be run at the specified time.
-	 * To select the command for the new schedule, simply run it
-	 * as you normally would in the callback. Instead of it running
-	 * immediately, it will be scheduled to run at the specified time.
-	 * It will automatically fail with an IOException, because there
-	 * will be no response. Note that GET methods cannot be scheduled,
-	 * so those will still run and return results immediately.
-	 * @param name name [0..32]
-	 * @param time time to run command
-	 * @param callback callback in which the command is specified
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws InvalidCommandException thrown if the scheduled command is larger than 90 bytes or otherwise invalid
-	 */
-	public void createSchedule(String name, Date time, ScheduleCallback callback) throws IOException, ApiException {
-		createSchedule(name, null, time, callback);
-	}
-	
-	/**
-	 * Schedules a new command to be run at the specified time.
-	 * To select the command for the new schedule, simply run it
-	 * as you normally would in the callback. Instead of it running
-	 * immediately, it will be scheduled to run at the specified time.
-	 * It will automatically fail with an IOException, because there
-	 * will be no response. Note that GET methods cannot be scheduled,
-	 * so those will still run and return results immediately.
-	 * @param name name [0..32]
-	 * @param description description [0..64]
-	 * @param time time to run command
-	 * @param callback callback in which the command is specified
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws InvalidCommandException thrown if the scheduled command is larger than 90 bytes or otherwise invalid
-	 */
-	public void createSchedule(String name, String description, Date time, ScheduleCallback callback) throws IOException, ApiException {
-		requireAuthentication();
-		
-		handleCommandCallback(callback);
-		
-		String body = gson.toJson(new CreateScheduleRequest(name, description, scheduleCommand, time));
-		Result result = http.post(getRelativeURL("schedules"), body);
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Returns detailed information for the given schedule.
-	 * @param schedule schedule
-	 * @return detailed schedule information
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the specified schedule no longer exists
-	 */
-	public FullSchedule getSchedule(Schedule schedule) throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL("schedules/" + enc(schedule.getId())));
-		
-		handleErrors(result);
-		
-		FullSchedule fullSchedule = safeFromJson(result.getBody(), FullSchedule.class);
-		fullSchedule.setId(schedule.getId());
-		return fullSchedule;
-	}
-	
-	/**
-	 * Changes a schedule.
-	 * @param schedule schedule
-	 * @param update changes
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the specified schedule no longer exists
-	 */
-	public void setSchedule(Schedule schedule, ScheduleUpdate update) throws IOException, ApiException {
-		requireAuthentication();
-		
-		String body = update.toJson();
-		Result result = http.put(getRelativeURL("schedules/" + enc(schedule.getId())), body);
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Changes the command of a schedule.
-	 * @param schedule schedule
-	 * @param callback callback for new command
-	 * @see #createSchedule(String, String, Date, ScheduleCallback)
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws InvalidCommandException thrown if the scheduled command is larger than 90 bytes or otherwise invalid
-	 */
-	public void setScheduleCommand(Schedule schedule, ScheduleCallback callback) throws IOException, ApiException {
-		requireAuthentication();
-		
-		handleCommandCallback(callback);
-		
-		String body = gson.toJson(new CreateScheduleRequest(null, null, scheduleCommand, null));
-		Result result = http.put(getRelativeURL("schedules/" + enc(schedule.getId())), body);
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Callback to specify a schedule command.
-	 */
-	public interface ScheduleCallback {
-		/**
-		 * Run the command you want to schedule as if you're executing
-		 * it normally. The request will automatically fail to produce
-		 * a result by throwing an IOException. Requests that only
-		 * get data (e.g. getGroups) will still execute immediately,
-		 * because those cannot be scheduled.
-		 * @param bridge this bridge for convenience
-		 * @throws IOException always thrown right after executing a command
-		 */
-		public void onScheduleCommand(HueBridge bridge) throws IOException, ApiException;
-	}
-	
-	private ScheduleCommand scheduleCommand = null;
-	private ScheduleCommand handleCommandCallback(ScheduleCallback callback) throws ApiException {
-		// Temporarily reroute requests to a fake HTTP client
-		HttpClient realClient = http;
-		http = new HttpClient() {
-			@Override
-			protected Result doNetwork(String address, String requestMethod, String body) throws IOException {
-				// GET requests cannot be scheduled, so will continue working normally for convenience
-				if (requestMethod.equals("GET")) {
-					return super.doNetwork(address, requestMethod, body);
-				} else {
-					address = Util.quickMatch("^http://[^/]+(.+)$", address);
-					JsonElement commandBody = new JsonParser().parse(body);
-					scheduleCommand = new ScheduleCommand(address, requestMethod, commandBody);
-					
-					// Return a fake result that will cause an exception and the callback to end
-					return new Result(null, 405);
-				}
-			}
-		};
-		
-		// Run command
-		try {
-			scheduleCommand = null;
-			callback.onScheduleCommand(this);
-		} catch (IOException e) {
-			// Command will automatically fail to return a result because of deferred execution
-		} finally {
-			if (scheduleCommand != null && Util.stringSize(scheduleCommand.getBody()) > 90) {
-				throw new InvalidCommandException("Commmand body is larger than 90 bytes");
-			}
-		}
-		
-		// Restore HTTP client
-		http = realClient;
-		
-		return scheduleCommand;
-	}
-	
-	/**
-	 * Delete a schedule.
-	 * @param schedule schedule
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 * @throws EntityNotAvailableException thrown if the schedule no longer exists
-	 */
-	public void deleteSchedule(Schedule schedule) throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.delete(getRelativeURL("schedules/" + enc(schedule.getId())));
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Authenticate on the bridge as the specified user.
-	 * This function verifies that the specified username is valid and will use
-	 * it for subsequent requests if it is, otherwise an UnauthorizedException
-	 * is thrown and the internal username is not changed.
-	 * @param username username to authenticate
-	 * @throws UnauthorizedException thrown if authentication failed
-	 */
-	public void authenticate(String username) throws IOException, ApiException {
-		try {
-			this.username = username;
-			getLights();
-		} catch (Exception e) {
-			this.username = null;
-			throw new UnauthorizedException(e.toString());
-		}
-	}
-	
-	/**
-	 * Link with bridge using the specified username and device type.
-	 * @param username username for new user [10..40]
-	 * @param devicetype identifier of application [0..40]
-	 * @throws LinkButtonException thrown if the bridge button has not been pressed
-	 */
-	public void link(String username, String devicetype) throws IOException, ApiException {
-		this.username = link(new CreateUserRequest(username, devicetype));
-	}
-	
-	/**
-	 * Link with bridge using the specified device type. A random valid username will be generated by the bridge and returned.
-	 * @return new random username generated by bridge
-	 * @param devicetype identifier of application [0..40]
-	 * @throws LinkButtonException thrown if the bridge button has not been pressed
-	 */
-	public String link(String devicetype) throws IOException, ApiException {
-		return (this.username = link(new CreateUserRequest(devicetype)));
-	}
-	
-	private String link(CreateUserRequest request) throws IOException, ApiException {
-		if (this.username != null) {
-			throw new IllegalStateException("already linked");
-		}
-		
-		String body = gson.toJson(request);
-		Result result = http.post(getRelativeURL(""), body);
-		
-		handleErrors(result);
-		
-		List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
-		SuccessResponse response = entries.get(0);
-	
-		return (String) response.success.get("username");
-	}
-	
-	/**
-	 * Returns bridge configuration.
-	 * @see Config
-	 * @return bridge configuration
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public Config getConfig() throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL("config"));
-		
-		handleErrors(result);
-		
-		return safeFromJson(result.getBody(), Config.class);
-	}
-	
-	/**
-	 * Change the configuration of the bridge.
-	 * @param update changes to the configuration
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public void setConfig(ConfigUpdate update) throws IOException, ApiException {
-		requireAuthentication();
-		
-		String body = update.toJson();
-		Result result = http.put(getRelativeURL("config"), body);
-		
-		handleErrors(result);
-	}
-	
-	/**
-	 * Unlink the current user from the bridge.
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public void unlink() throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.delete(getRelativeURL("config/whitelist/" + enc(username)));
+    /**
+     * Returns detailed information for the given light.
+     *
+     * @param light light
+     * @return detailed light information
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if a light with the given id doesn't exist
+     */
+    public FullLight getLight(Light light) throws IOException, ApiException {
+        requireAuthentication();
 
-		handleErrors(result);
-	}
-	
-	/**
-	 * Returns the entire bridge configuration.
-	 * This request is rather resource intensive for the bridge,
-	 * don't use it more often than necessary. Prefer using requests for
-	 * specific information your app needs.
-	 * @return full bridge configuration
-	 * @throws UnauthorizedException thrown if the user no longer exists
-	 */
-	public FullConfig getFullConfig() throws IOException, ApiException {
-		requireAuthentication();
-		
-		Result result = http.get(getRelativeURL(""));
-		
-		handleErrors(result);
-		
-		return gson.fromJson(result.getBody(), FullConfig.class);
-	}
-	
-	// Used as assert in requests that require authentication
-	private void requireAuthentication() {
-		if (this.username == null) {
-			throw new IllegalStateException("linking is required before interacting with the bridge");
-		}
-	}
-	
-	// Methods that convert gson exceptions into ApiExceptions
-	private <T> T safeFromJson(String json, Type typeOfT) throws ApiException {
-		try {
-			return gson.fromJson(json, typeOfT);
-		} catch (JsonParseException e) {
-			throw new ApiException("API returned unexpected result: " + e.getMessage());
-		}
-	}
-	
-	private <T> T safeFromJson(String json, Class<T> classOfT) throws ApiException {
-		try {
-			return gson.fromJson(json, classOfT);
-		} catch (JsonParseException e) {
-			throw new ApiException("API returned unexpected result: " + e.getMessage());
-		}
-	}
-	
-	// Used as assert in all requests to elegantly catch common errors
-	private void handleErrors(Result result) throws IOException, ApiException {
-		if (result.getResponseCode() != 200) {
-			throw new IOException();
-		} else {
-			try {
-				List<ErrorResponse> errors = gson.fromJson(result.getBody(), ErrorResponse.gsonType);
-				if (errors == null) return;
-				
-				for (ErrorResponse error : errors) {					
-					switch (error.getType()) {
-					case 1:
-						username = null;
-						throw new UnauthorizedException(error.getDescription());
-					case 3:
-						throw new EntityNotAvailableException(error.getDescription());
-					case 7:
-						throw new InvalidCommandException(error.getDescription());
-					case 101:
-						throw new LinkButtonException(error.getDescription());
-					case 201:
-						throw new DeviceOffException(error.getDescription());
-					case 301:
-						throw new GroupTableFullException(error.getDescription());
-					default:
-						throw new ApiException(error.getDescription());
-					}
-				}
-			} catch (JsonParseException e) {
-				// Not an error
-			} catch (NullPointerException e) {
-				// Object that looks like error
-			}
-		}
-	}
-	
-	// UTF-8 URL encode
-	private String enc(String str) {
-		try {
-			return URLEncoder.encode(str, "utf-8");
-		} catch (UnsupportedEncodingException e) {
-			// throw new EndOfTheWorldException()
-			throw new UnsupportedOperationException("UTF-8 not supported");
-		}
-	}
-	
-	private String getRelativeURL(String path) {
-		if (username == null) {
-			return "http://" + ip + "/api/" + path;
-		} else {
-			return "http://" + ip + "/api/" + enc(username) + "/" + path;
-		}
-	}
+        Result result = http.get(getRelativeURL("lights/" + enc(light.getId())));
+
+        handleErrors(result);
+
+        FullLight fullLight = safeFromJson(result.getBody(), FullLight.class);
+        fullLight.setId(light.getId());
+        return fullLight;
+    }
+
+    /**
+     * Changes the name of the light and returns the new name.
+     * A number will be appended to duplicate names, which may result in a new name exceeding 32 characters.
+     *
+     * @param light light
+     * @param name new name [0..32]
+     * @return new name
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified light no longer exists
+     */
+    public String setLightName(Light light, String name) throws IOException, ApiException {
+        requireAuthentication();
+
+        String body = gson.toJson(new SetAttributesRequest(name));
+        Result result = http.put(getRelativeURL("lights/" + enc(light.getId())), body);
+
+        handleErrors(result);
+
+        List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
+        SuccessResponse response = entries.get(0);
+
+        return (String) response.success.get("/lights/" + enc(light.getId()) + "/name");
+    }
+
+    /**
+     * Changes the state of a light.
+     *
+     * @param light light
+     * @param update changes to the state
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified light no longer exists
+     * @throws DeviceOffException thrown if the specified light is turned off
+     */
+    public void setLightState(Light light, StateUpdate update) throws IOException, ApiException {
+        requireAuthentication();
+
+        String body = update.toJson();
+        Result result = http.put(getRelativeURL("lights/" + enc(light.getId()) + "/state"), body);
+
+        handleErrors(result);
+    }
+
+    /**
+     * Returns a group object representing all lights.
+     *
+     * @return all lights pseudo group
+     */
+    public Group getAllGroup() {
+        requireAuthentication();
+
+        return new Group();
+    }
+
+    /**
+     * Returns the list of groups, including the unmodifiable all lights group.
+     *
+     * @return list of groups
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public List<Group> getGroups() throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.get(getRelativeURL("groups"));
+
+        handleErrors(result);
+
+        Map<String, Group> groupMap = safeFromJson(result.getBody(), Group.gsonType);
+        ArrayList<Group> groupList = new ArrayList<>();
+
+        groupList.add(new Group());
+
+        for (String id : groupMap.keySet()) {
+            Group group = groupMap.get(id);
+            group.setId(id);
+            groupList.add(group);
+        }
+
+        return groupList;
+    }
+
+    /**
+     * Creates a new group and returns it.
+     * Due to API limitations, the name of the returned object
+     * will simply be "Group". The bridge will append a number to this
+     * name if it's a duplicate. To get the final name, call getGroup
+     * with the returned object.
+     *
+     * @param lights lights in group
+     * @return object representing new group
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws GroupTableFullException thrown if the group limit has been reached
+     */
+    public Group createGroup(List<Light> lights) throws IOException, ApiException {
+        requireAuthentication();
+
+        String body = gson.toJson(new SetAttributesRequest(lights));
+        Result result = http.post(getRelativeURL("groups"), body);
+
+        handleErrors(result);
+
+        List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
+        SuccessResponse response = entries.get(0);
+
+        Group group = new Group();
+        group.setName("Group");
+        group.setId(Util.quickMatch("^/groups/([0-9]+)$", (String) response.success.values().toArray()[0]));
+        return group;
+    }
+
+    /**
+     * Creates a new group and returns it.
+     * Due to API limitations, the name of the returned object
+     * will simply be the same as the name parameter. The bridge will
+     * append a number to the name if it's a duplicate. To get the final
+     * name, call getGroup with the returned object.
+     *
+     * @param name new group name
+     * @param lights lights in group
+     * @return object representing new group
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws GroupTableFullException thrown if the group limit has been reached
+     */
+    public Group createGroup(String name, List<Light> lights) throws IOException, ApiException {
+        requireAuthentication();
+
+        String body = gson.toJson(new SetAttributesRequest(name, lights));
+        Result result = http.post(getRelativeURL("groups"), body);
+
+        handleErrors(result);
+
+        List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
+        SuccessResponse response = entries.get(0);
+
+        Group group = new Group();
+        group.setName(name);
+        group.setId(Util.quickMatch("^/groups/([0-9]+)$", (String) response.success.values().toArray()[0]));
+        return group;
+    }
+
+    /**
+     * Returns detailed information for the given group.
+     *
+     * @param group group
+     * @return detailed group information
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if a group with the given id doesn't exist
+     */
+    public FullGroup getGroup(Group group) throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.get(getRelativeURL("groups/" + enc(group.getId())));
+
+        handleErrors(result);
+
+        FullGroup fullGroup = safeFromJson(result.getBody(), FullGroup.class);
+        fullGroup.setId(group.getId());
+        return fullGroup;
+    }
+
+    /**
+     * Changes the name of the group and returns the new name.
+     * A number will be appended to duplicate names, which may result in a new name exceeding 32 characters.
+     *
+     * @param group group
+     * @param name new name [0..32]
+     * @return new name
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified group no longer exists
+     */
+    public String setGroupName(Group group, String name) throws IOException, ApiException {
+        requireAuthentication();
+
+        if (!group.isModifiable()) {
+            throw new IllegalArgumentException("Group cannot be modified");
+        }
+
+        String body = gson.toJson(new SetAttributesRequest(name));
+        Result result = http.put(getRelativeURL("groups/" + enc(group.getId())), body);
+
+        handleErrors(result);
+
+        List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
+        SuccessResponse response = entries.get(0);
+
+        return (String) response.success.get("/groups/" + enc(group.getId()) + "/name");
+    }
+
+    /**
+     * Changes the lights in the group.
+     *
+     * @param group group
+     * @param lights new lights [1..16]
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified group no longer exists
+     */
+    public void setGroupLights(Group group, List<Light> lights) throws IOException, ApiException {
+        requireAuthentication();
+
+        if (!group.isModifiable()) {
+            throw new IllegalArgumentException("Group cannot be modified");
+        }
+
+        String body = gson.toJson(new SetAttributesRequest(lights));
+        Result result = http.put(getRelativeURL("groups/" + enc(group.getId())), body);
+
+        handleErrors(result);
+    }
+
+    /**
+     * Changes the name and the lights of a group and returns the new name.
+     *
+     * @param group group
+     * @param name new name [0..32]
+     * @param lights [1..16]
+     * @return new name
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified group no longer exists
+     */
+    public String setGroupAttributes(Group group, String name, List<Light> lights) throws IOException, ApiException {
+        requireAuthentication();
+
+        if (!group.isModifiable()) {
+            throw new IllegalArgumentException("Group cannot be modified");
+        }
+
+        String body = gson.toJson(new SetAttributesRequest(name, lights));
+        Result result = http.put(getRelativeURL("groups/" + enc(group.getId())), body);
+
+        handleErrors(result);
+
+        List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
+        SuccessResponse response = entries.get(0);
+
+        return (String) response.success.get("/groups/" + enc(group.getId()) + "/name");
+    }
+
+    /**
+     * Changes the state of a group.
+     *
+     * @param group group
+     * @param update changes to the state
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified group no longer exists
+     */
+    public void setGroupState(Group group, StateUpdate update) throws IOException, ApiException {
+        requireAuthentication();
+
+        String body = update.toJson();
+        Result result = http.put(getRelativeURL("groups/" + enc(group.getId()) + "/action"), body);
+
+        handleErrors(result);
+    }
+
+    /**
+     * Delete a group.
+     *
+     * @param group group
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified group no longer exists
+     */
+    public void deleteGroup(Group group) throws IOException, ApiException {
+        requireAuthentication();
+
+        if (!group.isModifiable()) {
+            throw new IllegalArgumentException("Group cannot be modified");
+        }
+
+        Result result = http.delete(getRelativeURL("groups/" + enc(group.getId())));
+
+        handleErrors(result);
+    }
+
+    /**
+     * Returns a list of schedules on the bridge.
+     *
+     * @return schedules
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public List<Schedule> getSchedules() throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.get(getRelativeURL("schedules"));
+
+        handleErrors(result);
+
+        Map<String, Schedule> scheduleMap = safeFromJson(result.getBody(), Schedule.gsonType);
+
+        ArrayList<Schedule> scheduleList = new ArrayList<>();
+
+        for (String id : scheduleMap.keySet()) {
+            Schedule schedule = scheduleMap.get(id);
+            schedule.setId(id);
+            scheduleList.add(schedule);
+        }
+
+        return scheduleList;
+    }
+
+    /**
+     * Schedules a new command to be run at the specified time.
+     * To select the command for the new schedule, simply run it
+     * as you normally would in the callback. Instead of it running
+     * immediately, it will be scheduled to run at the specified time.
+     * It will automatically fail with an IOException, because there
+     * will be no response. Note that GET methods cannot be scheduled,
+     * so those will still run and return results immediately.
+     *
+     * @param time time to run command
+     * @param callback callback in which the command is specified
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws InvalidCommandException thrown if the scheduled command is larger than 90 bytes or otherwise invalid
+     */
+    public void createSchedule(Date time, ScheduleCallback callback) throws IOException, ApiException {
+        createSchedule(null, null, time, callback);
+    }
+
+    /**
+     * Schedules a new command to be run at the specified time.
+     * To select the command for the new schedule, simply run it
+     * as you normally would in the callback. Instead of it running
+     * immediately, it will be scheduled to run at the specified time.
+     * It will automatically fail with an IOException, because there
+     * will be no response. Note that GET methods cannot be scheduled,
+     * so those will still run and return results immediately.
+     *
+     * @param name name [0..32]
+     * @param time time to run command
+     * @param callback callback in which the command is specified
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws InvalidCommandException thrown if the scheduled command is larger than 90 bytes or otherwise invalid
+     */
+    public void createSchedule(String name, Date time, ScheduleCallback callback) throws IOException, ApiException {
+        createSchedule(name, null, time, callback);
+    }
+
+    /**
+     * Schedules a new command to be run at the specified time.
+     * To select the command for the new schedule, simply run it
+     * as you normally would in the callback. Instead of it running
+     * immediately, it will be scheduled to run at the specified time.
+     * It will automatically fail with an IOException, because there
+     * will be no response. Note that GET methods cannot be scheduled,
+     * so those will still run and return results immediately.
+     *
+     * @param name name [0..32]
+     * @param description description [0..64]
+     * @param time time to run command
+     * @param callback callback in which the command is specified
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws InvalidCommandException thrown if the scheduled command is larger than 90 bytes or otherwise invalid
+     */
+    public void createSchedule(String name, String description, Date time, ScheduleCallback callback)
+            throws IOException, ApiException {
+        requireAuthentication();
+
+        handleCommandCallback(callback);
+
+        String body = gson.toJson(new CreateScheduleRequest(name, description, scheduleCommand, time));
+        Result result = http.post(getRelativeURL("schedules"), body);
+
+        handleErrors(result);
+    }
+
+    /**
+     * Returns detailed information for the given schedule.
+     *
+     * @param schedule schedule
+     * @return detailed schedule information
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified schedule no longer exists
+     */
+    public FullSchedule getSchedule(Schedule schedule) throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.get(getRelativeURL("schedules/" + enc(schedule.getId())));
+
+        handleErrors(result);
+
+        FullSchedule fullSchedule = safeFromJson(result.getBody(), FullSchedule.class);
+        fullSchedule.setId(schedule.getId());
+        return fullSchedule;
+    }
+
+    /**
+     * Changes a schedule.
+     *
+     * @param schedule schedule
+     * @param update changes
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the specified schedule no longer exists
+     */
+    public void setSchedule(Schedule schedule, ScheduleUpdate update) throws IOException, ApiException {
+        requireAuthentication();
+
+        String body = update.toJson();
+        Result result = http.put(getRelativeURL("schedules/" + enc(schedule.getId())), body);
+
+        handleErrors(result);
+    }
+
+    /**
+     * Changes the command of a schedule.
+     *
+     * @param schedule schedule
+     * @param callback callback for new command
+     * @see #createSchedule(String, String, Date, ScheduleCallback)
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws InvalidCommandException thrown if the scheduled command is larger than 90 bytes or otherwise invalid
+     */
+    public void setScheduleCommand(Schedule schedule, ScheduleCallback callback) throws IOException, ApiException {
+        requireAuthentication();
+
+        handleCommandCallback(callback);
+
+        String body = gson.toJson(new CreateScheduleRequest(null, null, scheduleCommand, null));
+        Result result = http.put(getRelativeURL("schedules/" + enc(schedule.getId())), body);
+
+        handleErrors(result);
+    }
+
+    /**
+     * Callback to specify a schedule command.
+     */
+    public interface ScheduleCallback {
+        /**
+         * Run the command you want to schedule as if you're executing
+         * it normally. The request will automatically fail to produce
+         * a result by throwing an IOException. Requests that only
+         * get data (e.g. getGroups) will still execute immediately,
+         * because those cannot be scheduled.
+         *
+         * @param bridge this bridge for convenience
+         * @throws IOException always thrown right after executing a command
+         */
+        public void onScheduleCommand(HueBridge bridge) throws IOException, ApiException;
+    }
+
+    private ScheduleCommand scheduleCommand = null;
+
+    private ScheduleCommand handleCommandCallback(ScheduleCallback callback) throws ApiException {
+        // Temporarily reroute requests to a fake HTTP client
+        HttpClient realClient = http;
+        http = new HttpClient() {
+            @Override
+            protected Result doNetwork(String address, String requestMethod, String body) throws IOException {
+                // GET requests cannot be scheduled, so will continue working normally for convenience
+                if (requestMethod.equals("GET")) {
+                    return super.doNetwork(address, requestMethod, body);
+                } else {
+                    address = Util.quickMatch("^http://[^/]+(.+)$", address);
+                    JsonElement commandBody = new JsonParser().parse(body);
+                    scheduleCommand = new ScheduleCommand(address, requestMethod, commandBody);
+
+                    // Return a fake result that will cause an exception and the callback to end
+                    return new Result(null, 405);
+                }
+            }
+        };
+
+        // Run command
+        try {
+            scheduleCommand = null;
+            callback.onScheduleCommand(this);
+        } catch (IOException e) {
+            // Command will automatically fail to return a result because of deferred execution
+        } finally {
+            if (scheduleCommand != null && Util.stringSize(scheduleCommand.getBody()) > 90) {
+                throw new InvalidCommandException("Commmand body is larger than 90 bytes");
+            }
+        }
+
+        // Restore HTTP client
+        http = realClient;
+
+        return scheduleCommand;
+    }
+
+    /**
+     * Delete a schedule.
+     *
+     * @param schedule schedule
+     * @throws UnauthorizedException thrown if the user no longer exists
+     * @throws EntityNotAvailableException thrown if the schedule no longer exists
+     */
+    public void deleteSchedule(Schedule schedule) throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.delete(getRelativeURL("schedules/" + enc(schedule.getId())));
+
+        handleErrors(result);
+    }
+
+    /**
+     * Authenticate on the bridge as the specified user.
+     * This function verifies that the specified username is valid and will use
+     * it for subsequent requests if it is, otherwise an UnauthorizedException
+     * is thrown and the internal username is not changed.
+     *
+     * @param username username to authenticate
+     * @throws UnauthorizedException thrown if authentication failed
+     */
+    public void authenticate(String username) throws IOException, ApiException {
+        try {
+            this.username = username;
+            getLights();
+        } catch (Exception e) {
+            this.username = null;
+            throw new UnauthorizedException(e.toString());
+        }
+    }
+
+    /**
+     * Link with bridge using the specified username and device type.
+     *
+     * @param username username for new user [10..40]
+     * @param devicetype identifier of application [0..40]
+     * @throws LinkButtonException thrown if the bridge button has not been pressed
+     */
+    public void link(String username, String devicetype) throws IOException, ApiException {
+        this.username = link(new CreateUserRequest(username, devicetype));
+    }
+
+    /**
+     * Link with bridge using the specified device type. A random valid username will be generated by the bridge and
+     * returned.
+     *
+     * @return new random username generated by bridge
+     * @param devicetype identifier of application [0..40]
+     * @throws LinkButtonException thrown if the bridge button has not been pressed
+     */
+    public String link(String devicetype) throws IOException, ApiException {
+        return (this.username = link(new CreateUserRequest(devicetype)));
+    }
+
+    private String link(CreateUserRequest request) throws IOException, ApiException {
+        if (this.username != null) {
+            throw new IllegalStateException("already linked");
+        }
+
+        String body = gson.toJson(request);
+        Result result = http.post(getRelativeURL(""), body);
+
+        handleErrors(result);
+
+        List<SuccessResponse> entries = safeFromJson(result.getBody(), SuccessResponse.gsonType);
+        SuccessResponse response = entries.get(0);
+
+        return (String) response.success.get("username");
+    }
+
+    /**
+     * Returns bridge configuration.
+     *
+     * @see Config
+     * @return bridge configuration
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public Config getConfig() throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.get(getRelativeURL("config"));
+
+        handleErrors(result);
+
+        return safeFromJson(result.getBody(), Config.class);
+    }
+
+    /**
+     * Change the configuration of the bridge.
+     *
+     * @param update changes to the configuration
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public void setConfig(ConfigUpdate update) throws IOException, ApiException {
+        requireAuthentication();
+
+        String body = update.toJson();
+        Result result = http.put(getRelativeURL("config"), body);
+
+        handleErrors(result);
+    }
+
+    /**
+     * Unlink the current user from the bridge.
+     *
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public void unlink() throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.delete(getRelativeURL("config/whitelist/" + enc(username)));
+
+        handleErrors(result);
+    }
+
+    /**
+     * Returns the entire bridge configuration.
+     * This request is rather resource intensive for the bridge,
+     * don't use it more often than necessary. Prefer using requests for
+     * specific information your app needs.
+     *
+     * @return full bridge configuration
+     * @throws UnauthorizedException thrown if the user no longer exists
+     */
+    public FullConfig getFullConfig() throws IOException, ApiException {
+        requireAuthentication();
+
+        Result result = http.get(getRelativeURL(""));
+
+        handleErrors(result);
+
+        return gson.fromJson(result.getBody(), FullConfig.class);
+    }
+
+    // Used as assert in requests that require authentication
+    private void requireAuthentication() {
+        if (this.username == null) {
+            throw new IllegalStateException("linking is required before interacting with the bridge");
+        }
+    }
+
+    // Methods that convert gson exceptions into ApiExceptions
+    private <T> T safeFromJson(String json, Type typeOfT) throws ApiException {
+        try {
+            return gson.fromJson(json, typeOfT);
+        } catch (JsonParseException e) {
+            throw new ApiException("API returned unexpected result: " + e.getMessage());
+        }
+    }
+
+    private <T> T safeFromJson(String json, Class<T> classOfT) throws ApiException {
+        try {
+            return gson.fromJson(json, classOfT);
+        } catch (JsonParseException e) {
+            throw new ApiException("API returned unexpected result: " + e.getMessage());
+        }
+    }
+
+    // Used as assert in all requests to elegantly catch common errors
+    private void handleErrors(Result result) throws IOException, ApiException {
+        if (result.getResponseCode() != 200) {
+            throw new IOException();
+        } else {
+            try {
+                List<ErrorResponse> errors = gson.fromJson(result.getBody(), ErrorResponse.gsonType);
+                if (errors == null) {
+                    return;
+                }
+
+                for (ErrorResponse error : errors) {
+                    switch (error.getType()) {
+                        case 1:
+                            username = null;
+                            throw new UnauthorizedException(error.getDescription());
+                        case 3:
+                            throw new EntityNotAvailableException(error.getDescription());
+                        case 7:
+                            throw new InvalidCommandException(error.getDescription());
+                        case 101:
+                            throw new LinkButtonException(error.getDescription());
+                        case 201:
+                            throw new DeviceOffException(error.getDescription());
+                        case 301:
+                            throw new GroupTableFullException(error.getDescription());
+                        default:
+                            throw new ApiException(error.getDescription());
+                    }
+                }
+            } catch (JsonParseException e) {
+                // Not an error
+            } catch (NullPointerException e) {
+                // Object that looks like error
+            }
+        }
+    }
+
+    // UTF-8 URL encode
+    private String enc(String str) {
+        try {
+            return URLEncoder.encode(str, "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            // throw new EndOfTheWorldException()
+            throw new UnsupportedOperationException("UTF-8 not supported");
+        }
+    }
+
+    private String getRelativeURL(String path) {
+        if (username == null) {
+            return "http://" + ip + "/api/" + path;
+        } else {
+            return "http://" + ip + "/api/" + enc(username) + "/" + path;
+        }
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueConfigStatusMessage.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueConfigStatusMessage.java
@@ -12,7 +12,7 @@ import org.eclipse.smarthome.config.core.status.ConfigStatusMessage;
 /**
  * The {@link HueConfigStatusMessage} defines
  * the keys to be used for {@link ConfigStatusMessage}s.
- * 
+ *
  * @author Alexander Kostadinov - Initial contribution
  *
  */

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueThingHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueThingHandlerFactory.java
@@ -7,8 +7,7 @@
  */
 package org.eclipse.smarthome.binding.hue.internal;
 
-import static org.eclipse.smarthome.binding.hue.HueBindingConstants.LIGHT_ID;
-import static org.eclipse.smarthome.binding.hue.HueBindingConstants.SERIAL_NUMBER;
+import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
 
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -98,8 +97,8 @@ public class HueThingHandlerFactory extends BaseThingHandlerFactory {
     private synchronized void registerLightDiscoveryService(HueBridgeHandler bridgeHandler) {
         HueLightDiscoveryService discoveryService = new HueLightDiscoveryService(bridgeHandler);
         discoveryService.activate();
-        this.discoveryServiceRegs.put(bridgeHandler.getThing().getUID(), bundleContext.registerService(
-                DiscoveryService.class.getName(), discoveryService, new Hashtable<String, Object>()));
+        this.discoveryServiceRegs.put(bridgeHandler.getThing().getUID(), bundleContext
+                .registerService(DiscoveryService.class.getName(), discoveryService, new Hashtable<String, Object>()));
     }
 
     @Override
@@ -108,8 +107,8 @@ public class HueThingHandlerFactory extends BaseThingHandlerFactory {
             ServiceRegistration<?> serviceReg = this.discoveryServiceRegs.get(thingHandler.getThing().getUID());
             if (serviceReg != null) {
                 // remove discovery service, if bridge handler is removed
-                HueLightDiscoveryService service = (HueLightDiscoveryService) bundleContext.getService(serviceReg
-                        .getReference());
+                HueLightDiscoveryService service = (HueLightDiscoveryService) bundleContext
+                        .getService(serviceReg.getReference());
                 service.deactivate();
                 serviceReg.unregister();
                 discoveryServiceRegs.remove(thingHandler.getThing().getUID());

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Light.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Light.java
@@ -19,30 +19,34 @@ import com.google.gson.reflect.TypeToken;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class Light {
-	public final static Type gsonType = new TypeToken<Map<String, Light>>(){}.getType();
-	
-	private String id;
-	private String name;
-	
-	Light() {}
-	
-	void setId(String id) {
-		this.id = id;
-	}
-	
-	/**
-	 * Returns the id of the light.
-	 * @return id
-	 */
-	public String getId() {
-		return id;
-	}
-	
-	/**
-	 * Returns the name of the light.
-	 * @return name
-	 */
-	public String getName() {
-		return name;
-	}
+    public final static Type gsonType = new TypeToken<Map<String, Light>>() {
+    }.getType();
+
+    private String id;
+    private String name;
+
+    Light() {
+    }
+
+    void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * Returns the id of the light.
+     *
+     * @return id
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Returns the name of the light.
+     *
+     * @return name
+     */
+    public String getName() {
+        return name;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/NewLightsResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/NewLightsResponse.java
@@ -13,5 +13,5 @@ package org.eclipse.smarthome.binding.hue.internal;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 class NewLightsResponse {
-	public String lastscan;
+    public String lastscan;
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/PortalDiscoveryResult.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/PortalDiscoveryResult.java
@@ -18,11 +18,12 @@ import com.google.gson.reflect.TypeToken;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 class PortalDiscoveryResult {
-	public final static Type gsonType = new TypeToken<List<PortalDiscoveryResult>>(){}.getType();
-	
-	private String internalipaddress;
-	
-	public String getIPAddress() {
-		return internalipaddress;
-	}
+    public final static Type gsonType = new TypeToken<List<PortalDiscoveryResult>>() {
+    }.getType();
+
+    private String internalipaddress;
+
+    public String getIPAddress() {
+        return internalipaddress;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Schedule.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Schedule.java
@@ -19,20 +19,21 @@ import com.google.gson.reflect.TypeToken;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class Schedule {
-	public final static Type gsonType = new TypeToken<Map<String, Schedule>>(){}.getType();
-	
-	private String id;
-	private String name;
-	
-	void setId(String id) {
-		this.id = id;
-	}
-	
-	public String getId() {
-		return id;
-	}
-	
-	public String getName() {
-		return name;
-	}
+    public final static Type gsonType = new TypeToken<Map<String, Schedule>>() {
+    }.getType();
+
+    private String id;
+    private String name;
+
+    void setId(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/ScheduleCommand.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/ScheduleCommand.java
@@ -16,38 +16,41 @@ import com.google.gson.JsonElement;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class ScheduleCommand {
-	private String address;
-	private String method;
-	private JsonElement body;
-	
-	ScheduleCommand(String address, String method, JsonElement body) {
-		this.address = address;
-		this.method = method;
-		this.body = body;
-	}
-	
-	/**
-	 * Returns the relative request url.
-	 * @return request url
-	 */
-	public String getAddress() {
-		return address;
-	}
-	
-	/**
-	 * Returns the request method.
-	 * Can be GET, PUT, POST or DELETE.
-	 * @return request method
-	 */
-	public String getMethod() {
-		return method;
-	}
-	
-	/**
-	 * Returns the request body.
-	 * @return request body
-	 */
-	public String getBody() {
-		return body.toString();
-	}
+    private String address;
+    private String method;
+    private JsonElement body;
+
+    ScheduleCommand(String address, String method, JsonElement body) {
+        this.address = address;
+        this.method = method;
+        this.body = body;
+    }
+
+    /**
+     * Returns the relative request url.
+     *
+     * @return request url
+     */
+    public String getAddress() {
+        return address;
+    }
+
+    /**
+     * Returns the request method.
+     * Can be GET, PUT, POST or DELETE.
+     *
+     * @return request method
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * Returns the request body.
+     *
+     * @return request body
+     */
+    public String getBody() {
+        return body.toString();
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/ScheduleUpdate.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/ScheduleUpdate.java
@@ -17,56 +17,61 @@ import java.util.Date;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding, minor code cleanup
  */
 public class ScheduleUpdate {
-	private ArrayList<Command> commands = new ArrayList<>();
-	
-	String toJson() {
-		StringBuilder json = new StringBuilder("{");
-		
-		for (int i = 0; i < commands.size(); i++) {
-			json.append(commands.get(i).toJson());
-			if (i < commands.size() - 1) json.append(",");
-		}
-		
-		json.append("}");
-		
-		return json.toString();
-	}
-	
-	/**
-	 * Set the name of the schedule.
-	 * @param name new name
-	 * @return this object for chaining calls
-	 */
-	public ScheduleUpdate setName(String name) {
-		if (Util.stringSize(name) > 32) {
-			throw new IllegalArgumentException("Schedule name can be at most 32 characters long");
-		}
-		
-		commands.add(new Command("name", name));
-		return this;
-	}
-	
-	/**
-	 * Set the description of the schedule.
-	 * @param description new description
-	 * @return this object for chaining calls
-	 */
-	public ScheduleUpdate setDescription(String description) {
-		if (Util.stringSize(description) > 64) {
-			throw new IllegalArgumentException("Schedule description can be at most 64 characters long");
-		}
-		
-		commands.add(new Command("description", description));
-		return this;
-	}
-	
-	/**
-	 * Set the time of the schedule.
-	 * @param time new time
-	 * @return this object for chaining calls
-	 */
-	public ScheduleUpdate setTime(Date time) {
-		commands.add(new Command("time", time));
-		return this;
-	}
+    private ArrayList<Command> commands = new ArrayList<>();
+
+    String toJson() {
+        StringBuilder json = new StringBuilder("{");
+
+        for (int i = 0; i < commands.size(); i++) {
+            json.append(commands.get(i).toJson());
+            if (i < commands.size() - 1) {
+                json.append(",");
+            }
+        }
+
+        json.append("}");
+
+        return json.toString();
+    }
+
+    /**
+     * Set the name of the schedule.
+     *
+     * @param name new name
+     * @return this object for chaining calls
+     */
+    public ScheduleUpdate setName(String name) {
+        if (Util.stringSize(name) > 32) {
+            throw new IllegalArgumentException("Schedule name can be at most 32 characters long");
+        }
+
+        commands.add(new Command("name", name));
+        return this;
+    }
+
+    /**
+     * Set the description of the schedule.
+     *
+     * @param description new description
+     * @return this object for chaining calls
+     */
+    public ScheduleUpdate setDescription(String description) {
+        if (Util.stringSize(description) > 64) {
+            throw new IllegalArgumentException("Schedule description can be at most 64 characters long");
+        }
+
+        commands.add(new Command("description", description));
+        return this;
+    }
+
+    /**
+     * Set the time of the schedule.
+     *
+     * @param time new time
+     * @return this object for chaining calls
+     */
+    public ScheduleUpdate setTime(Date time) {
+        commands.add(new Command("time", time));
+        return this;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/SearchForLightsRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/SearchForLightsRequest.java
@@ -21,8 +21,7 @@ class SearchForLightsRequest {
 
     public SearchForLightsRequest(List<String> deviceid) {
         if (deviceid != null && (deviceid.size() == 0 || deviceid.size() > 16)) {
-            throw new IllegalArgumentException(
-                    "Group cannot be empty and cannot have more than 16 lights");
+            throw new IllegalArgumentException("Group cannot be empty and cannot have more than 16 lights");
         }
         if (deviceid != null) {
             this.deviceid = deviceid;

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/SetAttributesRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/SetAttributesRequest.java
@@ -16,25 +16,27 @@ import java.util.List;
  */
 @SuppressWarnings("unused")
 class SetAttributesRequest {
-	private String name;
-	private List<String> lights;
-	
-	public SetAttributesRequest(String name) {
-		this(name, null);
-	}
-	
-	public SetAttributesRequest(List<Light> lights) {
-		this(null, lights);
-	}
-	
-	public SetAttributesRequest(String name, List<Light> lights) {
-		if (name != null && Util.stringSize(name) > 32) {
-			throw new IllegalArgumentException("Name can be at most 32 characters long");
-		} else if (lights != null && (lights.size() == 0 || lights.size() > 16)) {
-			throw new IllegalArgumentException("Group cannot be empty and cannot have more than 16 lights");
-		}
-		
-		this.name = name;
-		if (lights != null) this.lights = Util.lightsToIds(lights);
-	}
+    private String name;
+    private List<String> lights;
+
+    public SetAttributesRequest(String name) {
+        this(name, null);
+    }
+
+    public SetAttributesRequest(List<Light> lights) {
+        this(null, lights);
+    }
+
+    public SetAttributesRequest(String name, List<Light> lights) {
+        if (name != null && Util.stringSize(name) > 32) {
+            throw new IllegalArgumentException("Name can be at most 32 characters long");
+        } else if (lights != null && (lights.size() == 0 || lights.size() > 16)) {
+            throw new IllegalArgumentException("Group cannot be empty and cannot have more than 16 lights");
+        }
+
+        this.name = name;
+        if (lights != null) {
+            this.lights = Util.lightsToIds(lights);
+        }
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/SoftwareUpdate.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/SoftwareUpdate.java
@@ -14,41 +14,45 @@ package org.eclipse.smarthome.binding.hue.internal;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class SoftwareUpdate {
-	private int updatestate;
-	private String url;
-	private String text;
-	private boolean notify;
-	
-	/**
-	 * Returns the state of the update.
-	 * TODO: Actual meaning currently undocumented
-	 * @return state of update
-	 */
-	public int getUpdateState() {
-		return updatestate;
-	}
-	
-	/**
-	 * Returns the url of the changelog.
-	 * @return changelog url
-	 */
-	public String getUrl() {
-		return url;
-	}
-	
-	/**
-	 * Returns a description of the update.
-	 * @return update description
-	 */
-	public String getText() {
-		return text;
-	}
-	
-	/**
-	 * Returns if there will be a notification about this update.
-	 * @return true for notification, false otherwise
-	 */
-	public boolean isNotified() {
-		return notify;
-	}
+    private int updatestate;
+    private String url;
+    private String text;
+    private boolean notify;
+
+    /**
+     * Returns the state of the update.
+     * TODO: Actual meaning currently undocumented
+     *
+     * @return state of update
+     */
+    public int getUpdateState() {
+        return updatestate;
+    }
+
+    /**
+     * Returns the url of the changelog.
+     *
+     * @return changelog url
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Returns a description of the update.
+     *
+     * @return update description
+     */
+    public String getText() {
+        return text;
+    }
+
+    /**
+     * Returns if there will be a notification about this update.
+     *
+     * @return true for notification, false otherwise
+     */
+    public boolean isNotified() {
+        return notify;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/State.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/State.java
@@ -14,152 +14,163 @@ package org.eclipse.smarthome.binding.hue.internal;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class State {
-	private boolean on;
-	private int bri;
-	private int hue;
-	private int sat;
-	private float[] xy;
-	private int ct;
-	private String alert;
-	private String effect;
-	private String colormode;
-	private boolean reachable;
-	
-	State() {}
-	
-	/**
-	 * Color modes of a light.
-	 */
-	public enum ColorMode {
-		/**
-		 * CIE color space coordinates
-		 */
-		XY,
-		
-		/**
-		 * Hue and saturation
-		 */
-		HS,
-		
-		/**
-		 * Color temperature in mirek
-		 */
-		CT;
-	}
-	
-	/**
-	 * Alert modes of a light.
-	 */
-	public enum AlertMode {
-		/**
-		 * Light is not performing alert effect
-		 */
-		NONE,
-		
-		/**
-		 * Light is performing one breathe cycle
-		 */
-		SELECT,
-		
-		/**
-		 * Light is performing breathe cycles for 30 seconds (unless cancelled)
-		 */
-		LSELECT
-	}
-	
-	/**
-	 * Effects possible for a light.
-	 */
-	public enum Effect {
-		/**
-		 * No effect
-		 */
-		NONE,
-		
-		/**
-		 * Cycle through all hues with current saturation and brightness
-		 */
-		COLORLOOP
-	}
-	
-	/**
-	 * Returns the on state.
-	 * @return true if the light is on, false if it isn't
-	 */
-	public boolean isOn() {
-		return on;
-	}
-	
-	/**
-	 * Returns the brightness.
-	 * @return brightness
-	 */
-	public int getBrightness() {
-		return bri;
-	}
-	
-	/**
-	 * Returns the hue.
-	 * @return hue
-	 */
-	public int getHue() {
-		return hue;
-	}
-	
-	/**
-	 * Returns the saturation.
-	 * @return saturation
-	 */
-	public int getSaturation() {
-		return sat;
-	}
-	
-	/**
-	 * Returns the coordinates in CIE color space.
-	 * @return cie color spaces coordinates
-	 */
-	public float[] getXY() {
-		return xy;
-	}
-	
-	/**
-	 * Returns the color temperature.
-	 * @return color temperature
-	 */
-	public int getColorTemperature() {
-		return ct;
-	}
-	
-	/**
-	 * Returns the last alert mode set.
-	 * Future firmware updates may change this to actually report the current alert mode.
-	 * @return last alert mode
-	 */
-	public AlertMode getAlertMode() {
-		return AlertMode.valueOf(alert.toUpperCase());
-	}
-	
-	/**
-	 * Returns the current color mode.
-	 * @return current color mode
-	 */
-	public ColorMode getColorMode() {
-		return ColorMode.valueOf(colormode.toUpperCase());
-	}
-	
-	/**
-	 * Returns the current active effect.
-	 * @return current active effect
-	 */
-	public Effect getEffect() {
-		return Effect.valueOf(effect.toUpperCase());
-	}
-	
-	/**
-	 * Returns reachability.
-	 * @return true if reachable, false if it isn't
-	 */
-	public boolean isReachable() {
-		return reachable;
-	}
+    private boolean on;
+    private int bri;
+    private int hue;
+    private int sat;
+    private float[] xy;
+    private int ct;
+    private String alert;
+    private String effect;
+    private String colormode;
+    private boolean reachable;
+
+    State() {
+    }
+
+    /**
+     * Color modes of a light.
+     */
+    public enum ColorMode {
+        /**
+         * CIE color space coordinates
+         */
+        XY,
+
+        /**
+         * Hue and saturation
+         */
+        HS,
+
+        /**
+         * Color temperature in mirek
+         */
+        CT;
+    }
+
+    /**
+     * Alert modes of a light.
+     */
+    public enum AlertMode {
+        /**
+         * Light is not performing alert effect
+         */
+        NONE,
+
+        /**
+         * Light is performing one breathe cycle
+         */
+        SELECT,
+
+        /**
+         * Light is performing breathe cycles for 30 seconds (unless cancelled)
+         */
+        LSELECT
+    }
+
+    /**
+     * Effects possible for a light.
+     */
+    public enum Effect {
+        /**
+         * No effect
+         */
+        NONE,
+
+        /**
+         * Cycle through all hues with current saturation and brightness
+         */
+        COLORLOOP
+    }
+
+    /**
+     * Returns the on state.
+     *
+     * @return true if the light is on, false if it isn't
+     */
+    public boolean isOn() {
+        return on;
+    }
+
+    /**
+     * Returns the brightness.
+     *
+     * @return brightness
+     */
+    public int getBrightness() {
+        return bri;
+    }
+
+    /**
+     * Returns the hue.
+     *
+     * @return hue
+     */
+    public int getHue() {
+        return hue;
+    }
+
+    /**
+     * Returns the saturation.
+     *
+     * @return saturation
+     */
+    public int getSaturation() {
+        return sat;
+    }
+
+    /**
+     * Returns the coordinates in CIE color space.
+     *
+     * @return cie color spaces coordinates
+     */
+    public float[] getXY() {
+        return xy;
+    }
+
+    /**
+     * Returns the color temperature.
+     *
+     * @return color temperature
+     */
+    public int getColorTemperature() {
+        return ct;
+    }
+
+    /**
+     * Returns the last alert mode set.
+     * Future firmware updates may change this to actually report the current alert mode.
+     *
+     * @return last alert mode
+     */
+    public AlertMode getAlertMode() {
+        return AlertMode.valueOf(alert.toUpperCase());
+    }
+
+    /**
+     * Returns the current color mode.
+     *
+     * @return current color mode
+     */
+    public ColorMode getColorMode() {
+        return ColorMode.valueOf(colormode.toUpperCase());
+    }
+
+    /**
+     * Returns the current active effect.
+     *
+     * @return current active effect
+     */
+    public Effect getEffect() {
+        return Effect.valueOf(effect.toUpperCase());
+    }
+
+    /**
+     * Returns reachability.
+     *
+     * @return true if reachable, false if it isn't
+     */
+    public boolean isReachable() {
+        return reachable;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/StateUpdate.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/StateUpdate.java
@@ -20,164 +20,178 @@ import org.eclipse.smarthome.binding.hue.internal.State.Effect;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding, minor code cleanup
  */
 public class StateUpdate {
-	private ArrayList<Command> commands = new ArrayList<>();
-	
-	String toJson() {
-		StringBuilder json = new StringBuilder("{");
-		
-		for (int i = 0; i < commands.size(); i++) {
-			json.append(commands.get(i).toJson());
-			if (i < commands.size() - 1) json.append(",");
-		}
-		
-		json.append("}");
-		
-		return json.toString();
-	}
-	
-	/**
-	 * Turn light on.
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate turnOn() {
-		return setOn(true);
-	}
-	
-	/**
-	 * Turn light off.
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate turnOff() {
-		return setOn(false);
-	}
-	
-	/**
-	 * Turn light on or off.
-	 * @param on on if true, off otherwise
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setOn(boolean on) {
-		commands.add(new Command("on", on));
-		return this;
-	}
-	
-	/**
-	 * Set brightness of light.
-	 * Brightness 0 is not the same as off.
-	 * @param brightness brightness [1..254]
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setBrightness(int brightness) {
-		if (brightness < 1 || brightness > 254) {
-			throw new IllegalArgumentException("Brightness out of range");
-		}
-		
-		commands.add(new Command("bri", brightness));
-		return this;
-	}
-	
-	/**
-	 * Switch to HS color mode and set hue.
-	 * @param hue hue [0..65535]
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setHue(int hue) {
-		if (hue < 0 || hue > 65535) {
-			throw new IllegalArgumentException("Hue out of range");
-		}
-		
-		commands.add(new Command("hue", hue));
-		return this;
-	}
-	
-	/**
-	 * Switch to HS color mode and set saturation.
-	 * @param saturation saturation [0..254]
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setSat(int saturation) {
-		if (saturation < 0 || saturation > 254) {
-			throw new IllegalArgumentException("Saturation out of range");
-		}
-		
-		commands.add(new Command("sat", saturation));
-		return this;
-	}
-	
-	/**
-	 * Switch to XY color mode and set CIE color space coordinates.
-	 * @param x x coordinate [0..1]
-	 * @param y y coordinate [0..1]
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setXY(float x, float y) {
-		return setXY(new float[] {x, y});
-	}
-	
-	/**
-	 * Switch to XY color mode and set CIE color space coordinates.
-	 * @param xy x and y coordinates [0..1, 0..1]
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setXY(float[] xy) {
-		if (xy.length != 2) {
-			throw new IllegalArgumentException("Invalid coordinate array given");
-		} else if (xy[0] < 0.0f || xy[0] > 1.0f || xy[1] < 0.0f || xy[1] > 1.0f) {
-			throw new IllegalArgumentException("X and/or Y coordinate(s) out of bounds");
-		}
-		
-		commands.add(new Command("xy", xy));
-		return this;
-	}
-	
-	/**
-	 * Switch to CT color mode and set color temperature in mired.
-	 * @param colorTemperature color temperature [153..500]
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setColorTemperature(int colorTemperature) {
-		if (colorTemperature < 153 || colorTemperature > 500) {
-			throw new IllegalArgumentException("Color temperature out of range");
-		}
-		
-		commands.add(new Command("ct", colorTemperature));
-		return this;
-	}
-	
-	/**
-	 * Set the alert mode.
-	 * @see AlertMode
-	 * @param mode alert mode
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setAlert(AlertMode mode) {
-		commands.add(new Command("alert", mode.toString().toLowerCase()));
-		return this;
-	}
-	
-	/**
-	 * Set the current effect.
-	 * @see Effect
-	 * @param effect effect 
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setEffect(Effect effect) {
-		commands.add(new Command("effect", effect.toString().toLowerCase()));
-		return this;
-	}
-	
-	/**
-	 * Set the transition time from the current state to the new state.
-	 * Time is accurate to 100 milliseconds.
-	 * @param timeMillis time in milliseconds [0..6553600]
-	 * @return this object for chaining calls
-	 */
-	public StateUpdate setTransitionTime(int timeMillis) {
-		if (timeMillis < 0 || timeMillis > 6553600) {
-			throw new IllegalArgumentException("Transition time out of range");
-		}
-		
-		commands.add(new Command("transitiontime", timeMillis / 100));
-		return this;
-	}
+    private ArrayList<Command> commands = new ArrayList<>();
+
+    String toJson() {
+        StringBuilder json = new StringBuilder("{");
+
+        for (int i = 0; i < commands.size(); i++) {
+            json.append(commands.get(i).toJson());
+            if (i < commands.size() - 1) {
+                json.append(",");
+            }
+        }
+
+        json.append("}");
+
+        return json.toString();
+    }
+
+    /**
+     * Turn light on.
+     *
+     * @return this object for chaining calls
+     */
+    public StateUpdate turnOn() {
+        return setOn(true);
+    }
+
+    /**
+     * Turn light off.
+     *
+     * @return this object for chaining calls
+     */
+    public StateUpdate turnOff() {
+        return setOn(false);
+    }
+
+    /**
+     * Turn light on or off.
+     *
+     * @param on on if true, off otherwise
+     * @return this object for chaining calls
+     */
+    public StateUpdate setOn(boolean on) {
+        commands.add(new Command("on", on));
+        return this;
+    }
+
+    /**
+     * Set brightness of light.
+     * Brightness 0 is not the same as off.
+     *
+     * @param brightness brightness [1..254]
+     * @return this object for chaining calls
+     */
+    public StateUpdate setBrightness(int brightness) {
+        if (brightness < 1 || brightness > 254) {
+            throw new IllegalArgumentException("Brightness out of range");
+        }
+
+        commands.add(new Command("bri", brightness));
+        return this;
+    }
+
+    /**
+     * Switch to HS color mode and set hue.
+     *
+     * @param hue hue [0..65535]
+     * @return this object for chaining calls
+     */
+    public StateUpdate setHue(int hue) {
+        if (hue < 0 || hue > 65535) {
+            throw new IllegalArgumentException("Hue out of range");
+        }
+
+        commands.add(new Command("hue", hue));
+        return this;
+    }
+
+    /**
+     * Switch to HS color mode and set saturation.
+     *
+     * @param saturation saturation [0..254]
+     * @return this object for chaining calls
+     */
+    public StateUpdate setSat(int saturation) {
+        if (saturation < 0 || saturation > 254) {
+            throw new IllegalArgumentException("Saturation out of range");
+        }
+
+        commands.add(new Command("sat", saturation));
+        return this;
+    }
+
+    /**
+     * Switch to XY color mode and set CIE color space coordinates.
+     *
+     * @param x x coordinate [0..1]
+     * @param y y coordinate [0..1]
+     * @return this object for chaining calls
+     */
+    public StateUpdate setXY(float x, float y) {
+        return setXY(new float[] { x, y });
+    }
+
+    /**
+     * Switch to XY color mode and set CIE color space coordinates.
+     *
+     * @param xy x and y coordinates [0..1, 0..1]
+     * @return this object for chaining calls
+     */
+    public StateUpdate setXY(float[] xy) {
+        if (xy.length != 2) {
+            throw new IllegalArgumentException("Invalid coordinate array given");
+        } else if (xy[0] < 0.0f || xy[0] > 1.0f || xy[1] < 0.0f || xy[1] > 1.0f) {
+            throw new IllegalArgumentException("X and/or Y coordinate(s) out of bounds");
+        }
+
+        commands.add(new Command("xy", xy));
+        return this;
+    }
+
+    /**
+     * Switch to CT color mode and set color temperature in mired.
+     *
+     * @param colorTemperature color temperature [153..500]
+     * @return this object for chaining calls
+     */
+    public StateUpdate setColorTemperature(int colorTemperature) {
+        if (colorTemperature < 153 || colorTemperature > 500) {
+            throw new IllegalArgumentException("Color temperature out of range");
+        }
+
+        commands.add(new Command("ct", colorTemperature));
+        return this;
+    }
+
+    /**
+     * Set the alert mode.
+     *
+     * @see AlertMode
+     * @param mode alert mode
+     * @return this object for chaining calls
+     */
+    public StateUpdate setAlert(AlertMode mode) {
+        commands.add(new Command("alert", mode.toString().toLowerCase()));
+        return this;
+    }
+
+    /**
+     * Set the current effect.
+     *
+     * @see Effect
+     * @param effect effect
+     * @return this object for chaining calls
+     */
+    public StateUpdate setEffect(Effect effect) {
+        commands.add(new Command("effect", effect.toString().toLowerCase()));
+        return this;
+    }
+
+    /**
+     * Set the transition time from the current state to the new state.
+     * Time is accurate to 100 milliseconds.
+     *
+     * @param timeMillis time in milliseconds [0..6553600]
+     * @return this object for chaining calls
+     */
+    public StateUpdate setTransitionTime(int timeMillis) {
+        if (timeMillis < 0 || timeMillis > 6553600) {
+            throw new IllegalArgumentException("Transition time out of range");
+        }
+
+        commands.add(new Command("transitiontime", timeMillis / 100));
+        return this;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/SuccessResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/SuccessResponse.java
@@ -19,7 +19,8 @@ import com.google.gson.reflect.TypeToken;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 class SuccessResponse {
-	public final static Type gsonType = new TypeToken<List<SuccessResponse>>(){}.getType();
-	
-	public Map<String, Object> success;
+    public final static Type gsonType = new TypeToken<List<SuccessResponse>>() {
+    }.getType();
+
+    public Map<String, Object> success;
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/User.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/User.java
@@ -18,35 +18,38 @@ import com.google.gson.annotations.SerializedName;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 public class User {
-	@SerializedName("last use date")
-	private Date lastUseDate;
-	
-	@SerializedName("create date")
-	private Date createDate;
-	
-	private String name;
-	
-	/**
-	 * Returns the last time a command was issued as this user.
-	 * @return time of last command by this user
-	 */
-	public Date getLastUseDate() {
-		return lastUseDate;
-	}
-	
-	/**
-	 * Returns the date this user was created.
-	 * @return creation date of user
-	 */
-	public Date getCreationDate() {
-		return createDate;
-	}
-	
-	/**
-	 * Returns the username of this user.
-	 * @return username
-	 */
-	public String getUsername() {
-		return name;
-	}
+    @SerializedName("last use date")
+    private Date lastUseDate;
+
+    @SerializedName("create date")
+    private Date createDate;
+
+    private String name;
+
+    /**
+     * Returns the last time a command was issued as this user.
+     *
+     * @return time of last command by this user
+     */
+    public Date getLastUseDate() {
+        return lastUseDate;
+    }
+
+    /**
+     * Returns the date this user was created.
+     *
+     * @return creation date of user
+     */
+    public Date getCreationDate() {
+        return createDate;
+    }
+
+    /**
+     * Returns the username of this user.
+     *
+     * @return username
+     */
+    public String getUsername() {
+        return name;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Util.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/Util.java
@@ -19,42 +19,43 @@ import java.util.regex.Pattern;
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
 class Util {
-	private Util() {}
-	
-	// This is used to check what byte size strings have, because the bridge doesn't natively support UTF-8
-	public static int stringSize(String str) {
-		try {
-			return str.getBytes("utf-8").length;
-		} catch (UnsupportedEncodingException e) {
-			throw new UnsupportedOperationException("UTF-8 not supported");
-		}
-	}
-	
-	public static List<Light> idsToLights(List<String> ids) {
-		List<Light> lights = new ArrayList<Light>();
-		
-		for (String id : ids) {
-			Light light = new Light();
-			light.setId(id);
-			lights.add(light);
-		}
-		
-		return lights;
-	}
-	
-	public static List<String> lightsToIds(List<Light> lights) {
-		List<String> ids = new ArrayList<String>();
-		
-		for (Light light : lights) {
-			ids.add(light.getId());
-		}
-		
-		return ids;
-	}
-	
-	public static String quickMatch(String needle, String haystack) {
-		Matcher m = Pattern.compile(needle).matcher(haystack);
-		m.find();
-		return m.group(1);
-	}
+    private Util() {
+    }
+
+    // This is used to check what byte size strings have, because the bridge doesn't natively support UTF-8
+    public static int stringSize(String str) {
+        try {
+            return str.getBytes("utf-8").length;
+        } catch (UnsupportedEncodingException e) {
+            throw new UnsupportedOperationException("UTF-8 not supported");
+        }
+    }
+
+    public static List<Light> idsToLights(List<String> ids) {
+        List<Light> lights = new ArrayList<>();
+
+        for (String id : ids) {
+            Light light = new Light();
+            light.setId(id);
+            lights.add(light);
+        }
+
+        return lights;
+    }
+
+    public static List<String> lightsToIds(List<Light> lights) {
+        List<String> ids = new ArrayList<>();
+
+        for (Light light : lights) {
+            ids.add(light.getId());
+        }
+
+        return ids;
+    }
+
+    public static String quickMatch(String needle, String haystack) {
+        Matcher m = Pattern.compile(needle).matcher(haystack);
+        m.find();
+        return m.group(1);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -7,9 +7,7 @@
  */
 package org.eclipse.smarthome.binding.hue.internal.discovery;
 
-import static org.eclipse.smarthome.binding.hue.HueBindingConstants.HOST;
-import static org.eclipse.smarthome.binding.hue.HueBindingConstants.SERIAL_NUMBER;
-import static org.eclipse.smarthome.binding.hue.HueBindingConstants.THING_TYPE_BRIDGE;
+import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
@@ -85,7 +85,7 @@ public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
 
     /**
      * Builds the bridge properties.
-     * 
+     *
      * @param host the ip of the bridge
      * @param serialNumber the id of the bridge
      * @return the bridge properties
@@ -155,12 +155,12 @@ public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
         } catch (JsonParseException je) {
             logger.debug("Invalid json respone from Hue NUPnP service. Can't discover bridges");
         }
-        return new ArrayList<BridgeJsonParameters>();
+        return new ArrayList<>();
     }
 
     /**
      * Introduced in order to enable testing.
-     * 
+     *
      * @param url the url
      * @return the http request result as String
      * @throws IOException if request failed

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -18,6 +18,8 @@ import java.util.Set;
 import org.eclipse.smarthome.binding.hue.handler.HueBridgeHandler;
 import org.eclipse.smarthome.binding.hue.handler.HueLightHandler;
 import org.eclipse.smarthome.binding.hue.handler.LightStatusListener;
+import org.eclipse.smarthome.binding.hue.internal.FullLight;
+import org.eclipse.smarthome.binding.hue.internal.HueBridge;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
@@ -27,9 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableMap;
-
-import org.eclipse.smarthome.binding.hue.internal.FullLight;
-import org.eclipse.smarthome.binding.hue.internal.HueBridge;
 
 /**
  * The {@link HueBridgeServiceTracker} tracks for hue lights which are connected

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/ApiException.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/ApiException.java
@@ -15,9 +15,10 @@ package org.eclipse.smarthome.binding.hue.internal.exceptions;
  */
 @SuppressWarnings("serial")
 public class ApiException extends Exception {
-	public ApiException() {}
-	
-	public ApiException(String message) {
-		super(message);
-	}
+    public ApiException() {
+    }
+
+    public ApiException(String message) {
+        super(message);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/DeviceOffException.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/DeviceOffException.java
@@ -15,9 +15,10 @@ package org.eclipse.smarthome.binding.hue.internal.exceptions;
  */
 @SuppressWarnings("serial")
 public class DeviceOffException extends ApiException {
-	public DeviceOffException() {}
-	
-	public DeviceOffException(String message) {
-		super(message);
-	}
+    public DeviceOffException() {
+    }
+
+    public DeviceOffException(String message) {
+        super(message);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/EntityNotAvailableException.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/EntityNotAvailableException.java
@@ -15,9 +15,10 @@ package org.eclipse.smarthome.binding.hue.internal.exceptions;
  */
 @SuppressWarnings("serial")
 public class EntityNotAvailableException extends ApiException {
-	public EntityNotAvailableException() {}
-	
-	public EntityNotAvailableException(String message) {
-		super(message);
-	}
+    public EntityNotAvailableException() {
+    }
+
+    public EntityNotAvailableException(String message) {
+        super(message);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/GroupTableFullException.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/GroupTableFullException.java
@@ -15,9 +15,10 @@ package org.eclipse.smarthome.binding.hue.internal.exceptions;
  */
 @SuppressWarnings("serial")
 public class GroupTableFullException extends ApiException {
-	public GroupTableFullException() {}
-	
-	public GroupTableFullException(String message) {
-		super(message);
-	}
+    public GroupTableFullException() {
+    }
+
+    public GroupTableFullException(String message) {
+        super(message);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/InvalidCommandException.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/InvalidCommandException.java
@@ -15,9 +15,10 @@ package org.eclipse.smarthome.binding.hue.internal.exceptions;
  */
 @SuppressWarnings("serial")
 public class InvalidCommandException extends ApiException {
-	public InvalidCommandException() {}
-	
-	public InvalidCommandException(String message) {
-		super(message);
-	}
+    public InvalidCommandException() {
+    }
+
+    public InvalidCommandException(String message) {
+        super(message);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/LinkButtonException.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/LinkButtonException.java
@@ -15,9 +15,10 @@ package org.eclipse.smarthome.binding.hue.internal.exceptions;
  */
 @SuppressWarnings("serial")
 public class LinkButtonException extends ApiException {
-	public LinkButtonException() {}
-	
-	public LinkButtonException(String message) {
-		super(message);
-	}
+    public LinkButtonException() {
+    }
+
+    public LinkButtonException(String message) {
+        super(message);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/UnauthorizedException.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/exceptions/UnauthorizedException.java
@@ -15,9 +15,10 @@ package org.eclipse.smarthome.binding.hue.internal.exceptions;
  */
 @SuppressWarnings("serial")
 public class UnauthorizedException extends ApiException {
-	public UnauthorizedException() {}
-	
-	public UnauthorizedException(String message) {
-		super(message);
-	}
+    public UnauthorizedException() {
+    }
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
 }


### PR DESCRIPTION
With my work on #3122 I realized that the internalized Jue library does not use the correct format.
This make further changes difficult to read, because a minimal change to the file will read to a lot of changes, because of the reformatting.

This PR does NOT change any code, but applies the clean up rules on the files.