### PR TITLE
PaperUI: Install extensions by dropping url

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.extension.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.extension.js
@@ -70,13 +70,8 @@ angular.module('PaperUI.controllers.extension', [ 'PaperUI.constants' ]).control
         thingTypeRepository.setDirty(true);
     };
     $scope.installExtensionFromURL = function(url) {
-        extension.inProgress = true;
-        extensionService.installFromURL({
+        return extensionService.installFromURL({
             url : url
-        }, function() {
-            toastService.showDefaultToast('Extension installed from url' + url);
-        }, function() {
-            toastService.showDefaultToast('Extension installation from url' + url + ' failed');
         });
     };
     $scope.uninstall = function(extensionId) {
@@ -120,15 +115,6 @@ angular.module('PaperUI.controllers.extension', [ 'PaperUI.constants' ]).control
         $scope.masonry(true);
     });
 
-    $scope.linkDropped = function(ev) {
-        ev.preventDefault();
-        var data = ev.dataTransfer.getData("text");
-        alert(data);
-    }
-    $scope.acceptDrop = function(ev) {
-        ev.preventDefault();
-    }
-
     eventService.onEvent('smarthome/extensions/*', function(topic, extensionObject) {
         var id = extensionObject;
         if (extensionObject && Array.isArray(extensionObject)) {
@@ -153,7 +139,7 @@ angular.module('PaperUI.controllers.extension', [ 'PaperUI.constants' ]).control
             }
         }
     });
-}).directive('droppable', function() {
+}).directive('droppable', function(toastService) {
     return {
         restrict : 'A',
         link : function(scope, element, attrs) {
@@ -185,7 +171,15 @@ angular.module('PaperUI.controllers.extension', [ 'PaperUI.constants' ]).control
             element[0].addEventListener('drop', function(event) {
                 event.preventDefault();
                 var data = event.dataTransfer.getData("Text");
-                scope.installExtensionFromURL();
+                var response = scope.installExtensionFromURL(data);
+                response.$promise.then(function() {
+                    toastService.showDefaultToast('Extension installed from URL');
+                    scope.ondrag = false;
+                }, function() {
+                    toastService.showDefaultToast('Extension installation from URL failed');
+                    scope.ondrag = false;
+                });
+
             });
 
         }

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.extension.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.extension.js
@@ -69,6 +69,16 @@ angular.module('PaperUI.controllers.extension', [ 'PaperUI.constants' ]).control
         bindingRepository.setDirty(true);
         thingTypeRepository.setDirty(true);
     };
+    $scope.installExtensionFromURL = function(url) {
+        extension.inProgress = true;
+        extensionService.installFromURL({
+            url : url
+        }, function() {
+            toastService.showDefaultToast('Extension installed from url' + url);
+        }, function() {
+            toastService.showDefaultToast('Extension installation from url' + url + ' failed');
+        });
+    };
     $scope.uninstall = function(extensionId) {
         var extension = $scope.getExtension(extensionId);
         extension.inProgress = true;
@@ -110,6 +120,15 @@ angular.module('PaperUI.controllers.extension', [ 'PaperUI.constants' ]).control
         $scope.masonry(true);
     });
 
+    $scope.linkDropped = function(ev) {
+        ev.preventDefault();
+        var data = ev.dataTransfer.getData("text");
+        alert(data);
+    }
+    $scope.acceptDrop = function(ev) {
+        ev.preventDefault();
+    }
+
     eventService.onEvent('smarthome/extensions/*', function(topic, extensionObject) {
         var id = extensionObject;
         if (extensionObject && Array.isArray(extensionObject)) {
@@ -134,4 +153,41 @@ angular.module('PaperUI.controllers.extension', [ 'PaperUI.constants' ]).control
             }
         }
     });
+}).directive('droppable', function() {
+    return {
+        restrict : 'A',
+        link : function(scope, element, attrs) {
+
+            scope.ondrag = false;
+            var counter = 0;
+            element[0].addEventListener('dragover', function(event) {
+                event.preventDefault();
+            });
+            element[0].addEventListener('dragenter', function(event) {
+                event.preventDefault();
+                if (counter == 0) {
+                    scope.$apply(function() {
+                        scope.ondrag = true;
+                    });
+                }
+                counter++;
+            });
+            element[0].addEventListener('dragleave', function(event) {
+                event.preventDefault();
+                counter--;
+                if (counter == 0) {
+                    scope.$apply(function() {
+                        scope.ondrag = false;
+                    });
+                }
+
+            });
+            element[0].addEventListener('drop', function(event) {
+                event.preventDefault();
+                var data = event.dataTransfer.getData("Text");
+                scope.installExtensionFromURL();
+            });
+
+        }
+    };
 });

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.rest.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.rest.js
@@ -395,6 +395,13 @@ angular.module('PaperUI.services.rest', [ 'PaperUI.constants' ]).config(function
             },
             url : restConfig.restPath + '/extensions/:id/install'
         },
+        installFromURL : {
+            method : 'POST',
+            params : {
+                url : '@url'
+            },
+            url : restConfig.restPath + '/extensions/url/:url/install'
+        },
         uninstall : {
             method : 'POST',
             params : {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/extensions.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/extensions.html
@@ -1,4 +1,4 @@
-<section id="main" class="white-bg extensions header-tabs">
+<section id="main" class="white-bg extensions header-tabs" droppable>
 	<div class="header-toolbar">
 		<md-button ng-click="refresh()" aria-label="Refresh"> <i class="material-icons">refresh</i></md-button>
 		<md-button ng-click="changeView(false)" aria-label="Refresh"> <i class="material-icons">view_list</i></md-button>
@@ -27,7 +27,7 @@
 			<hr class="border-line" ng-show="!$last" aria-hidden="false">
 		</div>
 	</div>
-	<div class="container" ng-if="showCards" ng-class="{'showCards':showCards}">
+	<div class="container" ng-show="showCards" ng-class="{'showCards':showCards}">
 		<div ng-attr-id="{{'extensions-' + extensionTypes.indexOf(extensionType)}}">
 			<div class="extension fab-item text-left col-lg-4 col-sm-6 col-xs-12" ng-repeat="extension in extensionType.extensions | filter:filterItems(['id','label'],searchText)" on-finish-render>
 				<div class="card item" style="background-color: {{extension.backgroundColor}}">
@@ -53,6 +53,6 @@
 			</div>
 		</div>
 	</div>
-
+	<div class="backdrop" ng-show="ondrag"></div>
 	</md-tab-content></md-tab>
 </section>


### PR DESCRIPTION
Allows installing extensions by dropping url from eclipse marketplace. Should be merged after support is added to server side for installing extensions from url.

Signed-off-by: Aoun Bukhari <bukhari@itemis.de>