### PR TITLE
Provide better status information when bridge is missing

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
@@ -567,7 +567,7 @@ class ThingManagerOSGiTest extends OSGiTest {
         // add thing - no thing initialization, because bridge is not available
         thingRegistry.add(thing)
         waitForAssert ({ assertThat thingInitCalled, is(false) })
-        statusInfo = ThingStatusInfoBuilder.create(ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_MISSING_ERROR).build()
+        statusInfo = ThingStatusInfoBuilder.create(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED).build()
         waitForAssert ({ assertThat thing.getStatusInfo(), is(statusInfo) })
 
         // add bridge - provokes bridge & thing initialization

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusDetail.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusDetail.java
@@ -23,7 +23,8 @@ public enum ThingStatusDetail {
     CONFIGURATION_ERROR,
     BRIDGE_OFFLINE,
     FIRMWARE_UPDATING,
-    DUTY_CYCLE;
+    DUTY_CYCLE,
+    BRIDGE_HANDLER_MISSING_ERROR;
 
     public static OnlineStatus ONLINE = new OnlineStatus();
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusDetail.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusDetail.java
@@ -24,7 +24,7 @@ public enum ThingStatusDetail {
     BRIDGE_OFFLINE,
     FIRMWARE_UPDATING,
     DUTY_CYCLE,
-    BRIDGE_HANDLER_MISSING_ERROR;
+    BRIDGE_UNINITIALIZED;
 
     public static OnlineStatus ONLINE = new OnlineStatus();
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -586,8 +586,8 @@ public class ThingManager extends AbstractItemEventSubscriber implements ThingTr
                     if (bridge != null && ThingHandlerHelper.isHandlerInitialized(bridge)) {
                         doRegisterHandler(thing, thingHandlerFactory);
                     } else {
-                        setThingStatus(thing,
-                                buildStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_MISSING_ERROR));
+                        setThingStatus(thing, buildStatusInfo(ThingStatus.UNINITIALIZED,
+                                ThingStatusDetail.BRIDGE_HANDLER_MISSING_ERROR));
                     }
                 }
             } else {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -586,8 +586,8 @@ public class ThingManager extends AbstractItemEventSubscriber implements ThingTr
                     if (bridge != null && ThingHandlerHelper.isHandlerInitialized(bridge)) {
                         doRegisterHandler(thing, thingHandlerFactory);
                     } else {
-                        setThingStatus(thing, buildStatusInfo(ThingStatus.UNINITIALIZED,
-                                ThingStatusDetail.BRIDGE_HANDLER_MISSING_ERROR));
+                        setThingStatus(thing,
+                                buildStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED));
                     }
                 }
             } else {

--- a/docs/documentation/concepts/things.md
+++ b/docs/documentation/concepts/things.md
@@ -47,11 +47,12 @@ The initial state of a thing is UNINITIALIZED. From UNINITIALIZED the thing goes
 A status is detailed further with a status detail object. The following table lists the different status details for each status:
 
 <table>
-<tr valign="top"><td rowspan="5">UNINITIALIZED</td><td>NONE</td><td>No further status details available.</td></tr>
+<tr valign="top"><td rowspan="6">UNINITIALIZED</td><td>NONE</td><td>No further status details available.</td></tr>
 <tr valign="top">                                  <td>HANDLER_MISSING_ERROR</td><td>The handler cannot be initialized, because the responsible binding is not available or started.</td></tr>
 <tr valign="top">                                  <td>HANDLER_REGISTERING_ERROR</td><td>The handler failed in the service registration phase.</td></tr>
 <tr valign="top">                                  <td>HANDLER_CONFIGURATION_PENDING</td><td>The handler is registered but can not be initialized caused by missing configuration parameters.</td></tr>
 <tr valign="top">                                  <td>HANDLER_INITIALIZING_ERROR</td><td>The handler failed in the initialization phase.</td></tr>
+<tr valign="top">                                  <td>BRIDGE_UNINITIALIZED</td><td>The bridge associated with this thing is not initialized.</td></tr>
 <tr valign="top"><td>INITIALIZING</td>             <td>NONE</td><td>No further status details available.</td></tr>
 <tr valign="top"><td>UNKNOWN</td>                  <td>NONE</td><td>No further status details available.</td></tr>
 <tr valign="top"><td rowspan="2">ONLINE</td>       <td>NONE</td><td>No further status details available.</td></tr>


### PR DESCRIPTION
Currently if there's an error with the bridge, it's things will have status HANDLER_MISSING which is wrong. This adds a BRIDGE_HANDLER_MISSING to provide a more accurate error message so we know where to look for the problem...
Signed-off-by: Chris Jackson <chris@cd-jackson.com>