### PR TITLE
Print warning instead of error if config file could not be read

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/folder/FolderObserver.java
+++ b/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/folder/FolderObserver.java
@@ -238,6 +238,9 @@ public class FolderObserver extends AbstractWatchService implements ManagedServi
                         if (parsers.contains(getExtension(file.getName()))) {
                             try (FileInputStream inputStream = FileUtils.openInputStream(file)) {
                                 modelRepo.addOrRefreshModel(file.getName(), inputStream);
+                            } catch (Exception e) {
+                                LoggerFactory.getLogger(FolderObserver.class)
+                                        .warn("Error while opening file during update: {}", file.getAbsolutePath());
                             }
                         } else {
                             ignoredFiles.add(file);

--- a/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/folder/FolderObserver.java
+++ b/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/folder/FolderObserver.java
@@ -12,6 +12,7 @@ import static java.nio.file.StandardWatchEventKinds.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FilenameFilter;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchEvent.Kind;
@@ -238,7 +239,7 @@ public class FolderObserver extends AbstractWatchService implements ManagedServi
                         if (parsers.contains(getExtension(file.getName()))) {
                             try (FileInputStream inputStream = FileUtils.openInputStream(file)) {
                                 modelRepo.addOrRefreshModel(file.getName(), inputStream);
-                            } catch (Exception e) {
+                            } catch (IOException e) {
                                 LoggerFactory.getLogger(FolderObserver.class)
                                         .warn("Error while opening file during update: {}", file.getAbsolutePath());
                             }


### PR DESCRIPTION
Fixes #3192 Well maybe not a real fix, but all we can do about it. We omit the stacktrace and just print a warning instead of an error.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>