### PR TITLE
Show thing label instead of thing UID in title

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.configuration.js
@@ -306,6 +306,7 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
     }
     $scope.refresh();
 }).controller('ViewThingController', function($scope, $mdDialog, toastService, thingTypeService, thingRepository, thingService, linkService, channelTypeService, configService, thingConfigService, util, itemRepository) {
+    $scope.setSubtitle([ 'Things' ]);
 
     var thingUID = $scope.path[4];
     $scope.thingTypeUID = null;
@@ -316,6 +317,7 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
     $scope.showAdvanced = false;
     $scope.channelTypes;
     $scope.items;
+    
     channelTypeService.getAll().$promise.then(function(channels) {
         $scope.channelTypes = channels;
         $scope.refreshChannels(false);
@@ -323,6 +325,7 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
     itemRepository.getAll(function(items) {
         $scope.items = items;
     });
+    
     $scope.remove = function(thing, event) {
         event.stopImmediatePropagation();
         $mdDialog.show({
@@ -522,11 +525,7 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
             $scope.thing = thing;
             $scope.thingTypeUID = thing.thingTypeUID;
             getThingType();
-            if (thing.item) {
-                $scope.setTitle(thing.label);
-            } else {
-                $scope.setTitle(thing.UID);
-            }
+            $scope.setSubtitle(['Things', thing.label]);
         }, refresh);
     }
     $scope.getThing(true);
@@ -696,6 +695,7 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
         $mdDialog.hide();
     }
 }).controller('EditThingController', function($scope, $mdDialog, toastService, thingTypeService, thingRepository, configService, configDescriptionService, thingService) {
+    $scope.setSubtitle([ 'Things' ]);
     $scope.setHeaderText('Click the \'Save\' button to apply the changes.');
 
     var thingUID = $scope.path[4];
@@ -764,11 +764,7 @@ angular.module('PaperUI.controllers.configuration', [ 'PaperUI.constants' ]).con
             
             // Get the thing type
             $scope.getThingType();
-            if (thing.item) {
-                $scope.setTitle('Edit ' + thing.label);
-            } else {
-                $scope.setTitle('Edit ' + thing.UID);
-            }
+            $scope.setSubtitle([ 'Things', 'Edit', thing.label]);
 
             // Now get the configuration information for this thing
             configDescriptionService.getByUri({


### PR DESCRIPTION
This is a small change to the title of thing configuration pages in the UI. I suspect this is a hangover from the time when things had items linked to them, and the items gave the thing label. For things with no items, the UID is displayed in the title and it's out of place (IMHO ;) ).

From the code, I believe it wants to display the thing.label, but it only does this if item is not null - as item is now null, it displays the UID instead. This simply corrects this, and also makes the breadcrumbs consistent.

**The current implementation...**

![image](https://cloud.githubusercontent.com/assets/1041475/25047815/fadacce6-2130-11e7-9c56-8404ac6b505c.png)

![image](https://cloud.githubusercontent.com/assets/1041475/25047821/027bbb9a-2131-11e7-8644-a8b3161db80d.png)

![image](https://cloud.githubusercontent.com/assets/1041475/25047832/0a143882-2131-11e7-8687-5d1a5b11a99f.png)

------------

------------

**The proposed implementation...**
![image](https://cloud.githubusercontent.com/assets/1041475/25047783/c9edeae6-2130-11e7-93eb-e9dd5891a6c7.png)

![image](https://cloud.githubusercontent.com/assets/1041475/25047793/d69b2650-2130-11e7-9c66-2c8b06b5831c.png)

![image](https://cloud.githubusercontent.com/assets/1041475/25047802/ded14624-2130-11e7-978a-393955e0afc3.png)





Signed-off-by: Chris Jackson <chris@cd-jackson.com>