### PR TITLE
changing waitForAssert to an absolute timeout

### DIFF
--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
@@ -202,13 +202,12 @@ abstract class OSGiTest {
      * @param sleepTime interval for checking the condition, default is 50ms
      */
     protected void waitForAssert(Closure<?> assertion, Closure<?> beforeLastCall, int timeout = 10000, int sleepTime = 50) {
-        def waitingTime = 0
-        while(waitingTime < timeout) {
+        def startingTime = System.nanoTime();
+        while((System.nanoTime() - startingTime) < timeout * 1000) {
             try {
                 assertion()
                 return
             } catch(Error | NullPointerException error) {
-                waitingTime += sleepTime
                 sleep sleepTime
             }
         }

--- a/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/java/JavaOSGiTest.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/java/JavaOSGiTest.java
@@ -372,12 +372,11 @@ public class JavaOSGiTest {
      * @return the return value of the supplied assertion object's function on success
      */
     protected <T> T waitForAssert(Supplier<T> assertion, Runnable beforeLastCall, int timeout, int sleepTime) {
-        int waitingTime = 0;
-        while (waitingTime < timeout) {
+        long startingTime = System.nanoTime();
+        while (System.nanoTime() - startingTime < timeout * 1000) {
             try {
                 return assertion.get();
             } catch (final Error | NullPointerException error) {
-                waitingTime += sleepTime;
                 internalSleep(sleepTime);
             }
         }


### PR DESCRIPTION
...as so far the timout was the aggregated sleep time, which
led to quite long-running tests in case of nested waitForAssert
blocks.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>