### PR TITLE
fixed DS declarations in automation script rule support

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/OSGI-INF/RuleSupportScriptExtension.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/OSGI-INF/RuleSupportScriptExtension.xml
@@ -14,8 +14,8 @@
       <provide interface="org.eclipse.smarthome.automation.module.script.ScriptExtensionProvider"/>
    </service>
    
-   <reference bind="setRuleRegistry" cardinality="1..1" interface="org.eclipse.smarthome.automation.RuleRegistry" name="RuleRegistry" policy="static" unbind="unsetRuleRegistry"/>
-   <reference bind="setRuleProvider" cardinality="1..1" interface="org.eclipse.smarthome.automation.module.script.rulesupport.shared.ScriptedRuleProvider" name="RuleProvider" policy="static" unbind="unsetRuleRegistry"/>
+   <reference bind="setRuleRegistry" cardinality="1..1" interface="org.eclipse.smarthome.automation.RuleRegistry" name="RuleRegistry" policy="static"/>
+   <reference bind="setRuleProvider" cardinality="1..1" interface="org.eclipse.smarthome.automation.module.script.rulesupport.shared.ScriptedRuleProvider" name="RuleProvider" policy="static"/>
    <reference bind="setScriptedCustomModuleHandlerFactory" cardinality="1..1" interface="org.eclipse.smarthome.automation.module.script.rulesupport.internal.ScriptedCustomModuleHandlerFactory" name="ScriptedCustomModuleHandlerFactory" policy="static"/>
    <reference bind="setScriptedCustomModuleTypeProvider" cardinality="1..1" interface="org.eclipse.smarthome.automation.module.script.rulesupport.internal.ScriptedCustomModuleTypeProvider" name="ScriptedCustomModuleTypeProvider" policy="static"/>
    <reference bind="setScriptedPrivateModuleHandlerFactory" cardinality="1..1" interface="org.eclipse.smarthome.automation.module.script.rulesupport.internal.ScriptedPrivateModuleHandlerFactory" name="ScriptedPrivateModuleHandlerFactory" policy="static"/>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/OSGI-INF/ScriptFileProvider.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/OSGI-INF/ScriptFileProvider.xml
@@ -11,5 +11,5 @@
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.automation.module.script.rulesupport.internal.loader.ScriptFileWatcher">
    <implementation class="org.eclipse.smarthome.automation.module.script.rulesupport.internal.loader.ScriptFileWatcher"/>
    <reference bind="setScriptEngineManager" cardinality="1..1" interface="org.eclipse.smarthome.automation.module.script.ScriptEngineManager" name="ScriptEngineManager"
-   policy="dynamic" />
+   policy="static"/>
 </scr:component>


### PR DESCRIPTION
* removed the "unbind" declarations as these methods don't exist (and as they're static dependencies they actually are not really required)
* made the ScriptFileProvider's dependency to the ScriptEngineManager static as this component does not make sense without it and it was not prepared to handle the dynamics anyway.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>