### PR TITLE
Introduce function NONE for item groups

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/Items.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/Items.xtext
@@ -27,7 +27,7 @@ ModelGroupItem :
 ;
 
 enum ModelGroupFunction :
-	AND='AND' | OR='OR' | NAND='NAND' | NOR='NOR' | AVG='AVG' | SUM='SUM' | MAX='MAX' | MIN='MIN' | COUNT='COUNT'
+	NONE='NONE' | AND='AND' | OR='OR' | NAND='NAND' | NOR='NOR' | AVG='AVG' | SUM='SUM' | MAX='MAX' | MIN='MIN' | COUNT='COUNT'
 ;
 
 ModelNormalItem :

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -200,7 +200,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
             GenericItem baseItem = createItemOfType(baseItemType, modelGroupItem.getName());
             if (baseItem != null) {
                 ModelGroupFunction function = modelGroupItem.getFunction();
-                if (function == null) {
+                if ("NONE".equals(function.getName())) {
                     item = new GroupItem(modelGroupItem.getName(), baseItem);
                 } else {
                     item = applyGroupFunction(baseItem, modelGroupItem, function);


### PR DESCRIPTION
Since ModelGroupFunction is defined as enum in xtext there will always be a function assigned to the group, to check if there is no function we can now use the new element NONE

Fixes #3161

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>