### PR TITLE
[Scheduler] Dropped usage of SimpleDateFormat for trace logging

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/AbstractExpression.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/AbstractExpression.java
@@ -8,7 +8,6 @@
 package org.eclipse.smarthome.core.scheduler;
 
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -29,8 +28,6 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractExpression<E extends AbstractExpressionPart> implements Expression {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
-
-    static SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 
     private int minimumCandidates = 1;
     private int maximumCandidates = 100;
@@ -95,7 +92,7 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
             throw new IllegalArgumentException("The start date of the rule must not be null");
         }
         this.startDate = startDate;
-        logger.trace("Setting the start date to {}", sdf.format(startDate));
+        logger.trace("Setting the start date to {}", startDate);
         parseExpression(expression);
     }
 
@@ -185,8 +182,10 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
             continueSearch = false;
         }
 
-        for (Date aDate : getCandidates()) {
-            logger.trace("Final candidate {} is {}", getCandidates().indexOf(aDate), sdf.format(aDate));
+        if (logger.isTraceEnabled()) {
+            for (Date aDate : getCandidates()) {
+                logger.trace("Final candidate {} is {}", getCandidates().indexOf(aDate), aDate);
+            }
         }
     }
 
@@ -197,9 +196,11 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
         for (ExpressionPart part : getExpressionParts()) {
             logger.trace("Expanding {} from {} candidates", part.getClass().getSimpleName(), getCandidates().size());
             setCandidates(part.apply(startDate, getCandidates()));
-            logger.trace("Expanded to {} candidates", getCandidates().size());
-            for (Date aDate : getCandidates()) {
-                logger.trace("Candidate {} is {}", getCandidates().indexOf(aDate), sdf.format(aDate));
+            if (logger.isTraceEnabled()) {
+                logger.trace("Expanded to {} candidates", getCandidates().size());
+                for (Date aDate : getCandidates()) {
+                    logger.trace("Candidate {} is {}", getCandidates().indexOf(aDate), aDate);
+                }
             }
             if (searchMode) {
                 pruneFarthest();


### PR DESCRIPTION
...as it slows down the scheduler and was used in a dangeriously
wrt thread-safety.

fixes #3505
fixes #3506
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>