### PR TITLE
Changed 'final static' to 'static final' in archetype

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -29,7 +29,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
  */
 public class ${bindingIdCamelCase}HandlerFactory extends BaseThingHandlerFactory {
 
-    private final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_SAMPLE);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_SAMPLE);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {


### PR DESCRIPTION
Related to PR [#3278](https://github.com/eclipse/smarthome/pull/3278) (Worked on a set of minor issues in the archetype).

Signed-off-by: Christoph Weitkamp github@christophweitkamp.de