### PR TITLE
Fix circular service reference

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/ConfigCoreTests.launch
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/ConfigCoreTests.launch
@@ -25,7 +25,7 @@
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.config.core.test"/>

--- a/bundles/core/org.eclipse.smarthome.core.test/CoreTests.launch
+++ b/bundles/core/org.eclipse.smarthome.core.test/CoreTests.launch
@@ -26,7 +26,7 @@
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.core.test"/>

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/org.eclipse.smarthome.core.thing.test.launch
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/org.eclipse.smarthome.core.thing.test.launch
@@ -26,7 +26,7 @@
 <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
 <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
-<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -console -consoleLog"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.core.thing.test"/>

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ChannelStateDescriptionProvider.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ChannelStateDescriptionProvider.xml
@@ -8,7 +8,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.core.thing.internal.ChannelStateDescriptionProvider">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" immediate="true" name="org.eclipse.smarthome.core.thing.internal.ChannelStateDescriptionProvider">
    <property name="service.ranking" type="Integer" value="-1"/>
    <implementation class="org.eclipse.smarthome.core.thing.internal.ChannelStateDescriptionProvider"/>
    <reference bind="setItemChannelLinkRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry" name="ItemChannelLinkRegistry" policy="static" unbind="unsetItemChannelLinkRegistry"/>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProvider.java
@@ -8,6 +8,7 @@
 package org.eclipse.smarthome.core.thing.internal;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.smarthome.core.items.Item;
@@ -19,6 +20,7 @@ import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateDescriptionProvider;
+import org.osgi.framework.Constants;
 
 /**
  * A {@link ChannelStateDescriptionProvider} provides localized {@link StateDescription}s from the type of a
@@ -31,6 +33,21 @@ public class ChannelStateDescriptionProvider implements StateDescriptionProvider
     private ItemChannelLinkRegistry itemChannelLinkRegistry;
     private ThingTypeRegistry thingTypeRegistry;
     private ThingRegistry thingRegistry;
+    private Integer rank;
+
+    protected void activate(Map<String, Object> properties) {
+        Object serviceRanking = properties.get(Constants.SERVICE_RANKING);
+        if (serviceRanking instanceof Integer) {
+            rank = (Integer) serviceRanking;
+        } else {
+            rank = 0;
+        }
+    }
+
+    @Override
+    public Integer getRank() {
+        return rank;
+    }
 
     @Override
     public StateDescription getStateDescription(String itemName, Locale locale) {

--- a/bundles/core/org.eclipse.smarthome.core/OSGI-INF/itemregistry.xml
+++ b/bundles/core/org.eclipse.smarthome.core/OSGI-INF/itemregistry.xml
@@ -15,4 +15,5 @@
       <provide interface="org.eclipse.smarthome.core.items.ItemRegistry"/>
    </service>
    <reference bind="setEventPublisher" cardinality="0..1" interface="org.eclipse.smarthome.core.events.EventPublisher" name="EventPublisher" policy="dynamic" unbind="unsetEventPublisher"/>
+   <reference bind="addStateDescriptionProvider" cardinality="0..n" interface="org.eclipse.smarthome.core.types.StateDescriptionProvider" name="StateDescriptionProvider" policy="dynamic" unbind="removeStateDescriptionProvider"/>
 </scr:component>

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/StateDescriptionProvider.java
@@ -27,4 +27,14 @@ public interface StateDescriptionProvider {
      */
     StateDescription getStateDescription(String itemName, Locale locale);
 
+    /**
+     * Return the service rank.
+     *
+     * Usually an implementation should piggy-back on the <code>service.ranking</code> OSGi component property.
+     * The default is 0 - the higher, the more like it is going to win.
+     *
+     * @return an integer value
+     */
+    Integer getRank();
+
 }

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -39,6 +39,7 @@ import org.eclipse.smarthome.model.items.ModelGroupFunction;
 import org.eclipse.smarthome.model.items.ModelGroupItem;
 import org.eclipse.smarthome.model.items.ModelItem;
 import org.eclipse.smarthome.model.items.ModelNormalItem;
+import org.osgi.framework.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +65,23 @@ public class GenericItemProvider extends AbstractProvider<Item>
 
     private Map<String, StateDescription> stateDescriptions = new ConcurrentHashMap<>();
 
+    private Integer rank;
+
     public GenericItemProvider() {
+    }
+
+    protected void activate(Map<String, Object> properties) {
+        Object serviceRanking = properties.get(Constants.SERVICE_RANKING);
+        if (serviceRanking instanceof Integer) {
+            rank = (Integer) serviceRanking;
+        } else {
+            rank = 0;
+        }
+    }
+
+    @Override
+    public Integer getRank() {
+        return rank;
     }
 
     public void setModelRepository(ModelRepository modelRepository) {


### PR DESCRIPTION
As it turned out there is the following "circle":

  StateDescriptionProvider
  -> ItemChannelLinkRegistry
     -> ItemRegistry

The ItemRegistryImpl opens a ServiceTracker to StateDescriptionProvider on activate().
As this last reference is not managed by DS it is not handled gracefully.

Therefore with this change I added dynamic service references into the ItemRegistry via DS.
As a side-effect I also introduced a callback interface for the items, so that the
actual service instances don't need to be injected into the items anymore, but the items
can get the most recent list via the StateDescriptionProviderAccessor interface.

fixes #3150
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>