### PR TITLE
Corrected and defined behavior of group functions

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
@@ -16,8 +16,11 @@ import org.eclipse.smarthome.core.items.events.GroupItemStateChangedEvent
 import org.eclipse.smarthome.core.items.events.ItemEventFactory
 import org.eclipse.smarthome.core.library.items.NumberItem
 import org.eclipse.smarthome.core.library.items.SwitchItem
+import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction
+import org.eclipse.smarthome.core.library.types.OnOffType
 import org.eclipse.smarthome.core.library.types.RawType
 import org.eclipse.smarthome.core.types.RefreshType
+import org.eclipse.smarthome.core.types.UnDefType
 import org.eclipse.smarthome.test.OSGiTest
 import org.junit.Assert
 import org.junit.Before
@@ -29,8 +32,12 @@ import org.junit.Test
  *
  * @author Dennis Nobel - Initial contribution
  * @author Christoph Knauf - event tests
+ * @author Stefan Triller - tests for group status with and without functions
  */
 class GroupItemTest extends OSGiTest {
+
+    /** Time to sleep when a file is created/modified/deleted, so the event can be handled */
+    private final static int WAIT_EVENT_TO_BE_HANDLED = 1000
 
     List<Event> events = []
     EventPublisher publisher
@@ -86,7 +93,7 @@ class GroupItemTest extends OSGiTest {
     @Test
     void 'assert that group item posts events for changes correctly' (){
         events.clear()
-        GroupItem groupItem = new GroupItem("root")
+        GroupItem groupItem = new GroupItem("root", new SwitchItem("mySwitch"), new GroupFunction.Equality())
         def member = new TestItem("member1")
         groupItem.addMember(member)
         groupItem.setEventPublisher(publisher)
@@ -116,5 +123,104 @@ class GroupItemTest extends OSGiTest {
         //State doesn't change -> no events are fired
         member.setState(member.getState())
         assertThat events.size(), is(0)
+    }
+
+    @Test
+    void 'assert that group item changes respect group function OR' (){
+        events.clear()
+        GroupItem groupItem = new GroupItem("root", new SwitchItem("mySwitch"), new ArithmeticGroupFunction.Or(OnOffType.ON, OnOffType.OFF))
+        def sw1 = new SwitchItem("switch1");
+        def sw2 = new SwitchItem("switch2");
+        groupItem.addMember(sw1)
+        groupItem.addMember(sw2)
+
+        groupItem.setEventPublisher(publisher)
+        def oldGroupState = groupItem.getState()
+
+        //State changes -> one change event is fired
+        sw1.setState(OnOffType.ON)
+
+        waitForAssert {
+            assertThat events.size(), is(1)
+        }
+
+        def changes = events.findAll{it instanceof GroupItemStateChangedEvent}
+        assertThat changes.size(), is(1)
+
+        def change = changes.getAt(0) as GroupItemStateChangedEvent
+        assertTrue change.getItemName().equals(groupItem.getName())
+
+        assertTrue change.getOldItemState().equals(UnDefType.NULL)
+        assertTrue change.getItemState().equals(OnOffType.ON)
+    }
+
+    @Test
+    void 'assert that group item changes respect group function AND' (){
+        events.clear()
+        GroupItem groupItem = new GroupItem("root", new SwitchItem("mySwitch"), new ArithmeticGroupFunction.And(OnOffType.ON, OnOffType.OFF))
+        def sw1 = new SwitchItem("switch1");
+        def sw2 = new SwitchItem("switch2");
+        groupItem.addMember(sw1)
+        groupItem.addMember(sw2)
+
+        groupItem.setEventPublisher(publisher)
+        def oldGroupState = groupItem.getState()
+
+        //State changes -> one change event is fired
+        sw1.setState(OnOffType.ON)
+
+        waitForAssert {
+            assertThat events.size(), is(1)
+        }
+
+        def changes = events.findAll{it instanceof GroupItemStateChangedEvent}
+        assertThat changes.size(), is(1)
+
+        def change = changes.getAt(0) as GroupItemStateChangedEvent
+        assertTrue change.getItemName().equals(groupItem.getName())
+
+        //we expect that the group should now have status "OFF"
+        assertTrue change.getOldItemState().equals(UnDefType.NULL)
+        assertTrue change.getItemState().equals(OnOffType.OFF)
+
+        events.clear();
+
+        //State changes -> one change event is fired
+        sw2.setState(OnOffType.ON)
+
+        waitForAssert {
+            assertThat events.size(), is(1)
+        }
+
+        changes = events.findAll{it instanceof GroupItemStateChangedEvent}
+        assertThat changes.size(), is(1)
+
+        change = changes.getAt(0) as GroupItemStateChangedEvent
+        assertTrue change.getItemName().equals(groupItem.getName())
+
+        //we expect that the group should now have status "ON"
+        assertTrue change.getOldItemState().equals(OnOffType.OFF)
+        assertTrue change.getItemState().equals(OnOffType.ON)
+
+    }
+
+    @Test
+    void 'assert that group item changes do not affect the group status if no function or baseItem are defined' (){
+        events.clear()
+        GroupItem groupItem = new GroupItem("root")
+        def member = new TestItem("member1")
+        groupItem.addMember(member)
+        groupItem.setEventPublisher(publisher)
+        def oldGroupState = groupItem.getState()
+
+        //State changes -> NO change event should be fired
+        member.setState(new RawType())
+
+        //wait to see that the event doesn't fire
+        sleep(WAIT_EVENT_TO_BE_HANDLED)
+
+        waitForAssert {
+            assertThat events.size(), is(0)
+        }
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
@@ -186,16 +186,12 @@ class GroupItemTest extends OSGiTest {
 
         sw2.setState(OnOffType.ON);
 
-        events.clear();
-
         sw2.setState(UnDefType.UNDEF);
 
         //wait to see that the event doesn't fire
         sleep(WAIT_EVENT_TO_BE_HANDLED)
 
-        waitForAssert {
-            assertThat events.size(), is(0)
-        }
+        assertThat events.size(), is(0)
 
         assertTrue groupItem.getState().equals(OnOffType.ON)
     }
@@ -265,9 +261,7 @@ class GroupItemTest extends OSGiTest {
         //wait to see that the event doesn't fire
         sleep(WAIT_EVENT_TO_BE_HANDLED)
 
-        waitForAssert {
-            assertThat events.size(), is(0)
-        }
+        assertThat events.size(), is(0)
 
         assertTrue groupItem.getState().equals(oldGroupState)
     }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
@@ -135,7 +135,6 @@ class GroupItemTest extends OSGiTest {
         groupItem.addMember(sw2)
 
         groupItem.setEventPublisher(publisher)
-        def oldGroupState = groupItem.getState()
 
         //State changes -> one change event is fired
         sw1.setState(OnOffType.ON)
@@ -152,6 +151,53 @@ class GroupItemTest extends OSGiTest {
 
         assertTrue change.getOldItemState().equals(UnDefType.NULL)
         assertTrue change.getItemState().equals(OnOffType.ON)
+
+        assertTrue groupItem.getState().equals(OnOffType.ON)
+    }
+
+    @Test
+    void 'assert that group item changes respect group function OR with UNDEF' (){
+        events.clear()
+        GroupItem groupItem = new GroupItem("root", new SwitchItem("mySwitch"), new ArithmeticGroupFunction.Or(OnOffType.ON, OnOffType.OFF))
+        def sw1 = new SwitchItem("switch1");
+        def sw2 = new SwitchItem("switch2");
+        groupItem.addMember(sw1)
+        groupItem.addMember(sw2)
+
+        groupItem.setEventPublisher(publisher)
+
+        //State changes -> one change event is fired
+        sw1.setState(OnOffType.ON)
+
+        waitForAssert {
+            assertThat events.size(), is(1)
+        }
+
+        def changes = events.findAll{it instanceof GroupItemStateChangedEvent}
+        assertThat changes.size(), is(1)
+
+        def change = changes.getAt(0) as GroupItemStateChangedEvent
+        assertTrue change.getItemName().equals(groupItem.getName())
+
+        assertTrue change.getOldItemState().equals(UnDefType.NULL)
+        assertTrue change.getItemState().equals(OnOffType.ON)
+
+        events.clear();
+
+        sw2.setState(OnOffType.ON);
+
+        events.clear();
+
+        sw2.setState(UnDefType.UNDEF);
+
+        //wait to see that the event doesn't fire
+        sleep(WAIT_EVENT_TO_BE_HANDLED)
+
+        waitForAssert {
+            assertThat events.size(), is(0)
+        }
+
+        assertTrue groupItem.getState().equals(OnOffType.ON)
     }
 
     @Test
@@ -164,7 +210,6 @@ class GroupItemTest extends OSGiTest {
         groupItem.addMember(sw2)
 
         groupItem.setEventPublisher(publisher)
-        def oldGroupState = groupItem.getState()
 
         //State changes -> one change event is fired
         sw1.setState(OnOffType.ON)
@@ -202,6 +247,7 @@ class GroupItemTest extends OSGiTest {
         assertTrue change.getOldItemState().equals(OnOffType.OFF)
         assertTrue change.getItemState().equals(OnOffType.ON)
 
+        assertTrue groupItem.getState().equals(OnOffType.ON)
     }
 
     @Test
@@ -222,5 +268,7 @@ class GroupItemTest extends OSGiTest {
         waitForAssert {
             assertThat events.size(), is(0)
         }
+
+        assertTrue groupItem.getState().equals(oldGroupState)
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -35,17 +35,29 @@ public class GroupItem extends GenericItem implements StateChangeListener {
 
     protected GroupFunction function;
 
+    /**
+     * Creates a plain GroupItem
+     * 
+     * @param name name of the group
+     */
     public GroupItem(String name) {
         this(name, null, null);
     }
 
-    public GroupItem(String name, GenericItem baseItem) {
-        // this(name, baseItem, new GroupFunction.Equality());
-        this(name, baseItem, null);
-    }
-
+    /**
+     * Creates a GroupItem with function
+     * 
+     * @param name name of the group
+     * @param baseItem type of items in the group
+     * @param function function to calculate group status out of member status
+     */
     public GroupItem(String name, GenericItem baseItem, GroupFunction function) {
         super(TYPE, name);
+
+        if ((baseItem != null && function == null) || (baseItem == null && function != null)) {
+            throw new IllegalArgumentException("baseItem AND function have to be passed as arguments");
+        }
+
         members = new CopyOnWriteArraySet<Item>();
         this.function = function;
         this.baseItem = baseItem;
@@ -287,7 +299,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     @Override
     public void stateUpdated(Item item, State state) {
         State oldState = this.state;
-        if (null != function) {
+        if (function != null) {
             setState(function.calculate(members));
         }
         if (!oldState.equals(this.state)) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -36,11 +36,12 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     protected GroupFunction function;
 
     public GroupItem(String name) {
-        this(name, null);
+        this(name, null, null);
     }
 
     public GroupItem(String name, GenericItem baseItem) {
-        this(name, baseItem, new GroupFunction.Equality());
+        // this(name, baseItem, new GroupFunction.Equality());
+        this(name, baseItem, null);
     }
 
     public GroupItem(String name, GenericItem baseItem, GroupFunction function) {
@@ -286,7 +287,9 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     @Override
     public void stateUpdated(Item item, State state) {
         State oldState = this.state;
-        setState(function.calculate(members));
+        if (null != function) {
+            setState(function.calculate(members));
+        }
         if (!oldState.equals(this.state)) {
             sendGroupStateChangedEvent(item.getName(), this.state, oldState);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
@@ -190,7 +190,7 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
                     GroupFunction function = getGroupFunction(persistedItem, baseItem);
                     item = new GroupItem(itemName, baseItem, function);
                 } else {
-                    item = new GroupItem(itemName, baseItem);
+                    item = new GroupItem(itemName, baseItem, new GroupFunction.Equality());
                 }
             } else {
                 item = new GroupItem(itemName);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
@@ -151,6 +151,9 @@ public class ItemDTOMapper {
             case "MAX":
                 groupFunction = new ArithmeticGroupFunction.Max();
                 break;
+            case "EQUAL":
+                groupFunction = new GroupFunction.Equality();
+                break;
             default:
                 LoggerFactory.getLogger(ItemDTOMapper.class)
                         .error("Unknown group function '" + function.name + "'. Using Equality instead.");

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/Items.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/Items.xtext
@@ -27,7 +27,7 @@ ModelGroupItem :
 ;
 
 enum ModelGroupFunction :
-	NONE='NONE' | AND='AND' | OR='OR' | NAND='NAND' | NOR='NOR' | AVG='AVG' | SUM='SUM' | MAX='MAX' | MIN='MIN' | COUNT='COUNT'
+	EQUAL='EQUAL' | AND='AND' | OR='OR' | NAND='NAND' | NOR='NOR' | AVG='AVG' | SUM='SUM' | MAX='MAX' | MIN='MIN' | COUNT='COUNT'
 ;
 
 ModelNormalItem :

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -200,11 +200,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
             GenericItem baseItem = createItemOfType(baseItemType, modelGroupItem.getName());
             if (baseItem != null) {
                 ModelGroupFunction function = modelGroupItem.getFunction();
-                if ("NONE".equals(function.getName())) {
-                    item = new GroupItem(modelGroupItem.getName(), baseItem);
-                } else {
-                    item = applyGroupFunction(baseItem, modelGroupItem, function);
-                }
+                item = applyGroupFunction(baseItem, modelGroupItem, function);
             } else {
                 item = new GroupItem(modelGroupItem.getName());
             }

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -199,6 +199,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
             String baseItemType = modelGroupItem.getType();
             GenericItem baseItem = createItemOfType(baseItemType, modelGroupItem.getName());
             if (baseItem != null) {
+                // if the user did not specify a function the first value of the enum in xtext (EQUAL) will be used
                 ModelGroupFunction function = modelGroupItem.getFunction();
                 item = applyGroupFunction(baseItem, modelGroupItem, function);
             } else {


### PR DESCRIPTION
A plain group without type does NOT have a function now.
A group with a type uses the EQUALITY function by default
A group with type and function uses the specified function

Fixes #3051

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>