### PR TITLE
Giving the NtpHandler a little more time to initialize

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/src/test/java/org/eclipse/smarthome/binding/ntp/test/NtpOSGiTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/src/test/java/org/eclipse/smarthome/binding/ntp/test/NtpOSGiTest.java
@@ -38,6 +38,7 @@ import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingProvider;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
@@ -393,8 +394,9 @@ public class NtpOSGiTest extends JavaOSGiTest {
         ntpHandler = waitForAssert(() -> {
             final ThingHandler thingHandler = ntpThing.getHandler();
             assertThat(thingHandler, is(instanceOf(NtpHandler.class)));
+            assertThat(ntpThing.getStatus(), is(equalTo(ThingStatus.ONLINE)));
             return (NtpHandler) thingHandler;
-        });
+        }, DFL_TIMEOUT * 3, DFL_SLEEP_TIME);
 
         if (acceptedItemType.equals(ACCEPTED_ITEM_TYPE_STRING)) {
             testItem = new StringItem(TEST_ITEM_NAME);


### PR DESCRIPTION
...during test execution.

relates to #3231, #3280
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>