### PR TITLE
Add basic test classes for static import on content assist.

### DIFF
--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -403,6 +403,10 @@
           value="2"/>
       <setupTask
           xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.ui/content_assist_favorite_static_members"
+          value="org.junit.Assert.*;org.mockito.Mockito.*;org.mockito.MockitoAnnotations.*;org.hamcrest.CoreMatchers.*"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.ui/editor_save_participant_org.eclipse.jdt.ui.postsavelistener.cleanup"
           value="true"/>
       <setupTask


### PR DESCRIPTION
Add the following types for static import on content assist:

* org.junit.Assert.*
* org.mockito.Mockito.*
* org.mockito.MockitoAnnotations.*
* org.hamcrest.CoreMatchers.*