### PR TITLE
Fix unglify angular code for PaperUI

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -151,7 +151,7 @@ gulp.task('concat', function () {
                 path.basename += '.min';
                 return path;
             }))
-            .pipe(uglify())
+            .pipe(uglify({mangle: false}))
             .pipe(gulp.dest('./web/js'));
     });
 });


### PR DESCRIPTION
do not uglify names in angular code to leave DI intact

Signed-off-by: Henning Treu <henning.treu@telekom.de>