### PR TITLE
use a different jetty port for test execution

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/org.eclipse.smarthome.binding.wemo.tests.launch
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/org.eclipse.smarthome.binding.wemo.tests.launch
@@ -31,7 +31,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.binding.wemo.test"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dlogback.configurationFile=logback_debug.xml -Djetty.home.bundle=org.eclipse.jetty.osgi.boot"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Djetty.port=9090 -Dlogback.configurationFile=logback_debug.xml -Djetty.home.bundle=org.eclipse.jetty.osgi.boot"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.equinox.p2.director.app.product"/>
 <booleanAttribute key="run_in_ui_thread" value="true"/>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/pom.xml
@@ -154,7 +154,7 @@
 					<!--This property should specify the symbolic name of a bundle which contains a directory called jettyhome/. The` jettyhome/` 
 						directory should have a subdirectory called etc/ that contains the xml files to be applied to Jetty on startup. The jetty-osgi-boot.jar 
 						contains a` jettyhome/` directory with a default set of xml configuration files. -->
-					<argLine>-Djetty.home.bundle=org.eclipse.jetty.osgi.boot</argLine>
+					<argLine>-Djetty.port=9090 -Djetty.home.bundle=org.eclipse.jetty.osgi.boot</argLine>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/internal/http/test/WemoHttpCallOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/internal/http/test/WemoHttpCallOSGiTest.groovy
@@ -28,9 +28,9 @@ import org.osgi.service.http.HttpService
  *
  * @author Svilen Valkanov - Initial contribution
  */
-class WemoHttpCallOSGiTest extends OSGiTest{
-    
-    def ORG_OSGI_SERVICE_HTTP_PORT = 8080
+class WemoHttpCallOSGiTest extends OSGiTest {
+
+    def ORG_OSGI_SERVICE_HTTP_PORT = 9090
     def DESTINATION_URL = "http://127.0.0.1:${ORG_OSGI_SERVICE_HTTP_PORT}"
     def SERVLET_URL = "/test"
     def servlet = null
@@ -91,7 +91,7 @@ class WemoHttpCallOSGiTest extends OSGiTest{
             contentType = req.getContentType()
             soapHeader = req.getHeader("SOAPACTION")
             content = req.getInputStream().getText()
-            
+
             resp.setContentType(contentType)
         }
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoOSGiTest.groovy
@@ -10,6 +10,7 @@ package org.eclipse.smarthome.binding.wemo.test
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
+import groovy.xml.Namespace
 
 import javax.servlet.http.HttpServlet
 import javax.servlet.http.HttpServletRequest
@@ -57,19 +58,17 @@ import org.osgi.service.http.HttpService
 
 import com.google.common.collect.ImmutableSet
 
-import groovy.xml.Namespace
-
 /**
  * Generic test class for all Wemo related tests that contains methods and constants used across the different test classes
  *
  * @author Svilen Valkanov - Initial contribution
  */
-public abstract class GenericWemoOSGiTest extends OSGiTest{
+public abstract class GenericWemoOSGiTest extends OSGiTest {
 
     static final def DEVICE_MANUFACTURER = "Belkin"
 
     //This port is included in the run configuration
-    def ORG_OSGI_SERVICE_HTTP_PORT = 8080
+    def ORG_OSGI_SERVICE_HTTP_PORT = 9090
 
     //Thing information
     def TEST_THING_ID = "TestThing"


### PR DESCRIPTION
Hoping to fix failing tests on Hudson through this.
Same change as has been done for https://github.com/eclipse/smarthome/pull/3264.

Signed-off-by: Kai Kreuzer <kai@openhab.org>