### PR TITLE
added access to itemRegistry to scripts

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
@@ -150,7 +150,8 @@ public class DefaultScriptScopeProvider implements ScriptScopeProvider {
             elements.put("StringType", StringType.class);
 
             // services
-            elements.put("items", new ItemRegistryDelegate(itemRegistry));
+            elements.put("states", new ItemRegistryDelegate(itemRegistry));
+            elements.put("items", itemRegistry);
             elements.put("things", thingRegistry);
             elements.put("events", busEvent);
             elements.put("rules", ruleRegistry);


### PR DESCRIPTION
Working on some new use cases, I quickly noticed that only having access to item states in scripts isn't enough - similar as we make the ThingRegistry available, we also need the ItemRegistry.
Nonetheless, it can also be helpful to have a quick access to the states directly - so I have kept that in place.
Wrt the naming, it didn't make any sense to keep "items" as a key for the states, so I have changed this to "states", which is effectively a breaking change.

Signed-off-by: Kai Kreuzer <kai@openhab.org>