### PR TITLE
Returning only copies of rules - fixes returning actual rules.

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleRegistryImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleRegistryImpl.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import java.util.stream.Stream;
+
 import org.eclipse.smarthome.automation.Rule;
 import org.eclipse.smarthome.automation.RuleProvider;
 import org.eclipse.smarthome.automation.RuleRegistry;
@@ -80,6 +82,7 @@ import org.slf4j.LoggerFactory;
  * @author Ana Dimova - Persistence implementation & updating rules from providers
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation and other fixes
  * @author Benedikt Niehues - added events for rules
+ * @author Victor Toni - return only copies of {@link Rule}s
  */
 public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvider>
         implements RuleRegistry, StatusInfoCallback, RegistryChangeListener<RuleTemplate> {
@@ -372,6 +375,12 @@ public class RuleRegistryImpl extends AbstractRegistry<Rule, String, RuleProvide
             }
         }
         return null;
+    }
+
+    @Override
+    public Stream<Rule> stream() {
+        // create copies for consumers
+        return super.stream().map( r -> RuleUtils.getRuleCopy(r) );
     }
 
     @Override


### PR DESCRIPTION
The RuleRegistryImpl is different to other registries insofar as it returns
copies of its elements instead of the actual elements.
Therefor the default streams() implementation had to be overriden for RuleRegistryImpl.

Signed-off-by: Victor Toni <victor.toni@gmail.com>