### PR TITLE
use toFullString when creating GroupItemStateChangeEvent

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/events/ItemEventFactoryTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/events/ItemEventFactoryTest.groovy
@@ -16,9 +16,10 @@ import org.eclipse.smarthome.core.items.GroupItem
 import org.eclipse.smarthome.core.items.dto.ItemDTOMapper
 import org.eclipse.smarthome.core.items.events.ItemEventFactory.ItemEventPayloadBean
 import org.eclipse.smarthome.core.items.events.ItemEventFactory.ItemStateChangedEventPayloadBean
-import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.library.CoreItemFactory
 import org.eclipse.smarthome.core.library.items.SwitchItem
 import org.eclipse.smarthome.core.library.types.OnOffType
+import org.eclipse.smarthome.core.library.types.RawType
 import org.eclipse.smarthome.core.types.RefreshType
 import org.eclipse.smarthome.core.types.UnDefType
 import org.eclipse.smarthome.test.OSGiTest
@@ -60,6 +61,11 @@ class ItemEventFactoryTest extends OSGiTest {
     def ITEM_STATE_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(ITEM_STATE.getClass().getSimpleName(), ITEM_STATE.toString()))
     def ITEM_ADDED_EVENT_PAYLOAD = new Gson().toJson(ItemDTOMapper.map(ITEM))
     def ITEM_STATE_CHANGED_EVENT_PAYLOAD = new Gson().toJson(new ItemStateChangedEventPayloadBean(NEW_ITEM_STATE.getClass().getSimpleName(),NEW_ITEM_STATE.toString(),ITEM_STATE.getClass().getSimpleName(),ITEM_STATE.toString()))
+
+    def RAW_ITEM_STATE = new RawType(([1, 2, 3, 4, 5]as byte[]), RawType.DEFAULT_MIME_TYPE)
+    def NEW_RAW_ITEM_STATE = new RawType(([5, 4, 3, 2, 1]as byte[]), RawType.DEFAULT_MIME_TYPE)
+
+
 
     @Test
     void 'ItemEventFactory creates Event as ItemCommandEvent OnOffType correctly'() {
@@ -186,5 +192,25 @@ class ItemEventFactoryTest extends OSGiTest {
         assertThat event.getItem(), not(null)
         assertThat event.getItem().name, is(ITEM_NAME)
         assertThat event.getItem().type, is(CoreItemFactory.SWITCH)
+    }
+
+    @Test
+    void 'ItemEventFactory creates GroupItemStateChangedEvent with RawTypes correctly'() {
+        def giEvent_source = ItemEventFactory.createGroupStateChangedEvent(GROUP_NAME, ITEM_NAME, NEW_RAW_ITEM_STATE, RAW_ITEM_STATE) as GroupItemStateChangedEvent
+
+        def giEvent_parsed = factory.createEvent(giEvent_source.getType(), giEvent_source.getTopic(), giEvent_source.getPayload(), giEvent_source.getSource())
+
+
+        assertThat giEvent_parsed, is(instanceOf(GroupItemStateChangedEvent))
+        GroupItemStateChangedEvent groupItemStateChangedEvent = giEvent_parsed as GroupItemStateChangedEvent
+
+        assertThat groupItemStateChangedEvent.getType(), is(GROUPITEM_CHANGED_EVENT_TYPE)
+        assertThat groupItemStateChangedEvent.getTopic(), is(GROUPITEM_STATE_CHANGED_EVENT_TOPIC)
+        assertThat groupItemStateChangedEvent.getPayload(), is(giEvent_source.getPayload())
+        assertThat groupItemStateChangedEvent.getItemName(), is(GROUP_NAME)
+        assertThat groupItemStateChangedEvent.getMemberName(), is(ITEM_NAME)
+        assertThat groupItemStateChangedEvent.getSource(), is(null)
+        assertThat groupItemStateChangedEvent.getItemState(), is(NEW_RAW_ITEM_STATE)
+        assertThat groupItemStateChangedEvent.getOldItemState(), is(RAW_ITEM_STATE)
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -264,8 +264,8 @@ public class ItemEventFactory extends AbstractEventFactory {
         assertValidArguments(itemName, memberName, newState, "state");
         String topic = buildGroupTopic(GROUPITEM_STATE_CHANGED_EVENT_TOPIC, itemName, memberName);
         ItemStateChangedEventPayloadBean bean = new ItemStateChangedEventPayloadBean(
-                newState.getClass().getSimpleName(), newState.toString(), oldState.getClass().getSimpleName(),
-                oldState.toString());
+                newState.getClass().getSimpleName(), newState.toFullString(), oldState.getClass().getSimpleName(),
+                oldState.toFullString());
         String payload = serializePayload(bean);
         return new GroupItemStateChangedEvent(topic, payload, itemName, memberName, newState, oldState);
     }


### PR DESCRIPTION
fix for #3408
Signed-off-by: Benedikt Niehues <benedikt.niehues@itemis.de>