### PR TITLE
Fix Proxy time-outs #3184. Make the number of threads at least the do…

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/proxy/ProxyServletService.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/proxy/ProxyServletService.java
@@ -139,7 +139,8 @@ public class ProxyServletService extends HttpServlet {
 
         // must specify for Jetty proxy servlet, per http://stackoverflow.com/a/27625380
         if (props.get(CONFIG_MAX_THREADS) == null) {
-            props.put(CONFIG_MAX_THREADS, String.valueOf(DEFAULT_MAX_THREADS));
+            props.put(CONFIG_MAX_THREADS,
+                    String.valueOf(Math.max(DEFAULT_MAX_THREADS, Runtime.getRuntime().availableProcessors())));
         }
 
         return props;


### PR DESCRIPTION
…uble of the number of selector threads that are created by the HttpClient, so that the QueuedThreadPool is not clogged with blocking “selector” threads

Signed-off-by: Karel Goderis <karel.goderis@me.com>