### PR TITLE
cleanup for scripting rule support

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/.classpath
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,0 @@
-eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
-org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
-org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/shared/RuleSupportRuleRegistryDelegate.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/shared/RuleSupportRuleRegistryDelegate.java
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.automation.module.script.rulesupport.shared;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Map;
 
 import org.eclipse.smarthome.automation.Rule;
 import org.eclipse.smarthome.automation.RuleRegistry;
@@ -137,8 +138,8 @@ public class RuleSupportRuleRegistryDelegate implements RuleRegistry {
     }
 
     @Override
-    public void runNow(String ruleUID, boolean considerConditions) {
-        ruleRegistry.runNow(ruleUID, considerConditions);
+    public void runNow(String ruleUID, boolean considerConditions, Map<String, Object> context) {
+        ruleRegistry.runNow(ruleUID, considerConditions, context);
     }
 
 }

--- a/bundles/automation/org.eclipse.smarthome.automation.provider.file/src/main/java/org/eclipse/smarthome/automation/internal/provider/file/AbstractFileProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.provider.file/src/main/java/org/eclipse/smarthome/automation/internal/provider/file/AbstractFileProvider.java
@@ -27,6 +27,7 @@ import org.eclipse.smarthome.automation.template.Template;
 import org.eclipse.smarthome.automation.template.TemplateProvider;
 import org.eclipse.smarthome.automation.type.ModuleType;
 import org.eclipse.smarthome.automation.type.ModuleTypeProvider;
+import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.slf4j.Logger;
@@ -79,7 +80,7 @@ public abstract class AbstractFileProvider<E> implements Provider<E> {
 
     public AbstractFileProvider(String root) {
         this.rootSubdirectory = root;
-        configurationRoots = new String[] { "automation" };
+        configurationRoots = new String[] { ConfigConstants.getConfigFolder() + File.separator + "automation" };
     }
 
     public void activate(Map<String, Object> config) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/WatchQueueReader.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/WatchQueueReader.java
@@ -15,6 +15,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.WatchEvent;
@@ -97,6 +98,8 @@ public class WatchQueueReader implements Runnable {
             } else {
                 registerDirectoryInternal(watchService, watchService.getWatchEventKinds(toWatch), toWatch);
             }
+        } catch (NoSuchFileException e) {
+            logger.debug("Not watching folder '{}' as it does not exist.", toWatch);
         } catch (IOException e) {
             logger.warn("Cannot customize folder watcher for folder '{}'", toWatch, e);
         }
@@ -132,8 +135,7 @@ public class WatchQueueReader implements Runnable {
         try {
             registrationKey = directory.register(this.watchService, kinds);
         } catch (IOException e) {
-            e.printStackTrace();
-            logger.debug("The directory '{}' was not registered in the watch service", directory, e);
+            logger.debug("The directory '{}' was not registered in the watch service: {}", directory, e.getMessage());
         }
         if (registrationKey != null) {
             registeredKeys.put(registrationKey, directory);

--- a/features/karaf/esh-core/src/main/feature/feature.xml
+++ b/features/karaf/esh-core/src/main/feature/feature.xml
@@ -115,6 +115,13 @@
     <bundle>mvn:org.eclipse.smarthome.automation/org.eclipse.smarthome.automation.module.script.defaultscope/${project.version}</bundle>
   </feature>
 
+  <feature name="esh-automation-module-script-rulesupport" version="${project.version}">
+    <feature>esh-base</feature>
+    <feature dependency="true">esh-automation-api</feature>
+    <feature dependency="true">esh-automation-module-script</feature>
+    <bundle>mvn:org.eclipse.smarthome.automation/org.eclipse.smarthome.automation.module.script.rulesupport/${project.version}</bundle>
+  </feature>
+
   <feature name="esh-automation-module-media" version="${project.version}">
     <feature>esh-base</feature>
     <feature dependency="true">esh-automation-api</feature>

--- a/features/org.eclipse.smarthome.feature.runtime.automation/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.automation/feature.xml
@@ -20,7 +20,7 @@ Automation support
    </description>
 
    <copyright>
-      Copyright (c) 2014-2016 by the respective copyright holders.
+      Copyright (c) 2014-2017 by the respective copyright holders.
    </copyright>
 
    <license url="%licenseURL">
@@ -75,6 +75,13 @@ Automation support
 
    <plugin
          id="org.eclipse.smarthome.automation.module.script.defaultscope"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.smarthome.automation.module.script.rulesupport"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
- changed project JRE to use default (1.8)
- removed project specific compiler settings
- updated RuleRegistry implementation to latest interface in order to resolve compilation errors
- changed folder watchers to use configuration dir as a root
- addressed exceptions in the log if folders do not exist
- added the bundle to p2 automation feature
- added new Karaf feature

Signed-off-by: Kai Kreuzer <kai@openhab.org>