### PR TITLE
Add kickstart instructions for Paper UI contributors

### DIFF
--- a/docs/documentation/development/notes.md
+++ b/docs/documentation/development/notes.md
@@ -28,15 +28,15 @@ PaperUI development (JS/HTML)
 The initial setup of PaperUI can be done in two ways:
 
 1. By running the maven build.
-2. Running an 'npm install' followed by 'gulp' build.
+2. Running an `npm install` followed by `npm run build`.
 
 The JS/HTML files of PaperUI are packaged using the 'Gulp' plugin. There are two important gulp tasks needed for development. For normal development you need to run the following command on console:
 
-    gulp serve --development
+    npm start
 
 This will automatically inject all the needed files to index.html and will launch a browsersync instance running on http://localhost:3000/ (default). The calls to rest end-point are also proxied by this gulp task. After running this, any changes made into the files of folder 'web-src' will be available in the browser after refreshing the page.
 The distribution version of PaperUI can be seen using the command:
 
-    gulp default
+    npm run build
 
 This will minify the files and copy all the sources to 'web' folder. The changes can be seen at 'http://localhost:8080/' (default port for smarthome web server).

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
@@ -2,6 +2,11 @@
   "name": "org.eclipse.smarthome.ui.paperui",
   "version": "0.9.0",
   "private": true,
+  "scripts": {
+    "start": "gulp serve --development",
+    "build": "gulp default",
+    "test": "gulp test"
+  },
   "dependencies": {
     "angular": "1.4.8",
     "angular-animate": "1.4.8",

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
@@ -59,10 +59,10 @@
           <execution>
             <id>gulp build</id>
             <goals>
-              <goal>gulp</goal>
+              <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>default</arguments>
+              <arguments>run build</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
Allow first-time frontend contributors to get started quickly by
leveraging `npm` for the frontend build, thus avoiding a global `gulp`
installation.

Also adds a missing peer dependency to support npm >= 3.
