### PR TITLE
Removed obfuscation from README

### DIFF
--- a/tools/archetype/binding/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/tools/archetype/binding/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -28,9 +28,14 @@
 				<include>about.html</include>
 				<include>build.properties</include>
 				<include>pom.xml</include>
-				<include>README.md</include>
 				<include>.project</include>
 				<include>.classpath</include>
+			</includes>
+		</fileSet>
+		<fileSet filtered="false" packaged="false" encoding="UTF-8">
+			<directory></directory>
+			<includes>
+				<include>README.md</include>
 			</includes>
 		</fileSet>
 		<fileSet filtered="true" packaged="false" encoding="UTF-8">

--- a/tools/archetype/binding/src/main/resources/archetype-resources/README.md
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/README.md
@@ -1,22 +1,20 @@
-#set( $H = '#' )
-##
-$H ${bindingIdCamelCase} Binding
+# <bindingName> Binding
 
 _Give some details about what this binding is meant for - a protocol, system, specific device._
 
 _If possible, provide some resources like pictures, a YouTube video, etc. to give an impression of what can be done with this binding. You can place such resources into a `doc` folder next to this README.md._
 
-$H$H Supported Things
+## Supported Things
 
 _Please describe the different supported things / devices within this section._
 _Which different types are supported, which models were tested etc.?_
 _Note that it is planned to generate some part of this based on the XML files within ```ESH-INF/thing``` of your binding._
 
-$H$H Discovery
+## Discovery
 
 _Describe the available auto-discovery features here. Mention for what it works and what needs to be kept in mind when using it._
 
-$H$H Binding Configuration
+## Binding Configuration
 
 _If your binding requires or supports general configuration settings, please create a folder ```cfg``` and place the configuration file ```<bindingId>.cfg``` inside it. In this section, you should link to this file and provide some information about the options. The file could e.g. look like:_
 
@@ -33,22 +31,22 @@ _Note that it is planned to generate some part of this based on the information 
 
 _If your binding does not offer any generic configurations, you can remove this section completely._
 
-$H$H Thing Configuration
+## Thing Configuration
 
 _Describe what is needed to manually configure a thing, either through the (Paper) UI or via a thing-file. This should be mainly about its mandatory and optional configuration parameters. A short example entry for a thing file can help!_
 
 _Note that it is planned to generate some part of this based on the XML files within ```ESH-INF/thing``` of your binding._
 
-$H$H Channels
+## Channels
 
 _Here you should provide information about available channel types, what their meaning is and how they can be used._
 
 _Note that it is planned to generate some part of this based on the XML files within ```ESH-INF/thing``` of your binding._
 
-$H$H Full Example
+## Full Example
 
 _Provide a full usage example based on textual configuration files (*.things, *.items, *.sitemap)._
 
-$H$H Any custom content here!
+## Any custom content here!
 
 _Feel free to add additional sections for whatever you think should also be mentioned about your binding!_


### PR DESCRIPTION
Removed obfuscation from README so it can be both used from the archetype and is human readable, see also remark of Kai: https://github.com/eclipse/smarthome/pull/3278#issuecomment-304664364

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>