### PR TITLE
Fixes #3389 by setting saturation to 0% when LIFX color temperature channel changes

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
@@ -472,11 +472,17 @@ public class LifxLightHandler extends BaseThingHandler {
     }
 
     private void handleTemperatureCommand(PercentType temperature) {
-        getLightStateForCommand().setTemperature(temperature);
+        HSBK newColor = getLightStateForCommand().getNullSafeColor();
+        newColor.setSaturation(PercentType.ZERO);
+        newColor.setTemperature(temperature);
+        getLightStateForCommand().setColor(newColor);
     }
 
     private void handleTemperatureCommand(PercentType temperature, int zoneIndex) {
-        getLightStateForCommand().setTemperature(temperature, zoneIndex);
+        HSBK newColor = getLightStateForCommand().getNullSafeColor(zoneIndex);
+        newColor.setSaturation(PercentType.ZERO);
+        newColor.setTemperature(temperature);
+        getLightStateForCommand().setColor(newColor, zoneIndex);
     }
 
     private void handleHSBCommand(HSBType hsb) {


### PR DESCRIPTION
I've done some testing and it still works well to do a full HSBK value update in rules by first changing the temperature channel state and then immediately change the color channel state.