### PR TITLE
Fixed all JavaDoc paragraphs throughout ESH.

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigurableService.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigurableService.java
@@ -17,14 +17,12 @@ import org.osgi.service.component.ComponentConstants;
  * {@link ConfigurableService#SERVICE_PROPERTY_DESCRIPTION_URI} set will be considered as a configurable service. The
  * properties {@link ConfigurableService#SERVICE_PROPERTY_LABEL} and
  * {@link ConfigurableService#SERVICE_PROPERTY_CATEGORY} are optional.
- * </p>
  *
  * <p>
  * The services are configured through the OSGi configuration admin. Therefore each service must provide a PID or a
  * component name service property if the configuration is done by declarative services. If the
  * {@link Constants#SERVICE_PID} property is not set the
  * {@link ComponentConstants#COMPONENT_NAME} property will be used as fallback.
- * </p>
  *
  * @author Dennis Nobel - Initial contribution
  *

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusMessage.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/status/ConfigStatusMessage.java
@@ -28,7 +28,6 @@ import com.google.common.base.Preconditions;
  * <li>config-status.error.any-suffix</li>
  * <li>config-status.pending.any-suffix</li>
  * </ul>
- * </p>
  *
  * @author Thomas Höfer - Initial contribution
  * @author Chris Jackson - Add withMessageKey and remove message from other methods

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/ConfigValidationException.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/validation/ConfigValidationException.java
@@ -74,7 +74,6 @@ public final class ConfigValidationException extends RuntimeException {
      * <p>
      * If there is no I18nProvider available then this operation will return the default validation messages by using
      * {@link ConfigValidationException#getValidationMessages()}.
-     * </p>
      *
      * @param locale the locale to be used; if null then the default locale will be used
      *

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
@@ -43,23 +43,22 @@ import org.slf4j.LoggerFactory;
  * The name of the configuration folder can be provided as a program argument "smarthome.configdir" (default is "conf").
  * Configurations for OSGi services are kept in a subfolder that can be provided as a program argument
  * "smarthome.servicedir" (default is "services"). Any file in this folder with the extension .cfg will be processed.
- * </p>
  *
  * <p>
  * The format of the configuration file is similar to a standard property file, with the exception that the property
  * name can be prefixed by the service pid of the {@link ManagedService}:
- * </p>
+ * 
  * <p>
  * &lt;service-pid&gt;:&lt;property&gt;=&lt;value&gt;
- * </p>
+ * 
  * <p>
  * In case the pid does not contain any ".", the default service pid namespace is prefixed, which can be defined by the
  * program argument "smarthome.servicepid" (default is "org.eclipse.smarthome").
- * </p>
+ * 
  * <p>
  * If no pid is defined in the property line, the default pid namespace will be used together with the filename. E.g. if
  * you have a file "security.cfg", the pid that will be used is "org.eclipse.smarthome.security".
- * </p>
+ * 
  * <p>
  * Last but not least, a pid can be defined in the first line of a cfg file by prefixing it with "pid:", e.g.
  * "pid: com.acme.smarthome.security".

--- a/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/FilterCriteria.java
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/FilterCriteria.java
@@ -18,11 +18,11 @@ import org.eclipse.smarthome.core.types.State;
  * It is designed as a Java bean, for which the different properties are constraints on the query result. These
  * properties include the item name, begin and end date and the item state. A compare operator can be defined to compare
  * not only state equality, but also its decimal value (<,>).
- * <p>
+ * 
  * <p>
  * Additionally, the filter criteria supports ordering and paging of the result, so the caller can ask to only return
  * chunks of the result of a certain size (=pageSize) from a starting index (pageNumber*pageSize).
- * </p>
+ * 
  * <p>
  * All setter methods return the filter criteria instance, so that the methods can be easily chained in order to define
  * a filter.

--- a/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/HistoricItem.java
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/HistoricItem.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.types.State;
  * <p>
  * Note that this interface does not extend {@link Item} as the persistence services could not provide an implementation
  * that correctly implement getAcceptedXTypes() and getGroupNames().
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  */

--- a/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/ModifiablePersistenceService.java
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/ModifiablePersistenceService.java
@@ -24,16 +24,15 @@ public interface ModifiablePersistenceService extends QueryablePersistenceServic
     /**
      * <p>
      * Stores the historic item value. This allows the item, time and value to be specified.
-     * </p>
+     * 
      * <p>
      * Adding data with the same time as an existing record should update the current record value rather than adding a
      * new record.
-     * </p>
+     * 
      * <p>
      * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
      * long running operations should be processed asynchronously. E.g. <code>store</code> adds things to a queue which
      * is processed by some asynchronous workers (Quartz Job, Thread, etc.).
-     * </p>
      *
      * @param item the data to be stored
      * @param date the date of the record

--- a/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/PersistenceService.java
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/PersistenceService.java
@@ -45,7 +45,6 @@ public interface PersistenceService {
      * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
      * long running operations should be processed asynchronously. E.g. <code>store</code> adds things to a queue which
      * is processed by some asynchronous workers (Quartz Job, Thread, etc.).
-     * </p>
      *
      * @param item the item which state should be persisted.
      */
@@ -54,12 +53,11 @@ public interface PersistenceService {
     /**
      * <p>
      * Stores the current value of the given item under a specified alias.
-     * </p>
+     * 
      * <p>
      * Implementors should keep in mind that all registered {@link PersistenceService}s are called synchronously. Hence
      * long running operations should be processed asynchronously. E.g. <code>store</code> adds things to a queue which
      * is processed by some asynchronous workers (Quartz Job, Thread, etc.).
-     * </p>
      *
      * @param item the item which state should be persisted.
      * @param alias the alias under which the item should be persisted.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Thing.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Thing.java
@@ -78,7 +78,7 @@ public interface Thing {
 
     /**
      * Gets the status of a thing.
-     * </p>
+     * 
      * In order to get all status information (status, status detail and status description)
      * please use {@link Thing#getStatusInfo()}.
      *
@@ -88,7 +88,7 @@ public interface Thing {
 
     /**
      * Gets the status info of a thing.
-     * </p>
+     * 
      * The status info consists of the status itself, the status detail and a status description.
      *
      * @return the status info

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -525,7 +525,6 @@ public abstract class BaseThingHandler implements ThingHandler {
      * Updates the given property value for the thing that is handled by this thing handler instance. The value is only
      * set for the given property name if there has not been set any value yet or if the value has been changed. If the
      * value of the property to be set is null then the property is removed.
-     * </p>
      *
      * If multiple properties should be changed at the same time, the {@link BaseThingHandler#editProperties()} method
      * should be used.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/Firmware.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/Firmware.java
@@ -29,19 +29,23 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 
 /**
+ * <p>
  * The {@link Firmware} is the description of a firmware to be installed on the physical device of a {@link Thing}. A
  * firmware relates always to exactly one {@link ThingType}. By its {@link FirmwareUID} it is ensured that there is only
  * one firmware in a specific version for a thing type available. Firmwares can be easily created by the
  * {@link Firmware.Builder}.
- * </p>
+ * 
+ * <p>
  * Firmwares are made available to the system by {@link FirmwareProvider}s that are tracked by the
  * {@link FirmwareRegistry}. The registry can be used to get a dedicated firmware or to get all available firmwares for
  * a specific {@link ThingType}.
- * </p>
+ * 
+ * <p>
  * The {@link FirmwareUpdateService} is responsible to provide the current {@link FirmwareStatusInfo} of a thing.
  * Furthermore this service is the central instance to start a firmware update process. In order that the firmware of a
  * thing can be updated the hander of the thing has to implement the {@link FirmwareUpdateHandler} interface.
- * </p>
+ * 
+ * <p>
  * The {@link Firmware} implements the {@link Comparable} interface in order to be able to sort firmwares based on their
  * versions. Firmwares are sorted in a descending sequence, i.e. that the latest firmware will be the first
  * element in a sorted result set. The implementation of {@link Firmware#compareTo(Firmware)} splits the firmware
@@ -50,7 +54,8 @@ import com.google.common.base.Preconditions;
  * <i>1-9_9.9_abc</i>. Consequently <i>2.0-0</i>, <i>2-0_0</i> and <i>2_0.0</i> represent the same firmware version.
  * Furthermore firmware version <i>xyz_1</i> is newer than firmware version <i>abc.2</i> which again is newer than
  * firmware version <i>2-0-1</i>.
- * </p>
+ * 
+ * <p>
  * A {@link Firmware} consists of various meta information like a version, a vendor or a description. Additionally
  * {@link FirmwareProvider}s can specify further meta information in form of properties (e.g. a factory reset of the
  * device is required afterwards) so that {@link FirmwareUpdateHandler}s can handle this information accordingly.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
@@ -179,8 +179,6 @@ public final class FirmwareUpdateService implements EventSubscriber {
      * <p>
      * This operation is a non-blocking operation by spawning a new thread around the invocation of the firmware update
      * handler. The time out of the thread is 30 minutes.
-     * </p>
-     *
      *
      * @param thingUID the thing UID (must not be null)
      * @param firmwareUID the UID of the firmware to be updated (must not be null)

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingStatusInfoI18nLocalizationService.java
@@ -19,10 +19,12 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
 
 /**
+ * <p>
  * The {@link ThingStatusInfoI18nLocalizationService} can be used to localize the {@link ThingStatusInfo} of a thing
  * using the I18N mechanism of the Eclipse SmartHome framework. Currently the description of the {@link ThingStatusInfo}
  * is the single attribute which can be localized.
- * </p>
+ * 
+ * <p>
  * In order to provide a localized description the corresponding {@link ThingHandler} of the thing does not provide a
  * localized string in the <i>ThingStatus.description</i> attribute, but instead provides the reference of the
  * localization string, e.g &#64;text/rate_limit. The handler is able to provide placeholder values as a JSON-serialized

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ThingTypeRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ThingTypeRegistry.java
@@ -127,7 +127,6 @@ public class ThingTypeRegistry {
      * fetch the thing type first using
      * {@link ThingTypeRegistry#getThingType(ThingTypeUID)} and use
      * {@link ThingType#getChannelType(ChannelUID)} afterwards.
-     * </p>
      *
      * @param channel channel
      * @return channel type or null if no channel type was found
@@ -144,7 +143,6 @@ public class ThingTypeRegistry {
      * fetch the thing type first using
      * {@link ThingTypeRegistry#getThingType(ThingTypeUID)} and use
      * {@link ThingType#getChannelType(ChannelUID)} afterwards.
-     * </p>
      *
      * @param channel channel
      * @param locale locale (can be null)

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
@@ -101,7 +101,6 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
      * Transforms the input <code>source</code> by the according method defined in subclass to another string.
      * It expects the transformation to be read from a file which is stored
      * under the 'conf/transform'
-     * </p>
      *
      * @param filename
      *            the name of the file which contains the transformation definition.
@@ -144,7 +143,6 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
      * <p>
      * Abstract method defined by subclasses to effectively operate the
      * transformation according to its rules
-     * </p>
      *
      * @param transform
      *            transformation held by the file provided to <code>transform</code> method
@@ -162,7 +160,6 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
      * <p>
      * Abstract method defined by subclasses to effectively read the transformation
      * source file according to their own needs.
-     * </p>
      *
      * @param filename
      *            Name of the file to be read. This filename may have been transposed

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -30,14 +30,13 @@ import org.slf4j.LoggerFactory;
  * The created thread pools have named threads, so that it is easy to find them in the debugger. Additionally, it is
  * possible to configure the pool sizes through the configuration admin service, so that solutions have the chance to
  * tweak the pool sizes according to their needs.
- * </p>
+ * 
  * <p>
  * The configuration can be done as
  * <br/>
  * {@code org.eclipse.smarthome.threadpool:<poolName>=<poolSize>}
  * <br/>
  * All threads will time out after {@link THREAD_TIMEOUT}.
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution
  *

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableList;
  * It provides the possibility to transform the element into another java class, that can be persisted. This is needed,
  * if the original element class is not directly persistable. If the element type can be persisted directly the
  * {@link DefaultAbstractManagedProvider} can be used as base class.
- * </p>
  *
  * @author Dennis Nobel - Initial contribution
  *

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/Item.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/Item.java
@@ -21,10 +21,9 @@ import org.eclipse.smarthome.core.types.UnDefType;
 /**
  * <p>
  * This interface defines the core features of an Eclipse SmartHome item.
- * </p>
+ * 
  * <p>
  * Item instances are used for all stateful services and are especially important for the {@link ItemRegistry}.
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  *
@@ -63,18 +62,16 @@ public interface Item {
     /**
      * <p>
      * This method provides a list of all data types that can be used to update the item state
-     * </p>
+     * 
      * <p>
      * Imagine e.g. a dimmer device: It's status could be 0%, 10%, 50%, 100%, but also OFF or ON and maybe UNDEFINED. So
      * the accepted data types would be in this case {@link PercentType}, {@link OnOffType} and {@link UnDefType}
-     * </p>
      *
      * <p>
      * The order of data types denotes the order of preference. So in case a state needs to be converted
      * in order to be accepted, it will be attempted to convert it to a type from top to bottom. Therefore
      * the type with the least information loss should be on top of the list - in the example above the
      * {@link PercentType} carries more information than the {@link OnOffType}, hence it is listed first.
-     * </p>
      * 
      * @return a list of data types that can be used to update the item state
      */
@@ -83,11 +80,11 @@ public interface Item {
     /**
      * <p>
      * This method provides a list of all command types that can be used for this item
-     * </p>
+     * 
      * <p>
      * Imagine e.g. a dimmer device: You could ask it to dim to 0%, 10%, 50%, 100%, but also to turn OFF or ON. So the
      * accepted command types would be in this case {@link PercentType}, {@link OnOffType}
-     * </p>
+     * 
      *
      * @return a list of all command types that can be used for this item
      */

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/StateChangeListener.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/StateChangeListener.java
@@ -12,10 +12,9 @@ import org.eclipse.smarthome.core.types.State;
 /**
  * <p>
  * This interface must be implemented by all classes that want to be notified about changes in the state of an item.
- * </p>
+ * 
  * <p>
  * The {@link GenericItem} class provides the possibility to register such listeners.
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  *

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/AbstractItemEventSubscriber.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/AbstractItemEventSubscriber.java
@@ -16,8 +16,9 @@ import org.eclipse.smarthome.core.events.EventSubscriber;
 import com.google.common.collect.ImmutableSet;
 
 /**
+ * <p>
  * The {@link AbstractItemEventSubscriber} defines an abstract implementation of the {@link EventSubscriber} interface
- * for receiving {@link ItemStateEvent}s and {@link ItemCommandEvent}s from the Eclipse SmartHome event bus. </p>
+ * for receiving {@link ItemStateEvent}s and {@link ItemCommandEvent}s from the Eclipse SmartHome event bus.
  * 
  * A subclass can implement the methods {@link #receiveUpdate(ItemStateEvent)} and
  * {@link #receiveCommand(ItemCommandEvent)} in order to receive and handle such events.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
@@ -140,7 +140,6 @@ public class PointType implements ComplexType, Command, State {
      * Formats the value of this type according to a pattern (@see {@link Formatter}). One single value of this type can
      * be referenced by the pattern using an index. The item order is defined by the natural (alphabetical) order of
      * their keys.
-     * </p>
      *
      * @param pattern the pattern to use containing indexes to reference the
      *            single elements of this type.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringListType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringListType.java
@@ -73,7 +73,6 @@ public class StringListType implements Command, State {
      * {@link Formatter}). One single value of this type can be referenced
      * by the pattern using an index. The item order is defined by the natural
      * (alphabetical) order of their keys.
-     * </p>
      *
      * @param pattern the pattern to use containing indexes to reference the
      *            single elements of this type.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/TypeParser.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/TypeParser.java
@@ -51,11 +51,10 @@ public final class TypeParser {
      * <p>
      * Determines a state from a string. Possible state types are passed as a parameter. Note that the order matters
      * here; the first type that accepts the string as a valid value, will be used for the state.
-     * </p>
+     * 
      * <p>
      * Example: The type list is OnOffType.class,StringType.class. The string "ON" is now accepted by the OnOffType and
      * thus OnOffType.ON will be returned (and not a StringType with value "ON").
-     * </p>
      *
      * @param types possible types of the state to consider
      * @param s the string to parse
@@ -82,11 +81,10 @@ public final class TypeParser {
      * <p>
      * Determines a command from a string. Possible command types are passed as a parameter. Note that the order matters
      * here; the first type that accepts the string as a valid value, will be used for the command.
-     * </p>
+     * 
      * <p>
      * Example: The type list is OnOffType.class,StringType.class. The string "ON" is now accepted by the OnOffType and
      * thus OnOffType.ON will be returned (and not a StringType with value "ON").
-     * </p>
      *
      * @param types possible types of the command to consider
      * @param s the string to parse

--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
@@ -38,10 +38,9 @@ public class ExecUtil {
      * properly. In that cases another exec-method is to be used. To accomplish this please use the special delimiter '
      * <code>@@</code>'. If <code>commandLine</code> contains this delimiter it is split into a String[] array and the
      * special exec-method is used.
-     * </p>
+     * 
      * <p>
      * A possible {@link IOException} gets logged but no further processing is done.
-     * </p>
      *
      * @param commandLine
      *            the command line to execute
@@ -69,10 +68,9 @@ public class ExecUtil {
      * properly. In that cases another exec-method is to be used. To accomplish this please use the special delimiter '
      * <code>@@</code>'. If <code>commandLine</code> contains this delimiter it is split into a String[] array and the
      * special exec-method is used.
-     * </p>
+     * 
      * <p>
      * A possible {@link IOException} gets logged but no further processing is done.
-     * </p>
      *
      * @param commandLine
      *            the command line to execute

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
@@ -71,15 +71,12 @@ import io.swagger.annotations.ApiResponses;
  * <p>
  * This class acts as a REST resource for items and provides different methods to interact with them, like retrieving
  * lists of items, sending commands to them or checking a single status.
- * </p>
  *
  * <p>
  * The typical content types are plain text for status values and XML or JSON(P) for more complex data structures
- * </p>
  *
  * <p>
  * This resource is registered with the Jersey servlet.
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Dennis Nobel - Added methods for item management

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -88,7 +88,6 @@ import io.swagger.annotations.ApiResponses;
  * <p>
  * This class acts as a REST resource for sitemaps and provides different methods to interact with them, like retrieving
  * a list of all available sitemaps or just getting the widgets of a single page.
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Chris Jackson

--- a/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/RootResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/RootResource.java
@@ -34,14 +34,12 @@ import org.slf4j.LoggerFactory;
 /**
  * <p>
  * This class acts as an entry point / root resource for the REST API.
- * </p>
+ * 
  * <p>
  * In good HATEOAS manner, it provides links to other offered resources.
- * </p>
  *
  * <p>
  * The result is returned as JSON
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  */

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
@@ -23,10 +23,9 @@ import org.eclipse.smarthome.core.autoupdate.AutoUpdateBindingConfigProvider;
  * This class can parse information from the generic binding format and provides AutoUpdate binding information from it.
  * If no binding configuration is provided <code>autoupdate</code> is evaluated to true. This means every received
  * <code>Command</code> will update its corresponding <code>State</code> by default.
- * </p>
+ * 
  * <p>
  * This class registers as a {@link AutoUpdateBindingConfigProvider} service as well.
- * </p>
  *
  * <p>
  * A valid binding configuration strings looks like this:

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/actions/Exec.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/actions/Exec.java
@@ -26,10 +26,9 @@ public class Exec {
      * properly. In that cases another exec-method is to be used. To accomplish this please use the special delimiter '
      * <code>@@</code>'. If <code>commandLine</code> contains this delimiter it is split into a String[] array and the
      * special exec-method is used.
-     * </p>
+     * 
      * <p>
      * A possible {@link IOException} gets logged but no further processing is done.
-     * </p>
      *
      * @param commandLine
      *            the command line to execute
@@ -45,10 +44,9 @@ public class Exec {
      * properly. In that cases another exec-method is to be used. To accomplish this please use the special delimiter '
      * <code>@@</code>'. If <code>commandLine</code> contains this delimiter it is split into a String[] array and the
      * special exec-method is used.
-     * </p>
+     * 
      * <p>
      * A possible {@link IOException} gets logged but no further processing is done.
-     * </p>
      *
      * @param commandLine
      *            the command line to execute

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/items/ItemUIProvider.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/items/ItemUIProvider.java
@@ -52,10 +52,9 @@ public interface ItemUIProvider {
      * Provides a widget for a given item. This can be used to overwrite the widget listed in the sitemap. A use case
      * for this is that the sitemap defines merely the parent-child-relation of widgets, but the concrete widget to be
      * used for rendering might be selected dynamically at runtime.
-     * </p>
+     * 
      * <p>
      * If the sitemap widget should not be overridden, this method must return <code>null</code>.
-     * </p>
      *
      * @param itemName the item name to get the widget for
      * @return a widget to use for the given item or <code>null</code> if sitemap should not be overridden.

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/BridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/BridgeHandler.java
@@ -67,7 +67,6 @@ import org.slf4j.LoggerFactory;
  * <li>implements the {@link ConnectionListener} to manage the {@link ThingStatus} of this {@link BridgeHandler}</li>
  * <li>and implements the {@link TotalPowerConsumptionListener} to update his Channels.</li>
  * </ul>
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/listener/DeviceStatusListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/listener/DeviceStatusListener.java
@@ -22,7 +22,6 @@ import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices
  * For that the {@link DeviceStatusListener} has to be registered on the
  * {@link DeviceStatusManager#registerDeviceListener(DeviceStatusListener)}. Then the {@link DeviceStatusListener} gets
  * informed by the methods {@link #onDeviceAdded(Device)} and {@link #onDeviceRemoved(Device)}.
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/listener/SceneStatusListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/listener/SceneStatusListener.java
@@ -20,7 +20,6 @@ import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.scene.I
  * For that the {@link SceneStatusListener} has to be registered on the
  * {@link SceneManager#registerSceneListener(SceneStatusListener)}. Then the {@link SceneStatusListener} gets
  * informed by the methods {@link #onSceneAdded(InternalScene)} and {@link #onSceneRemoved(InternalScene)}.
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/DeviceStatusManager.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/DeviceStatusManager.java
@@ -30,14 +30,14 @@ import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.scene.I
  * configurations of the physically device will be synchronized to the internally managed model and updated as required.
  * The {@link DeviceStatusManager} also initializes {@link SensorJob}'s with the {@link SensorJobExecutor} and
  * {@link SceneReadingJobExecutor} to update required sensor and scene data.
- * </p>
+ * 
  * <p>
  * Therefore the {@link DeviceStatusManager} uses the {@link StructureManager} for the internal management of the
  * structure of the digitalSTROM-system, {@link ConnectionManager} to check the connectivity,
  * {@link ScenesManager} to identify externally called scenes and to update the affected devices of these
  * called scenes to the internal model. The most methods of the above-named managers will be directly called over the
  * {@link DeviceStatusManager}, because they are linked to the affected managers.
- * </P>
+ * 
  * <p>
  * To get informed by all relevant information you can register some useful listeners. Here the list of all listeners
  * which can registered or unregistered:
@@ -55,7 +55,6 @@ import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.scene.I
  * {@link #unregisterDeviceListener(DeviceStatusListener)}</li>
  * </ul>
  * For what the listener can be used please have a look at the listener.
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/SceneManager.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/SceneManager.java
@@ -30,11 +30,10 @@ import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.scene.s
  * {@link #callInternalScene(InternalScene)}, {@link #callInternalScene(String)},
  * {@link #callDeviceScene(Device, Short)}
  * , {@link #callDeviceScene(String, Short)} etc. can be used.
- * </p>
+ * 
  * <p>
  * If you call the {@link #start()} method a {@link EventListener} will be started to handle scene calls and undos from
  * the outside.
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/AbstractSensorJobExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/AbstractSensorJobExecutor.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
  * <li>{@link #addMediumPriorityJob(SensorJob)}</li>
  * <li>{@link #addHighPriorityJob(SensorJob)}</li>
  * </ul>
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/SceneReadingJobExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/SceneReadingJobExecutor.java
@@ -21,12 +21,11 @@ import org.slf4j.LoggerFactory;
  * <p>
  * In addition priorities can be assigned to jobs therefore the {@link SceneReadingJobExecutor} offers the methods
  * {@link #addHighPriorityJob()}, {@link #addLowPriorityJob()} and {@link #addLowPriorityJob()}.
- * </p>
+ * 
  * <p>
  * <b>NOTE:</b><br>
  * In contrast to the {@link SensorJobExecutor} the {@link SceneReadingJobExecutor} will execute {@link SensorJob}'s
  * with high priority always before medium priority {@link SensorJob}s and so on.
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/SensorJobExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorJobExecutor/SensorJobExecutor.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
  * <li>medium priority: read cycles before execution is set in {@link Config.MEDIUM_PRIORITY_FACTOR}</li>
  * <li>high priority: read cycles before execution 0</li>
  * </ul>
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverConnection/impl/HttpTransportImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverConnection/impl/HttpTransportImpl.java
@@ -49,14 +49,13 @@ import org.slf4j.LoggerFactory;
  * {@link Config#getCert()}. If there is no SSL-Certificate, but an path to an external SSL-Certificate file what is set
  * in {@link Config#getTrustCertPath()} this will be set. If no SSL-Certificate is set in the {@link Config} it will be
  * red out from the server and set in {@link Config#setCert(String)}.
- * </p>
+ * 
  * <p>
  * If no {@link Config} is given the SSL-Certificate will be stored locally.
- * </p>
+ * 
  * <p>
  * The method {@link #writePEMCertFile(String)} saves the SSL-Certificate in a file at the given path. If all
  * SSL-Certificates shout be ignored the flag <i>exeptAllCerts</i> have to be true at the constructor
- * </p>
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/DeviceStateUpdate.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceParameters/DeviceStateUpdate.java
@@ -69,7 +69,6 @@ public interface DeviceStateUpdate {
      * <li>For all SensorUpdate-types will read the sensor data directly, if the value is 0, otherwise a
      * {@link SensorJob} will be added to the {@link SensorJobExecutor}.</li>
      * </ul>
-     * </p>
      *
      * @return new state value
      */

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GenericHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/GenericHandler.java
@@ -17,7 +17,6 @@ import java.nio.ByteBuffer;
  * <p>
  * Packet types must have an empty constructor and cannot require any
  * additional logic (other than parsing).
- * </p>
  *
  * @param <T> the packet subtype this handler constructs
  * 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Packet.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Packet.java
@@ -30,7 +30,6 @@ import org.eclipse.smarthome.binding.lifx.internal.fields.UInt8Field;
  * in each subtype, followed by a listing of fields contained in the packet.
  * Field definitions should remain accessible to outside classes in the event
  * they need to worked with directly elsewhere.
- * </p>
  *
  * @author Tim Buckley - Initial Contribution
  * @author Karel Goderis - Enhancement for the V2 LIFX Firmware and LAN Protocol Specification
@@ -241,7 +240,6 @@ public abstract class Packet {
      * The length of the buffer is the sum of the lengths of the defined
      * preamble fields (see {@link #PREAMBLE_FIELDS} for an ordered list), which
      * may also be accessed via {@link #preambleLength()}.
-     * </p>
      *
      * <p>
      * Certain fields are set to default values based on other class methods.
@@ -348,7 +346,6 @@ public abstract class Packet {
      * Note that returned ByteBuffers will have {@link ByteBuffer#rewind()}
      * called automatically before they are appended to the final packet
      * buffer.
-     * </p>
      *
      * @return the packet payload
      */

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -19,7 +19,6 @@ import com.jayway.jsonpath.PathNotFoundException;
 /**
  * <p>
  * The implementation of {@link TransformationService} which transforms the input by JSonPath Expressions.
- * </p>
  *
  * @author Gaël L'hopital
  * @author Sebastian Janzen

--- a/extensions/transform/org.eclipse.smarthome.transform.map/src/main/java/org/eclipse/smarthome/transform/map/internal/MapTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/src/main/java/org/eclipse/smarthome/transform/map/internal/MapTransformationService.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 /**
  * <p>
  * The implementation of {@link TransformationService} which simply maps strings to other strings
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Gaël L'hopital - Make it localizable
@@ -34,7 +33,6 @@ public class MapTransformationService extends AbstractFileTransformationService<
      * Transforms the input <code>source</code> by mapping it to another string. It expects the mappings to be read from
      * a file which is stored under the 'configurations/transform' folder. This file should be in property syntax, i.e.
      * simple lines with "key=value" pairs. To organize the various transformations one might use subfolders.
-     * </p>
      *
      * @param properties
      *            the list of properties which contains the key value pairs for the mapping.

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 /**
  * <p>
  * The implementation of {@link TransformationService} which transforms the input by Regular Expressions.
- * </p>
+ * 
  * <p>
  * <b>Note:</b> the given Regular Expression must contain exactly one group!
  *

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationService.java
@@ -26,7 +26,6 @@ import org.xml.sax.InputSource;
 /**
  * <p>
  * The implementation of {@link TransformationService} which transforms the input by XPath Expressions.
- * </p>
  *
  * @author Thomas.Eichstaedt-Engelen
  */

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 /**
  * <p>
  * The implementation of {@link TransformationService} which transforms the input by XSLT.
- * </p>
  *
  * @author Thomas.Eichstaedt-Engelen
  */

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ColorpickerRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ColorpickerRenderer.java
@@ -21,12 +21,10 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
  * <p>
  * This is an implementation of the {@link WidgetRenderer} interface, which can produce HTML code for Colorpicker
  * widgets.
- * </p>
  *
  * <p>
  * Note: This renderer requires the files "jquery.miniColors.css" and "jquery.miniColors.js" in the web folder of this
  * bundle
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Vlad Ivanov - BasicUI changes

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
@@ -17,12 +17,10 @@ import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
 /**
  * <p>
  * This is an implementation of the {@link WidgetRenderer} interface, which can produce HTML code for Slider widgets.
- * </p>
  *
  * <p>
  * Note: As the WebApp.Net framework cannot render real sliders in the UI, we instead show buttons to increase or
  * decrease the value.
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Vlad Ivanov - BasicUI changes

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ColorpickerRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ColorpickerRenderer.java
@@ -21,12 +21,10 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
  * <p>
  * This is an implementation of the {@link WidgetRenderer} interface, which can produce HTML code for Colorpicker
  * widgets.
- * </p>
  *
  * <p>
  * Note: This renderer requires the files "jquery.miniColors.css" and "jquery.miniColors.js" in the web folder of this
  * bundle
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  *

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SliderRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SliderRenderer.java
@@ -18,12 +18,10 @@ import org.eclipse.smarthome.ui.classic.render.WidgetRenderer;
 /**
  * <p>
  * This is an implementation of the {@link WidgetRenderer} interface, which can produce HTML code for Slider widgets.
- * </p>
  *
  * <p>
  * Note: As the WebApp.Net framework cannot render real sliders in the UI, we instead show buttons to increase or
  * decrease the value.
- * </p>
  *
  * @author Kai Kreuzer - Initial contribution and API
  *


### PR DESCRIPTION
Throughout all java classes, all closing `</p>` tags in JavaDoc are removed and only the opening `<p>` are left, since this complies to the official Oracle rules. See [How to Write Doc Comments for the Javadoc Tool](http://www.oracle.com/technetwork/articles/java/index-137868.html), section "Writing Doc Comments".

PR suggested by @maggu2810 

Signed-off-by: Alexander Kostadinov <alexander.g.kostadinov@gmail.com>