### PR TITLE
remove "Type" postfix from state types in item events

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/events/ItemEventFactoryTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/events/ItemEventFactoryTest.groovy
@@ -11,6 +11,7 @@ import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
+import org.apache.commons.lang.StringUtils
 import org.eclipse.smarthome.core.events.Event
 import org.eclipse.smarthome.core.items.GroupItem
 import org.eclipse.smarthome.core.items.dto.ItemDTOMapper
@@ -53,14 +54,19 @@ class ItemEventFactoryTest extends OSGiTest {
 
 
     def ITEM_COMMAND = OnOffType.ON
-    def ITEM_COMMAND_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(ITEM_COMMAND.getClass().getSimpleName(), ITEM_COMMAND.toString()))
-    def ITEM_REFRESH_COMMAND_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(RefreshType.REFRESH.getClass().getSimpleName(), RefreshType.REFRESH.toString()))
-    def ITEM_UNDEF_STATE_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(UnDefType.UNDEF.getClass().getSimpleName(), UnDefType.UNDEF.toString()))
+    def ITEM_COMMAND_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(createTypeString(ITEM_COMMAND), ITEM_COMMAND.toString()))
+
+    def ITEM_REFRESH_COMMAND_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(createTypeString(RefreshType.REFRESH), RefreshType.REFRESH.toString()))
+    def ITEM_UNDEF_STATE_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(createTypeString(UnDefType.UNDEF), UnDefType.UNDEF.toString()))
     def ITEM_STATE = OnOffType.OFF
     def NEW_ITEM_STATE = OnOffType.ON
-    def ITEM_STATE_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(ITEM_STATE.getClass().getSimpleName(), ITEM_STATE.toString()))
+    def ITEM_STATE_EVENT_PAYLOAD = new Gson().toJson(new ItemEventPayloadBean(createTypeString(ITEM_STATE), ITEM_STATE.toString()))
     def ITEM_ADDED_EVENT_PAYLOAD = new Gson().toJson(ItemDTOMapper.map(ITEM))
-    def ITEM_STATE_CHANGED_EVENT_PAYLOAD = new Gson().toJson(new ItemStateChangedEventPayloadBean(NEW_ITEM_STATE.getClass().getSimpleName(),NEW_ITEM_STATE.toString(),ITEM_STATE.getClass().getSimpleName(),ITEM_STATE.toString()))
+    def ITEM_STATE_CHANGED_EVENT_PAYLOAD = new Gson().toJson(new ItemStateChangedEventPayloadBean(createTypeString(NEW_ITEM_STATE), NEW_ITEM_STATE.toString(), createTypeString(ITEM_STATE), ITEM_STATE.toString()))
+
+    private createTypeString(type) {
+        StringUtils.removeEnd(type.class.getSimpleName(), "Type")
+    }
 
     def RAW_ITEM_STATE = new RawType(([1, 2, 3, 4, 5]as byte[]), RawType.DEFAULT_MIME_TYPE)
     def NEW_RAW_ITEM_STATE = new RawType(([5, 4, 3, 2, 1]as byte[]), RawType.DEFAULT_MIME_TYPE)

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -7,10 +7,12 @@
  */
 package org.eclipse.smarthome.core.items.events;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.events.AbstractEventFactory;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.items.Item;
@@ -32,6 +34,8 @@ import com.google.common.collect.Sets;
  * @author Stefan Bußweiler - Initial contribution
  */
 public class ItemEventFactory extends AbstractEventFactory {
+
+    private static final String TYPE_POSTFIX = "Type";
 
     private static final String CORE_LIBRARY_PACKAGE = "org.eclipse.smarthome.core.library.types.";
 
@@ -85,18 +89,12 @@ public class ItemEventFactory extends AbstractEventFactory {
         State state = getState(bean.getType(), bean.getValue());
         State oldState = getState(bean.getOldType(), bean.getOldValue());
         return new GroupItemStateChangedEvent(topic, payload, itemName, memberName, state, oldState);
-
     }
 
     private Event createCommandEvent(String topic, String payload, String source) {
         String itemName = getItemName(topic);
         ItemEventPayloadBean bean = deserializePayload(payload, ItemEventPayloadBean.class);
-        Command command = null;
-        try {
-            command = (Command) parse(bean.getType(), bean.getValue());
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Parsing of item command event failed.", e);
-        }
+        Command command = parseType(bean.getType(), bean.getValue(), Command.class);
         return new ItemCommandEvent(topic, payload, itemName, command, source);
     }
 
@@ -116,13 +114,7 @@ public class ItemEventFactory extends AbstractEventFactory {
     }
 
     private State getState(String type, String value) {
-        State state = null;
-        try {
-            state = (State) parse(type, value);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Parsing of item state event failed.", e);
-        }
-        return state;
+        return parseType(type, value, State.class);
     }
 
     private String getItemName(String topic) {
@@ -141,16 +133,44 @@ public class ItemEventFactory extends AbstractEventFactory {
         return topicElements[3];
     }
 
-    private Object parse(String typeName, String valueToParse) throws Exception {
-        if (typeName.equals(UnDefType.class.getSimpleName())) {
+    private <T> T parseType(String typeName, String valueToParse, Class<T> desiredClass) {
+        Object parsedObject = null;
+        String simpleClassName = typeName + TYPE_POSTFIX;
+        parsedObject = parseSimpleClassName(simpleClassName, valueToParse);
+
+        if (parsedObject == null || !desiredClass.isAssignableFrom(parsedObject.getClass())) {
+            String parsedObjectClassName = parsedObject != null ? parsedObject.getClass().getName() : "<undefined>";
+            throw new IllegalArgumentException("Error parsing simpleClasssName '" + simpleClassName + "' with value '"
+                    + valueToParse + "'. Desired type was '" + desiredClass.getName() + "' but got '"
+                    + parsedObjectClassName + "'.");
+        }
+
+        return desiredClass.cast(parsedObject);
+    }
+
+    private Object parseSimpleClassName(String simpleClassName, String valueToParse) {
+        if (simpleClassName.equals(UnDefType.class.getSimpleName())) {
             return UnDefType.valueOf(valueToParse);
         }
-        if (typeName.equals(RefreshType.class.getSimpleName())) {
+        if (simpleClassName.equals(RefreshType.class.getSimpleName())) {
             return RefreshType.valueOf(valueToParse);
         }
-        Class<?> stateClass = Class.forName(CORE_LIBRARY_PACKAGE + typeName);
-        Method valueOfMethod = stateClass.getMethod("valueOf", String.class);
-        return valueOfMethod.invoke(stateClass, valueToParse);
+
+        try {
+            Class<?> stateClass = Class.forName(CORE_LIBRARY_PACKAGE + simpleClassName);
+            Method valueOfMethod = stateClass.getMethod("valueOf", String.class);
+            return valueOfMethod.invoke(null, valueToParse);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException("Error getting class for simple name: '" + simpleClassName
+                    + "' using package name '" + CORE_LIBRARY_PACKAGE + "'.", e);
+        } catch (NoSuchMethodException | SecurityException e) {
+            throw new IllegalStateException(
+                    "Error getting method #valueOf(String) of class '" + CORE_LIBRARY_PACKAGE + simpleClassName + "'.",
+                    e);
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            throw new IllegalStateException("Error invoking #valueOf(String) on class '" + CORE_LIBRARY_PACKAGE
+                    + simpleClassName + "' with value '" + valueToParse + "'.", e);
+        }
     }
 
     private Event createAddedEvent(String topic, String payload) {
@@ -185,7 +205,7 @@ public class ItemEventFactory extends AbstractEventFactory {
     public static ItemCommandEvent createCommandEvent(String itemName, Command command, String source) {
         assertValidArguments(itemName, command, "command");
         String topic = buildTopic(ITEM_COMAND_EVENT_TOPIC, itemName);
-        ItemEventPayloadBean bean = new ItemEventPayloadBean(command.getClass().getSimpleName(), command.toString());
+        ItemEventPayloadBean bean = new ItemEventPayloadBean(getCommandType(command), command.toString());
         String payload = serializePayload(bean);
         return new ItemCommandEvent(topic, payload, itemName, command, source);
     }
@@ -218,8 +238,7 @@ public class ItemEventFactory extends AbstractEventFactory {
     public static ItemStateEvent createStateEvent(String itemName, State state, String source) {
         assertValidArguments(itemName, state, "state");
         String topic = buildTopic(ITEM_STATE_EVENT_TOPIC, itemName);
-        ItemEventPayloadBean bean = new ItemEventPayloadBean(state.getClass().getSimpleName(),
-                state.toFullString());
+        ItemEventPayloadBean bean = new ItemEventPayloadBean(getStateType(state), state.toFullString());
         String payload = serializePayload(bean);
         return new ItemStateEvent(topic, payload, itemName, state, source);
     }
@@ -252,9 +271,8 @@ public class ItemEventFactory extends AbstractEventFactory {
     public static ItemStateChangedEvent createStateChangedEvent(String itemName, State newState, State oldState) {
         assertValidArguments(itemName, newState, "state");
         String topic = buildTopic(ITEM_STATE_CHANGED_EVENT_TOPIC, itemName);
-        ItemStateChangedEventPayloadBean bean = new ItemStateChangedEventPayloadBean(
-                newState.getClass().getSimpleName(), newState.toFullString(), oldState.getClass().getSimpleName(),
-                oldState.toFullString());
+        ItemStateChangedEventPayloadBean bean = new ItemStateChangedEventPayloadBean(getStateType(newState),
+                newState.toFullString(), getStateType(oldState), oldState.toFullString());
         String payload = serializePayload(bean);
         return new ItemStateChangedEvent(topic, payload, itemName, newState, oldState);
     }
@@ -263,9 +281,8 @@ public class ItemEventFactory extends AbstractEventFactory {
             State newState, State oldState) {
         assertValidArguments(itemName, memberName, newState, "state");
         String topic = buildGroupTopic(GROUPITEM_STATE_CHANGED_EVENT_TOPIC, itemName, memberName);
-        ItemStateChangedEventPayloadBean bean = new ItemStateChangedEventPayloadBean(
-                newState.getClass().getSimpleName(), newState.toFullString(), oldState.getClass().getSimpleName(),
-                oldState.toFullString());
+        ItemStateChangedEventPayloadBean bean = new ItemStateChangedEventPayloadBean(getStateType(newState),
+                newState.toFullString(), getStateType(oldState), oldState.toFullString());
         String payload = serializePayload(bean);
         return new GroupItemStateChangedEvent(topic, payload, itemName, memberName, newState, oldState);
     }
@@ -339,6 +356,14 @@ public class ItemEventFactory extends AbstractEventFactory {
         return ItemDTOMapper.map(item);
     }
 
+    private static String getStateType(State state) {
+        return StringUtils.removeEnd(state.getClass().getSimpleName(), TYPE_POSTFIX);
+    }
+
+    private static String getCommandType(Command command) {
+        return StringUtils.removeEnd(command.getClass().getSimpleName(), TYPE_POSTFIX);
+    }
+
     private static void assertValidArguments(String itemName, Type type, String typeArgumentName) {
         Preconditions.checkArgument(itemName != null && !itemName.isEmpty(),
                 "The argument 'itemName' must not be null or empty.");
@@ -367,6 +392,7 @@ public class ItemEventFactory extends AbstractEventFactory {
         /**
          * Default constructor for deserialization e.g. by Gson.
          */
+        @SuppressWarnings("unused")
         protected ItemEventPayloadBean() {
         }
 
@@ -396,6 +422,7 @@ public class ItemEventFactory extends AbstractEventFactory {
         /**
          * Default constructor for deserialization e.g. by Gson.
          */
+        @SuppressWarnings("unused")
         protected ItemStateChangedEventPayloadBean() {
         }
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
@@ -104,7 +104,7 @@ angular.module('PaperUI.controllers', [ 'PaperUI.constants' ]).controller('BodyC
                     }
                 }
                 if (item.type === "Rollershutter") {
-                    if (stateObject.type == "PercentType" || stateObject.type == "DecimalType") {
+                    if (stateObject.type == "Percent" || stateObject.type == "Decimal") {
                         state = parseInt(stateObject.value);
                     }
                 }
@@ -131,7 +131,7 @@ angular.module('PaperUI.controllers', [ 'PaperUI.constants' ]).controller('BodyC
 
     eventService.onEvent('smarthome/items/*/statechanged', function(topic, stateObject) {
         var itemName = topic.split('/')[2];
-        if (itemName && (stateObject.type == "PercentType" || stateObject.type == "DecimalType")) {
+        if (itemName && (stateObject.type == "Percent" || stateObject.type == "Decimal")) {
             var index = getItemIndex(itemName);
             if (index !== -1) {
                 $scope.$apply(function(scope) {


### PR DESCRIPTION
This removes the "Type" postfix from state types in Item specific events. PaperUI event handling is adopted. From what I can see in the code the BasicUI is not affected by this change.

Fixes #3282.