### PR TITLE
fix scope in automation script rule support

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
@@ -9,7 +9,6 @@ package org.eclipse.smarthome.automation.module.script.rulesupport.internal;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -117,7 +116,7 @@ public class RuleSupportScriptExtension implements ScriptExtensionProvider {
 
     @Override
     public Collection<String> getDefaultPresets() {
-        return Collections.emptyList();
+        return presets.keySet();
     }
 
     @Override


### PR DESCRIPTION
I observed that the scope has been empty in JS rules without this change. However, as there is no documentation so far, I'm not 100% sure whether I really got the idea right. 
Therefore, @smerschjohann, it would be good if you could have a quick look at this too...?

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>