### PR TITLE
add missing uglify for concatenated content

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -151,6 +151,7 @@ gulp.task('concat', function () {
                 path.basename += '.min';
                 return path;
             }))
+            .pipe(uglify())
             .pipe(gulp.dest('./web/js'));
     });
 });


### PR DESCRIPTION
Related to: https://github.com/eclipse/smarthome/issues/3318#issuecomment-297478687

@cdjackson Do you like to have a look at?