### PR TITLE
Add LIFX signalstrength channel, improve online/offline detection and exception handling

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/colorirlight.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/colorirlight.xml
@@ -9,6 +9,7 @@
             <channel id="color" typeId="color" />
             <channel id="temperature" typeId="temperature" />
             <channel id="infrared" typeId="infrared" />
+            <channel id="signalstrength" typeId="system.signal-strength" />
         </channels>
         <config-description-ref uri="thing-type:lifx:light" />
     </thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/colorlight.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/colorlight.xml
@@ -8,6 +8,7 @@
         <channels>
             <channel id="color" typeId="color" />
             <channel id="temperature" typeId="temperature" />
+            <channel id="signalstrength" typeId="system.signal-strength" />
         </channels>
         <config-description-ref uri="thing-type:lifx:light" />
     </thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/colormzlight.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/colormzlight.xml
@@ -8,6 +8,7 @@
         <channels>
             <channel id="color" typeId="color" />
             <channel id="temperature" typeId="temperature" />
+            <channel id="signalstrength" typeId="system.signal-strength" />
         </channels>
         <config-description-ref uri="thing-type:lifx:light" />
     </thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/whitelight.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/thing/whitelight.xml
@@ -8,6 +8,7 @@
         <channels>
             <channel id="brightness" typeId="brightness" />
             <channel id="temperature" typeId="temperature" />
+            <channel id="signalstrength" typeId="system.signal-strength" />
         </channels>
         <config-description-ref uri="thing-type:lifx:light" />
     </thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
@@ -64,6 +64,7 @@ All devices support some of the following channels:
 | color           | Color     | This channel supports full color control with hue, saturation and brightness values. | colorlight, colorirlight, colormzlight |
 | colorzone       | Color     | This channel supports full zone color control with hue, saturation and brightness values. | colormzlight |
 | infrared        | Dimmer    | This channel supports adjusting the infrared value. *Note:* IR capable lights only activate their infrared LEDs when the brightness drops below a certain level. | colorirlight |
+| signalstrength  | Number    | This channel represents signal strength with values 0, 1, 2, 3 or 4; 0 being worst strength and 4 being best strength. | colorlight, colorirlight, colormzlight, whitelight |
 | temperature     | Dimmer    | This channel supports adjusting the color temperature from cold (0%) to warm (100%). | colorlight, colorirlight, colormzlight, whitelight |
 | temperaturezone | Dimmer    | This channel supports adjusting the zone color temperature from cold (0%) to warm (100%). |  colormzlight |
 
@@ -126,6 +127,7 @@ Dimmer Living2_Temperature { channel="lifx:colorlight:living2:temperature" }
 Color Porch_Color { channel="lifx:colorirlight:porch:color" }
 Dimmer Porch_Infrared { channel="lifx:colorirlight:porch:infrared" }
 Dimmer Porch_Temperature { channel="lifx:colorirlight:porch:temperature" }
+Number Porch_Signal_Strength { channel="lifx:colorirlight:porch:signalstrength" }
 
 // Ceiling
 Color Ceiling_Color { channel="lifx:colormzlight:ceiling:color" }
@@ -166,6 +168,7 @@ sitemap demo label="Main Menu"
         Colorpicker item=Porch_Color
         Slider item=Porch_Temperature
         Slider item=Porch_Infrared
+        Text item=Porch_Signal_Strength
     }
 
     Frame label="Ceiling" {

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
@@ -47,6 +47,7 @@ public class LifxBindingConstants {
     public static final String CHANNEL_COLOR = "color";
     public static final String CHANNEL_COLOR_ZONE = "colorzone";
     public static final String CHANNEL_INFRARED = "infrared";
+    public static final String CHANNEL_SIGNAL_STRENGTH = "signalstrength";
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_TEMPERATURE_ZONE = "temperaturezone";
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
@@ -258,12 +258,9 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
 
     private void broadcastPacket(Packet packet, SelectionKey broadcastKey) {
         for (InetSocketAddress address : broadcastAddresses) {
-            boolean result = false;
-            while (!result) {
-                LifxNetworkThrottler.lock();
-                result = sendPacket(packet, address, broadcastKey);
-                LifxNetworkThrottler.unlock();
-            }
+            LifxNetworkThrottler.lock();
+            sendPacket(packet, address, broadcastKey);
+            LifxNetworkThrottler.unlock();
         }
     }
 
@@ -283,49 +280,35 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
         boolean result = false;
 
         try {
-            boolean sent = false;
-
-            while (!sent) {
-                try {
-                    selector.selectNow();
-                } catch (IOException e) {
-                    logger.error("An exception occurred while selecting: {}", e.getMessage());
-                }
-
+            while (!result) {
+                selector.selectNow();
                 Set<SelectionKey> selectedKeys = selector.selectedKeys();
-
                 Iterator<SelectionKey> keyIterator = selectedKeys.iterator();
 
-                while (keyIterator.hasNext()) {
+                while (!result && keyIterator.hasNext()) {
                     SelectionKey key = keyIterator.next();
 
                     if (key.isValid() && key.isWritable() && key.equals(selectedKey)) {
                         SelectableChannel channel = key.channel();
-                        try {
-                            if (channel instanceof DatagramChannel) {
-                                logger.trace(
-                                        "Discovery : Sending packet type '{}' from '{}' to '{}' for '{}' with sequence '{}' and source '{}'",
-                                        new Object[] { packet.getClass().getSimpleName(),
-                                                ((InetSocketAddress) ((DatagramChannel) channel).getLocalAddress())
-                                                        .toString(),
-                                                address.toString(), packet.getTarget().getHex(), packet.getSequence(),
-                                                Long.toString(packet.getSource(), 16) });
-                                ((DatagramChannel) channel).send(packet.bytes(), address);
-
-                                sent = true;
-                                result = true;
-                            } else if (channel instanceof SocketChannel) {
-                                ((SocketChannel) channel).write(packet.bytes());
-                            }
-                        } catch (Exception e) {
-                            logger.error("An exception occurred while writing data : '{}'", e.getMessage());
+                        if (channel instanceof DatagramChannel) {
+                            logger.trace(
+                                    "Discovery : Sending packet type '{}' from '{}' to '{}' for '{}' with sequence '{}' and source '{}'",
+                                    new Object[] { packet.getClass().getSimpleName(),
+                                            ((InetSocketAddress) ((DatagramChannel) channel).getLocalAddress())
+                                                    .toString(),
+                                            address.toString(), packet.getTarget().getHex(), packet.getSequence(),
+                                            Long.toString(packet.getSource(), 16) });
+                            ((DatagramChannel) channel).send(packet.bytes(), address);
+                            result = true;
+                        } else if (channel instanceof SocketChannel) {
+                            ((SocketChannel) channel).write(packet.bytes());
+                            result = true;
                         }
                     }
                 }
             }
-
         } catch (Exception e) {
-            logger.error("An exception occurred while communicating with the light : '{}'", e.getMessage());
+            logger.debug("An exception occurred while sending a packet to the light : '{}'", e.getMessage());
         }
 
         return result;
@@ -432,7 +415,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
                 }
                 isScanning = false;
             } catch (Exception e) {
-                logger.error("An exception occurred while communicating with the light : '{}'", e.getMessage(), e);
+                logger.debug("An exception occurred while communicating with the light : '{}'", e.getMessage(), e);
             }
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.eclipse.smarthome.binding.lifx.internal.fields.HSBK;
 import org.eclipse.smarthome.binding.lifx.internal.listener.LifxLightStateListener;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.PowerState;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.SignalStrength;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -30,6 +31,7 @@ public class LifxLightState {
     private PowerState powerState;
     private HSBK[] colors;
     private PercentType infrared;
+    private SignalStrength signalStrength;
 
     private long lastChange;
 
@@ -39,6 +41,7 @@ public class LifxLightState {
         this.powerState = other.getPowerState();
         this.colors = other.getColors();
         this.infrared = other.getInfrared();
+        this.signalStrength = other.getSignalStrength();
     }
 
     public PowerState getPowerState() {
@@ -82,6 +85,10 @@ public class LifxLightState {
 
     public PercentType getInfrared() {
         return infrared;
+    }
+
+    public SignalStrength getSignalStrength() {
+        return signalStrength;
     }
 
     public void setColor(HSBType newHSB) {
@@ -164,6 +171,15 @@ public class LifxLightState {
         updateLastChange();
         for (LifxLightStateListener listener : listeners) {
             listener.handleInfraredChange(oldInfrared, newInfrared);
+        }
+    }
+
+    public void setSignalStrength(SignalStrength newSignalStrength) {
+        SignalStrength oldSignalStrength = this.signalStrength;
+        this.signalStrength = newSignalStrength;
+        updateLastChange();
+        for (LifxLightStateListener listener : listeners) {
+            listener.handleSignalStrengthChange(oldSignalStrength, newSignalStrength);
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightStateChanger.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightStateChanger.java
@@ -39,6 +39,7 @@ import org.eclipse.smarthome.binding.lifx.internal.protocol.SetColorZonesRequest
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SetLightInfraredRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SetLightPowerRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SetPowerRequest;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.SignalStrength;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.slf4j.Logger;
@@ -308,6 +309,11 @@ public class LifxLightStateChanger implements LifxLightStateListener, LifxRespon
         int infrared = percentTypeToInfrared(pendingLightState.getInfrared());
         SetLightInfraredRequest packet = new SetLightInfraredRequest(infrared);
         replacePacketsInMap(packet);
+    }
+
+    @Override
+    public void handleSignalStrengthChange(SignalStrength oldSignalStrength, SignalStrength newSignalStrength) {
+        // Nothing to handle
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/listener/LifxLightStateListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/listener/LifxLightStateListener.java
@@ -10,6 +10,7 @@ package org.eclipse.smarthome.binding.lifx.internal.listener;
 import org.eclipse.smarthome.binding.lifx.internal.LifxLightState;
 import org.eclipse.smarthome.binding.lifx.internal.fields.HSBK;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.PowerState;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.SignalStrength;
 import org.eclipse.smarthome.core.library.types.PercentType;
 
 /**
@@ -42,4 +43,12 @@ public interface LifxLightStateListener {
      * @param newInfrared the new infrared value
      */
     void handleInfraredChange(PercentType oldInfrared, PercentType newInfrared);
+
+    /**
+     * Called when the signal strength property changes.
+     *
+     * @param oldSignalStrength the old signal strength value
+     * @param newSignalStrength the new signal strength value
+     */
+    void handleSignalStrengthChange(SignalStrength oldSignalStrength, SignalStrength newSignalStrength);
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetHostInfoRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GetHostInfoRequest.java
@@ -15,7 +15,7 @@ import java.nio.ByteBuffer;
  */
 public class GetHostInfoRequest extends Packet {
 
-    public static final int TYPE = 0x0D;
+    public static final int TYPE = 0x0C;
 
     public GetHostInfoRequest() {
         setTagged(false);

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SignalStrength.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SignalStrength.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.lifx.internal.protocol;
+
+/**
+ * The signal strength of a light.
+ *
+ * @author Wouter Born - Add signal strength channel
+ */
+public class SignalStrength {
+
+    private double milliWatts;
+
+    public SignalStrength(double milliWatts) {
+        this.milliWatts = milliWatts;
+    }
+
+    /**
+     * Returns the signal strength.
+     *
+     * @return the signal strength in milliwatts (mW).
+     */
+    public double getMilliWatts() {
+        return milliWatts;
+    }
+
+    /**
+     * Returns the signal strength as a quality percentage:
+     * <ul>
+     * <li>RSSI <= -100: returns 0
+     * <li>-100 < RSSI < -50: returns a value between 0 and 1 (linearly distributed)
+     * <li>RSSI >= -50: returns 1
+     * <ul>
+     *
+     * @return a value between 0 and 1. 0 being worst strength and 1
+     *         being best strength.
+     */
+    public double toQualityPercentage() {
+        return Math.min(100, Math.max(0, 2 * (toRSSI() + 100))) / 100;
+    }
+
+    /**
+     * Returns the signal strength as a quality rating.
+     *
+     * @return one of the values: 0, 1, 2, 3 or 4. 0 being worst strength and 4
+     *         being best strength.
+     */
+    public byte toQualityRating() {
+        return (byte) Math.round(toQualityPercentage() * 4);
+    }
+
+    /**
+     * Returns the received signal strength indicator (RSSI).
+     *
+     * @return a value <= 0. 0 being best strength and more negative values indicate worser strength.
+     */
+    public double toRSSI() {
+        return 10 * Math.log10(milliWatts);
+    }
+
+    @Override
+    public String toString() {
+        return "SignalStrength [milliWatts=" + milliWatts + ", rssi=" + Math.round(toRSSI()) + "]";
+    }
+
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateHostInfoResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateHostInfoResponse.java
@@ -20,7 +20,7 @@ import org.eclipse.smarthome.binding.lifx.internal.fields.UInt32Field;
  */
 public class StateHostInfoResponse extends Packet {
 
-    public static final int TYPE = 0x0C;
+    public static final int TYPE = 0x0D;
 
     public static final Field<Float> FIELD_SIGNAL = new FloatField().little();
     public static final Field<Long> FIELD_TX = new UInt32Field().little();
@@ -31,28 +31,16 @@ public class StateHostInfoResponse extends Packet {
     private long tx;
     private long rx;
 
-    public float getSignal() {
-        return signal;
-    }
-
-    public void setSignal(float signal) {
-        this.signal = signal;
+    public SignalStrength getSignalStrength() {
+        return new SignalStrength(signal);
     }
 
     public long getTx() {
         return tx;
     }
 
-    public void setTx(long tx) {
-        this.tx = tx;
-    }
-
     public long getRx() {
         return rx;
-    }
-
-    public void setRx(long rx) {
-        this.rx = rx;
     }
 
     public StateHostInfoResponse() {

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateWifiInfoResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateWifiInfoResponse.java
@@ -32,8 +32,8 @@ public class StateWifiInfoResponse extends Packet {
     private long tx;
     private int mcuTemperature;
 
-    public float getSignal() {
-        return signal;
+    public SignalStrength getSignalStrength() {
+        return new SignalStrength(signal);
     }
 
     public long getRx() {


### PR DESCRIPTION
This PR adds a new `signalstrength` channel to all LIFX light Things. The channel contains the received signal strength at a LIFX light. It reuses the `system.signal-strength` typeId and is based on the `signal` value in the [StateWifiInfo](https://lan.developer.lifx.com/docs/device-messages#section-statewifiinfo-17) packet. The binding will only poll for this information when the `signalstrength` channel is linked to an item.

The lights can also send a [StateHostInfo](https://lan.developer.lifx.com/docs/device-messages#section-statehostinfo-13) packet but for some reason it always has a `signal` value of 0. The binding had mixed up the TYPE values in `GetHostInfoRequest` and `StateHostInfoResponse` so I've corrected that.

Furthermore the light online/offline detection has been improved. The `LifxLightOnlineStateUpdater` now piggybacks on all received packets. It assumes the light is online for as long as some packets are received (due to light state polling). It starts its own polling when no packets have been received for a while. This makes online/offline detection more stable while reducing network traffic at the same time.

Finally the exception handling has been improved for #3376. The binding no longer endlessly loops when packets are sent and exceptions occur. Instead is now sets the light offline and checks once every 15 seconds if a connection to the light can be made. The binding now logs such exceptions using debug level.
