### PR TITLE
rule engine to depend on the Xtext/EMF setup for rules

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/ruleengine.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/ruleengine.xml
@@ -18,4 +18,5 @@
    <reference bind="setModelRepository" cardinality="1..1" interface="org.eclipse.smarthome.model.core.ModelRepository" name="ModelRepository" policy="static" unbind="unsetModelRepository"/>
    <reference bind="setScriptEngine" cardinality="1..1" interface="org.eclipse.smarthome.model.script.engine.ScriptEngine" name="ScriptEngine" policy="static" unbind="unsetScriptEngine"/>
    <reference bind="setThingRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="static" unbind="unsetThingRegistry"/>
+   <reference cardinality="1..1" interface="org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator" name="RuleRuntimeActivator" policy="static"/>
 </scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/runtime.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/runtime.xml
@@ -12,6 +12,7 @@
    <implementation class="org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator"/>
    <service>
       <provide interface="org.eclipse.smarthome.model.core.ModelParser"/>
+      <provide interface="org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator"/>
    </service>
    <reference cardinality="1..1" interface="org.eclipse.smarthome.model.script.ScriptServiceUtil" name="ScriptServiceUtil" policy="static"/>
 </scr:component>


### PR DESCRIPTION
Let the rule engine not even attempt to run before the Xtext/EMF stuff has been initialized.

Just for the sake of completeness: The visual effects produced by this missing dependency looked like following:

```
java.lang.NullPointerException
	at org.eclipse.smarthome.model.rule.runtime.internal.engine.RuleEngineImpl.activate(RuleEngineImpl.java:99)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.internal.ds.model.ServiceComponent.activate(ServiceComponent.java:235)
   [...]
Caused by: java.lang.NullPointerException
	at org.eclipse.smarthome.model.rule.runtime.internal.engine.RuleEngineImpl.activate(RuleEngineImpl.java:99)
	... 54 more

```

I don't think it is directly related to #3562, but as we have seen it we should fix it nevertheless.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>