### PR TITLE
fix ConcurrentModificationException in AbstractWatchServiceTest

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.groovy
@@ -15,6 +15,7 @@ import static org.junit.matchers.JUnitMatchers.*
 import java.nio.file.Path
 import java.nio.file.WatchEvent
 import java.nio.file.WatchEvent.Kind
+import java.util.concurrent.CopyOnWriteArrayList
 
 import org.apache.commons.lang.SystemUtils
 import org.eclipse.smarthome.test.OSGiTest
@@ -381,7 +382,7 @@ class AbstractWatchServiceTest extends OSGiTest {
         boolean watchDirectoryChanges
 
         // Synchronize list as several watcher threads can write into it
-        def allFullEvents = [].asSynchronized()
+        def allFullEvents = new CopyOnWriteArrayList<FullEvent>()
 
         RelativeWatchService(String rootPath, boolean watchSubDirectories, boolean watchDirChanges){
             super(rootPath);


### PR DESCRIPTION
As Travis found out [here](https://travis-ci.org/eclipse/smarthome/builds/234385901#L1778), it's not enough to use synchronized collections. They will still fail when iterating over them.

This fix is not nice performance-wise, but keeps the tests better readable than doing proper synchronization. It's just a test, after all.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>