### PR TITLE
fix AbstractWatchServiceTest for macOS - again

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/WatchQueueReader.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/WatchQueueReader.java
@@ -264,13 +264,6 @@ public class WatchQueueReader implements Runnable {
                 return null;
             }
 
-            // the resolved 'path' is the pure directory name while resolvedContextPath may be
-            // baseWatchedDir/registeredPath
-            // on systems like macOS
-            if (baseWatchedDir.resolve(path).toFile().isDirectory()) {
-                return path;
-            }
-
             return resolvedContextPath;
         }
 


### PR DESCRIPTION
WatchQueueReader was "fixed" due to incorrect tests. This roles back the change and fixes the test.

Signed-off-by: Henning Treu <henning.treu@telekom.de>