### PR TITLE
Item.setState() enforces acceptedDataTypes + Tests

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/CallItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/CallItemTest.java
@@ -12,10 +12,16 @@ import static org.junit.Assert.assertEquals;
 import org.eclipse.smarthome.core.library.types.StringListType;
 import org.junit.Test;
 
+/**
+ *
+ * @author Gaël L'hopital - Initial version
+ * @author Stefan Triller - Added state tests
+ *
+ */
 public class CallItemTest {
 
     @Test
-    public void testError() {
+    public void testSetStringListType() {
 
         StringListType callType1 = new StringListType("0699222222", "0179999998");
         CallItem callItem1 = new CallItem("testItem");
@@ -28,5 +34,17 @@ public class CallItemTest {
         callItem1.setState(callType1);
         assertEquals(callItem1.toString(),
                 "testItem (Type=CallItem, State=0699222222,0179999998, Label=null, Category=null)");
+    }
+
+    @Test
+    public void testSetUndefType() {
+        CallItem callItem = new CallItem("testItem");
+        StateUtil.testUndefStates(callItem);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        CallItem item = new CallItem("testItem");
+        StateUtil.testAcceptedStates(item);
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/ColorItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/ColorItemTest.java
@@ -11,12 +11,14 @@ import static org.junit.Assert.assertEquals;
 
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.junit.Test;
 
 /**
  *
  * @author Simon Kaufmann - initial contribution and API
+ * @author Stefan Triller - test with on/off type
  *
  */
 public class ColorItemTest {
@@ -36,10 +38,24 @@ public class ColorItemTest {
     }
 
     @Test
-    public void testSetStateWithDecimalType() {
+    public void testSetStateWithOnOffType() {
         ColorItem item = new ColorItem("test");
-        item.setState(new DecimalType("0.5"));
-        assertEquals(new HSBType("0,0,50"), item.getState());
+        item.setState(OnOffType.ON);
+        assertEquals(new HSBType("0,0,100"), item.getState());
+        item.setState(OnOffType.OFF);
+        assertEquals(new HSBType("0,0,0"), item.getState());
+    }
+
+    @Test
+    public void testUndefType() {
+        ColorItem item = new ColorItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        ColorItem item = new ColorItem("test");
+        StateUtil.testAcceptedStates(item);
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/ContactItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/ContactItemTest.java
@@ -1,0 +1,36 @@
+package org.eclipse.smarthome.core.library.items;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.junit.Test;
+
+/**
+ *
+ * @author Stefan Triller - Initial version
+ *
+ */
+public class ContactItemTest {
+
+    @Test
+    public void testOpenCloseType() {
+        ContactItem item = new ContactItem("test");
+        item.setState(OpenClosedType.OPEN);
+        assertEquals(OpenClosedType.OPEN, item.getState());
+
+        item.setState(OpenClosedType.CLOSED);
+        assertEquals(OpenClosedType.CLOSED, item.getState());
+    }
+
+    @Test
+    public void testUndefType() {
+        ContactItem item = new ContactItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        ContactItem item = new ContactItem("test");
+        StateUtil.testAcceptedStates(item);
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/DateTimeItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/DateTimeItemTest.java
@@ -1,0 +1,35 @@
+package org.eclipse.smarthome.core.library.items;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.junit.Test;
+
+/**
+ *
+ * @author Stefan Triller
+ *
+ */
+public class DateTimeItemTest {
+
+    @Test
+    public void testDateTimeType() {
+        DateTimeItem item = new DateTimeItem("test");
+        DateTimeType state = new DateTimeType();
+        item.setState(state);
+        assertEquals(state, item.getState());
+    }
+
+    @Test
+    public void testUndefType() {
+        DateTimeItem item = new DateTimeItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        DateTimeItem item = new DateTimeItem("test");
+        StateUtil.testAcceptedStates(item);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/DimmerItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/DimmerItemTest.java
@@ -12,7 +12,8 @@ import static org.junit.Assert.assertEquals;
 import java.math.BigDecimal;
 
 import org.eclipse.smarthome.core.items.Item;
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
@@ -20,6 +21,7 @@ import org.junit.Test;
 /**
  * @author Chris Jackson - Initial contribution
  * @author Markus Rathgeb - Add more tests
+ * @author Stefan Triller - tests for type conversions
  */
 public class DimmerItemTest {
 
@@ -45,27 +47,50 @@ public class DimmerItemTest {
     }
 
     @Test
-    public void getAsDecimalFromDecimal() {
-        final BigDecimal origin = new BigDecimal(0.25);
-        final DimmerItem item = createDimmerItem(new DecimalType(origin));
-        final BigDecimal result = getState(item, DecimalType.class);
-        assertEquals(origin.compareTo(result), 0);
-    }
-
-    @Test
-    public void getAsPercentFromDecimal() {
-        final BigDecimal origin = new BigDecimal(0.25);
-        final DimmerItem item = createDimmerItem(new DecimalType(origin));
+    public void getAsPercentFromOn() {
+        final DimmerItem item = createDimmerItem(OnOffType.ON);
         final BigDecimal result = getState(item, PercentType.class);
-        assertEquals(origin.multiply(new BigDecimal(100)).compareTo(result), 0);
+        assertEquals(new BigDecimal(100), result);
     }
 
     @Test
-    public void getAsDecimalFromPercent() {
-        final BigDecimal origin = new BigDecimal(25);
-        final DimmerItem item = createDimmerItem(new PercentType(origin));
-        final BigDecimal result = getState(item, DecimalType.class);
-        assertEquals(origin.divide(new BigDecimal(100)).compareTo(result), 0);
+    public void getAsPercentFromOff() {
+        final DimmerItem item = createDimmerItem(OnOffType.OFF);
+        final BigDecimal result = getState(item, PercentType.class);
+        assertEquals(new BigDecimal(0), result);
+    }
+
+    @Test
+    public void getAsPercentFromHSB() {
+        // HSBType is supported because it is a sub-type of PercentType
+        HSBType origin = new HSBType("23,42,75");
+        final DimmerItem item = createDimmerItem(origin);
+        final BigDecimal result = getState(item, PercentType.class);
+        assertEquals(origin.getBrightness().toBigDecimal(), result);
+    }
+
+    @Test
+    public void getAsPercentFromDummy() {
+        DummyType origin = new DummyType();
+        final DimmerItem item = createDimmerItem(origin);
+        final BigDecimal result = getState(item, PercentType.class);
+        assertEquals(origin.getBrightness().toBigDecimal(), result);
+    }
+
+    @Test
+    public void testUndefType() {
+        DimmerItem item = new DimmerItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        DimmerItem item = new DimmerItem("test");
+        StateUtil.testAcceptedStates(item);
+    }
+
+    private class DummyType extends HSBType {
+
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/ImageItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/ImageItemTest.java
@@ -1,0 +1,36 @@
+package org.eclipse.smarthome.core.library.items;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.RawType;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+
+/**
+ *
+ * @author Stefan Triller - Initial version
+ *
+ */
+public class ImageItemTest {
+
+    @Test
+    public void testRawType() {
+        ImageItem item = new ImageItem("test");
+        State state = new RawType(new byte[0], "application/octet-stream");
+        item.setState(state);
+        assertEquals(state, item.getState());
+    }
+
+    @Test
+    public void testUndefType() {
+        ImageItem item = new ImageItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        DateTimeItem item = new DateTimeItem("test");
+        StateUtil.testAcceptedStates(item);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/LocationItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/LocationItemTest.java
@@ -14,7 +14,8 @@ import org.eclipse.smarthome.core.library.types.PointType;
 import org.junit.Test;
 
 /**
- * @author Gaël L'hopital
+ * @author Gaël L'hopital - Initial version
+ * @author Stefan Triller - tests for undef and illegal states
  */
 public class LocationItemTest {
 
@@ -33,6 +34,18 @@ public class LocationItemTest {
 
         double parisBerlin = locationParis.distanceFrom(locationBerlin).doubleValue();
         assertEquals(parisBerlin, 878400, 50);
+    }
+
+    @Test
+    public void testUndefType() {
+        ImageItem item = new ImageItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        DateTimeItem item = new DateTimeItem("test");
+        StateUtil.testAcceptedStates(item);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/NumberItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/NumberItemTest.java
@@ -1,0 +1,54 @@
+package org.eclipse.smarthome.core.library.items;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+
+/**
+ *
+ * @author Stefan Triller - Initial version
+ *
+ */
+public class NumberItemTest {
+
+    @Test
+    public void setDecimalType() {
+        NumberItem item = new NumberItem("test");
+        State decimal = new DecimalType("23");
+        item.setState(decimal);
+        assertEquals(decimal, item.getState());
+    }
+
+    @Test
+    public void setPercentType() {
+        NumberItem item = new NumberItem("test");
+        State percent = new PercentType(50);
+        item.setState(percent);
+        assertEquals(percent, item.getState());
+    }
+
+    @Test
+    public void setHSBType() {
+        NumberItem item = new NumberItem("test");
+        State hsb = new HSBType("5,23,42");
+        item.setState(hsb);
+        assertEquals(hsb, item.getState());
+    }
+
+    @Test
+    public void testUndefType() {
+        NumberItem item = new NumberItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        NumberItem item = new NumberItem("test");
+        StateUtil.testAcceptedStates(item);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/PlayerItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/PlayerItemTest.java
@@ -1,0 +1,48 @@
+package org.eclipse.smarthome.core.library.items;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.PlayPauseType;
+import org.eclipse.smarthome.core.library.types.RewindFastforwardType;
+import org.junit.Test;
+
+/**
+ *
+ * @author Stefan Triller - Initial version
+ *
+ */
+public class PlayerItemTest {
+
+    @Test
+    public void setPlayPause() {
+        PlayerItem item = new PlayerItem("test");
+        item.setState(PlayPauseType.PLAY);
+        assertEquals(PlayPauseType.PLAY, item.getState());
+
+        item.setState(PlayPauseType.PAUSE);
+        assertEquals(PlayPauseType.PAUSE, item.getState());
+    }
+
+    @Test
+    public void setRewindFastforward() {
+        PlayerItem item = new PlayerItem("test");
+        item.setState(RewindFastforwardType.REWIND);
+        assertEquals(RewindFastforwardType.REWIND, item.getState());
+
+        item.setState(RewindFastforwardType.FASTFORWARD);
+        assertEquals(RewindFastforwardType.FASTFORWARD, item.getState());
+    }
+
+    @Test
+    public void testUndefType() {
+        PlayerItem item = new PlayerItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        PlayerItem item = new PlayerItem("test");
+        StateUtil.testAcceptedStates(item);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/RollershutterItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/RollershutterItemTest.java
@@ -9,12 +9,18 @@ package org.eclipse.smarthome.core.library.items;
 
 import static org.junit.Assert.assertEquals;
 
-import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
 
+/**
+ *
+ * @author Hans Hazelius - Initial version
+ * @author Stefan Triller - Tests for type conversions
+ *
+ */
 public class RollershutterItemTest {
 
     @Test
@@ -42,11 +48,23 @@ public class RollershutterItemTest {
     }
 
     @Test
-    public void setState_stateDecimal050_returnPercent50() {
+    public void setState_stateHSB50_returnPercent50() {
+        // HSB supported because it is a sub-type of PercentType
         RollershutterItem sut = new RollershutterItem("Test");
-        State state = new DecimalType(0.50);
+        State state = new HSBType("5,23,42");
         sut.setState(state);
-        assertEquals(new PercentType(50), sut.getState());
+        assertEquals(new PercentType(42), sut.getState());
     }
 
+    @Test
+    public void setState_stateUndef() {
+        RollershutterItem sut = new RollershutterItem("Test");
+        StateUtil.testUndefStates(sut);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        RollershutterItem item = new RollershutterItem("testItem");
+        StateUtil.testAcceptedStates(item);
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/StateUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/StateUtil.java
@@ -1,0 +1,119 @@
+package org.eclipse.smarthome.core.library.items;
+
+import static org.junit.Assert.*;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.smarthome.core.items.GenericItem;
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.OpenClosedType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.PlayPauseType;
+import org.eclipse.smarthome.core.library.types.PointType;
+import org.eclipse.smarthome.core.library.types.RawType;
+import org.eclipse.smarthome.core.library.types.RewindFastforwardType;
+import org.eclipse.smarthome.core.library.types.StringListType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+
+/**
+ * Utility class for testing states on items
+ *
+ * @author Stefan Triller - Initial version
+ *
+ */
+public class StateUtil {
+
+    public static List<State> getAllStates() {
+        LinkedList<State> states = new LinkedList<>();
+
+        DateTimeType dateTime = new DateTimeType();
+        states.add(dateTime);
+
+        DecimalType decimal = new DecimalType(23);
+        states.add(decimal);
+
+        PercentType percent = new PercentType(50);
+        states.add(percent);
+
+        HSBType hsb = new HSBType("50,75,42");
+        states.add(hsb);
+
+        states.add(OnOffType.ON);
+        states.add(OnOffType.OFF);
+
+        states.add(OpenClosedType.OPEN);
+        states.add(OpenClosedType.CLOSED);
+
+        states.add(PlayPauseType.PLAY);
+        states.add(PlayPauseType.PAUSE);
+
+        PointType point = new PointType("42.23,23.5");
+        states.add(point);
+
+        RawType raw = new RawType(new byte[0], "application/octet-stream");
+        states.add(raw);
+
+        states.add(RewindFastforwardType.REWIND);
+        states.add(RewindFastforwardType.FASTFORWARD);
+
+        StringListType stringList = new StringListType(new String[] { "foo", "bar" });
+        states.add(stringList);
+
+        StringType string = new StringType("foo");
+        states.add(string);
+
+        states.add(UnDefType.NULL);
+        states.add(UnDefType.UNDEF);
+
+        states.add(UpDownType.UP);
+        states.add(UpDownType.DOWN);
+
+        return states;
+    }
+
+    public static void testAcceptedStates(GenericItem item) {
+        HashSet<Class<? extends State>> successfullStates = new HashSet<>();
+
+        for (State s : getAllStates()) {
+            item.setState(s);
+            if (item.isAcceptedState(item.getAcceptedDataTypes(), s)) {
+                if (s.equals(UnDefType.NULL)) {
+                    // if we set null, the item should stay null
+                    assertEquals(UnDefType.NULL, item.getState());
+                } else {
+                    // the state should be set on the item now
+                    assertNotEquals(UnDefType.NULL, item.getState());
+                    successfullStates.add(s.getClass());
+                }
+                // reset item
+                item.setState(UnDefType.NULL);
+            } else {
+                assertEquals(UnDefType.NULL, item.getState());
+            }
+        }
+
+        // test if the item accepts a state that is not in our test state list
+        for (Class<? extends State> acceptedState : item.getAcceptedDataTypes()) {
+            if (!successfullStates.contains(acceptedState)) {
+                fail("Item '" + item.getType() + "' accepts untested state: " + acceptedState);
+            }
+        }
+    }
+
+    public static void testUndefStates(GenericItem item) {
+        item.setState(UnDefType.UNDEF);
+        assertEquals(UnDefType.UNDEF, item.getState());
+
+        item.setState(UnDefType.NULL);
+        assertEquals(UnDefType.NULL, item.getState());
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/StringItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/StringItemTest.java
@@ -1,0 +1,44 @@
+package org.eclipse.smarthome.core.library.items;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Test;
+
+/**
+ *
+ * @author Stefan Triller - Initial version
+ *
+ */
+public class StringItemTest {
+
+    @Test
+    public void setStringType() {
+        StringItem item = new StringItem("test");
+        State state = new StringType("foobar");
+        item.setState(state);
+        assertEquals(state, item.getState());
+    }
+
+    @Test
+    public void setDateTimeTypeType() {
+        StringItem item = new StringItem("test");
+        State state = new DateTimeType();
+        item.setState(state);
+        assertEquals(state, item.getState());
+    }
+
+    @Test
+    public void testUndefType() {
+        StringItem item = new StringItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        StringItem item = new StringItem("test");
+        StateUtil.testAcceptedStates(item);
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/SwitchItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/SwitchItemTest.java
@@ -9,12 +9,15 @@ package org.eclipse.smarthome.core.library.items;
 
 import static org.junit.Assert.assertEquals;
 
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.junit.Test;
 
 /**
  * @author Chris Jackson - Initial contribution
+ * @author Stefan Triller - more tests for type conversions
  */
 public class SwitchItemTest {
 
@@ -22,6 +25,39 @@ public class SwitchItemTest {
     public void getAsPercentFromSwitch() {
         SwitchItem item = new SwitchItem("Test");
         item.setState(OnOffType.ON);
-        assertEquals("100", item.getStateAs(PercentType.class).toString());
+        assertEquals(new PercentType(100), item.getStateAs(PercentType.class));
+        item.setState(OnOffType.OFF);
+        assertEquals(new PercentType(0), item.getStateAs(PercentType.class));
     }
+
+    @Test
+    public void getAsDecimalFromSwitch() {
+        SwitchItem item = new SwitchItem("Test");
+        item.setState(OnOffType.ON);
+        assertEquals(new DecimalType(1), item.getStateAs(DecimalType.class));
+        item.setState(OnOffType.OFF);
+        assertEquals(new DecimalType(0), item.getStateAs(DecimalType.class));
+    }
+
+    @Test
+    public void getAsHSBFromSwitch() {
+        SwitchItem item = new SwitchItem("Test");
+        item.setState(OnOffType.ON);
+        assertEquals(new HSBType("0,0,100"), item.getStateAs(HSBType.class));
+        item.setState(OnOffType.OFF);
+        assertEquals(new HSBType("0,0,0"), item.getStateAs(HSBType.class));
+    }
+
+    @Test
+    public void testUndefType() {
+        SwitchItem item = new SwitchItem("test");
+        StateUtil.testUndefStates(item);
+    }
+
+    @Test
+    public void testAcceptedStates() {
+        SwitchItem item = new SwitchItem("test");
+        StateUtil.testAcceptedStates(item);
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 /**
  * @author Thomas.Eichstaedt-Engelen
+ * @author Stefan Triller - more tests for type conversions
  */
 public class DecimalTypeTest {
 
@@ -112,4 +113,14 @@ public class DecimalTypeTest {
         assertEquals(new HSBType("0,0,50"), new DecimalType("0.5").as(HSBType.class));
     }
 
+    @Test
+    public void testConversionToPercentType() {
+        assertEquals(new PercentType(70), new DecimalType("0.7").as(PercentType.class));
+    }
+
+    @Test
+    public void testConversionToPointType() {
+        // should not be possible => null
+        assertEquals(null, new DecimalType("0.23").as(PointType.class));
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/HSBTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/HSBTypeTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 /**
  *
  * @author Chris Jackson - added fromRGB() test
+ * @author Stefan Triller - more tests for type conversions
  *
  */
 public class HSBTypeTest {
@@ -99,6 +100,12 @@ public class HSBTypeTest {
         assertEquals(PercentType.HUNDRED, new HSBType("100,100,100").as(PercentType.class));
         assertEquals(new PercentType("1"), new HSBType("100,100,1").as(PercentType.class));
         assertEquals(PercentType.ZERO, new HSBType("100,100,0").as(PercentType.class));
+    }
+
+    @Test
+    public void testConversionToPointType() {
+        // should not be possible => null
+        assertEquals(null, new HSBType("100,100,100").as(PointType.class));
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/OnOffTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/OnOffTypeTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 /**
  * @author Simon Kaufmann - Initial contribution and API
+ * @author Stefan Triller - more tests for type conversions
  */
 public class OnOffTypeTest {
 
@@ -32,5 +33,12 @@ public class OnOffTypeTest {
     public void testConversionToHSBType() {
         assertEquals(HSBType.WHITE, OnOffType.ON.as(HSBType.class));
         assertEquals(HSBType.BLACK, OnOffType.OFF.as(HSBType.class));
+    }
+
+    @Test
+    public void testConversionToPointType() {
+        // should not be possible => null
+        assertEquals(null, OnOffType.ON.as(PointType.class));
+        assertEquals(null, OnOffType.OFF.as(PointType.class));
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/OpenClosedTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/OpenClosedTypeTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 /**
  * @author Simon Kaufmann - Initial contribution and API
+ * @author Stefan Triller - more tests for type conversions
  */
 public class OpenClosedTypeTest {
 
@@ -26,5 +27,12 @@ public class OpenClosedTypeTest {
     public void testConversionToDecimalType() {
         assertEquals(DecimalType.ZERO, OpenClosedType.CLOSED.as(DecimalType.class));
         assertEquals(new DecimalType(1), OpenClosedType.OPEN.as(DecimalType.class));
+    }
+
+    @Test
+    public void testConversionToPointType() {
+        // should not be possible => null
+        assertEquals(null, OpenClosedType.CLOSED.as(PointType.class));
+        assertEquals(null, OpenClosedType.OPEN.as(PointType.class));
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/UpDownTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/UpDownTypeTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 
 /**
  * @author Simon Kaufmann - Initial contribution and API
+ * @author Stefan Triller - more tests for type conversions
  */
 public class UpDownTypeTest {
 
@@ -28,4 +29,10 @@ public class UpDownTypeTest {
         assertEquals(new DecimalType(1), UpDownType.DOWN.as(DecimalType.class));
     }
 
+    @Test
+    public void testConversionToPointType() {
+        // should not be possible => null
+        assertEquals(null, UpDownType.UP.as(PointType.class));
+        assertEquals(null, UpDownType.DOWN.as(PointType.class));
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -425,4 +425,19 @@ abstract public class GenericItem implements ActiveItem {
         return null;
     }
 
+    /**
+     * Tests if state is within acceptedDataTypes list or a subclass of one of them
+     *
+     * @param acceptedDataTypes list of datatypes this items accepts as a state
+     * @param state to be tested
+     * @return true if state is an acceptedDataType or subclass thereof
+     */
+    public boolean isAcceptedState(List<Class<? extends State>> acceptedDataTypes, State state) {
+        if (acceptedDataTypes.stream().map(clazz -> clazz.isAssignableFrom(state.getClass()))
+                .filter(found -> found == true).findAny().isPresent()) {
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/CallItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/CallItem.java
@@ -17,6 +17,8 @@ import org.eclipse.smarthome.core.library.types.StringListType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This item identifies a telephone call by its origin and destination.
@@ -25,6 +27,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  * @author Gaël L'hopital - port to Eclipse SmartHome
  */
 public class CallItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -48,4 +52,13 @@ public class CallItem extends GenericItem {
         return Collections.unmodifiableList(acceptedCommandTypes);
     }
 
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
+        }
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
@@ -22,6 +22,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A ColorItem can be used for color values, e.g. for LED lights
@@ -30,6 +32,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class ColorItem extends DimmerItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -70,33 +74,37 @@ public class ColorItem extends DimmerItem {
      */
     @Override
     public void setState(State state) {
-        State currentState = this.state;
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            State currentState = this.state;
 
-        if (currentState instanceof HSBType) {
-            DecimalType hue = ((HSBType) currentState).getHue();
-            PercentType saturation = ((HSBType) currentState).getSaturation();
-            // we map ON/OFF values to dark/bright, so that the hue and saturation values are not changed
-            if (state == OnOffType.OFF) {
-                applyState(new HSBType(hue, saturation, PercentType.ZERO));
-            } else if (state == OnOffType.ON) {
-                applyState(new HSBType(hue, saturation, PercentType.HUNDRED));
-            } else if (state instanceof PercentType && !(state instanceof HSBType)) {
-                applyState(new HSBType(hue, saturation, (PercentType) state));
-            } else if (state instanceof DecimalType && !(state instanceof HSBType)) {
-                applyState(new HSBType(hue, saturation,
-                        new PercentType(((DecimalType) state).toBigDecimal().multiply(BigDecimal.valueOf(100)))));
+            if (currentState instanceof HSBType) {
+                DecimalType hue = ((HSBType) currentState).getHue();
+                PercentType saturation = ((HSBType) currentState).getSaturation();
+                // we map ON/OFF values to dark/bright, so that the hue and saturation values are not changed
+                if (state == OnOffType.OFF) {
+                    applyState(new HSBType(hue, saturation, PercentType.ZERO));
+                } else if (state == OnOffType.ON) {
+                    applyState(new HSBType(hue, saturation, PercentType.HUNDRED));
+                } else if (state instanceof PercentType && !(state instanceof HSBType)) {
+                    applyState(new HSBType(hue, saturation, (PercentType) state));
+                } else if (state instanceof DecimalType && !(state instanceof HSBType)) {
+                    applyState(new HSBType(hue, saturation,
+                            new PercentType(((DecimalType) state).toBigDecimal().multiply(BigDecimal.valueOf(100)))));
+                } else {
+                    applyState(state);
+                }
             } else {
-                applyState(state);
+                // try conversion
+                State convertedState = state.as(HSBType.class);
+                if (convertedState != null) {
+                    applyState(convertedState);
+                } else {
+                    applyState(state);
+                }
             }
         } else {
-            // try conversion
-            State convertedState = state.as(HSBType.class);
-            if (convertedState != null) {
-                applyState(convertedState);
-            } else {
-                applyState(state);
-            }
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
         }
     }
-
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ContactItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ContactItem.java
@@ -18,6 +18,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A ContactItem can be used for sensors that return an "open" or "close" as a state.
@@ -27,6 +29,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class ContactItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -52,4 +56,13 @@ public class ContactItem extends GenericItem {
         return Collections.unmodifiableList(acceptedCommandTypes);
     }
 
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
+        }
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DateTimeItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DateTimeItem.java
@@ -18,6 +18,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A DateTimeItem stores a timestamp including a valid time zone.
@@ -27,6 +29,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class DateTimeItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -57,4 +61,13 @@ public class DateTimeItem extends GenericItem {
         internalSend(command);
     }
 
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
+        }
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
@@ -19,6 +19,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A DimmerItem can be used as a switch (ON/OFF), but it also accepts percent values
@@ -29,6 +31,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class DimmerItem extends SwitchItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -71,12 +75,17 @@ public class DimmerItem extends SwitchItem {
      */
     @Override
     public void setState(State state) {
-        // try conversion
-        State convertedState = state.as(PercentType.class);
-        if (convertedState != null) {
-            applyState(convertedState);
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            // try conversion
+            State convertedState = state.as(PercentType.class);
+            if (convertedState != null) {
+                applyState(convertedState);
+            } else {
+                applyState(state);
+            }
         } else {
-            applyState(state);
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ImageItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ImageItem.java
@@ -18,6 +18,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An ImageItem holds the binary image data as its status.
@@ -26,6 +28,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class ImageItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -51,4 +55,13 @@ public class ImageItem extends GenericItem {
         return Collections.unmodifiableList(acceptedCommandTypes);
     }
 
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
+        }
+    }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/LocationItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/LocationItem.java
@@ -19,6 +19,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A LocationItem can be used to store GPS related informations, addresses...
@@ -28,6 +30,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class LocationItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -73,5 +77,15 @@ public class LocationItem extends GenericItem {
             return thisPoint.distanceFrom(awayPoint);
         }
         return new DecimalType(-1);
+    }
+
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
+        }
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
@@ -18,6 +18,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A NumberItem has a decimal value and is usually used for all kinds
@@ -29,6 +31,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class NumberItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -57,6 +61,16 @@ public class NumberItem extends GenericItem {
 
     public void send(DecimalType command) {
         internalSend(command);
+    }
+
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
+        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/PlayerItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/PlayerItem.java
@@ -20,6 +20,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An {@link PlayerItem} allows to control a player, e.g. an audio player.
@@ -27,6 +29,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  * @author Alex Tugarev
  */
 public class PlayerItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -46,7 +50,7 @@ public class PlayerItem extends GenericItem {
         super(CoreItemFactory.PLAYER, name);
     }
 
-    /* package */PlayerItem(String type, String name) {
+    /* package */ PlayerItem(String type, String name) {
         super(type, name);
     }
 
@@ -70,6 +74,16 @@ public class PlayerItem extends GenericItem {
 
     public void send(NextPreviousType command) {
         internalSend(command);
+    }
+
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
+        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/RollershutterItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/RollershutterItem.java
@@ -20,6 +20,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A RollershutterItem allows the control of roller shutters, i.e.
@@ -30,6 +32,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class RollershutterItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -77,12 +81,17 @@ public class RollershutterItem extends GenericItem {
      */
     @Override
     public void setState(State state) {
-        // try conversion
-        State convertedState = state.as(PercentType.class);
-        if (convertedState != null) {
-            applyState(convertedState);
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            // try conversion
+            State convertedState = state.as(PercentType.class);
+            if (convertedState != null) {
+                applyState(convertedState);
+            } else {
+                applyState(state);
+            }
         } else {
-            applyState(state);
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/StringItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/StringItem.java
@@ -20,6 +20,8 @@ import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A StringItem can be used for any kind of string to either send or receive
@@ -29,6 +31,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class StringItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -69,6 +73,16 @@ public class StringItem extends GenericItem {
             return convertedState;
         } else {
             return super.getStateAs(typeClass);
+        }
+    }
+
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
         }
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/SwitchItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/SwitchItem.java
@@ -18,6 +18,8 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A SwitchItem represents a normal switch that can be ON or OFF.
@@ -27,6 +29,8 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  */
 public class SwitchItem extends GenericItem {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static List<Class<? extends State>> acceptedDataTypes = new ArrayList<Class<? extends State>>();
     private static List<Class<? extends Command>> acceptedCommandTypes = new ArrayList<Class<? extends Command>>();
@@ -59,6 +63,16 @@ public class SwitchItem extends GenericItem {
     @Override
     public List<Class<? extends Command>> getAcceptedCommandTypes() {
         return Collections.unmodifiableList(acceptedCommandTypes);
+    }
+
+    @Override
+    public void setState(State state) {
+        if (isAcceptedState(acceptedDataTypes, state)) {
+            super.setState(state);
+        } else {
+            logger.error("Tried to set invalid state {} on item {} of type {}, ignoring it", state, getName(),
+                    getClass().getSimpleName());
+        }
     }
 
 }


### PR DESCRIPTION
Item.setState() enforces acceptedDataTypes + Tests
    
Items will now check the state to be set against their acceptedDataTypes. If they do not accept it an error will be logged and the state to be set will be discarded. Accepted types are all which are specified in acceptedDataTypes plus their sub-types.    

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>