### PR TITLE
Scheduler: fix ConcurrentModificationException

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolManager.java
@@ -105,20 +105,9 @@ public class ExpressionThreadPoolManager extends ThreadPoolManager {
             super.afterExecute(runnable, throwable);
 
             if (runnable instanceof Future) {
-                for (Runnable aRunnable : futures.keySet()) {
-                    Future<?> toDelete = null;
-                    synchronized (futures) {
-                        for (Future<?> future : futures.get(aRunnable)) {
-                            if (future == runnable) {
-                                toDelete = future;
-                                break;
-                            }
-                        }
-                        if (toDelete != null) {
-                            logger.trace("Removing Future '{}' (out of {}) for Runnable '{}'", toDelete,
-                                    futures.get(aRunnable).size(), aRunnable);
-                            futures.get(aRunnable).remove(toDelete);
-                        }
+                synchronized (futures) {
+                    for (Runnable aRunnable : futures.keySet()) {
+                        futures.get(aRunnable).removeIf(future -> future == runnable);
                     }
                 }
 


### PR DESCRIPTION
... by expanding the synchronized block to include the outer loop. 

And while being at it anyway I also vaporized the removal logic to a single line.

fixes #3504
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>