### PR TITLE
Made linked items list responsive

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -171,10 +171,10 @@
 										</button>
 									</h3>
 									<div ng-repeat="item in channel.items | orderBy" class="row cursor-pointer " ng-class="{'borderhidden':$last}" ng-click="navigateTo('item/edit/' + item.name)">
-										<div class="col-xs-1">
+										<div class="col-lg-1 col-md-2 col-xs-3">
 											<span class="circle">{{item.label.substring(0,1).toUpperCase()}}</span>
 										</div>
-										<div class="col-xs-9 name">
+										<div class="col-lg-9 col-md-8 col-xs-7 name">
 											{{item.label}} <small><span>({{item.name}})</span></small>
 										</div>
 										<div class="col-xs-2 action">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.html
@@ -171,10 +171,10 @@
 										</button>
 									</h3>
 									<div ng-repeat="item in channel.items | orderBy" class="row cursor-pointer " ng-class="{'borderhidden':$last}" ng-click="navigateTo('item/edit/' + item.name)">
-										<div class="col-lg-1 col-md-2 col-xs-3">
+										<div class="col-lg-1 col-sm-2 col-xs-3">
 											<span class="circle">{{item.label.substring(0,1).toUpperCase()}}</span>
 										</div>
-										<div class="col-lg-9 col-md-8 col-xs-7 name">
+										<div class="col-lg-9 col-sm-8 col-xs-7 name">
 											{{item.label}} <small><span>({{item.name}})</span></small>
 										</div>
 										<div class="col-xs-2 action">


### PR DESCRIPTION
Label of linked items overlaps with the icon on small screens.

Before:
<img width="635" alt="screen shot 2017-05-11 at 09 25 53" src="https://cloud.githubusercontent.com/assets/5161937/25947408/9c3a9354-364f-11e7-82ed-a6b997fca6bf.png">

After:
<img width="625" alt="screen shot 2017-05-11 at 13 40 32" src="https://cloud.githubusercontent.com/assets/5161937/25947422/a4d1341e-364f-11e7-81d4-b3b508c81789.png">



Signed-off-by: Aoun Bukhari <bukhari@itemis.de>