### PR TITLE
Fix WatchQueueReader to return the watched subDir…

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/WatchQueueReader.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/WatchQueueReader.java
@@ -263,6 +263,14 @@ public class WatchQueueReader implements Runnable {
                 // As we have found a directory event and do not want to track directory changes - we will skip it
                 return null;
             }
+
+            // the resolved 'path' is the pure directory name while resolvedContextPath may be
+            // baseWatchedDir/registeredPath
+            // on systems like macOS
+            if (baseWatchedDir.resolve(path).toFile().isDirectory()) {
+                return path;
+            }
+
             return resolvedContextPath;
         }
 


### PR DESCRIPTION
…instead of baseDir/subDir on macOS

Signed-off-by: Henning Treu <henning.treu@telekom.de>