### PR TITLE
generate revision info into bundles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,10 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+      </plugin>      
     </plugins>
 
     <pluginManagement>
@@ -341,6 +345,37 @@
           <artifactId>maven-clean-plugin</artifactId>
           <version>2.5</version>
         </plugin>
+        <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>2.2.1</version>
+          <executions>
+            <execution>
+              <id>get-the-git-infos</id>
+              <goals>
+                <goal>revision</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <generateGitPropertiesFile>true</generateGitPropertiesFile>
+            <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+            <format>properties</format>
+            <injectAllReactorProjects>false</injectAllReactorProjects>
+            <failOnNoGitDirectory>false</failOnNoGitDirectory>
+            <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+            <runOnlyOnce>false</runOnlyOnce>
+            <useNativeGit>false</useNativeGit>
+            <commitIdGenerationMode>flat</commitIdGenerationMode>
+            <includeOnlyProperties>
+              <includeOnlyProperty>^git.build.time$</includeOnlyProperty>
+              <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
+              <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+              <includeOnlyProperty>^git.commit.time$</includeOnlyProperty>
+              <includeOnlyProperty>^git.dirty$</includeOnlyProperty>
+            </includeOnlyProperties>
+          </configuration>
+        </plugin>      
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
This is just a suggestion to include the git commit ID in our bundles' binaries. 

The used maven plugin would generate a "git.properties" file for each bundle, containing the following information (I reduced it to only the most relevant entries, the plugin actually could generate many more it we let it...):

```
#Generated by Git-Commit-Id-Plugin
#Tue May 23 12:54:27 CEST 2017
git.dirty=true
git.commit.time=23.05.2017 @ 12\:53\:27 MESZ
git.commit.id.abbrev=259b030
git.commit.id=259b03051341aa9ccbfb2597228b61b192e07eb2
git.build.time=23.05.2017 @ 12\:54\:22 MESZ

```

This would give us some additional traceability, as build numbers etc. are nice for users (like e.g. in https://github.com/openhab/openhab-core/pull/149), but technically are unreliable as they are only usable as long as the build is retained on the build server. 

What do you think?

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>