### PR TITLE
New API function to retrieve members of a GroupItem

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
@@ -10,6 +10,8 @@ package org.eclipse.smarthome.core.items
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 
+import java.util.function.Predicate
+
 import org.eclipse.smarthome.core.events.Event
 import org.eclipse.smarthome.core.events.EventPublisher
 import org.eclipse.smarthome.core.items.events.GroupItemStateChangedEvent
@@ -89,6 +91,55 @@ class GroupItemTest extends OSGiTest {
                 fail("There are no GroupItems allowed in this Collection")
             }
         }
+    }
+
+    @Test
+    public void testGetAllMembersWithFilter() {
+        GroupItem rootGroupItem = new GroupItem("root")
+
+        TestItem member1 = new TestItem("member1");
+        member1.setLabel("mem1");
+        rootGroupItem.addMember(member1)
+
+        TestItem member2 = new TestItem("member2");
+        member2.setLabel("mem1");
+        rootGroupItem.addMember(member2)
+
+        rootGroupItem.addMember(new TestItem("member3"))
+        GroupItem subGroup = new GroupItem("subGroup1")
+        subGroup.addMember(new TestItem("subGroup member 1"))
+        subGroup.addMember(new TestItem("subGroup member 2"))
+        subGroup.addMember(new TestItem("subGroup member 3"))
+        subGroup.addMember(member1)
+        rootGroupItem.addMember(subGroup)
+
+        Predicate<Item> groupItemsInMembers = new Predicate<Item>() {
+                    @Override
+                    public boolean test(Item t) {
+                        if(t instanceof GroupItem) {
+                            return true;
+                        }
+                        return false;
+                    }
+                };
+
+        Set<Item> members = rootGroupItem.getMembers(groupItemsInMembers)
+        assertThat members.size(), is(1)
+
+        Predicate<Item> allMem1labelItems = new Predicate<Item>() {
+                    @Override
+                    public boolean test(Item t) {
+                        if(t.getLabel().equals("mem1")) {
+                            return true;
+                        }
+                        return false;
+                    }
+                };
+
+        members = rootGroupItem.getMembers(allMem1labelItems)
+        assertThat members.size(), is(2)
+
+        println "done"
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GroupItemTest.groovy
@@ -10,8 +10,6 @@ package org.eclipse.smarthome.core.items
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 
-import java.util.function.Predicate
-
 import org.eclipse.smarthome.core.events.Event
 import org.eclipse.smarthome.core.events.EventPublisher
 import org.eclipse.smarthome.core.items.events.GroupItemStateChangedEvent
@@ -113,33 +111,11 @@ class GroupItemTest extends OSGiTest {
         subGroup.addMember(member1)
         rootGroupItem.addMember(subGroup)
 
-        Predicate<Item> groupItemsInMembers = new Predicate<Item>() {
-                    @Override
-                    public boolean test(Item t) {
-                        if(t instanceof GroupItem) {
-                            return true;
-                        }
-                        return false;
-                    }
-                };
-
-        Set<Item> members = rootGroupItem.getMembers(groupItemsInMembers)
+        Set<Item> members = rootGroupItem.getMembers({Item i -> i instanceof GroupItem})
         assertThat members.size(), is(1)
 
-        Predicate<Item> allMem1labelItems = new Predicate<Item>() {
-                    @Override
-                    public boolean test(Item t) {
-                        if(t.getLabel().equals("mem1")) {
-                            return true;
-                        }
-                        return false;
-                    }
-                };
-
-        members = rootGroupItem.getMembers(allMem1labelItems)
+        members = rootGroupItem.getMembers({Item i -> i.getLabel().equals("mem1")})
         assertThat members.size(), is(2)
-
-        println "done"
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -111,8 +111,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @return all members of this and all contained {@link GroupItem}s
      */
     public Set<Item> getAllMembers() {
-        Set<Item> allMembers = getMembers((Item i) -> !(i instanceof GroupItem));
-        return ImmutableSet.copyOf(allMembers);
+        return ImmutableSet.copyOf(getMembers((Item i) -> !(i instanceof GroupItem)));
     }
 
     private void collectMembers(Set<Item> allMembers, Set<Item> members) {
@@ -120,7 +119,6 @@ public class GroupItem extends GenericItem implements StateChangeListener {
             if (member instanceof GroupItem) {
                 collectMembers(allMembers, ((GroupItem) member).members);
                 allMembers.add(member);
-
             } else {
                 allMembers.add(member);
             }
@@ -136,7 +134,6 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     public Set<Item> getMembers(Predicate<Item> filterItem) {
         Set<Item> allMembers = new HashSet<Item>();
         collectMembers(allMembers, members);
-
         return allMembers.stream().filter(filterItem).collect(Collectors.toSet());
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -111,18 +111,16 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @return all members of this and all contained {@link GroupItem}s
      */
     public Set<Item> getAllMembers() {
-        Set<Item> allMembers = new HashSet<Item>();
-        collectMembers(allMembers, members, false);
+        Set<Item> allMembers = getMembers((Item i) -> !(i instanceof GroupItem));
         return ImmutableSet.copyOf(allMembers);
     }
 
-    private void collectMembers(Set<Item> allMembers, Set<Item> members, boolean withGroupItems) {
+    private void collectMembers(Set<Item> allMembers, Set<Item> members) {
         for (Item member : members) {
             if (member instanceof GroupItem) {
-                collectMembers(allMembers, ((GroupItem) member).members, withGroupItems);
-                if (withGroupItems) {
-                    allMembers.add(member);
-                }
+                collectMembers(allMembers, ((GroupItem) member).members);
+                allMembers.add(member);
+
             } else {
                 allMembers.add(member);
             }
@@ -137,7 +135,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      */
     public Set<Item> getMembers(Predicate<Item> filterItem) {
         Set<Item> allMembers = new HashSet<Item>();
-        collectMembers(allMembers, members, true);
+        collectMembers(allMembers, members);
 
         return allMembers.stream().filter(filterItem).collect(Collectors.toSet());
     }


### PR DESCRIPTION
With Java 8 we can now use streams and their filter functions, so this method can retrieve any members matching a given filter

Fixes #586

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>