### PR TITLE
Moved ExpiringCache from Yahoo Weather Binding to Eclipse SmartHome Core

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheMapTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheMapTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.cache;
+
+import static org.junit.Assert.*;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test class for the {@link ExpiringCacheMap} class.
+ *
+ * @author Christoph Weitkamp - Initial contribution.
+ */
+public class ExpiringCacheMapTest {
+
+    private final Logger logger = LoggerFactory.getLogger(ExpiringCacheMapTest.class);
+
+    public static final long CACHE_EXPIRY = 2 * 1000; // 2s
+
+    public static final Supplier<String> CACHE_ACTION = () -> {
+        return RandomStringUtils.random(8);
+    };
+
+    public static final String FIRST_TEST_KEY = "FIRST_TEST_KEY";
+    public static final String SECOND_TEST_KEY = "SECOND_TEST_KEY";
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddIllegalArgumentException1() throws IllegalArgumentException {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        final Supplier<String> action = null;
+        cache.put(FIRST_TEST_KEY, action);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddIllegalArgumentException2() throws IllegalArgumentException {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        final ExpiringCache<String> item = null;
+        cache.put(FIRST_TEST_KEY, item);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddIllegalArgumentException3() throws IllegalArgumentException {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        cache.put(null, CACHE_ACTION);
+    }
+
+    @Test
+    public void testKeys() {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+
+        // get all keys
+        final Set<String> expected_keys = new LinkedHashSet<String>();
+        expected_keys.add(FIRST_TEST_KEY);
+
+        final Set<String> keys = cache.keys();
+        assertEquals(expected_keys, keys);
+    }
+
+    @Test
+    public void testValues() {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+
+        // use the same key twice
+        String value1 = cache.get(FIRST_TEST_KEY);
+        assertNotNull(value1);
+        String value2 = cache.get(FIRST_TEST_KEY);
+        assertNotNull(value2);
+        assertEquals(value1, value2);
+
+        cache.put(SECOND_TEST_KEY, CACHE_ACTION);
+
+        // use a different key
+        String value3 = cache.get(SECOND_TEST_KEY);
+        assertNotNull(value3);
+        assertNotEquals(value1, value3);
+
+        // get all values
+        final Collection<String> expected_values = new LinkedList<String>();
+        expected_values.add(value3);
+        expected_values.add(value1);
+
+        final Collection<String> values = cache.values();
+        assertEquals(expected_values, values);
+
+        // use another different key
+        String value4 = cache.get("KEY_NOT_FOUND");
+        assertNull(value4);
+    }
+
+    @Test
+    public void testExpired() throws InterruptedException {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+
+        String value1 = cache.get(FIRST_TEST_KEY);
+
+        // wait until cache expires
+        Thread.sleep(CACHE_EXPIRY + 100);
+
+        String value2 = cache.get(FIRST_TEST_KEY);
+        assertNotEquals(value1, value2);
+    }
+
+    @Test
+    public void testInvalidate() {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+
+        String value1 = cache.get(FIRST_TEST_KEY);
+
+        // invalidate item
+        cache.invalidate(FIRST_TEST_KEY);
+
+        String value2 = cache.get(FIRST_TEST_KEY);
+        assertNotEquals(value1, value2);
+
+        // invalidate all
+        cache.invalidateAll();
+
+        String value3 = cache.get(FIRST_TEST_KEY);
+        assertNotEquals(value2, value3);
+    }
+
+    @Test
+    public void testRefresh() {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+
+        String value1 = cache.get(FIRST_TEST_KEY);
+
+        // refresh item
+        String value2 = cache.refresh(FIRST_TEST_KEY);
+        assertNotEquals(value1, value2);
+
+        // refresh all
+        final Collection<String> expected_values = new LinkedList<String>();
+        expected_values.add(value2);
+
+        final Collection<String> values = cache.refreshAll();
+        assertNotEquals(expected_values, values);
+    }
+
+    @Test
+    public void testRemove() {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+
+        // remove item
+        cache.remove(FIRST_TEST_KEY);
+
+        String value1 = cache.get(FIRST_TEST_KEY);
+        assertNull(value1);
+
+    }
+
+    @Test
+    public void testClear() {
+        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<String, String>(CACHE_EXPIRY);
+
+        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+
+        // clear cache
+        cache.clear();
+
+        String value1 = cache.get(FIRST_TEST_KEY);
+        assertNull(value1);
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.cache;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test class for the {@link ExpiringCache} class.
+ *
+ * @author Christoph Weitkamp - Initial contribution.
+ */
+public class ExpiringCacheTest {
+
+    private final Logger logger = LoggerFactory.getLogger(ExpiringCacheTest.class);
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalArgumentException1() throws IllegalArgumentException {
+        new ExpiringCache<String>(ExpiringCacheMapTest.CACHE_EXPIRY, null);
+    }
+
+    @Test
+    public void testGetValue() {
+        final ExpiringCache<String> single_cache = new ExpiringCache<String>(ExpiringCacheMapTest.CACHE_EXPIRY,
+                ExpiringCacheMapTest.CACHE_ACTION);
+
+        // use the same key twice
+        String value1 = single_cache.getValue();
+        assertNotNull(value1);
+        String value2 = single_cache.getValue();
+        assertNotNull(value2);
+        assertEquals(value1, value2);
+    }
+
+    @Test
+    public void testExpired() throws InterruptedException {
+        final ExpiringCache<String> single_cache = new ExpiringCache<String>(ExpiringCacheMapTest.CACHE_EXPIRY,
+                ExpiringCacheMapTest.CACHE_ACTION);
+
+        String value1 = single_cache.getValue();
+        assertFalse(single_cache.isExpired());
+
+        // wait until cache expires
+        Thread.sleep(ExpiringCacheMapTest.CACHE_EXPIRY + 100);
+        assertTrue(single_cache.isExpired());
+
+        String value2 = single_cache.getValue();
+        assertFalse(single_cache.isExpired());
+        assertNotEquals(value1, value2);
+    }
+
+    @Test
+    public void testInvalidate() {
+        final ExpiringCache<String> single_cache = new ExpiringCache<String>(ExpiringCacheMapTest.CACHE_EXPIRY,
+                ExpiringCacheMapTest.CACHE_ACTION);
+
+        String value1 = single_cache.getValue();
+
+        // invalidate item
+        single_cache.invalidateValue();
+
+        String value2 = single_cache.getValue();
+        assertNotEquals(value1, value2);
+    }
+
+    @Test
+    public void testRefresh() {
+        final ExpiringCache<String> single_cache = new ExpiringCache<String>(ExpiringCacheMapTest.CACHE_EXPIRY,
+                ExpiringCacheMapTest.CACHE_ACTION);
+
+        String value1 = single_cache.getValue();
+
+        // refresh item
+        String value2 = single_cache.refreshValue();
+        assertNotEquals(value1, value2);
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Export-Package: org.eclipse.smarthome.core.auth,
  org.eclipse.smarthome.core.binding,
  org.eclipse.smarthome.core.binding.dto,
+ org.eclipse.smarthome.core.cache,
  org.eclipse.smarthome.core.common,
  org.eclipse.smarthome.core.common.osgi,
  org.eclipse.smarthome.core.common.registry,

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCache.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCache.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.cache;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a simple expiring and reloading cache implementation.
+ *
+ * There must be provided an action in order to retrieve/calculate the value. This action will be called only if the
+ * answer from the last calculation is not valid anymore, i.e. if it is expired.
+ *
+ * @author Christoph Weitkamp - Initial contribution and API.
+ * 
+ * @param <V> the type of the value
+ */
+public class ExpiringCache<V> {
+
+    private final Logger logger = LoggerFactory.getLogger(ExpiringCache.class);
+
+    private final long expiry;
+    private final Supplier<V> action;
+    private V value;
+    private long expiresAt;
+
+    /**
+     * Create a new instance.
+     * 
+     * @param expiry the duration in milliseconds for how long the value stays valid
+     * @param action the action to retrieve/calculate the value
+     */
+    public ExpiringCache(long expiry, Supplier<V> action) {
+        if (action == null) {
+            throw new IllegalArgumentException("ExpiringCacheItem cannot be created as action is null.");
+        }
+
+        this.expiry = TimeUnit.MILLISECONDS.toNanos(expiry);
+        this.action = action;
+
+        invalidateValue();
+    }
+
+    /**
+     * Returns the value - possibly from the cache, if it is still valid.
+     * 
+     * @return the value
+     */
+    public synchronized V getValue() {
+        if (value == null || isExpired()) {
+            return refreshValue();
+        }
+        return value;
+    }
+
+    /**
+     * Invalidates the value in the cache.
+     */
+    public synchronized void invalidateValue() {
+        value = null;
+        expiresAt = 0;
+    }
+
+    /**
+     * Refreshes and returns the value in the cache.
+     * 
+     * @return the new value
+     */
+    public synchronized V refreshValue() {
+        value = action.get();
+        expiresAt = System.nanoTime() + expiry;
+        return value;
+    }
+
+    /**
+     * Checks if the value is expired.
+     * 
+     * @return true if the value is expired
+     */
+    public boolean isExpired() {
+        return expiresAt < System.nanoTime();
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheMap.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheMap.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.cache;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a simple expiring and reloading multiple key-value-pair cache implementation. The value expires after the
+ * specified duration has passed since the item was created, or the most recent replacement of the value.
+ *
+ * @author Christoph Weitkamp - Initial contribution and API.
+ *
+ * @param <K> the type of the key
+ * @param <V> the type of the value
+ */
+public class ExpiringCacheMap<K, V> {
+
+    private final Logger logger = LoggerFactory.getLogger(ExpiringCacheMap.class);
+
+    private final long expiry;
+    private final ConcurrentMap<K, ExpiringCache<V>> items;
+
+    /**
+     * Creates a new instance.
+     * 
+     * @param expiry the duration in milliseconds for how long the value stays valid
+     */
+    public ExpiringCacheMap(long expiry) {
+        this.expiry = expiry;
+        this.items = new ConcurrentHashMap<K, ExpiringCache<V>>();
+    }
+
+    /**
+     * Creates an {@link ExpiringCache} and adds it to the cache.
+     * 
+     * @param key the key with which the specified value is to be associated
+     * @param action the action for the item to be associated with the specified key to retrieve/calculate the value
+     */
+    public void put(K key, Supplier<V> action) {
+        put(key, new ExpiringCache<V>(expiry, action));
+    }
+
+    /**
+     * Adds an {@link ExpiringCache} to the cache.
+     * 
+     * @param key the key with which the specified value is to be associated
+     * @param item the item to be associated with the specified key
+     */
+    public void put(K key, ExpiringCache<V> item) {
+        if (key == null) {
+            throw new IllegalArgumentException("Item cannot be added as key is null.");
+        }
+        if (item == null) {
+            throw new IllegalArgumentException("Item cannot be added as item is null.");
+        }
+
+        items.put(key, item);
+    }
+
+    /**
+     * Removes the item associated with the given key from the cache.
+     * 
+     * @param key the key whose associated value is to be removed
+     */
+    public void remove(K key) {
+        items.remove(key);
+    }
+
+    /**
+     * Discards all items from the cache.
+     */
+    public void clear() {
+        items.clear();
+    }
+
+    /**
+     * Returns a set of all keys.
+     * 
+     * @return the set of all keys
+     */
+    public synchronized Set<K> keys() {
+        final Set<K> keys = new LinkedHashSet<K>();
+        for (final K key : items.keySet()) {
+            keys.add(key);
+        }
+        return keys;
+    }
+
+    /**
+     * Returns the value associated with the given key - possibly from the cache, if it is still valid.
+     * 
+     * @param key the key whose associated value is to be returned
+     * @return the value associated with the given key, or null if there is no cached value for the given key
+     */
+    public V get(K key) {
+        final ExpiringCache<V> item = items.get(key);
+        if (item == null) {
+            logger.debug("No item for key '{}' found", key);
+            return null;
+        } else {
+            return item.getValue();
+        }
+    }
+
+    /**
+     * Returns a collection of all values - possibly from the cache, if they are still valid.
+     * 
+     * @return the collection of all values
+     */
+    public synchronized Collection<V> values() {
+        final Collection<V> values = new LinkedList<V>();
+        for (final ExpiringCache<V> item : items.values()) {
+            values.add(item.getValue());
+        }
+        return values;
+    }
+
+    /**
+     * Invalidates the value associated with the given key in the cache.
+     * 
+     * @param key the key whose associated value is to be invalidated
+     */
+    public synchronized void invalidate(K key) {
+        final ExpiringCache<V> item = items.get(key);
+        if (item == null) {
+            logger.debug("No item for key '{}' found", key);
+        } else {
+            item.invalidateValue();
+        }
+    }
+
+    /**
+     * Invalidates all values in the cache.
+     */
+    public synchronized void invalidateAll() {
+        items.values().forEach(item -> item.invalidateValue());
+    }
+
+    /**
+     * Refreshes and returns the value associated with the given key in the cache.
+     * 
+     * @param key the key whose associated value is to be refreshed
+     * @return the value associated with the given key, or null if there is no cached value for the given key
+     */
+    public synchronized V refresh(K key) {
+        final ExpiringCache<V> item = items.get(key);
+        if (item == null) {
+            logger.debug("No item for key '{}' found", key);
+            return null;
+        } else {
+            return item.refreshValue();
+        }
+    }
+
+    /**
+     * Refreshes and returns a collection of all new values in the cache.
+     * 
+     * @return the collection of all values
+     */
+    public synchronized Collection<V> refreshAll() {
+        final Collection<V> values = new LinkedList<V>();
+        for (final ExpiringCache<V> item : items.values()) {
+            values.add(item.refreshValue());
+        }
+        return values;
+    }
+}


### PR DESCRIPTION
* Moved `ExpiringCache` from Yahoo Weather Binding to Eclipse SmartHome Core
* Replaced Interface `LoadAction` with Interface `java.util.function.Supplier`
* Added `invalidate` an `refresh` methods
* Added `ExpiringCacheMap` to support handling multiple cache values
* Added `ExpiringCacheTest` and `ExpiringCacheMapTest`

Closes #3302 

Also-by: Simon Kaufmann <simon.kfm@googlemail.com>
Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>