### PR TITLE
Update the template for the BindingConstants file

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/__bindingIdCamelCase__BindingConstants.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/__bindingIdCamelCase__BindingConstants.java
@@ -10,7 +10,7 @@ package ${package};
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
- * The {@link ${bindingIdCamelCase}Binding} class defines common constants, which are 
+ * The {@link ${bindingIdCamelCase}BindingConstants} class defines common constants, which are
  * used across the whole binding.
  * 
  * @author ${author} - Initial contribution
@@ -20,9 +20,9 @@ public class ${bindingIdCamelCase}BindingConstants {
     public static final String BINDING_ID = "${bindingId}";
     
     // List of all Thing Type UIDs
-    public final static ThingTypeUID THING_TYPE_SAMPLE = new ThingTypeUID(BINDING_ID, "sample");
+    public static final ThingTypeUID THING_TYPE_SAMPLE = new ThingTypeUID(BINDING_ID, "sample");
 
     // List of all Channel ids
-    public final static String CHANNEL_1 = "channel1";
+    public static final String CHANNEL_1 = "channel1";
 
 }


### PR DESCRIPTION
The template file does not use recommended order for the modifiers and creates an incorrect link in the docblock, which can be seen in most bindings :-(

http://stackoverflow.com/questions/16731240/what-is-a-reasonable-order-of-java-modifiers-abstract-final-public-static-e

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl> (github: martinvw)