### PR TITLE
Updated ItemRegistryImpl to make use of {@inheritDoc} notation

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/factory/CoreModuleHandlerFactory.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/factory/CoreModuleHandlerFactory.java
@@ -136,12 +136,6 @@ public class CoreModuleHandlerFactory extends BaseModuleHandlerFactory {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.eclipse.smarthome.automation.handler.
-     * BaseCustomizedModuleHandlerFactory#dispose ()
-     */
     @Override
     public void dispose() {
         super.dispose();

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/src/main/java/org/eclipse/smarthome/automation/module/timer/internal/Activator.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/src/main/java/org/eclipse/smarthome/automation/module/timer/internal/Activator.java
@@ -28,12 +28,6 @@ public class Activator implements BundleActivator {
     @SuppressWarnings("rawtypes")
     private ServiceRegistration factoryRegistration;
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.
-     * BundleContext)
-     */
     @Override
     public void start(BundleContext bundleContext) throws Exception {
         this.moduleHandlerFactory = new TimerModuleHandlerFactory();
@@ -43,12 +37,6 @@ public class Activator implements BundleActivator {
         logger.debug("started bundle timer.module");
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
-     */
     @Override
     public void stop(BundleContext bundleContext) throws Exception {
         this.moduleHandlerFactory.dispose();

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/Activator.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/Activator.java
@@ -31,11 +31,6 @@ public final class Activator implements BundleActivator {
     private ServiceBinder configDescriptionRegistryServiceBinder;
     private ServiceBinder i18nProviderServiceBinder;
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
-     */
     @Override
     public void start(BundleContext context) throws Exception {
         Activator.bundleContext = context;
@@ -48,11 +43,6 @@ public final class Activator implements BundleActivator {
         i18nProviderServiceBinder.open();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
-     */
     @Override
     public void stop(BundleContext context) throws Exception {
         Activator.bundleContext = null;

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusInfo.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusInfo.java
@@ -152,11 +152,6 @@ public final class ConfigStatusInfo {
         return Collections.unmodifiableCollection(Collections2.filter(configStatusMessages, predicate));
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -165,11 +160,6 @@ public final class ConfigStatusInfo {
         return result;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
@@ -187,11 +177,6 @@ public final class ConfigStatusInfo {
         return true;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "ConfigStatusInfo [configStatusMessages=" + configStatusMessages + "]";

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/MinMaxValidator.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/MinMaxValidator.java
@@ -25,13 +25,6 @@ import org.eclipse.smarthome.config.core.validation.internal.TypeIntrospections.
  */
 final class MinMaxValidator implements ConfigDescriptionParameterValidator {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.config.core.validation.internal.ConfigDescriptionParameterValidator#validate(org.eclipse.
-     * smarthome.config.core.ConfigDescriptionParameter, java.lang.Object)
-     */
     @Override
     public ConfigValidationMessage validate(ConfigDescriptionParameter parameter, Object value) {
         if (value == null || parameter.getType() == Type.BOOLEAN) {

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/PatternValidator.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/PatternValidator.java
@@ -19,13 +19,6 @@ import org.eclipse.smarthome.config.core.validation.ConfigValidationMessage;
  */
 final class PatternValidator implements ConfigDescriptionParameterValidator {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.config.core.validation.internal.ConfigDescriptionParameterValidator#validate(org.eclipse.
-     * smarthome.config.core.ConfigDescriptionParameter, java.lang.Object)
-     */
     @Override
     public ConfigValidationMessage validate(ConfigDescriptionParameter parameter, Object value) {
         if (value == null || parameter.getType() != Type.TEXT || parameter.getPattern() == null) {

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/RequiredValidator.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/RequiredValidator.java
@@ -17,13 +17,6 @@ import org.eclipse.smarthome.config.core.validation.ConfigValidationMessage;
  */
 final class RequiredValidator implements ConfigDescriptionParameterValidator {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.config.core.validation.internal.ConfigDescriptionParameterValidator#validate(org.eclipse.
-     * smarthome.config.core.ConfigDescriptionParameter, java.lang.Object)
-     */
     @Override
     public ConfigValidationMessage validate(ConfigDescriptionParameter param, Object value) {
         if (param.isRequired() && value == null) {

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/TypeValidator.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/internal/TypeValidator.java
@@ -20,13 +20,6 @@ import org.eclipse.smarthome.config.core.validation.internal.TypeIntrospections.
  */
 final class TypeValidator implements ConfigDescriptionParameterValidator {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.config.core.validation.internal.ConfigDescriptionParameterValidator#validate(org.eclipse.
-     * smarthome.config.core.ConfigDescriptionParameter, java.lang.Object)
-     */
     @Override
     public ConfigValidationMessage validate(ConfigDescriptionParameter parameter, Object value) {
         if (value == null) {

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
@@ -131,25 +131,11 @@ public class ConfigDispatcher extends AbstractWatchService {
         this.configAdmin = null;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.service.AbstractWatchService#watchSubDirectories
-     * ()
-     */
     @Override
     protected boolean watchSubDirectories() {
         return false;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.service.AbstractWatchService#registerDirectory
-     * (java.nio.file.Path)
-     */
     @Override
     protected Kind<?>[] getWatchEventKinds(Path subDir) {
         return new Kind<?>[] { ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY };

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -62,12 +62,6 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
         thingTrackers.add(thingTracker);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.thing.ThingRegistry#getByUID(java.lang.String)
-     */
     @Override
     public Thing get(final ThingUID uid) {
         for (final Map.Entry<Provider<Thing>, Collection<Thing>> entry : elementMap.entrySet()) {

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
@@ -110,9 +110,6 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
      * @param source
      *            the input to transform
      * @throws TransformationException
-     *
-     * @{inheritDoc
-     *
      */
     @Override
     public String transform(String filename, String source) throws TransformationException {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -53,13 +53,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         super(ItemProvider.class);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.internal.items.ItemRegistry#getItem(java.lang
-     * .String)
-     */
     @Override
     public Item getItem(String name) throws ItemNotFoundException {
         final Item item = get(name);
@@ -82,13 +75,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         return null;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.internal.items.ItemRegistry#getItemByPattern
-     * (java.lang.String)
-     */
     @Override
     public Item getItemByPattern(String name) throws ItemNotFoundException, ItemNotUniqueException {
         Collection<Item> items = getItems(name);
@@ -105,11 +91,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.eclipse.smarthome.core.internal.items.ItemRegistry#getItems()
-     */
     @Override
     public Collection<Item> getItems() {
         return getAll();
@@ -128,13 +109,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         return matchedItems;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.internal.items.ItemRegistry#getItems(java.
-     * lang.String)
-     */
     @Override
     public Collection<Item> getItems(String pattern) {
         String regex = pattern.replace("?", ".?").replace("*", ".*?");

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -77,41 +77,26 @@ abstract public class GenericItem implements ActiveItem {
         this.type = type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public State getState() {
         return state;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public State getStateAs(Class<? extends State> typeClass) {
         return state.as(typeClass);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getName() {
         return name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getType() {
         return type;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public List<String> getGroupNames() {
         return ImmutableList.copyOf(groupNames);
@@ -243,9 +228,6 @@ abstract public class GenericItem implements ActiveItem {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupFunction.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupFunction.java
@@ -55,9 +55,6 @@ public interface GroupFunction {
      */
     static class Equality implements GroupFunction {
 
-        /**
-         * @{inheritDoc
-         */
         @Override
         public State calculate(Set<Item> items) {
             if (items.size() > 0) {
@@ -74,9 +71,6 @@ public interface GroupFunction {
             }
         }
 
-        /**
-         * @{inheritDoc
-         */
         @Override
         public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
             State state = calculate(items);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -234,9 +234,6 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         }
     }
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     protected void internalSend(Command command) {
         if (eventPublisher != null) {
@@ -247,9 +244,6 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         }
     }
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public State getStateAs(Class<? extends State> typeClass) {
         // if a group does not have a function it cannot have a state
@@ -269,9 +263,6 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         return newState;
     }
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -312,16 +303,10 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         return sb.toString();
     }
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public void stateChanged(Item item, State oldState, State newState) {
     }
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public void stateUpdated(Item item, State state) {
         State oldState = this.state;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/CoreItemFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/CoreItemFactory.java
@@ -44,9 +44,6 @@ public class CoreItemFactory implements ItemFactory {
     public static final String STRING = "String";
     public static final String SWITCH = "Switch";
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public GenericItem createItem(String itemTypeName, String itemName) {
         if (itemTypeName == null) {
@@ -83,9 +80,6 @@ public class CoreItemFactory implements ItemFactory {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String[] getSupportedItemTypes() {
         return new String[] { SWITCH, ROLLERSHUTTER, CONTACT, STRING, NUMBER, DIMMER, DATETIME, COLOR, IMAGE, PLAYER,

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/internal/CoreLibraryActivator.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/internal/CoreLibraryActivator.java
@@ -12,20 +12,10 @@ import org.osgi.framework.BundleContext;
 
 public class CoreLibraryActivator implements BundleActivator {
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
-     */
     @Override
     public void start(BundleContext context) throws Exception {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
-     */
     @Override
     public void stop(BundleContext context) throws Exception {
     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/ColorItem.java
@@ -65,9 +65,6 @@ public class ColorItem extends DimmerItem {
         return Collections.unmodifiableList(acceptedCommandTypes);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setState(State state) {
         State currentState = this.state;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
@@ -66,9 +66,6 @@ public class DimmerItem extends SwitchItem {
         return Collections.unmodifiableList(acceptedCommandTypes);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setState(State state) {
         // try conversion

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/RollershutterItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/RollershutterItem.java
@@ -72,9 +72,6 @@ public class RollershutterItem extends GenericItem {
         internalSend(command);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setState(State state) {
         // try conversion

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunction.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunction.java
@@ -215,9 +215,6 @@ public interface ArithmeticGroupFunction extends GroupFunction {
         public Avg() {
         }
 
-        /**
-         * @{inheritDoc
-         */
         @Override
         public State calculate(Set<Item> items) {
             BigDecimal sum = BigDecimal.ZERO;
@@ -238,9 +235,6 @@ public interface ArithmeticGroupFunction extends GroupFunction {
             }
         }
 
-        /**
-         * @{inheritDoc
-         */
         @Override
         public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
             State state = calculate(items);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/WatchQueueReader.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/WatchQueueReader.java
@@ -172,11 +172,6 @@ public class WatchQueueReader implements Runnable {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.eclipse.smarthome.core.service.IWatchService#activate()
-     */
     @Override
     public void run() {
         try {

--- a/bundles/designer/org.eclipse.smarthome.designer.core/src/main/java/org/eclipse/smarthome/designer/core/CoreActivator.java
+++ b/bundles/designer/org.eclipse.smarthome.designer.core/src/main/java/org/eclipse/smarthome/designer/core/CoreActivator.java
@@ -41,13 +41,6 @@ public class CoreActivator extends Plugin {
     public CoreActivator() {
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext
-     * )
-     */
     @Override
     public void start(BundleContext context) throws Exception {
         super.start(context);
@@ -59,13 +52,6 @@ public class CoreActivator extends Plugin {
         configurationAdminTracker.open();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext
-     * )
-     */
     @Override
     public void stop(BundleContext context) throws Exception {
         plugin = null;

--- a/bundles/designer/org.eclipse.smarthome.designer.ui/src/main/java/org/eclipse/smarthome/designer/ui/UIActivator.java
+++ b/bundles/designer/org.eclipse.smarthome.designer.ui/src/main/java/org/eclipse/smarthome/designer/ui/UIActivator.java
@@ -32,11 +32,6 @@ public class UIActivator extends AbstractUIPlugin {
     public UIActivator() {
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
-     */
     @Override
     public void start(BundleContext context) throws Exception {
         super.start(context);
@@ -45,11 +40,6 @@ public class UIActivator extends AbstractUIPlugin {
         plugin = this;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
-     */
     @Override
     public void stop(BundleContext context) throws Exception {
         plugin = null;

--- a/bundles/designer/org.eclipse.smarthome.designer.ui/src/main/java/org/eclipse/smarthome/designer/ui/internal/application/Application.java
+++ b/bundles/designer/org.eclipse.smarthome.designer.ui/src/main/java/org/eclipse/smarthome/designer/ui/internal/application/Application.java
@@ -20,11 +20,6 @@ import org.eclipse.ui.PlatformUI;
  */
 public class Application implements IApplication {
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.equinox.app.IApplication#start(org.eclipse.equinox.app.IApplicationContext)
-     */
     @Override
     public Object start(IApplicationContext context) {
         Display display = PlatformUI.createDisplay();
@@ -39,11 +34,6 @@ public class Application implements IApplication {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.equinox.app.IApplication#stop()
-     */
     @Override
     public void stop() {
         if (!PlatformUI.isWorkbenchRunning())

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -627,9 +627,6 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
 
         private boolean changed = false;
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public void stateChanged(Item item, State oldState, State newState) {
             changed = true;
@@ -644,9 +641,6 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
             return changed;
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public void stateUpdated(Item item, State state) {
             // ignore if the state did not change

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
@@ -65,9 +65,6 @@ public class MDNSClientImpl implements MDNSClient {
         return addresses;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Set<JmDNS> getClientInstances() {
         return jmdnsInstances;
@@ -93,9 +90,6 @@ public class MDNSClientImpl implements MDNSClient {
         close();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void addServiceListener(String type, ServiceListener listener) {
         for (JmDNS instance : jmdnsInstances) {
@@ -103,9 +97,6 @@ public class MDNSClientImpl implements MDNSClient {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void removeServiceListener(String type, ServiceListener listener) {
         for (JmDNS instance : jmdnsInstances) {
@@ -113,9 +104,6 @@ public class MDNSClientImpl implements MDNSClient {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void registerService(ServiceDescription description) throws IOException {
         for (JmDNS instance : jmdnsInstances) {
@@ -128,9 +116,6 @@ public class MDNSClientImpl implements MDNSClient {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void unregisterService(ServiceDescription description) {
         for (JmDNS instance : jmdnsInstances) {
@@ -146,9 +131,6 @@ public class MDNSClientImpl implements MDNSClient {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void unregisterAllServices() {
         for (JmDNS instance : jmdnsInstances) {
@@ -156,9 +138,6 @@ public class MDNSClientImpl implements MDNSClient {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ServiceInfo[] list(String type) {
         ServiceInfo[] services = new ServiceInfo[0];
@@ -168,9 +147,6 @@ public class MDNSClientImpl implements MDNSClient {
         return services;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void close() {
         for (JmDNS jmdns : jmdnsInstances) {

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSServiceImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSServiceImpl.java
@@ -70,9 +70,6 @@ public class MDNSServiceImpl implements MDNSService {
         mdnsClient.unregisterAllServices();
     }
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public void registerService(final ServiceDescription description) {
         if (mdnsClient == null) {
@@ -97,9 +94,6 @@ public class MDNSServiceImpl implements MDNSService {
         }
     }
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public void unregisterService(ServiceDescription description) {
         if (mdnsClient != null) {

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttWillAndTestament.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttWillAndTestament.java
@@ -130,9 +130,6 @@ public class MqttWillAndTestament {
         this.retain = retain;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/ModelRepositoryChangeListener.java
+++ b/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/ModelRepositoryChangeListener.java
@@ -9,5 +9,9 @@ package org.eclipse.smarthome.model.core;
 
 public interface ModelRepositoryChangeListener {
 
+    /**
+     * Performs dispatch of all binding configs and 
+     * fires all {@link ItemsChangeListener}s if {@code modelName} ends with "items".
+     */
     public void modelChanged(String modelName, EventType type);
 }

--- a/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/ModelCoreActivator.java
+++ b/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/internal/ModelCoreActivator.java
@@ -18,21 +18,11 @@ public class ModelCoreActivator implements BundleActivator {
         return context;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.osgi.framework.BundleActivator#start(org.osgi.framework.BundleContext)
-     */
     @Override
     public void start(BundleContext bundleContext) throws Exception {
         ModelCoreActivator.context = bundleContext;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.osgi.framework.BundleActivator#stop(org.osgi.framework.BundleContext)
-     */
     @Override
     public void stop(BundleContext bundleContext) throws Exception {
         ModelCoreActivator.context = null;

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
@@ -50,25 +50,16 @@ public class AutoUpdateGenericBindingConfigProvider implements AutoUpdateBinding
      */
     protected Map<String, Set<String>> contextMap = new ConcurrentHashMap<>();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getBindingType() {
         return "autoupdate";
     }
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public void validateItemType(String itemType, String bindingConfig) throws BindingConfigParseException {
         // as AutoUpdate is a default binding, each binding type is valid
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void processBindingConfiguration(String context, String itemType, String itemName, String bindingConfig)
             throws BindingConfigParseException {
@@ -96,18 +87,12 @@ public class AutoUpdateGenericBindingConfigProvider implements AutoUpdateBinding
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Boolean autoUpdate(String itemName) {
         AutoUpdateBindingConfig config = bindingConfigs.get(itemName);
         return config != null ? config.autoupdate : null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void startConfigurationUpdate(String context) {
         Set<String> itemNames = contextMap.get(context);
@@ -128,23 +113,14 @@ public class AutoUpdateGenericBindingConfigProvider implements AutoUpdateBinding
         bindingConfigs.put(itemName, config);
     }
 
-    /**
-     * @{inheritDoc
-     */
     public boolean providesBindingFor(String itemName) {
         return bindingConfigs.get(itemName) != null;
     }
 
-    /**
-     * @{inheritDoc
-     */
     public boolean providesBinding() {
         return !bindingConfigs.isEmpty();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public Collection<String> getItemNames() {
         return new ArrayList<String>(bindingConfigs.keySet());
     }

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -129,9 +129,6 @@ public class GenericItemProvider extends AbstractProvider<Item>
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<Item> getAll() {
         List<Item> items = new ArrayList<Item>();
@@ -339,11 +336,6 @@ public class GenericItemProvider extends AbstractProvider<Item>
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Dispatches all binding configs and fires all {@link ItemsChangeListener}s if {@code modelName} ends with "items".
-     */
     @Override
     public void modelChanged(String modelName, EventType type) {
         if (modelName.endsWith("items")) {

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptEngineImpl.java
@@ -81,17 +81,11 @@ public class ScriptEngineImpl implements ScriptEngine, ModelParser {
     protected void unsetScriptRuntime(final ScriptRuntime scriptRuntime) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Script newScriptFromString(String scriptAsString) throws ScriptParsingException {
         return newScriptFromXExpression(parseScriptIntoXTextEObject(scriptAsString));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Script newScriptFromXExpression(XExpression expression) {
         ScriptImpl script = ScriptRuntimeStandaloneSetup.getInjector().getInstance(ScriptImpl.class);
@@ -99,9 +93,6 @@ public class ScriptEngineImpl implements ScriptEngine, ModelParser {
         return script;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Object executeScript(String scriptAsString) throws ScriptParsingException, ScriptExecutionException {
         return newScriptFromString(scriptAsString).execute();

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/sitemap/internal/SitemapProviderImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/sitemap/internal/SitemapProviderImpl.java
@@ -39,11 +39,6 @@ public class SitemapProviderImpl implements SitemapProvider {
         this.modelRepo = null;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.eclipse.smarthome.model.sitemap.internal.SitemapProvider#getSitemap(java.lang.String)
-     */
     @Override
     public Sitemap getSitemap(String sitemapName) {
         if (modelRepo != null) {

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/DumbThingTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/DumbThingTypeProvider.java
@@ -46,25 +46,11 @@ public class DumbThingTypeProvider implements ThingTypeProvider {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.thing.binding.ThingTypeProvider#getThingTypes
-     * (java.util.Locale)
-     */
     @Override
     public Collection<ThingType> getThingTypes(Locale locale) {
         return thingTypes.values();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.thing.binding.ThingTypeProvider#getThingType
-     * (org.eclipse.smarthome.core.thing.ThingTypeUID, java.util.Locale)
-     */
     @Override
     public ThingType getThingType(ThingTypeUID thingTypeUID, Locale locale) {
         return thingTypes.get(thingTypeUID);

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingTypeProvider.java
@@ -83,25 +83,11 @@ public class TestHueThingTypeProvider implements ThingTypeProvider {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.thing.binding.ThingTypeProvider#getThingTypes
-     * (java.util.Locale)
-     */
     @Override
     public Collection<ThingType> getThingTypes(Locale locale) {
         return thingTypes.values();
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * org.eclipse.smarthome.core.thing.binding.ThingTypeProvider#getThingType
-     * (org.eclipse.smarthome.core.thing.ThingTypeUID, java.util.Locale)
-     */
     @Override
     public ThingType getThingType(ThingTypeUID thingTypeUID, Locale locale) {
         return thingTypes.get(thingTypeUID);

--- a/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/JsonStorage.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/JsonStorage.java
@@ -115,9 +115,6 @@ public class JsonStorage<T> implements Storage<T> {
 
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T put(String key, T value) {
         Map<String, Object> val = new LinkedHashMap<String, Object>();
@@ -136,9 +133,6 @@ public class JsonStorage<T> implements Storage<T> {
         return deserialize(previousValue);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T remove(String key) {
         Map<String, Object> removedElement = map.remove(key);
@@ -146,9 +140,6 @@ public class JsonStorage<T> implements Storage<T> {
         return deserialize(removedElement);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T get(String key) {
         Map<String, Object> value = map.get(key);
@@ -158,17 +149,11 @@ public class JsonStorage<T> implements Storage<T> {
         return deserialize(value);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<String> getKeys() {
         return map.keySet();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<T> getValues() {
         Collection<T> values = new ArrayList<T>();

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/src/main/java/org/eclipse/smarthome/storage/mapdb/MapDbStorage.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/src/main/java/org/eclipse/smarthome/storage/mapdb/MapDbStorage.java
@@ -48,9 +48,6 @@ public class MapDbStorage<T> implements Storage<T> {
         this.mapper = new GsonBuilder().registerTypeAdapterFactory(new PropertiesTypeAdapterFactory()).create();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T put(String key, T value) {
         String previousValue = map.put(key, serialize(value));
@@ -58,9 +55,6 @@ public class MapDbStorage<T> implements Storage<T> {
         return deserialize(previousValue);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T remove(String key) {
         String removedElement = map.remove(key);
@@ -68,25 +62,16 @@ public class MapDbStorage<T> implements Storage<T> {
         return deserialize(removedElement);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T get(String key) {
         return deserialize(map.get(key));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<String> getKeys() {
         return map.keySet();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<T> getValues() {
         Collection<T> values = new ArrayList<T>();

--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/storage/VolatileStorage.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/storage/VolatileStorage.java
@@ -23,41 +23,26 @@ public class VolatileStorage<T> implements Storage<T> {
 
     Map<String, T> storage = new ConcurrentHashMap<String, T>();
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T put(String key, T value) {
         return storage.put(key, value);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T remove(String key) {
         return storage.remove(key);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public T get(String key) {
         return storage.get(key);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<String> getKeys() {
         return storage.keySet();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<T> getValues() {
         return storage.values();

--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/storage/VolatileStorageService.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/storage/VolatileStorageService.java
@@ -24,11 +24,6 @@ public class VolatileStorageService implements StorageService {
     @SuppressWarnings("rawtypes")
     Map<String, Storage> storages = new ConcurrentHashMap<String, Storage>();
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @return
-     */
     @Override
     @SuppressWarnings("unchecked")
     public synchronized <T> Storage<T> getStorage(String name) {
@@ -38,11 +33,6 @@ public class VolatileStorageService implements StorageService {
         return storages.get(name);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @return
-     */
     @Override
     public <T> Storage<T> getStorage(String name, ClassLoader classLoader) {
         return getStorage(name);

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/ChartServlet.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/ChartServlet.java
@@ -273,32 +273,20 @@ public class ChartServlet extends HttpServlet {
         return defaultHttpContext;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void init(ServletConfig config) throws ServletException {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ServletConfig getServletConfig() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getServletInfo() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void destroy() {
     }

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/DefaultChartProvider.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/DefaultChartProvider.java
@@ -104,9 +104,6 @@ public class DefaultChartProvider implements ChartProvider {
     protected void deactivate() {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public void destroy() {
     }
 

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -120,9 +120,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         itemUIProviders.remove(itemUIProvider);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getCategory(String itemName) {
         for (ItemUIProvider provider : itemUIProviders) {
@@ -156,9 +153,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getLabel(String itemName) {
         for (ItemUIProvider provider : itemUIProviders) {
@@ -178,9 +172,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Widget getWidget(String itemName) {
         for (ItemUIProvider provider : itemUIProviders) {
@@ -192,9 +183,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Widget getDefaultWidget(Class<? extends Item> itemType, String itemName) {
         for (ItemUIProvider provider : itemUIProviders) {
@@ -277,9 +265,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return playerItemSwitch;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getLabel(Widget w) {
         String label = getLabelFromWidget(w);
@@ -446,9 +431,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return label;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getCategory(Widget w) {
         String widgetTypeName = w.eClass().getInstanceTypeName()
@@ -473,9 +455,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return category;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public State getState(Widget w) {
         String itemName = w.getItem();
@@ -519,9 +498,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return returnState;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Widget getWidget(Sitemap sitemap, String id) {
         if (id.length() > 0) {
@@ -549,9 +525,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> getChildren(Sitemap sitemap) {
         EList<Widget> widgets = sitemap.getChildren();
@@ -566,9 +539,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return result;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> getChildren(LinkableWidget w) {
         EList<Widget> widgets = null;
@@ -588,9 +558,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return result;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EObject getParent(Widget w) {
         Widget w2 = defaultWidgets.get(w);
@@ -685,9 +652,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Item getItem(String name) throws ItemNotFoundException {
         if (itemRegistry != null) {
@@ -697,9 +661,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Item getItemByPattern(String name) throws ItemNotFoundException, ItemNotUniqueException {
         if (itemRegistry != null) {
@@ -709,9 +670,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<Item> getItems() {
         if (itemRegistry != null) {
@@ -730,9 +688,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<Item> getItems(String pattern) {
         if (itemRegistry != null) {
@@ -742,9 +697,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void addRegistryChangeListener(RegistryChangeListener<Item> listener) {
         if (itemRegistry != null) {
@@ -752,9 +704,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void removeRegistryChangeListener(RegistryChangeListener<Item> listener) {
         if (itemRegistry != null) {
@@ -762,25 +711,16 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<Item> getAll() {
         return itemRegistry.getAll();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Stream<Item> stream() {
         return itemRegistry.stream();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getWidgetId(Widget w) {
         Widget w2 = defaultWidgets.get(w);
@@ -816,9 +756,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return id;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     private boolean matchStateToValue(State state, String value, String matchCondition) {
         // Check if the value is equal to the supplied value
         boolean matched = false;
@@ -935,9 +872,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return matched;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     private String processColorDefinition(State state, List<ColorArray> colorList) {
         // Sanity check
         if (colorList == null) {
@@ -1008,25 +942,16 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return colorString;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getLabelColor(Widget w) {
         return processColorDefinition(getState(w), w.getLabelColor());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getValueColor(Widget w) {
         return processColorDefinition(getState(w), w.getValueColor());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean getVisiblity(Widget w) {
         // Default to visible if parameters not set

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/proxy/AsyncProxyServlet.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/proxy/AsyncProxyServlet.java
@@ -39,8 +39,6 @@ public class AsyncProxyServlet extends org.eclipse.jetty.proxy.AsyncProxyServlet
     }
 
     /**
-     * {@inheritDoc}
-     *
      * Override <code>newHttpClient</code> so we can proxy to HTTPS URIs.
      */
     @Override
@@ -49,8 +47,6 @@ public class AsyncProxyServlet extends org.eclipse.jetty.proxy.AsyncProxyServlet
     }
 
     /**
-     * {@inheritDoc}
-     *
      * Add Basic Authentication header to request if user and password are specified in URI.
      *
      * After Jetty is upgraded past 9.2.9, change to <code>copyRequestHeaders</code> to avoid deprecation warning.
@@ -63,17 +59,11 @@ public class AsyncProxyServlet extends org.eclipse.jetty.proxy.AsyncProxyServlet
         service.maybeAppendAuthHeader(service.uriFromRequest(clientRequest), proxyRequest);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected String rewriteTarget(HttpServletRequest request) {
         return Objects.toString(service.uriFromRequest(request), null);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void onProxyRewriteFailed(HttpServletRequest request, HttpServletResponse response) {
         service.sendError(request, response);

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/discovery/AstroDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/discovery/AstroDiscoveryService.java
@@ -38,9 +38,6 @@ public class AstroDiscoveryService extends AbstractDiscoveryService {
         super(ImmutableSet.of(new ThingTypeUID(BINDING_ID, "-")), DISCOVER_TIMEOUT_SECONDS, false);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void startScan() {
         logger.debug("Starting Astro discovery scan");

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/handler/AstroThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/handler/AstroThingHandler.java
@@ -62,9 +62,6 @@ public abstract class AstroThingHandler extends BaseThingHandler {
         super(thing);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void initialize() {
         logger.debug("Initializing thing {}", getThing().getUID());
@@ -102,9 +99,6 @@ public abstract class AstroThingHandler extends BaseThingHandler {
         logger.debug("Thing {} initialized {}", getThing().getUID(), getThing().getStatus());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void dispose() {
         logger.debug("Disposing thing {}", getThing().getUID());
@@ -117,9 +111,6 @@ public abstract class AstroThingHandler extends BaseThingHandler {
         logger.debug("Thing {} disposed", getThing().getUID());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (RefreshType.REFRESH == command) {
@@ -130,9 +121,6 @@ public abstract class AstroThingHandler extends BaseThingHandler {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void handleUpdate(ChannelUID channelUID, State newState) {
         logger.warn("The Astro-Binding is a read-only binding and can not handle channel updates");
@@ -256,18 +244,12 @@ public abstract class AstroThingHandler extends BaseThingHandler {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void channelLinked(ChannelUID channelUID) {
         linkedChannelChange(channelUID, 1);
         publishChannelIfLinked(channelUID);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void channelUnlinked(ChannelUID channelUID) {
         linkedChannelChange(channelUID, -1);

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/handler/MoonHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/handler/MoonHandler.java
@@ -39,52 +39,34 @@ public class MoonHandler extends AstroThingHandler {
         super(thing);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void publishDailyInfo() {
         moon = moonCalc.getMoonInfo(Calendar.getInstance(), thingConfig.getLatitude(), thingConfig.getLongitude());
         publishPositionalInfo();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void publishPositionalInfo() {
         moonCalc.setPositionalInfo(Calendar.getInstance(), thingConfig.getLatitude(), thingConfig.getLongitude(), moon);
         publishPlanet();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Planet getPlanet() {
         return moon;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void dispose() {
         super.dispose();
         moon = null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected String[] getPositionalChannelIds() {
         return positionalChannelIds;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Class<? extends AbstractDailyJob> getDailyJobClass() {
         return DailyJobMoon.class;

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/handler/SunHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/handler/SunHandler.java
@@ -39,9 +39,6 @@ public class SunHandler extends AstroThingHandler {
         super(thing);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void publishDailyInfo() {
         sun = sunCalc.getSunInfo(Calendar.getInstance(), thingConfig.getLatitude(), thingConfig.getLongitude(),
@@ -49,9 +46,6 @@ public class SunHandler extends AstroThingHandler {
         publishPositionalInfo();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void publishPositionalInfo() {
         sunCalc.setPositionalInfo(Calendar.getInstance(), thingConfig.getLatitude(), thingConfig.getLongitude(),
@@ -59,34 +53,22 @@ public class SunHandler extends AstroThingHandler {
         publishPlanet();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Planet getPlanet() {
         return sun;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void dispose() {
         super.dispose();
         sun = null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected String[] getPositionalChannelIds() {
         return positionalChannelIds;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected Class<? extends AbstractDailyJob> getDailyJobClass() {
         return DailyJobSun.class;

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/config/AstroThingConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/config/AstroThingConfig.java
@@ -96,9 +96,6 @@ public class AstroThingConfig {
         this.thingUid = thingUid;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         TimeZone tz = TimeZone.getDefault();

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/AbstractDailyJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/AbstractDailyJob.java
@@ -35,9 +35,6 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractDailyJob extends AbstractBaseJob {
     private final Logger logger = LoggerFactory.getLogger(AbstractDailyJob.class);
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void executeJob(String thingUid, JobDataMap jobDataMap) {
         AstroThingHandler handler = AstroHandlerFactory.getHandler(thingUid);

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/DailyJobMoon.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/DailyJobMoon.java
@@ -22,9 +22,6 @@ import org.eclipse.smarthome.binding.astro.internal.model.Planet;
  */
 public class DailyJobMoon extends AbstractDailyJob {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void schedulePlanetEvents(String thingUid, AstroThingHandler handler, Planet planet) {
         Moon moon = (Moon) planet;

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/DailyJobSun.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/DailyJobSun.java
@@ -22,9 +22,6 @@ import org.eclipse.smarthome.binding.astro.internal.model.SunPhaseName;
  */
 public class DailyJobSun extends AbstractDailyJob {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void schedulePlanetEvents(String thingUid, AstroThingHandler handler, Planet planet) {
         Sun sun = (Sun) planet;

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/EventJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/EventJob.java
@@ -19,9 +19,6 @@ import org.quartz.JobDataMap;
 public class EventJob extends AbstractBaseJob {
     public static final String KEY_EVENT = "event";
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void executeJob(String thingUid, JobDataMap jobDataMap) {
         AstroThingHandler astroHandler = AstroHandlerFactory.getHandler(thingUid);

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/PublishPlanetJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/PublishPlanetJob.java
@@ -18,9 +18,6 @@ import org.quartz.JobDataMap;
  */
 public class PublishPlanetJob extends AbstractBaseJob {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void executeJob(String thingUid, JobDataMap jobDataMap) {
         AstroThingHandler astroHandler = AstroHandlerFactory.getHandler(thingUid);

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/SunPhaseJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/SunPhaseJob.java
@@ -23,9 +23,6 @@ import org.quartz.JobDataMap;
  */
 public class SunPhaseJob extends AbstractBaseJob {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     protected void executeJob(String thingUid, JobDataMap jobDataMap) {
         AstroThingHandler astroHandler = AstroHandlerFactory.getHandler(thingUid);

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/model/Sun.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/model/Sun.java
@@ -272,9 +272,6 @@ public class Sun extends RiseSet implements Planet {
         return ranges;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("sunrise", getRise())

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/model/SunPhase.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/model/SunPhase.java
@@ -32,9 +32,6 @@ public class SunPhase {
         this.name = name;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String toString() {
         return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE).append("name", name).toString();

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/DeviceConsumptionSensorJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/DeviceConsumptionSensorJob.java
@@ -102,11 +102,6 @@ public class DeviceConsumptionSensorJob implements SensorJob {
         this.initalisationTime = time;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "DeviceConsumptionSensorJob [sensorType=" + sensorType + ", deviceDSID : " + device.getDSID().getValue()

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/DeviceOutputValueSensorJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/DeviceOutputValueSensorJob.java
@@ -114,11 +114,6 @@ public class DeviceOutputValueSensorJob implements SensorJob {
         this.initalisationTime = time;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "DeviceOutputValueSensorJob [deviceDSID : " + device.getDSID().getValue() + ", meterDSID=" + meterDSID

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/SceneConfigReadingJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/SceneConfigReadingJob.java
@@ -90,11 +90,6 @@ public class SceneConfigReadingJob implements SensorJob {
         this.initalisationTime = time;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "SceneConfigReadingJob [sceneID: " + sceneID + ", deviceDSID : " + device.getDSID().getValue()

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/SceneOutputValueReadingJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/sensorJob/impl/SceneOutputValueReadingJob.java
@@ -93,11 +93,6 @@ public class SceneOutputValueReadingJob implements SensorJob {
         this.initalisationTime = time;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return "SceneOutputValueReadingJob [sceneID: " + sceneID + ", deviceDSID : " + device.getDSID().getValue()

--- a/extensions/io/org.eclipse.smarthome.io.javasound/src/main/java/org/eclipse/smarthome/io/javasound/internal/JavaSoundInputStream.java
+++ b/extensions/io/org.eclipse.smarthome.io.javasound/src/main/java/org/eclipse/smarthome/io/javasound/internal/JavaSoundInputStream.java
@@ -39,9 +39,6 @@ public class JavaSoundInputStream extends AudioStream {
         this.input.start();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public int read() throws IOException {
         byte[] b = new byte[1];

--- a/extensions/transform/org.eclipse.smarthome.transform.map/src/main/java/org/eclipse/smarthome/transform/map/internal/MapTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/src/main/java/org/eclipse/smarthome/transform/map/internal/MapTransformationService.java
@@ -40,9 +40,6 @@ public class MapTransformationService extends AbstractFileTransformationService<
      *            the list of properties which contains the key value pairs for the mapping.
      * @param source
      *            the input to transform
-     *
-     * @{inheritDoc
-     *
      */
     @Override
     protected String internalTransform(Properties properties, String source) throws TransformationException {

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
@@ -30,9 +30,6 @@ public class RegExTransformationService implements TransformationService {
 
     private static final Pattern substPattern = Pattern.compile("^s/(.*?[^\\\\])/(.*?[^\\\\])/(.*)$");
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public String transform(String regExpression, String source) throws TransformationException {
 

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/ScaleTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/ScaleTransformationService.java
@@ -38,18 +38,16 @@ public class ScaleTransformationService extends AbstractFileTransformationServic
     private static final Pattern LIMITS_PATTERN = Pattern.compile("(\\[|\\])(.*)\\.\\.(.*)(\\[|\\])");
 
     /**
-     * <p>
-     * Transforms the input <code>source</code> by matching searching the range where it fits
-     * i.e. [min..max]=value or ]min..max]=value
-     * </p>
+     * Performs transformation of the input <code>source</code>
+     * 
+     * The method transforms the input <code>source</code> by matching searching
+     * the range where it fits i.e. [min..max]=value or ]min..max]=value
      *
      * @param properties
      *            the list of properties defining all the available ranges
      * @param source
      *            the input to transform
-     *
-     * @{inheritDoc
-     *
+     * 
      */
     @Override
     protected String internalTransform(Map<Range, String> data, String source) throws TransformationException {

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationService.java
@@ -34,9 +34,6 @@ public class XPathTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(XPathTransformationService.class);
 
-    /**
-     * @{inheritDoc
-     */
     @Override
     public String transform(String xpathExpression, String source) throws TransformationException {
 

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
@@ -35,20 +35,17 @@ public class XsltTransformationService implements TransformationService {
     private final Logger logger = LoggerFactory.getLogger(XsltTransformationService.class);
 
     /**
-     * <p>
-     * Transforms the input <code>source</code> by XSLT. It expects the transformation rule to be read from a file which
-     * is stored under the 'configurations/transform' folder. To organize the various transformations one should use
-     * subfolders.
-     * </p>
+     * Transforms the input <code>source</code> by XSLT.
+     * 
+     * The method expects the transformation rule to be read from a file which
+     * is stored under the 'configurations/transform' folder. To organize the
+     * various transformations one should use subfolders.
      *
      * @param filename
-     *            the name of the file which contains the XSLT transformation rule. The name may contain subfoldernames
-     *            as well
+     *            the name of the file which contains the XSLT transformation rule. 
+     *            The name may contain subfoldernames as well
      * @param source
      *            the input to transform
-     *
-     * @{inheritDoc
-     *
      */
     @Override
     public String transform(String filename, String source) throws TransformationException {

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ChartRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ChartRenderer.java
@@ -33,17 +33,11 @@ public class ChartRenderer extends AbstractWidgetRenderer {
 
     private final Logger logger = LoggerFactory.getLogger(ChartRenderer.class);
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Chart;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Chart chart = (Chart) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ColorpickerRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ColorpickerRenderer.java
@@ -34,17 +34,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class ColorpickerRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Colorpicker;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Colorpicker cp = (Colorpicker) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/FrameRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/FrameRenderer.java
@@ -28,17 +28,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class FrameRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Frame;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("frame");

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/GroupRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/GroupRenderer.java
@@ -24,17 +24,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class GroupRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Group;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("group");

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ImageRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ImageRenderer.java
@@ -30,17 +30,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class ImageRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Image;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Image image = (Image) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ListRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ListRenderer.java
@@ -24,17 +24,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class ListRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof List;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("list");

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/MapviewRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/MapviewRenderer.java
@@ -25,17 +25,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class MapviewRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Mapview;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Mapview mapview = (Mapview) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/PageRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/PageRenderer.java
@@ -157,9 +157,6 @@ public class PageRenderer extends AbstractWidgetRenderer {
 
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         for (WidgetRenderer renderer : widgetRenderers) {
@@ -170,17 +167,11 @@ public class PageRenderer extends AbstractWidgetRenderer {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setConfig(WebAppConfig config) {
         this.config = config;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SelectionRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SelectionRenderer.java
@@ -28,9 +28,6 @@ import com.google.gson.JsonObject;
  */
 public class SelectionRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Selection;
@@ -51,9 +48,6 @@ public class SelectionRenderer extends AbstractWidgetRenderer {
         return result;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("selection");

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SetpointRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SetpointRenderer.java
@@ -28,17 +28,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class SetpointRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Setpoint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Setpoint sp = (Setpoint) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
@@ -30,17 +30,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class SliderRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Slider;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Slider s = (Slider) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SwitchRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SwitchRenderer.java
@@ -35,17 +35,11 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
 
     private final Logger logger = LoggerFactory.getLogger(SwitchRenderer.class);
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Switch;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Switch s = (Switch) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/TextRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/TextRenderer.java
@@ -24,17 +24,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class TextRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Text;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Text text = (Text) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/VideoRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/VideoRenderer.java
@@ -23,17 +23,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class VideoRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Video;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Video videoWidget = (Video) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/WebviewRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/WebviewRenderer.java
@@ -23,17 +23,11 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  */
 public class WebviewRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Webview;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Webview webview = (Webview) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/servlet/BaseServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/servlet/BaseServlet.java
@@ -54,32 +54,20 @@ public abstract class BaseServlet implements Servlet {
         return defaultHttpContext;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void init(ServletConfig config) throws ServletException {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ServletConfig getServletConfig() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getServletInfo() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void destroy() {
     }

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/servlet/CmdServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/servlet/CmdServlet.java
@@ -69,9 +69,6 @@ public class CmdServlet extends BaseServlet {
         httpService.unregister(WEBAPP_ALIAS + "/" + SERVLET_NAME);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
         for (Object key : req.getParameterMap().keySet()) {

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/servlet/WebAppServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/servlet/WebAppServlet.java
@@ -107,9 +107,6 @@ public class WebAppServlet extends BaseServlet {
         res.setContentType(CONTENT_TYPE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
         logger.debug("Servlet request received!");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ChartRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ChartRenderer.java
@@ -32,17 +32,11 @@ public class ChartRenderer extends AbstractWidgetRenderer {
 
     private final Logger logger = LoggerFactory.getLogger(ChartRenderer.class);
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Chart;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Chart chart = (Chart) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ColorpickerRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ColorpickerRenderer.java
@@ -33,17 +33,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class ColorpickerRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Colorpicker;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Colorpicker cp = (Colorpicker) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/FrameRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/FrameRenderer.java
@@ -24,17 +24,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class FrameRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Frame;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("frame");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/GroupRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/GroupRenderer.java
@@ -23,17 +23,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class GroupRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Group;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("group");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ImageRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ImageRenderer.java
@@ -29,17 +29,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class ImageRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Image;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Image image = (Image) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ListRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ListRenderer.java
@@ -23,17 +23,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class ListRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof List;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("list");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/MapviewRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/MapviewRenderer.java
@@ -24,16 +24,10 @@ import org.eclipse.smarthome.ui.classic.render.RenderException;
  */
 public class MapviewRenderer extends AbstractWidgetRenderer {
 
-	/**
-	 * {@inheritDoc}
-	 */
 	public boolean canRender(Widget w) {
 		return w instanceof Mapview;
 	}
 	
-	/**
-	 * {@inheritDoc}
-	 */
 	public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
 		Mapview mapview = (Mapview) w;
 		String snippet = getSnippet("mapview");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/PageRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/PageRenderer.java
@@ -154,9 +154,6 @@ public class PageRenderer extends AbstractWidgetRenderer {
 
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         // Check if this widget is visible
@@ -172,17 +169,11 @@ public class PageRenderer extends AbstractWidgetRenderer {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return false;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void setConfig(WebAppConfig config) {
         this.config = config;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SelectionRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SelectionRenderer.java
@@ -25,17 +25,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class SelectionRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Selection;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         String snippet = getSnippet("selection");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SetpointRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SetpointRenderer.java
@@ -28,17 +28,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class SetpointRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Setpoint;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Setpoint sp = (Setpoint) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SliderRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SliderRenderer.java
@@ -30,17 +30,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class SliderRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Slider;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Slider s = (Slider) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SwitchRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SwitchRenderer.java
@@ -35,17 +35,11 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
 
     private final Logger logger = LoggerFactory.getLogger(SwitchRenderer.class);
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Switch;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Switch s = (Switch) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/TextRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/TextRenderer.java
@@ -24,17 +24,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class TextRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Text;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Text text = (Text) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/VideoRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/VideoRenderer.java
@@ -23,17 +23,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class VideoRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Video;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Video videoWidget = (Video) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/WebviewRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/WebviewRenderer.java
@@ -23,17 +23,11 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  */
 public class WebviewRenderer extends AbstractWidgetRenderer {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public boolean canRender(Widget w) {
         return w instanceof Webview;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
         Webview webview = (Webview) w;

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/BaseServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/BaseServlet.java
@@ -54,32 +54,20 @@ public abstract class BaseServlet implements Servlet {
         return defaultHttpContext;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void init(ServletConfig config) throws ServletException {
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public ServletConfig getServletConfig() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getServletInfo() {
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void destroy() {
     }

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/CmdServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/CmdServlet.java
@@ -69,9 +69,6 @@ public class CmdServlet extends BaseServlet {
         httpService.unregister(WEBAPP_ALIAS + "/" + SERVLET_NAME);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
         res.setContentType("text/plain");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/WebAppServlet.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/servlet/WebAppServlet.java
@@ -99,9 +99,6 @@ public class WebAppServlet extends BaseServlet {
         logger.info("Stopped Classic UI");
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void service(ServletRequest req, ServletResponse res) throws ServletException, IOException {
         logger.debug("Servlet request received!");
@@ -253,9 +250,6 @@ public class WebAppServlet extends BaseServlet {
 
         private boolean changed = false;
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public void stateChanged(Item item, State oldState, State newState) {
             changed = true;
@@ -270,9 +264,6 @@ public class WebAppServlet extends BaseServlet {
             return changed;
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public void stateUpdated(Item item, State state) {
             // ignore if the state did not change

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/src/main/java/org/eclipse/smarthome/voice/mactts/internal/MacTTSVoice.java
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/src/main/java/org/eclipse/smarthome/voice/mactts/internal/MacTTSVoice.java
@@ -119,9 +119,6 @@ public class MacTTSVoice implements Voice {
         return label;
     }
 
-    /**
-     * @inheritDoc
-     */
     @Override
     public Locale getLocale() {
         Locale locale;


### PR DESCRIPTION
Removed `{@inheritDoc}` and `(non-Javadoc) @see` notations throughout ESH completely (code style consistency).

Signed-off-by: Alexander Kostadinov <alexander.g.kostadinov@gmail.com>