### PR TITLE
Add prominent link to issues for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ To build Eclipse SmartHome from the sources, Maven takes care of everything:
 
 The p2 repository that contains all bundles as a build result will be available in the folder 
 `products/org.eclipse.smarthome.repo/target`.
+
+# How to contribute
+
+If you want to become a contributor to the project, please read about [contributing](https://www.eclipse.org/smarthome/documentation/community/contributing.html) and check our [guidelines](https://www.eclipse.org/smarthome/documentation/development/guidelines.html) first. If you can't wait to get your hands dirty have a look at the open issues where we [need your help](https://github.com/eclipse/smarthome/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or one of the [open bugs](https://github.com/eclipse/smarthome/issues?q=is%3Aissue+is%3Aopen+label%3Abug).
+

--- a/docs/documentation/community/contributing.md
+++ b/docs/documentation/community/contributing.md
@@ -34,7 +34,7 @@ If you have found a bug or if you would like to propose a new feature, please fe
  
 # Code Contributions
 
-If you want to become a contributor to the project, please check our guidelines first:
+If you want to become a contributor to the project, please check our guidelines first. If you can't wait to get your hands dirty have a look at the open issues where we [need your help](https://github.com/eclipse/smarthome/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or one of the [open bugs](https://github.com/eclipse/smarthome/issues?q=is%3Aissue+is%3Aopen+label%3Abug).
 
 ## Pull requests are always welcome
 


### PR DESCRIPTION
To simplify the entry for new contributors links to "help wanted" and "bug" issues are added to the documentation and README.MD.