### PR TITLE
Javadoc is fixed #3269

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/Action.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/Action.java
@@ -9,7 +9,6 @@ package org.eclipse.smarthome.automation;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.smarthome.automation.type.ActionType;
 import org.eclipse.smarthome.automation.type.Input;
@@ -22,8 +21,7 @@ import org.eclipse.smarthome.config.core.Configuration;
  * Elements of this section are expected result of {@link Rule} execution. The
  * Action can have {@link Output} elements. These actions are used to process
  * input data as source data of other Actions. Building elements of actions ( {@link ConfigDescriptionParameter}s,
- * {@link Input}s and {@link Output}s) are
- * defined by {@link ActionType}
+ * {@link Input}s and {@link Output}s) are defined by {@link ActionType}
  *
  * @author Yordan Mihaylov - Initial Contribution
  * @author Ana Dimova - Initial Contribution
@@ -51,10 +49,10 @@ public class Action extends Module {
 
     /**
      * This method is used to get input connections of the Action. The connections
-     * are links between {@link Input}s of the {@link Module} and {@link Output}s
+     * are links between {@link Input}s of the this {@link Module} and {@link Output}s
      * of other {@link Module}s.
      *
-     * @return a {@link Set} of input {@link Input}s.
+     * @return map that contains the inputs of this action.
      */
     public Map<String, String> getInputs() {
         return inputs != null ? inputs : Collections.<String, String> emptyMap();
@@ -63,7 +61,7 @@ public class Action extends Module {
     /**
      * This method is used to connect {@link Input}s of the action to {@link Output}s of other {@link Module}s.
      *
-     * @param connections a {@link Set} of input {@link Input}s.
+     * @param inputs map that contains the inputs for this action.
      */
     public void setInputs(Map<String, String> inputs) {
         if (inputs != null) {

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/Condition.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/Condition.java
@@ -9,7 +9,6 @@ package org.eclipse.smarthome.automation;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import org.eclipse.smarthome.automation.type.ConditionType;
 import org.eclipse.smarthome.automation.type.Input;
@@ -47,11 +46,11 @@ public class Condition extends Module {
     }
 
     /**
-     * This method is used to get input connections of the Condition. The
-     * connections are links between {@link Input}s of the current {@link Module} and {@link Output}s of other
+     * This method is used to get input connections of the Condition. The connections
+     * are links between {@link Input}s of the current {@link Module} and {@link Output}s of other
      * {@link Module}s.
      *
-     * @return a {@link Map} of input connections.
+     * @return map that contains the inputs of this condition.
      */
     public Map<String, String> getInputs() {
         return inputs != null ? inputs : Collections.<String, String> emptyMap();
@@ -60,7 +59,7 @@ public class Condition extends Module {
     /**
      * This method is used to connect {@link Input}s of the Condition to {@link Output}s of other {@link Module}s.
      *
-     * @param connections a {@link Set} of input {@link Input}s.
+     * @param inputs map that contains the inputs for this condition.
      */
     public void setInputs(Map<String, String> inputs) {
         if (inputs != null) {

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/Rule.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/Rule.java
@@ -136,10 +136,12 @@ public class Rule {
 
     /**
      * Rules can have
+     * <ul>
      * <li><code>tags</code> - non-hierarchical keywords or terms for describing them. This method is
-     * used for getting the tags assign to this Rule. The tags are used to filter the rules.
+     * used for getting the tags assign to this Rule. The tags are used to filter the rules.</li>
+     * </ul>
      *
-     * @return a list of tags
+     * @return a {@link Set} of tags
      */
     public Set<String> getTags() {
         return tags = tags != null ? tags : Collections.<String> emptySet();
@@ -147,13 +149,14 @@ public class Rule {
 
     /**
      * Rules can have
+     * <ul>
      * <li><code>tags</code> - non-hierarchical keywords or terms for describing them. This method is
      * used for setting the tags to this rule. This property can be changed only when the Rule is not in active state.
-     * The tags are used to filter the rules.
+     * The tags are used to filter the rules.</li>
+     * </ul>
      *
      * @param ruleTags list of tags assign to this Rule.
-     * @throws IllegalStateException IllegalStateException when the rule is in
-     *             active state.
+     * @throws IllegalStateException when the rule is in active state.
      */
     public void setTags(Set<String> ruleTags) throws IllegalStateException {
         tags = ruleTags != null ? ruleTags : Collections.<String> emptySet();
@@ -223,9 +226,8 @@ public class Rule {
     }
 
     /**
-     * This method is used for getting the Set with {@link ConfigDescriptionParameter}s defining meta info for
-     * configuration
-     * properties of the Rule.<br/>
+     * This method is used for getting the {@link List} with {@link ConfigDescriptionParameter}s
+     * defining meta info for configuration properties of the Rule.
      *
      * @return a {@link Set} of {@link ConfigDescriptionParameter}s.
      */
@@ -310,7 +312,7 @@ public class Rule {
     }
 
     /**
-     * This method is used to return a group of module of this rule
+     * This method is used to return the module of this rule.
      *
      * @param moduleClazz optional parameter defining type looking modules. The
      *            types are {@link Trigger}, {@link Condition} or {@link Action}

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/RuleRegistry.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/RuleRegistry.java
@@ -16,10 +16,10 @@ import org.eclipse.smarthome.core.common.registry.Registry;
  * The {@link RuleRegistry} provides basic functionality for managing {@link Rule}s.
  * It can be used to
  * <ul>
- * <li>Add Rules with the {@link #add(Rule)} method.</li>
+ * <li>Add Rules with the {@link Registry#add(Object)} method.</li>
  * <li>Get the existing rules with the {@link #getByTag(String)}, {@link #getByTags(String[])} methods.</li>
- * <li>Update the existing rules with the {@link #update(Rule)} method.</li>
- * <li>Remove Rules with the {@link #remove(String)} method.</li>
+ * <li>Update the existing rules with the {@link Registry#update(Object)} method.</li>
+ * <li>Remove Rules with the {@link Registry#remove(Object)} method.</li>
  * <li>Manage the state (<b>enabled</b> or <b>disabled</b>) of the Rules:
  * <ul>
  * <li>A newly added Rule is always <b>enabled</b>.</li>
@@ -107,23 +107,23 @@ public interface RuleRegistry extends Registry<Rule, String> {
     public Boolean isEnabled(String ruleUID);
 
     /**
-     * The method "runNow(ruleUID)" skips triggers&conditions and directly executes the actions of the rule.
+     * The method "runNow(ruleUID)" skips the triggers and the conditions and directly executes the actions of the rule.
      * This should always be possible unless an action has a mandatory input that is linked to a trigger.
      * In that case the action is skipped and the RuleEngine continues execution of rest actions.
      *
-     * @param ruleUID id of rule whose actions have to be executed.
+     * @param ruleUID id of rule whose actions have to be executed
      *
      */
     public void runNow(String ruleUID);
-    
+
     /**
-	 * Same as {@link RuleRegistry#runNow(String)} with additional option to enable/disable evaluation of
-	 * conditions defined in the target rule. The context can be set here, too but also might be null.
-	 * 
-	 * @param ruleUID
-	 * @param considerConditions
-	 * @param context
-	 */
-	public void runNow(String ruleUID, boolean considerConditions, Map<String, Object> context);
+     * Same as {@link RuleRegistry#runNow(String)} with additional option to enable/disable evaluation of
+     * conditions defined in the target rule. The context can be set here, too but also might be null.
+     *
+     * @param ruleUID id of rule whose actions have to be executed
+     * @param considerConditions if <code>true</code> the conditions will be checked
+     * @param context the context that is passed to the conditions and the actions
+     */
+    public void runNow(String ruleUID, boolean considerConditions, Map<String, Object> context);
 
 }

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/AbstractRuleRegistryEvent.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/AbstractRuleRegistryEvent.java
@@ -24,10 +24,10 @@ public abstract class AbstractRuleRegistryEvent extends AbstractEvent {
     /**
      * Must be called in subclass constructor to create a new rule registry event.
      *
-     * @param topic
-     * @param payload
-     * @param source
-     * @param ruleDTO
+     * @param topic the topic of the event
+     * @param payload the payload of the event
+     * @param source the source of the event
+     * @param ruleDTO the ruleDTO for which this event is created
      */
     public AbstractRuleRegistryEvent(String topic, String payload, String source, RuleDTO rule) {
         super(topic, payload, source);
@@ -35,9 +35,7 @@ public abstract class AbstractRuleRegistryEvent extends AbstractEvent {
     }
 
     /**
-     * returns the RuleDTO which caused the Event
-     *
-     * @return
+     * @return the RuleDTO which caused the Event
      */
     public RuleDTO getRule() {
         return this.rule;

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleAddedEvent.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleAddedEvent.java
@@ -23,10 +23,10 @@ public class RuleAddedEvent extends AbstractRuleRegistryEvent {
     /**
      * constructs a new rule added event
      *
-     * @param topic
-     * @param payload
-     * @param source
-     * @param ruleDTO
+     * @param topic the topic of the event
+     * @param payload the payload of the event
+     * @param source the source of the event
+     * @param ruleDTO the rule for which this event is created
      */
     public RuleAddedEvent(String topic, String payload, String source, RuleDTO rule) {
         super(topic, payload, source, rule);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleEventFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleEventFactory.java
@@ -102,12 +102,12 @@ public class RuleEventFactory extends AbstractEventFactory {
     }
 
     /**
-     * creates a rule updated event
+     * Creates a rule updated event
      *
-     * @param rule the updated rule
-     * @param oldRule the old rule
-     * @param source
-     * @return
+     * @param rule the new rule
+     * @param oldRule the rule that has been updated
+     * @param source the source of the event
+     * @return {@link RuleUpdatedEvent} instance
      */
     public static RuleUpdatedEvent createRuleUpdatedEvent(Rule rule, Rule oldRule, String source) {
         String topic = buildTopic(RULE_UPDATED_EVENT_TOPIC, rule);
@@ -121,12 +121,12 @@ public class RuleEventFactory extends AbstractEventFactory {
     }
 
     /**
-     * creates a rule status info event
+     * Creates a rule status info event
      *
-     * @param statusInfo
-     * @param rule
-     * @param source
-     * @return
+     * @param statusInfo the status info of the event
+     * @param ruleUID the UID of the rule for which the event is created
+     * @param source the source of the event
+     * @return {@link RuleStatusInfoEvent} instance
      */
     public static RuleStatusInfoEvent createRuleStatusInfoEvent(RuleStatusInfo statusInfo, String ruleUID,
             String source) {
@@ -136,11 +136,11 @@ public class RuleEventFactory extends AbstractEventFactory {
     }
 
     /**
-     * creates a rule removed event
+     * Creates a rule removed event
      *
-     * @param rule
-     * @param source
-     * @return
+     * @param rule the rule for which this event is created
+     * @param source the source of the event
+     * @return {@link RuleRemovedEvent} instance
      */
     public static RuleRemovedEvent createRuleRemovedEvent(Rule rule, String source) {
         String topic = buildTopic(RULE_REMOVED_EVENT_TOPIC, rule);
@@ -150,11 +150,11 @@ public class RuleEventFactory extends AbstractEventFactory {
     }
 
     /**
-     * creates a rule added event
+     * Creates a rule added event
      *
-     * @param rule
-     * @param source
-     * @return
+     * @param rule the rule for which this event is created
+     * @param source the source of the event
+     * @return {@link RuleAddedEvent} instance
      */
     public static RuleAddedEvent createRuleAddedEvent(Rule rule, String source) {
         String topic = buildTopic(RULE_ADDED_EVENT_TOPIC, rule);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleRemovedEvent.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleRemovedEvent.java
@@ -21,12 +21,12 @@ public class RuleRemovedEvent extends AbstractRuleRegistryEvent {
     public static final String TYPE = RuleRemovedEvent.class.getSimpleName();
 
     /**
-     * constructs a new rule removed event
+     * Constructs a new rule removed event
      *
-     * @param topic
-     * @param payload
-     * @param source
-     * @param ruleDTO
+     * @param topic the topic of the event
+     * @param payload the payload of the event
+     * @param source the source of the event
+     * @param rule the rule for which this event is
      */
     public RuleRemovedEvent(String topic, String payload, String source, RuleDTO rule) {
         super(topic, payload, source, rule);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleStatusInfoEvent.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleStatusInfoEvent.java
@@ -28,10 +28,11 @@ public class RuleStatusInfoEvent extends AbstractEvent {
     /**
      * constructs a new rule status event
      *
-     * @param topic
-     * @param payload
-     * @param source
-     * @param ruleDTO
+     * @param topic the topic of the event
+     * @param payload the payload of the event
+     * @param source the source of the event
+     * @param statusInfo the status info for this event
+     * @param ruleId the rule for which this event is
      */
     public RuleStatusInfoEvent(String topic, String payload, String source, RuleStatusInfo statusInfo, String ruleId) {
         super(topic, payload, source);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleUpdatedEvent.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/events/RuleUpdatedEvent.java
@@ -25,10 +25,11 @@ public class RuleUpdatedEvent extends AbstractRuleRegistryEvent {
     /**
      * constructs a new rule updated event
      *
-     * @param topic
-     * @param payload
-     * @param source
-     * @param ruleDTO
+     * @param topic the topic of the event
+     * @param payload the payload of the event
+     * @param source the source of the event
+     * @param rule the rule for which is this event
+     * @param oldRule the rule that has been updated
      */
     public RuleUpdatedEvent(String topic, String payload, String source, RuleDTO rule, RuleDTO oldRule) {
         super(topic, payload, source, rule);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/handler/ModuleHandlerFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/handler/ModuleHandlerFactory.java
@@ -27,7 +27,7 @@ public interface ModuleHandlerFactory {
     /**
      * This method is used to return UIDs of module types supported by this {@link ModuleHandlerFactory}
      *
-     * @return collection of module type unequal ids supported by this factory.
+     * @return collection of module type unequal UID supported by this factory.
      */
     public Collection<String> getTypes();
 
@@ -35,17 +35,16 @@ public interface ModuleHandlerFactory {
      * This method is used to get a ModuleHandler instance for the passed module
      * instance
      *
-     * @param module module instance for which the {@link ModuleHandler} instance is
-     *            created for.
-     *
-     * @return ModuleHandler instance.
+     * @param module module instance for which the {@link ModuleHandler} instance is created.
+     * @param ruleUID the UID of the rule for which the handler instance is created.
+     * @return {@link ModuleHandler} instance.
      */
     public ModuleHandler getHandler(Module module, String ruleUID);
 
     /**
-     * This method signalizes the Factory that a ModuleHandler for the passed module is not needed anymore. Implementors
+     * This method signalises the Factory that a ModuleHandler for the passed module is not needed anymore. Implementors
      * must take care of invalidating caches and disposing the Handlers.
-     * 
+     *
      * @param module
      */
     public void ungetHandler(Module module, String ruleUID, ModuleHandler handler);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/RuleTemplate.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/RuleTemplate.java
@@ -96,12 +96,15 @@ public class RuleTemplate implements Template {
     /**
      * This constructor creates a {@link RuleTemplate} instance.
      *
-     * @param UID is an unique identifier of the {@link RuleTemplate} instance.
-     * @param triggers - list of unique {@link Trigger}s participating in the {@link Rule}
-     * @param conditions - list of unique {@link Condition}s participating in the {@link Rule}
-     * @param actions - list of unique {@link Action}s participating in the {@link Rule}
-     * @param configDescriptions - set of configuration properties of the {@link Rule}
-     * @param visibility defines if the template can be public or private.
+     * @param UID is an unique identifier of the {@link RuleTemplate} instance
+     * @param label short human readable description
+     * @param description a detailed human readable description
+     * @param tags a set of tags
+     * @param triggers list of unique {@link Trigger}s participating in the {@link Rule}
+     * @param conditions list of unique {@link Condition}s participating in the {@link Rule}
+     * @param actions list of unique {@link Action}s participating in the {@link Rule}
+     * @param configDescriptions set of configuration properties of the {@link Rule}
+     * @param visibility defines if the template can be public or private
      */
     public RuleTemplate(String UID, String label, String description, Set<String> tags, List<Trigger> triggers,
             List<Condition> conditions, List<Action> actions, List<ConfigDescriptionParameter> configDescriptions,
@@ -191,6 +194,7 @@ public class RuleTemplate implements Template {
      * This method is used to get a {@link Module} participating in Rule
      *
      * @param id unique id of the module in this rule.
+     * @param <T> the type of the module
      * @return module with specified id or null when it does not exist.
      */
     public <T extends Module> T getModule(String id) {
@@ -200,8 +204,9 @@ public class RuleTemplate implements Template {
     /**
      * This method is used to return a group of {@link Module}s of this rule
      *
-     * @param clazz optional parameter defining type looking modules. The types
+     * @param moduleClazz optional parameter defining type looking modules. The types
      *            are {@link Trigger}, {@link Condition} or {@link Action}
+     * @param <T> the type of the module that is required
      * @return list of modules of defined type or all modules when the type is not
      *         specified.
      */

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/RuleTemplateProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/RuleTemplateProvider.java
@@ -13,9 +13,23 @@
  *******************************************************************************/
 package org.eclipse.smarthome.automation.template;
 
+import java.util.Locale;
+
+import org.eclipse.smarthome.core.common.registry.Provider;
+import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
+
 /**
- * @author Ana Dimova
+ * The {@link RuleTemplateProvider} provides basic functionality for managing {@link RuleTemplate}s.
+ * It can be used for
+ * <ul>
+ * <li>Get the existing {@link RuleTemplate}s with the {@link Provider#getAll()},
+ * {@link TemplateProvider#getTemplates(Locale)} and {@link #getTemplate(String, Locale)} methods.</li>
+ * </ul>
+ * Listers that are listening for adding removing or updating can be added with the
+ * {@link #addProviderChangeListener(ProviderChangeListener)}
+ * and removed with the {@link #removeProviderChangeListener(ProviderChangeListener)} methods.
  *
+ * @author Ana Dimova
  */
 public interface RuleTemplateProvider extends TemplateProvider<RuleTemplate> {
 

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/Template.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/Template.java
@@ -38,8 +38,10 @@ public interface Template {
 
     /**
      * Templates can have
+     * <ul>
      * <li><code>tags</code> - non-hierarchical keywords or terms for describing them. The tags are
-     * used to filter the templates. This method is used for getting the assign tags to this Template.
+     * used to filter the templates. This method is used for getting the assign tags to this Template.</li>
+     * </ul>
      *
      * @return tags of the template
      */

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/TemplateRegistry.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/TemplateRegistry.java
@@ -37,7 +37,11 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
     /**
      * This method is used for getting the templates filtered by tag.
      *
-     * @param tag specifies the filter for getting the templates, if it is <code>null</code> then returns all templates.
+     * * @param tag specifies the filter for getting the templates, if it is <code>null</code> then returns all
+     * templates.
+     *
+     * @param locale specifies the localization of the returned element. If a localization resource for this
+     *            locale is not available the element is returned with the default localization.
      * @return the templates, which correspond to the specified filter.
      */
     public Collection<E> getByTag(String tag);
@@ -55,6 +59,9 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      *
      * @param tags set of tags which specifies the filter for getting the templates, if it is <code>null</code> then
      *            returns all templates.
+     * @param locale - specifies the localization of the returned element.
+     *            If a localization resource for this locale is not available the element is returned with the default
+     *            localiation
      * @return collection of templates, which correspond to the filter.
      */
     public Collection<E> getByTags(String... tags);
@@ -71,7 +78,9 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
     /**
      * This method is used for getting all templates, localized by specified locale,
      *
-     * @param moduleType the class of module which is looking for.
+     * @param locale - specifies the localization for the returned elements.
+     *            If a localization resources for this locale are not available the elements are returned with the
+     *            default localization.
      * @return collection of templates, corresponding to specified type
      */
     public Collection<E> getAll(Locale locale);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/TemplateRegistry.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/template/TemplateRegistry.java
@@ -40,8 +40,6 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      * * @param tag specifies the filter for getting the templates, if it is <code>null</code> then returns all
      * templates.
      *
-     * @param locale specifies the localization of the returned element. If a localization resource for this
-     *            locale is not available the element is returned with the default localization.
      * @return the templates, which correspond to the specified filter.
      */
     public Collection<E> getByTag(String tag);
@@ -59,9 +57,6 @@ public interface TemplateRegistry<E extends Template> extends Registry<E, String
      *
      * @param tags set of tags which specifies the filter for getting the templates, if it is <code>null</code> then
      *            returns all templates.
-     * @param locale - specifies the localization of the returned element.
-     *            If a localization resource for this locale is not available the element is returned with the default
-     *            localiation
      * @return collection of templates, which correspond to the filter.
      */
     public Collection<E> getByTags(String... tags);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ActionType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ActionType.java
@@ -102,7 +102,7 @@ public class ActionType extends ModuleType {
     }
 
     /**
-     * This method is used for getting the meta-information descriptions of {@link Input}s defined by this type.<br/>
+     * This method is used for getting the meta-information descriptions of {@link Input}s defined by this type.
      *
      * @return a {@link List} of {@link Input} definitions.
      */
@@ -111,7 +111,7 @@ public class ActionType extends ModuleType {
     }
 
     /**
-     * This method is used for getting the meta-information descriptions of {@link Output}s defined by this type.<br/>
+     * This method is used for getting the meta-information descriptions of {@link Output}s defined by this type.
      *
      * @return a {@link List} of {@link Output} definitions.
      */

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/Input.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/Input.java
@@ -95,7 +95,7 @@ public class Input {
      * @param description user friendly description of the {@code Input}.
      * @param tags are associated with the {@code Input}. The tags adds additional restrictions to connections between
      *            {@code Input}s and {@link Output}s. The input tags must be subset of the output tags to succeed the
-     *            connection.</br>
+     *            connection.
      *            For example: When we want to connect input to output and both have same
      *            java.lang.double data type. The the output has assign "temperature" and "celsius" tags then the input
      *            must have at least one of these output's tags (i.e. "temperature") to connect this {@code Input} to
@@ -176,7 +176,7 @@ public class Input {
     /**
      * This method is used for getting the tags of the Input. The tags add additional restrictions to connections
      * between {@link Input}s and {@link Output}s. The input tags must be subset of the output tags to succeed the
-     * connection.</br>
+     * connection.
      * For example: When we want to connect input to output and they both have same java.lang.double
      * data type, and the output has assign "temperature" and "celsius" tags then the input must have at least one of
      * these output's tags (i.e. "temperature") to connect this input to the selected output.

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ModuleType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ModuleType.java
@@ -114,8 +114,8 @@ public abstract class ModuleType {
     }
 
     /**
-     * This method is used for getting the Set of {@link ConfigDescriptionParameter}s defined by this {@link ModuleType}
-     * .<br/>
+     * This method is used for getting the Set of {@link ConfigDescriptionParameter}s defined by this
+     * {@link ModuleType}.
      *
      * @return a {@link Set} of meta-information configuration descriptions.
      */
@@ -125,9 +125,11 @@ public abstract class ModuleType {
 
     /**
      * {@link ModuleType}s can have
+     * <ul>
      * <li><code>tags</code> which are non-hierarchical keywords or terms for describing
      * them. The tags are used to filter the ModuleTypes. This method is used for getting the tags assign to this
-     * {@link ModuleType}.
+     * {@link ModuleType}.</li>
+     * </ul>
      *
      * @return {@link #tags} assign to this {@link ModuleType}
      */

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ModuleTypeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ModuleTypeProvider.java
@@ -29,6 +29,7 @@ public interface ModuleTypeProvider extends Provider<ModuleType> {
      *
      * @param UID unique id of module type.
      * @param locale defines localization of label and description of the {@link ModuleType} or null.
+     * @param <T> the type of the required object.
      * @return localized module type.
      */
     <T extends ModuleType> T getModuleType(String UID, Locale locale);
@@ -39,6 +40,7 @@ public interface ModuleTypeProvider extends Provider<ModuleType> {
      * with default localization is returned.
      *
      * @param locale defines localization of label and description of the {@link ModuleType}s or null.
+     * @param <T> the type of the required object.
      * @return collection of localized {@link ModuleType} provided by this
      *         provider
      */

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ModuleTypeRegistry.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/ModuleTypeRegistry.java
@@ -29,6 +29,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      *
      * @param moduleTypeUID the an unique id in scope of registered ModuleTypes
      * @param locale used for localization of the ModuleType
+     * @param <T> the type of the required object
      * @return ModuleType instance or null.
      */
     public <T extends ModuleType> T get(String moduleTypeUID, Locale locale);
@@ -38,6 +39,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      *
      * @param moduleTypeTag specifies the filter for getting the ModuleTypes, if
      *            it is <code>null</code> then returns all ModuleTypes.
+     * @param <T> the type of the required object
      * @return the ModuleTypes, which correspond to the specified filter.
      */
     public <T extends ModuleType> Collection<T> getByTag(String moduleTypeTag);
@@ -48,6 +50,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @param moduleTypeTag specifies the filter for getting the ModuleTypes, if
      *            it is <code>null</code> then returns all ModuleTypes.
      * @param locale used for localization of the ModuleType
+     * @param <T> the type of the required object
      * @return the ModuleTypes, which correspond to the specified filter.
      */
     public <T extends ModuleType> Collection<T> getByTag(String moduleTypeTag, Locale locale);
@@ -57,6 +60,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      *
      * @param tags specifies the filter for getting the ModuleTypes, if
      *            it is <code>null</code> then returns all ModuleTypes.
+     * @param <T> the type of the required object
      * @return the ModuleTypes, which correspond to the filter.
      */
     public <T extends ModuleType> Collection<T> getByTags(String... tags);
@@ -67,6 +71,7 @@ public interface ModuleTypeRegistry extends Registry<ModuleType, String> {
      * @param locale used for localization of the ModuleType
      * @param moduleTypeTag specifies the filter for getting the ModuleTypes, if
      *            it is <code>null</code> then returns all ModuleTypes.
+     * @param <T> the type of the required object
      * @return the ModuleTypes, which correspond to the filter.
      */
     public <T extends ModuleType> Collection<T> getByTags(Locale locale, String... tags);

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/Output.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/Output.java
@@ -110,7 +110,7 @@ public class Output {
      * @param description is an user friendly description of the {@code Output}.
      * @param tags are associated with the {@code Output}. The tags add additional restrictions to connections between
      *            {@link Input}s and {@link Output}s. The {@link Input}'s tags must be subset of the {@code Output}'s
-     *            tags to succeed the connection.</br>
+     *            tags to succeed the connection.<br>
      *            For example: When we want to connect {@link Input} to
      *            {@code Output} and both have same java.lang.double data type. The the output has assign "temperature"
      *            and "celsius" tags then the input must have at least one of these output's tags (i.e. "temperature")
@@ -191,7 +191,7 @@ public class Output {
     /**
      * This method is used for getting the tags of the {@code Output}. The tags add additional restrictions to
      * connections between {@link Input}s and {@code Output}s. The input tags must be subset of the output tags to
-     * succeed the connection.</br>
+     * succeed the connection.<br>
      * For example: When we want to connect {@link Input} to {@code Output} and they both
      * have same data type - java.lang.double and the {@link Output} has assign "temperature" and "celsius" tags, then
      * the {@link Input} must have at least one of these {@code Output}'s tags (i.e. "temperature") to connect this

--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/TriggerType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/type/TriggerType.java
@@ -76,7 +76,7 @@ public class TriggerType extends ModuleType {
     }
 
     /**
-     * This method is used for getting the meta-information descriptions of {@link Output}s defined by this type.<br/>
+     * This method is used for getting the meta-information descriptions of {@link Output}s defined by this type.<br>
      *
      * @return a {@link List} of {@link Output} definitions.
      */

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterBuilder.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterBuilder.java
@@ -68,7 +68,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the minimum value of the configuration parameter
      *
-     * @param min
+     * @param min the min value of the {@link ConfigDescriptionParameter}
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withMinimum(BigDecimal min) {
         this.min = min;
@@ -78,7 +79,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the maximum value of the configuration parameter
      *
-     * @param max
+     * @param max the max value of the {@link ConfigDescriptionParameter}
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withMaximum(BigDecimal max) {
         this.max = max;
@@ -88,7 +90,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the step size of the configuration parameter
      *
-     * @param step
+     * @param step the step of the {@link ConfigDescriptionParameter}
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withStepSize(BigDecimal step) {
         this.step = step;
@@ -98,7 +101,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the pattern of the configuration parameter
      *
-     * @param pattern
+     * @param pattern the pattern for the {@link ConfigDescriptionParameter}
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withPattern(String pattern) {
         this.pattern = pattern;
@@ -108,7 +112,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the configuration parameter as read only
      *
-     * @param readOnly
+     * @param readOnly <code>true</code> to make the parameter read only
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withReadOnly(Boolean readOnly) {
         this.readOnly = readOnly;
@@ -118,7 +123,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the configuration parameter to allow multiple selection
      *
-     * @param multiple
+     * @param multiple <code>true</code> for multiple selection
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withMultiple(Boolean multiple) {
         this.multiple = multiple;
@@ -128,7 +134,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the configuration parameter to allow multiple selection
      *
-     * @param multiple
+     * @param multipleLimit the parameters limit
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withMultipleLimit(Integer multipleLimit) {
         this.multipleLimit = multipleLimit;
@@ -138,7 +145,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the context of the configuration parameter
      *
-     * @param context
+     * @param context the context for this parameter
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withContext(String context) {
         this.context = context;
@@ -148,7 +156,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the configuration parameter to be required
      *
-     * @param required
+     * @param required <code>true</code> if the parameter is required
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withRequired(Boolean required) {
         this.required = required;
@@ -158,7 +167,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the default value of the configuration parameter
      *
-     * @param defaultValue
+     * @param defaultValue the default value of the configuration parameter
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withDefault(String defaultValue) {
         this.defaultValue = defaultValue;
@@ -168,7 +178,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the label of the configuration parameter
      *
-     * @param label
+     * @param label a short user friendly description
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withLabel(String label) {
         this.label = label;
@@ -178,7 +189,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the description of the configuration parameter
      *
-     * @param description
+     * @param description a detailed user friendly description
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withDescription(String description) {
         this.description = description;
@@ -188,7 +200,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the options of the configuration parameter
      *
-     * @param options
+     * @param options the options for this parameter
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withOptions(List<ParameterOption> options) {
         this.options = options;
@@ -198,7 +211,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the configuration parameter as an advanced parameter
      *
-     * @param options
+     * @param advanced <code>true</code> to make the parameter advanced
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withAdvanced(Boolean advanced) {
         this.advanced = advanced;
@@ -208,7 +222,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the configuration parameter to be limited to the values in the options list
      *
-     * @param options
+     * @param limitToOptions <code>true</code> if only the declared options are acceptable
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withLimitToOptions(Boolean limitToOptions) {
         this.limitToOptions = limitToOptions;
@@ -218,7 +233,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the configuration parameter to be limited to the values in the options list
      *
-     * @param options
+     * @param groupName the group name of this config description parameter
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withGroupName(String groupName) {
         this.groupName = groupName;
@@ -228,7 +244,8 @@ public class ConfigDescriptionParameterBuilder {
     /**
      * Set the filter criteria of the configuration parameter
      *
-     * @param filterCriteria
+     * @param filterCriteria the filter criteria
+     * @return the updated builder instance
      */
     public ConfigDescriptionParameterBuilder withFilterCriteria(List<FilterCriteria> filterCriteria) {
         this.filterCriteria = filterCriteria;

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
@@ -31,7 +31,7 @@ public class ConfigUtil {
     /**
      * Normalizes the types to the ones allowed for configurations.
      *
-     * @param configuration
+     * @param configuration the configuration that needs to be normalzed
      * @return normalized configuration
      */
     public static Map<String, Object> normalizeTypes(Map<String, Object> configuration) {
@@ -58,6 +58,7 @@ public class ConfigUtil {
      * Normalizes the type of the parameter to the one allowed for configurations.
      *
      * @param value the value to return as normalized type
+     * @param configDescriptionParameter the parameter that needs to be normalized
      * @return corresponding value as a valid type
      * @throws IllegalArgumentException if a invalid type has been given
      */

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/ProviderChangeListener.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/ProviderChangeListener.java
@@ -22,30 +22,24 @@ public interface ProviderChangeListener<E> {
     /**
      * Notifies the listener that a single element has been added.
      *
-     * @param provider
-     *            element provider
-     * @param element
-     *            the element that has been added
+     * @param provider the provider that provides the element
+     * @param element the element that has been added
      */
     void added(Provider<E> provider, E element);
 
     /**
      * Notifies the listener that a single element has been removed.
      *
-     * @param provider
-     *            element provider
-     * @param element
-     *            the element that has been removed
+     * @param provider the provider that provides the element
+     * @param element the element that has been removed
      */
     void removed(Provider<E> provider, E element);
 
     /**
      * Notifies the listener that a single element has been updated.
      *
-     * @param provider
-     *            element provider
-     * @param element
-     *            the element that has been update
+     * @param provider the provider that provides the element
+     * @param element the element that has been updated
      */
     void updated(Provider<E> provider, E oldelement, E element);
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/Registry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/Registry.java
@@ -11,20 +11,18 @@ import java.util.Collection;
 
 /**
  * The {@link Registry} interface represents a registry for elements of the type
- * E. The concrete subinterfaces are registered as OSGi services.
+ * E. The concrete sub interfaces are registered as OSGi services.
  *
  * @author Dennis Nobel - Initial contribution
  *
- * @param <E>
- *            type of the elements in the registry
+ * @param <E> type of the elements in the registry
  */
 public interface Registry<E, K> {
 
     /**
      * Adds a {@link RegistryChangeListener} to the registry.
      *
-     * @param listener
-     *            registry change listener
+     * @param listener registry change listener
      */
     void addRegistryChangeListener(RegistryChangeListener<E> listener);
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/RegistryChangeListener.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/RegistryChangeListener.java
@@ -13,32 +13,29 @@ package org.eclipse.smarthome.core.common.registry;
  *
  * @author Dennis Nobel - Initial contribution
  *
- * @param <E>
- *            type of the element in the registry
+ * @param <E> type of the element in the registry
  */
 public interface RegistryChangeListener<E> {
 
     /**
      * Notifies the listener that a single element has been added.
      *
-     * @param element
-     *            the element that has been added
+     * @param element the element that has been added
      */
     void added(E element);
 
     /**
      * Notifies the listener that a single element has been removed.
      *
-     * @param element
-     *            the element that has been removed
+     * @param element the element that has been removed
      */
     void removed(E element);
 
     /**
      * Notifies the listener that a single element has been updated.
      *
-     * @param element
-     *            the element that has been update
+     * @param element the new element
+     * @param oldElement the element that has been updated
      */
     void updated(E oldElement, E element);
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/events/AbstractEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/events/AbstractEventFactory.java
@@ -18,7 +18,7 @@ import com.google.gson.Gson;
  * must implement the abstract method {@link #createEventByType(String, String, String, String)} in order to create
  * event
  * instances based on the event type.
- * 
+ *
  * @author Stefan Bußweiler - Initial contribution
  */
 public abstract class AbstractEventFactory implements EventFactory {
@@ -29,7 +29,7 @@ public abstract class AbstractEventFactory implements EventFactory {
 
     /**
      * Must be called in subclass constructor to define the supported event types.
-     * 
+     *
      * @param supportedEventTypes the supported event types
      */
     public AbstractEventFactory(Set<String> supportedEventTypes) {
@@ -63,14 +63,14 @@ public abstract class AbstractEventFactory implements EventFactory {
 
     /**
      * Create a new event instance based on the event type.
-     * 
+     *
      * @param eventType the event type
      * @param topic the topic
      * @param payload the payload
      * @param source the source, can be null
-     * 
+     *
      * @return the created event instance
-     * 
+     *
      * @throws Exception if the creation of the event fails
      */
     protected abstract Event createEventByType(String eventType, String topic, String payload, String source)
@@ -78,9 +78,9 @@ public abstract class AbstractEventFactory implements EventFactory {
 
     /**
      * Serializes the payload object into its equivalent Json representation.
-     * 
+     *
      * @param payloadObject the payload object to serialize
-     * 
+     *
      * @return a serialized Json representation
      */
     protected static String serializePayload(Object payloadObject) {
@@ -89,10 +89,10 @@ public abstract class AbstractEventFactory implements EventFactory {
 
     /**
      * Deserializes the Json-payload into an object of the specified class.
-     * 
+     *
      * @param payload the payload from which the object is to be deserialized
      * @param classOfPayload the class T of the payload object
-     * 
+     * @param <T> the type of the returned object
      * @return an object of type T from the payload
      */
     protected static <T> T deserializePayload(String payload, Class<T> classOfPayload) {
@@ -101,9 +101,9 @@ public abstract class AbstractEventFactory implements EventFactory {
 
     /**
      * Gets the elements of the topic (splitted by '/').
-     * 
+     *
      * @param topic the topic
-     * 
+     *
      * @return the topic elements
      */
     protected String[] getTopicElements(String topic) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/storage/StorageService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/storage/StorageService.java
@@ -13,8 +13,7 @@ package org.eclipse.smarthome.core.storage;
  * different {@link StorageService}s that store these key-value pairs
  * differently. One can think of e.g in-memory or in-database {@link Storage}s
  * and many more. This {@link StorageService} decides which kind of {@link Storage} is returned on request. It is meant
- * to be injected into
- * service consumers with the need for storing generic key-value pairs like the
+ * to be injected into service consumers with the need for storing generic key-value pairs like the
  * ManagedXXXProviders.
  *
  * @author Thomas.Eichstaedt-Engelen - Initial Contribution and API
@@ -24,8 +23,7 @@ public interface StorageService {
 
     /**
      * Returns the {@link Storage} with the given {@code name}. If no {@link Storage} with this name exists a new
-     * initialized instance
-     * is returned.
+     * initialised instance is returned.
      *
      * @param name the name of the {@link StorageService} to return
      * @return a ready to use {@link Storage}, never {@code null}
@@ -34,13 +32,11 @@ public interface StorageService {
 
     /**
      * Returns the {@link Storage} with the given {@code name} and a given {@link ClassLoader}. If no {@link Storage}
-     * with this name exists a new
-     * initialized instance is returned.
+     * with this name exists a new initialised instance is returned.
      *
-     * @param name
-     *            the name of the {@link StorageService} to return
-     * @param classLoader
-     *            the class loader which should be used by the {@link Storage}
+     * @param name the name of the {@link StorageService} to return
+     * @param classLoader the class loader which should be used by the {@link Storage}
+     * @param <T> The type of the storage service
      * @return a ready to use {@link Storage}, never {@code null}
      */
     <T> Storage<T> getStorage(String name, ClassLoader classLoader);


### PR DESCRIPTION
Javadoc is fixed to pass java 1.8 build. #3269
I know that the `-Xdoclint:none` statement suppress the errors but i think more clean and full javadoc is welcome.

Missing `@param` statements are added.
Some of the descriptions are fixed.

Signed-off-by: Plamen Veselinov Peev <p.peev@prosyst.bg>