### PR TITLE
Worked on a set of minor issues in the archetype

### DIFF
--- a/tools/archetype/binding/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/tools/archetype/binding/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -20,62 +20,10 @@
 	</requiredProperties>
 
 	<fileSets>
-		<!-- General files -->
 		<fileSet filtered="true" packaged="false" encoding="UTF-8">
 			<directory></directory>
 			<includes>
-				<include>build.properties</include>
-				<include>pom.xml</include>
-				<include>.project</include>
-				<include>.classpath</include>
-			</includes>
-			<excludes />
-		</fileSet>
-		<!-- META-INF files -->
-		<fileSet filtered="true" packaged="false" encoding="UTF-8">
-			<directory>META-INF</directory>
-			<includes>
-				<include>MANIFEST.MF</include>
-			</includes>
-			<excludes />
-		</fileSet>
-		<!-- ESH-INF/binding files -->
-		<fileSet filtered="true" packaged="false" encoding="UTF-8">
-			<directory>ESH-INF/binding</directory>
-			<includes>
-				<include>binding.xml</include>
-			</includes>
-			<excludes />
-		</fileSet>
-		<!-- ESH-INF/thing files -->
-		<fileSet filtered="true" packaged="false" encoding="UTF-8">
-			<directory>ESH-INF/thing</directory>
-			<includes>
-				<include>thing-types.xml</include>
-			</includes>
-			<excludes />
-		</fileSet>
-		<!-- ESH-INF/i18n files -->
-		<fileSet filtered="true" packaged="false" encoding="UTF-8">
-			<directory>ESH-INF/i18n</directory>
-			<includes>
-				<include>*</include>
-			</includes>
-			<excludes />
-		</fileSet>		
-		<!-- OSGI-INF files -->
-		<fileSet filtered="true" packaged="false" encoding="UTF-8">
-			<directory>OSGI-INF</directory>
-			<includes>
-				<include>*.xml</include>
-			</includes>
-			<excludes />
-		</fileSet>
-		<!-- Java files -->
-		<fileSet filtered="true" packaged="true" encoding="UTF-8">
-			<directory>src/main/java</directory>
-			<includes>
-				<include>**/*.java</include>
+				<include>**/*.*</include>
 			</includes>
 			<excludes />
 		</fileSet>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/ESH-INF/binding/binding.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/ESH-INF/binding/binding.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <binding:binding id="${bindingId}"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
-        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				 xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+				 xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
-    <name>${bindingIdCamelCase} Binding</name>
-    <description>This is the binding for ${bindingIdCamelCase}.</description>
-    <author>${author}</author>
+	<name>${bindingIdCamelCase} Binding</name>
+	<description>This is the binding for ${bindingIdCamelCase}.</description>
+	<author>${author}</author>
 
 </binding:binding>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/ESH-INF/i18n/__bindingId___xx_XX.properties
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/ESH-INF/i18n/__bindingId___xx_XX.properties
@@ -1,3 +1,5 @@
+# FIXME: please substitute the xx_XX with a proper locale, ie. de_DE
+# FIXME: please do not add the file to the repo if you add or change no content
 # binding
 binding.${bindingId}.name = <Your localized Binding name>
 binding.${bindingId}.description = <Your localized Binding description>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/ESH-INF/thing/thing-types.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/ESH-INF/thing/thing-types.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="${bindingId}"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+						  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+						  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+						  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <!-- Sample Thing Type -->
-    <thing-type id="sample">
-        <label>${bindingIdCamelCase} Binding Thing</label>
-        <description>Sample thing for ${bindingIdCamelCase} Binding</description>
+	<!-- Sample Thing Type -->
+	<thing-type id="sample">
+		<label>${bindingIdCamelCase} Binding Thing</label>
+		<description>Sample thing for ${bindingIdCamelCase} Binding</description>
 
-        <channels>
-            <channel id="channel1" typeId="sample-channel"/>
-        </channels>
-    </thing-type>
+		<channels>
+			<channel id="channel1" typeId="sample-channel"/>
+		</channels>
+	</thing-type>
 
-    <!-- Sample Channel Type -->
-    <channel-type id="sample-channel">
-        <item-type>${bindingId}Item</item-type>
-        <label>${bindingIdCamelCase} Binding Channel</label>
-        <description>Sample channel for ${bindingIdCamelCase} Binding</description>
-    </channel-type>
+	<!-- Sample Channel Type -->
+	<channel-type id="sample-channel">
+		<item-type>${bindingId}Item</item-type>
+		<label>${bindingIdCamelCase} Binding Channel</label>
+		<description>Sample channel for ${bindingIdCamelCase} Binding</description>
+	</channel-type>
 
 </thing:thing-descriptions>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/OSGI-INF/__bindingIdCamelCase__HandlerFactory.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/OSGI-INF/__bindingIdCamelCase__HandlerFactory.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014-2017 by the respective copyright holders.
+    Copyright (c) 2010-2017 by the respective copyright holders.
+
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
@@ -10,10 +11,10 @@
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="binding.${bindingId}">
 
-   <implementation class="${package}.internal.${bindingIdCamelCase}HandlerFactory"/>
+	<implementation class="${package}.internal.${bindingIdCamelCase}HandlerFactory"/>
 
-   <service>
-      <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
-   </service>
+	<service>
+		<provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+	</service>
 
 </scr:component>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/OSGI-INF/__bindingIdCamelCase__HandlerFactory.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/OSGI-INF/__bindingIdCamelCase__HandlerFactory.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
+#set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
+#set( $year = $dt.getYear() + 1900 )
 
-    Copyright (c) 2010-2017 by the respective copyright holders.
+    Copyright (c) 2010-${year} by the respective copyright holders.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/tools/archetype/binding/src/main/resources/archetype-resources/README.md
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/README.md
@@ -1,20 +1,22 @@
-# <bindingName> Binding
+#set( $H = '#' )
+##
+$H ${bindingIdCamelCase} Binding
 
 _Give some details about what this binding is meant for - a protocol, system, specific device._
 
-_If possible, provide some resources like pictures, a YouTube video, etc. to give an impression of what can be done with this binding. You can place such resources into a `doc` folder next to this README.md._
+_If possible, provide some resources like pictures, a YouTube video, etc. to give an impression of what can be done with this binding. You can place such resources into a `doc` folder next to this README.md._
 
-## Supported Things
+$H$H Supported Things
 
 _Please describe the different supported things / devices within this section._
 _Which different types are supported, which models were tested etc.?_
 _Note that it is planned to generate some part of this based on the XML files within ```ESH-INF/thing``` of your binding._
 
-## Discovery
+$H$H Discovery
 
 _Describe the available auto-discovery features here. Mention for what it works and what needs to be kept in mind when using it._
 
-## Binding Configuration
+$H$H Binding Configuration
 
 _If your binding requires or supports general configuration settings, please create a folder ```cfg``` and place the configuration file ```<bindingId>.cfg``` inside it. In this section, you should link to this file and provide some information about the options. The file could e.g. look like:_
 
@@ -31,22 +33,22 @@ _Note that it is planned to generate some part of this based on the information 
 
 _If your binding does not offer any generic configurations, you can remove this section completely._
 
-## Thing Configuration
+$H$H Thing Configuration
 
 _Describe what is needed to manually configure a thing, either through the (Paper) UI or via a thing-file. This should be mainly about its mandatory and optional configuration parameters. A short example entry for a thing file can help!_
 
 _Note that it is planned to generate some part of this based on the XML files within ```ESH-INF/thing``` of your binding._
 
-## Channels
+$H$H Channels
 
 _Here you should provide information about available channel types, what their meaning is and how they can be used._
 
 _Note that it is planned to generate some part of this based on the XML files within ```ESH-INF/thing``` of your binding._
 
-## Full Example
+$H$H Full Example
 
 _Provide a full usage example based on textual configuration files (*.things, *.items, *.sitemap)._
 
-## Any custom content here!
+$H$H Any custom content here!
 
 _Feel free to add additional sections for whatever you think should also be mentioned about your binding!_

--- a/tools/archetype/binding/src/main/resources/archetype-resources/about.html
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/about.html
@@ -7,8 +7,11 @@
 </head>
 <body lang="EN-US">
 <h2>About This Content</h2>
-
-<p>June 5, 2006</p>
+#set( $stringClass = $package.getClass().forName("java.lang.String") )
+#set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
+#set( $df = $package.getClass().forName("java.text.SimpleDateFormat").getConstructor($stringClass).newInstance("MMMM d, YYYY") )
+#set( $today = $df.format($dt) )
+<p>${today}</p>
 <h3>License</h3>
 
 <p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;). Unless otherwise

--- a/tools/archetype/binding/src/main/resources/archetype-resources/about.html
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>June 5, 2006</p>
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;). Unless otherwise
+    indicated below, the Content is provided to you under the terms and conditions of the
+    Eclipse Public License Version 1.0 (&quot;EPL&quot;). A copy of the EPL is available
+    at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+    being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the Redistributor's license that was
+    provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise
+    indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+    and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/about.html
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/about.html
@@ -7,11 +7,7 @@
 </head>
 <body lang="EN-US">
 <h2>About This Content</h2>
-#set( $stringClass = $package.getClass().forName("java.lang.String") )
-#set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
-#set( $df = $package.getClass().forName("java.text.SimpleDateFormat").getConstructor($stringClass).newInstance("MMMM d, YYYY") )
-#set( $today = $df.format($dt) )
-<p>${today}</p>
+<p>June 5, 2006</p>
 <h3>License</h3>
 
 <p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;). Unless otherwise

--- a/tools/archetype/binding/src/main/resources/archetype-resources/build.properties
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/build.properties
@@ -1,6 +1,7 @@
-source.. = src/main/java/
-output.. = target/classes
-bin.includes = META-INF/,\
-               .,\
-               OSGI-INF/,\
-               ESH-INF/
+source..=src/main/java/
+output..=target/classes
+bin.includes=META-INF/,\
+             .,\
+             OSGI-INF/,\
+             ESH-INF/,\
+             about.html

--- a/tools/archetype/binding/src/main/resources/archetype-resources/cfg/__bindingId__.cfg
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/cfg/__bindingId__.cfg
@@ -1,0 +1,1 @@
+# ${bindingIdCamelCase} Binding Default Configuration

--- a/tools/archetype/binding/src/main/resources/archetype-resources/cfg/_bindingId_.cfg
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/cfg/_bindingId_.cfg
@@ -1,1 +1,0 @@
-# _bindingIdCamelCase_ Binding Default Configuration

--- a/tools/archetype/binding/src/main/resources/archetype-resources/pom.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>${namespace}.binding</groupId>
-    <artifactId>pom</artifactId>
-    <version>@${version}</version>
-  </parent>
+	<parent>
+		<groupId>${namespace}.binding</groupId>
+		<artifactId>pom</artifactId>
+		<version>@${version}</version>
+	</parent>
 
-  <groupId>@${groupId}</groupId>
-  <artifactId>${rootArtifactId}</artifactId>
-  <version>@${version}</version>
+	<artifactId>${rootArtifactId}</artifactId>
+	<version>@${version}</version>
 
-  <name>${bindingIdCamelCase} Binding</name>
-  <packaging>eclipse-plugin</packaging>
+	<name>${bindingIdCamelCase} Binding</name>
+	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/__bindingIdCamelCase__BindingConstants.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/__bindingIdCamelCase__BindingConstants.java
@@ -1,5 +1,7 @@
+#set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
+#set( $year = $dt.getYear() + 1900 )
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-${year} by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/__bindingIdCamelCase__BindingConstants.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/__bindingIdCamelCase__BindingConstants.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,13 +13,13 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 /**
  * The {@link ${bindingIdCamelCase}BindingConstants} class defines common constants, which are
  * used across the whole binding.
- * 
+ *
  * @author ${author} - Initial contribution
  */
 public class ${bindingIdCamelCase}BindingConstants {
 
-    public static final String BINDING_ID = "${bindingId}";
-    
+    private static final String BINDING_ID = "${bindingId}";
+
     // List of all Thing Type UIDs
     public static final ThingTypeUID THING_TYPE_SAMPLE = new ThingTypeUID(BINDING_ID, "sample");
 

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/handler/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/handler/__bindingIdCamelCase__Handler.java
@@ -1,5 +1,7 @@
+#set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
+#set( $year = $dt.getYear() + 1900 )
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-${year} by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/handler/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/handler/__bindingIdCamelCase__Handler.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -20,20 +21,20 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link ${bindingIdCamelCase}Handler} is responsible for handling commands, which are
  * sent to one of the channels.
- * 
+ *
  * @author ${author} - Initial contribution
  */
 public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
 
-    private Logger logger = LoggerFactory.getLogger(${bindingIdCamelCase}Handler.class);
+    private final Logger logger = LoggerFactory.getLogger(${bindingIdCamelCase}Handler.class);
 
-	public ${bindingIdCamelCase}Handler(Thing thing) {
-		super(thing);
-	}
+    public ${bindingIdCamelCase}Handler(Thing thing) {
+        super(thing);
+    }
 
-	@Override
-	public void handleCommand(ChannelUID channelUID, Command command) {
-        if(channelUID.getId().equals(CHANNEL_1)) {
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (channelUID.getId().equals(CHANNEL_1)) {
             // TODO: handle command
 
             // Note: if communication with thing fails for some reason,
@@ -41,7 +42,7 @@ public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
             // updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
             // "Could not control device at IP address x.x.x.x");
         }
-	}
+    }
 
     @Override
     public void initialize() {

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -1,5 +1,7 @@
+#set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
+#set( $year = $dt.getYear() + 1900 )
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
+ * Copyright (c) 2010-${year} by the respective copyright holders.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -19,15 +20,15 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 
 /**
- * The {@link ${bindingIdCamelCase}HandlerFactory} is responsible for creating things and thing 
+ * The {@link ${bindingIdCamelCase}HandlerFactory} is responsible for creating things and thing
  * handlers.
- * 
+ *
  * @author ${author} - Initial contribution
  */
 public class ${bindingIdCamelCase}HandlerFactory extends BaseThingHandlerFactory {
-    
+
     private final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_SAMPLE);
-    
+
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
         return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
@@ -35,7 +36,6 @@ public class ${bindingIdCamelCase}HandlerFactory extends BaseThingHandlerFactory
 
     @Override
     protected ThingHandler createHandler(Thing thing) {
-
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(THING_TYPE_SAMPLE)) {
@@ -45,4 +45,3 @@ public class ${bindingIdCamelCase}HandlerFactory extends BaseThingHandlerFactory
         return null;
     }
 }
-


### PR DESCRIPTION
Worked on a set of minor issues in the archetype:

- XML files should be formatted with tabs
- Files should have the proper copyright headers
- Java files should be formatted with spaces and follow the formatter guidelines
- Loggers should be ~~static~~ *final*
- The `BINDING_ID` is only used in this class in all (most) all bindings make it private by default
- Include the about.html in the `build.properties`
- Escape the h2-headers in the README and add it to be exported
- Include the cfg example in the generated binding
- Include the about.html in the binding (have to find out a way to override it for openHAB, maybe just a cp in the skeleton script?)
- Removed inherited `groupId` from `pom.xml`
- Also made the year of the copyright dynamic
- Made the date of the about.html the current
- Added a newline at the end of the about.html
