### PR TITLE
Add PaperUI setup to IDE setup task

### DIFF
--- a/docs/documentation/development/ide.md
+++ b/docs/documentation/development/ide.md
@@ -33,6 +33,7 @@ The Eclipse IDE is used for Eclipse SmartHome developments. The Eclipse Installe
 ![Step 7](images/ide7.png)
 10. Your workspace should now fully compile and you can start the runtime by launching the "SmartHome Runtime" launch configuration:
 ![Step 8](images/ide8.png)
+11. Access the PaperUI at [http://localhost:8080/paperui/index.html](http://localhost:8080/paperui/index.html). For more information about PaperUI see [PaperIU Development](notes.html#paperui-development-jshtml). 
 
 Note that you will find the sources in a subfolder called "git" within your selected installation folder. You can use any kind of git client here, if you do not want to use the git support from within the Eclipse IDE.
 If you want to push changes, you need to do so to [your personal fork of the Eclipse SmartHome repository](https://github.com/eclipse/smarthome/fork) in order to create a pull request. You will find more details in the ["How to contribute"](../community/contributing.html) documentation.

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/PaperUI Setup.launch
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/PaperUI Setup.launch
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="clean install"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JRE for JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/org.eclipse.smarthome.ui.paper}"/>
+</launchConfiguration>

--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -2413,6 +2413,10 @@
         content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;lifecycleMappingMetadata>&#xA;  &lt;pluginExecutions>&#xA;    &lt;pluginExecution>&#xA;      &lt;pluginExecutionFilter>&#xA;        &lt;groupId>org.codehaus.mojo&lt;/groupId>&#xA;        &lt;artifactId>build-helper-maven-plugin&lt;/artifactId>&#xA;        &lt;versionRange>1.8&lt;/versionRange>&#xA;        &lt;goals>&#xA;          &lt;goal>add-source&lt;/goal>&#xA;          &lt;goal>add-test-source&lt;/goal>&#xA;        &lt;/goals>&#xA;      &lt;/pluginExecutionFilter>&#xA;      &lt;action>&#xA;        &lt;ignore />&#xA;      &lt;/action>&#xA;    &lt;/pluginExecution>&#xA;  &lt;/pluginExecutions>&#xA;&lt;/lifecycleMappingMetadata>&#xA;"
         targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml"
         encoding="UTF-8"/>
+    <setupTask
+        xsi:type="launching:LaunchTask"
+        excludedTriggers="STARTUP"
+        launcher="PaperUI Setup"/>
     <stream
         name="master"/>
   </project>


### PR DESCRIPTION
* Add a launch config for `mvn clean install` to o.e.s.ui.paper project.
* Add launch config to manual IDE setup tasks.
* Adopt ID setup documentation.

Fixes #2384.