### PR TITLE
add support for retrieving channel specific config descriptions

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingConfigDescriptionProvider.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingConfigDescriptionProvider.xml
@@ -18,4 +18,5 @@
    <reference bind="setThingRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="static" unbind="unsetThingRegistry"/>
    <reference bind="setThingTypeRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.type.ThingTypeRegistry" name="ThingTypeRegistry" policy="static" unbind="unsetThingTypeRegistry"/>
    <reference bind="setConfigDescriptionRegistry" cardinality="1..1" interface="org.eclipse.smarthome.config.core.ConfigDescriptionRegistry" name="ConfigDescriptionRegistry" policy="static" unbind="unsetConfigDescriptionRegistry"/>
+   <reference bind="setChannelTypeRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry" name="ChannelTypeRegistry" policy="static" unbind="unsetChannelTypeRegistry"/>
 </scr:component>


### PR DESCRIPTION
...so that bindings have a chance to provide channel specific config options
via a ConfigOptionsProvider in the same way as it is possible for things already.

I therefore simply extended the already existing proxy to also handle the "channel" scheme.

The PaperUI will have to be adapted to actually use them (similar as #3215 which added this feature for things). 

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>