### PR TITLE
Fixes #3390 by using little-endian byte ordering for LIFX IR brightness values

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightInfraredRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightInfraredRequest.java
@@ -19,7 +19,7 @@ public class SetLightInfraredRequest extends Packet {
 
     public static final int TYPE = 0x7A;
 
-    public static final Field<Integer> FIELD_STATE = new UInt16Field();
+    public static final Field<Integer> FIELD_STATE = new UInt16Field().little();
 
     private int infrared;
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateLightInfraredResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateLightInfraredResponse.java
@@ -19,7 +19,7 @@ public class StateLightInfraredResponse extends Packet {
 
     public static final int TYPE = 0x79;
 
-    public static final Field<Integer> FIELD_STATE = new UInt16Field();
+    public static final Field<Integer> FIELD_STATE = new UInt16Field().little();
 
     private int infrared;
 


### PR DESCRIPTION
This PR fixes #3390 by using little-endian byte ordering for LIFX IR brightness values.