### PR TITLE
Write jsondb backup without renaming original file.

### DIFF
--- a/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/JsonStorage.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/JsonStorage.java
@@ -73,8 +73,8 @@ public class JsonStorage<T> implements Storage<T> {
         this.writeDelay = writeDelay;
         this.maxDeferredPeriod = maxDeferredPeriod;
 
-        this.mapper = new GsonBuilder().registerTypeAdapter(Map.class, new StringObjectMapDeserializer()).setPrettyPrinting()
-                .create();
+        this.mapper = new GsonBuilder().registerTypeAdapter(Map.class, new StringObjectMapDeserializer())
+                .setPrettyPrinting().create();
 
         commitTimer = new Timer();
 
@@ -261,18 +261,28 @@ public class JsonStorage<T> implements Storage<T> {
     }
 
     /**
-     * Write out any outstanding data
+     * Write out any outstanding data.
+     * <p>
+     * This creates the backup copy at the same time as writing the database file. This avoids
+     * having to either rename the file later (which may leave a small window for there to
+     * be no file if the system crashes during the write process), or to copy the file when
+     * writing the backup copy (which would require a read and write, and is thus slower).
      */
     public void commitDatabase() {
         String s = mapper.toJson(map);
 
         synchronized (map) {
-            // Rename the file for backup
-            File rename = new File(file.getParent() + File.separator + BACKUP_EXTENSION,
-                    System.currentTimeMillis() + SEPARATOR + file.getName());
-            file.renameTo(rename);
-
+            // Write the database file
             try (FileOutputStream outputStream = new FileOutputStream(file, false);) {
+                outputStream.write(s.getBytes());
+            } catch (Exception e) {
+                logger.error("Error writing JsonDB to {}. Cause {}.", file.getPath(), e.getMessage());
+            }
+
+            // And also write the backup
+            File backup = new File(file.getParent() + File.separator + BACKUP_EXTENSION,
+                    System.currentTimeMillis() + SEPARATOR + file.getName());
+            try (FileOutputStream outputStream = new FileOutputStream(backup, false);) {
                 outputStream.write(s.getBytes());
             } catch (Exception e) {
                 logger.error("Error writing JsonDB to {}. Cause {}.", file.getPath(), e.getMessage());


### PR DESCRIPTION
This changes the way the backup is written. The backup is now written at the same time as the data is stored, rather than storing a single file, and then having to rename it later. The main database file is overwritten so should not ever be removed unless the underlying filesystem is doing this (in which case there is probably nothing that can be done at Java level?).

This avoids the situation where there is no file for any period of time, and this should ensure the backup is read if the main file is corrupted due to a crash (etc).

Writing the backup at the same time as the main file avoids a (slower) read->write which would be required to copy the original file if it was done later.

This has another (arguable) advantage in that there are now two copies of the latest file, so two chances to load with the latest data.

Fixes #3433
Signed-off-by: Chris Jackson <chris@cd-jackson.com>