### PR TITLE
Refactor thing properties display in PaperUI

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -857,7 +857,7 @@ md-input-container .md-errors-spacer {
 }
 
 .thing-properties {
-	margin-left: -5px;
+	margin-left: 20px;
 	padding-left: 5px;
 }
 
@@ -865,8 +865,13 @@ md-input-container .md-errors-spacer {
     border-bottom: solid 1px #ddd;
 }
 
+.thing-properties-table td:nth-child(1) {
+    white-space: nowrap;
+	width: 25%;
+}
+
 .thing-properties-table td:nth-child(2) {
-    width: 100%;
+    width: 75%;
 }
 
 md-chips .md-chip-remove-container {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -861,8 +861,12 @@ md-input-container .md-errors-spacer {
 	padding-left: 5px;
 }
 
-.thing-properties+table {
-	width: 0%;
+.thing-properties-table {
+    border-bottom: solid 1px #ddd;
+}
+
+.thing-properties-table td:nth-child(2) {
+    width: 100%;
 }
 
 md-chips .md-chip-remove-container {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -127,13 +127,8 @@
 				<span>{{thing.statusInfo.description}}</span>
 			</p>
 			<div ng-init="details=false" ng-if="hasProperties(thing.properties)">
-				<md-button class="thing-properties" ng-click="details=!details">{{details?'hide':'show'}} properties</md-button>
-				<table class="table table-bordered">
-					<tr ng-show="details" ng-repeat="(key,value) in thing.properties">
-						<td>{{key}}</td>
-						<td>{{value}}</td>
-					</tr>
-				</table>
+				<md-button ng-click="details=!details">{{details?'hide':'show'}} properties</md-button>
+		        <div ng-include="'partials/configuration.thingproperties.html'" class="thing-properties"></div>
 			</div>
 			<h2 class="inline" ng-show="thing.channels.length > 0">Channels</h2>
 			<md-button class="showmore no-margin" ng-click="refreshChannels(showAdvanced=!showAdvanced)" ng-show="isAdvanced">{{showAdvanced ? 'show less' : 'show more'}}</md-button>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -128,7 +128,9 @@
 			</p>
 			<div ng-init="details=false" ng-if="hasProperties(thing.properties)">
 				<md-button ng-click="details=!details">{{details?'hide':'show'}} properties</md-button>
-		        <div ng-include="'partials/configuration.thingproperties.html'" class="thing-properties"></div>
+		        <div ng-show="details">
+    		        <div ng-include="'partials/configuration.thingproperties.html'" class="thing-properties"></div>
+		        </div>
 			</div>
 			<h2 class="inline" ng-show="thing.channels.length > 0">Channels</h2>
 			<md-button class="showmore no-margin" ng-click="refreshChannels(showAdvanced=!showAdvanced)" ng-show="isAdvanced">{{showAdvanced ? 'show less' : 'show more'}}</md-button>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.thingproperties.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.thingproperties.html
@@ -1,0 +1,6 @@
+<table class="thing-properties-table table">
+    <tr ng-show="details" ng-repeat="(key,value) in thing.properties">
+        <td>{{key}}</td>
+        <td>{{value}}</td>
+    </tr>
+</table>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.thingproperties.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.thingproperties.html
@@ -1,6 +1,6 @@
 <table class="thing-properties-table table">
-    <tr ng-show="details" ng-repeat="(key,value) in thing.properties">
-        <td>{{key}}</td>
-        <td>{{value}}</td>
-    </tr>
+	<tr ng-repeat="(key,value) in thing.properties">
+		<td>{{key}}</td>
+		<td>{{value}}</td>
+	</tr>
 </table>


### PR DESCRIPTION
The primary change here is to split the thing properties table into a separate partial so that it can be overridden in a fragment. I've also modified the styling of the properties slightly as I personally think it looks a bit better, but if y'all disagree I can always change it back.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>