### PR TITLE
Do not log CancellationException for AggregatingScanListener on Aborted Scan

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 
@@ -94,8 +95,11 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
                     }
                     errorOccurred = true;
                 } else {
-                    logger.warn("Error occurred while executing discovery service: " + exception.getMessage(),
-                            exception);
+                    // Skip error logging for aborted scans
+                    if (!(exception instanceof CancellationException)) {
+                        logger.warn("Error occurred while executing discovery service: {}", exception.getMessage(),
+                                exception);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Error logging is skipped in the AggregatingScanListener when a discovery scan is aborted (e.g. when a CancellationException is met)

Signed-off-by: Dimitar Ivanov <dstivanov@gmail.com>