### PR TITLE
Use the preferred way of creating BigDecimal from Double

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -45,7 +45,7 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
     }
 
     public DecimalType(double value) {
-        this.value = new BigDecimal(value);
+        this.value = BigDecimal.valueOf(value);
     }
 
     public DecimalType(String value) {


### PR DESCRIPTION
According to javadoc:

Note: This is generally the preferred way to convert a double (or float) into a BigDecimal, as the value returned is equal to that resulting from constructing a BigDecimal from the result of using Double.toString(double).


Signed-off-by: Ivaylo Ivanov <ivivanov.bg@gmail.com>