### PR TITLE
LIFX improvements

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Sets;
 public class LifxBindingConstants {
 
     public static final String BINDING_ID = "lifx";
-    public static final String THREADPOOL_NAME = "lifx";
 
     // The LIFX LAN Protocol Specification states that lights can process up to 20 messages per second, not more.
     public static final long PACKET_INTERVAL = 50;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCurrentStateUpdater.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCurrentStateUpdater.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.eclipse.smarthome.binding.lifx.LifxBindingConstants;
 import org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler.CurrentLightState;
 import org.eclipse.smarthome.binding.lifx.internal.fields.HSBK;
 import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
@@ -32,7 +31,6 @@ import org.eclipse.smarthome.binding.lifx.internal.protocol.StateMultiZoneRespon
 import org.eclipse.smarthome.binding.lifx.internal.protocol.StatePowerResponse;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.StateResponse;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.StateWifiInfoResponse;
-import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,14 +48,12 @@ public class LifxLightCurrentStateUpdater implements LifxResponsePacketListener 
     private final Logger logger = LoggerFactory.getLogger(LifxLightCurrentStateUpdater.class);
 
     private final String macAsHex;
+    private final ScheduledExecutorService scheduler;
     private final CurrentLightState currentLightState;
     private final LifxLightCommunicationHandler communicationHandler;
     private final Products product;
 
     private final ReentrantLock lock = new ReentrantLock();
-
-    private ScheduledExecutorService scheduler = ThreadPoolManager
-            .getScheduledPool(LifxBindingConstants.THREADPOOL_NAME);
 
     private boolean wasOnline;
     private boolean updateSignalStrength;
@@ -85,10 +81,11 @@ public class LifxLightCurrentStateUpdater implements LifxResponsePacketListener 
         }
     };
 
-    public LifxLightCurrentStateUpdater(MACAddress macAddress, CurrentLightState currentLightState,
-            LifxLightCommunicationHandler communicationHandler, Products product) {
+    public LifxLightCurrentStateUpdater(MACAddress macAddress, ScheduledExecutorService scheduler,
+            CurrentLightState currentLightState, LifxLightCommunicationHandler communicationHandler, Products product) {
         this.macAsHex = macAddress.getHex();
         this.currentLightState = currentLightState;
+        this.scheduler = scheduler;
         this.communicationHandler = communicationHandler;
         this.product = product;
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightOnlineStateUpdater.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightOnlineStateUpdater.java
@@ -15,14 +15,12 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.eclipse.smarthome.binding.lifx.LifxBindingConstants;
 import org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler.CurrentLightState;
 import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
 import org.eclipse.smarthome.binding.lifx.internal.listener.LifxResponsePacketListener;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetEchoRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.GetServiceRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.Packet;
-import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,21 +37,20 @@ public class LifxLightOnlineStateUpdater implements LifxResponsePacketListener {
     private final Logger logger = LoggerFactory.getLogger(LifxLightOnlineStateUpdater.class);
 
     private final String macAsHex;
+    private final ScheduledExecutorService scheduler;
     private final CurrentLightState currentLightState;
     private final LifxLightCommunicationHandler communicationHandler;
 
     private final ReentrantLock lock = new ReentrantLock();
 
-    private final ScheduledExecutorService scheduler = ThreadPoolManager
-            .getScheduledPool(LifxBindingConstants.THREADPOOL_NAME);
-
     private ScheduledFuture<?> echoJob;
     private LocalDateTime lastSeen = LocalDateTime.MIN;
     private int unansweredEchoPackets;
 
-    public LifxLightOnlineStateUpdater(MACAddress macAddress, CurrentLightState currentLightState,
-            LifxLightCommunicationHandler communicationHandler) {
+    public LifxLightOnlineStateUpdater(MACAddress macAddress, ScheduledExecutorService scheduler,
+            CurrentLightState currentLightState, LifxLightCommunicationHandler communicationHandler) {
         this.macAsHex = macAddress.getHex();
+        this.scheduler = scheduler;
         this.currentLightState = currentLightState;
         this.communicationHandler = communicationHandler;
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightPropertiesUpdater.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightPropertiesUpdater.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.lifx.internal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.eclipse.smarthome.binding.lifx.LifxBindingConstants;
+import org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler.CurrentLightState;
+import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
+import org.eclipse.smarthome.binding.lifx.internal.listener.LifxPropertiesUpdateListener;
+import org.eclipse.smarthome.binding.lifx.internal.listener.LifxResponsePacketListener;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.GetHostFirmwareRequest;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.GetVersionRequest;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.GetWifiFirmwareRequest;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.Packet;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.Products;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.StateHostFirmwareResponse;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.StateVersionResponse;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.StateWifiFirmwareResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+/**
+ * The {@link LifxLightPropertiesUpdater} updates the light properties when a light goes online. When packets get lost
+ * the requests are resend when the {@code UPDATE_INTERVAL} elapses.
+ *
+ * @author Wouter Born - Update light properties when online
+ */
+public class LifxLightPropertiesUpdater implements LifxResponsePacketListener {
+
+    private final Logger logger = LoggerFactory.getLogger(LifxLightPropertiesUpdater.class);
+
+    private static final int UPDATE_INTERVAL = 15;
+
+    private final MACAddress macAddress;
+    private final String macAsHex;
+    private final CurrentLightState currentLightState;
+    private final LifxLightCommunicationHandler communicationHandler;
+
+    private final List<LifxPropertiesUpdateListener> propertiesUpdateListeners = new CopyOnWriteArrayList<>();
+
+    private final List<Packet> requestPackets = Lists.newArrayList(new GetVersionRequest(),
+            new GetHostFirmwareRequest(), new GetWifiFirmwareRequest());
+    private final Set<Integer> receivedPacketTypes = new HashSet<>();
+
+    private final ReentrantLock lock = new ReentrantLock();
+    private final ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> updateJob;
+
+    private final Map<String, String> properties = new HashMap<>();
+    private boolean updating;
+    private boolean wasOnline;
+
+    public LifxLightPropertiesUpdater(MACAddress macAddress, ScheduledExecutorService scheduler,
+            CurrentLightState currentLightState, LifxLightCommunicationHandler communicationHandler) {
+        this.macAddress = macAddress;
+        this.macAsHex = macAddress.getHex();
+        this.scheduler = scheduler;
+        this.currentLightState = currentLightState;
+        this.communicationHandler = communicationHandler;
+    }
+
+    private Runnable updateRunnable = new Runnable() {
+
+        @Override
+        public void run() {
+            try {
+                lock.lock();
+
+                if (currentLightState.isOnline()) {
+                    if (!wasOnline) {
+                        if (propertiesUpdateListeners.size() > 0) {
+                            logger.debug("{} : Updating light properties", macAsHex);
+                            updating = true;
+                            properties.clear();
+                            receivedPacketTypes.clear();
+                            properties.put(LifxBindingConstants.PROPERTY_MAC_ADDRESS, macAddress.getAsLabel());
+                            sendPropertyRequestPackets();
+                        }
+                    } else if (updating && !receivedAllResponsePackets()) {
+                        logger.debug("{} : Resending requests for missing response packets", macAsHex);
+                        sendPropertyRequestPackets();
+                    }
+                }
+
+                wasOnline = currentLightState.isOnline();
+            } catch (Exception e) {
+                logger.error("Error occurred while polling online state", e);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private void sendPropertyRequestPackets() {
+            for (Packet packet : requestPackets) {
+                if (!receivedPacketTypes.contains(packet.expectedResponses()[0])) {
+                    communicationHandler.sendPacket(packet);
+                }
+            }
+        }
+    };
+
+    @Override
+    public void handleResponsePacket(Packet packet) {
+        if (!updating) {
+            return;
+        }
+
+        if (packet instanceof StateVersionResponse) {
+            Products products = Products.getProductFromProductID(((StateVersionResponse) packet).getProduct());
+            long productVersion = ((StateVersionResponse) packet).getVersion();
+
+            properties.put(LifxBindingConstants.PROPERTY_PRODUCT_ID, Long.toString(products.getProduct()));
+            properties.put(LifxBindingConstants.PROPERTY_PRODUCT_NAME, products.getName());
+            properties.put(LifxBindingConstants.PROPERTY_PRODUCT_VERSION, Long.toString(productVersion));
+            properties.put(LifxBindingConstants.PROPERTY_VENDOR_ID, Long.toString(products.getVendor()));
+            properties.put(LifxBindingConstants.PROPERTY_VENDOR_NAME, products.getVendorName());
+
+            receivedPacketTypes.add(packet.getPacketType());
+        } else if (packet instanceof StateHostFirmwareResponse) {
+            String hostVersion = ((StateHostFirmwareResponse) packet).getVersion().toString();
+            properties.put(LifxBindingConstants.PROPERTY_HOST_VERSION, hostVersion);
+            receivedPacketTypes.add(packet.getPacketType());
+        } else if (packet instanceof StateWifiFirmwareResponse) {
+            String wifiVersion = ((StateWifiFirmwareResponse) packet).getVersion().toString();
+            properties.put(LifxBindingConstants.PROPERTY_WIFI_VERSION, wifiVersion);
+            receivedPacketTypes.add(packet.getPacketType());
+        }
+
+        if (receivedAllResponsePackets()) {
+            updating = false;
+            for (LifxPropertiesUpdateListener listener : propertiesUpdateListeners) {
+                listener.handlePropertiesUpdate(properties);
+            }
+            logger.debug("{} : Finished updating light properties", macAsHex);
+        }
+    }
+
+    private boolean receivedAllResponsePackets() {
+        return requestPackets.size() == receivedPacketTypes.size();
+    }
+
+    public void addPropertiesUpdateListener(LifxPropertiesUpdateListener listener) {
+        propertiesUpdateListeners.add(listener);
+    }
+
+    public void removePropertiesUpdateListener(LifxPropertiesUpdateListener listener) {
+        propertiesUpdateListeners.remove(listener);
+    }
+
+    public void start() {
+        try {
+            lock.lock();
+            communicationHandler.addResponsePacketListener(this);
+            if (updateJob == null || updateJob.isCancelled()) {
+                updateJob = scheduler.scheduleWithFixedDelay(updateRunnable, 0, UPDATE_INTERVAL, TimeUnit.SECONDS);
+            }
+        } catch (Exception e) {
+            logger.error("Error occurred while starting properties update job", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void stop() {
+        try {
+            lock.lock();
+            communicationHandler.removeResponsePacketListener(this);
+            if (updateJob != null && !updateJob.isCancelled()) {
+                updateJob.cancel(true);
+                updateJob = null;
+            }
+        } catch (Exception e) {
+            logger.error("Error occurred while stopping properties update job", e);
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightStateChanger.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightStateChanger.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.eclipse.smarthome.binding.lifx.LifxBindingConstants;
 import org.eclipse.smarthome.binding.lifx.internal.fields.HSBK;
 import org.eclipse.smarthome.binding.lifx.internal.fields.MACAddress;
 import org.eclipse.smarthome.binding.lifx.internal.listener.LifxLightStateListener;
@@ -40,7 +39,6 @@ import org.eclipse.smarthome.binding.lifx.internal.protocol.SetLightInfraredRequ
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SetLightPowerRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SetPowerRequest;
 import org.eclipse.smarthome.binding.lifx.internal.protocol.SignalStrength;
-import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,15 +65,13 @@ public class LifxLightStateChanger implements LifxLightStateListener, LifxRespon
     private final Logger logger = LoggerFactory.getLogger(LifxLightStateChanger.class);
 
     private final String macAsHex;
+    private final ScheduledExecutorService scheduler;
     private final LifxLightState pendingLightState;
     private final LifxLightCommunicationHandler communicationHandler;
     private final long fadeTime;
     private final Products product;
 
     private final ReentrantLock lock = new ReentrantLock();
-
-    private ScheduledExecutorService scheduler = ThreadPoolManager
-            .getScheduledPool(LifxBindingConstants.THREADPOOL_NAME);
 
     private ScheduledFuture<?> sendJob;
 
@@ -131,9 +127,11 @@ public class LifxLightStateChanger implements LifxLightStateListener, LifxRespon
         }
     };
 
-    public LifxLightStateChanger(MACAddress macAddress, LifxLightState pendingLightState,
-            LifxLightCommunicationHandler communicationHandler, Products product, long fadeTime) {
+    public LifxLightStateChanger(MACAddress macAddress, ScheduledExecutorService scheduler,
+            LifxLightState pendingLightState, LifxLightCommunicationHandler communicationHandler, Products product,
+            long fadeTime) {
         this.macAsHex = macAddress.getHex();
+        this.scheduler = scheduler;
         this.pendingLightState = pendingLightState;
         this.communicationHandler = communicationHandler;
         this.product = product;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/fields/MACAddress.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/fields/MACAddress.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MACAddress {
 
-    private Logger logger = LoggerFactory.getLogger(MACAddress.class);
+    private final Logger logger = LoggerFactory.getLogger(MACAddress.class);
 
     private ByteBuffer bytes;
     private String hex;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/listener/LifxPropertiesUpdateListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/listener/LifxPropertiesUpdateListener.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.lifx.internal.listener;
+
+import java.util.Map;
+
+import org.eclipse.smarthome.binding.lifx.internal.LifxLightPropertiesUpdater;
+
+/**
+ * The {@link LifxPropertiesUpdateListener} is notified when the {@link LifxLightPropertiesUpdater} has
+ * updated light properties.
+ *
+ * @author Wouter Born - Update light properties when online
+ */
+public interface LifxPropertiesUpdateListener {
+
+    /**
+     * Called when the {@link LifxLightPropertiesUpdater} has updated light properties.
+     *
+     * @param packet the updated properties
+     */
+    public void handlePropertiesUpdate(Map<String, String> properties);
+}


### PR DESCRIPTION
* Update light properties when Thing goes online which fixes:
  * Properties not always updated for lights defined in .things files
  * Existing light Things which do not get new/updated properties from discovery (#3323)
* Don't power on IR lights when changing infrared channel brightness
* Reuse the default thing ScheduledExecutorService
* Use final Logger and ReentrantLock objects