### PR TITLE
make sure the service dependencies get activated

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/ruleengine.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/ruleengine.xml
@@ -18,5 +18,5 @@
    <reference bind="setModelRepository" cardinality="1..1" interface="org.eclipse.smarthome.model.core.ModelRepository" name="ModelRepository" policy="static" unbind="unsetModelRepository"/>
    <reference bind="setScriptEngine" cardinality="1..1" interface="org.eclipse.smarthome.model.script.engine.ScriptEngine" name="ScriptEngine" policy="static" unbind="unsetScriptEngine"/>
    <reference bind="setThingRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.ThingRegistry" name="ThingRegistry" policy="static" unbind="unsetThingRegistry"/>
-   <reference cardinality="1..1" interface="org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator" name="RuleRuntimeActivator" policy="static"/>
+   <reference bind="setRuleRuntimeActivator" cardinality="1..1" interface="org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator" name="RuleRuntimeActivator" policy="static" unbind="unsetRuleRuntimeActivator"/>
 </scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/runtime.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/OSGI-INF/runtime.xml
@@ -14,5 +14,5 @@
       <provide interface="org.eclipse.smarthome.model.core.ModelParser"/>
       <provide interface="org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator"/>
    </service>
-   <reference cardinality="1..1" interface="org.eclipse.smarthome.model.script.ScriptServiceUtil" name="ScriptServiceUtil" policy="static"/>
+   <reference bind="setScriptServiceUtil" cardinality="1..1" interface="org.eclipse.smarthome.model.script.ScriptServiceUtil" name="ScriptServiceUtil" policy="static" unbind="unsetScriptServiceUtil"/>
 </scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/RuleRuntimeActivator.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/RuleRuntimeActivator.java
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.model.rule.runtime.internal;
 
 import org.eclipse.smarthome.model.core.ModelParser;
 import org.eclipse.smarthome.model.rule.RulesStandaloneSetup;
+import org.eclipse.smarthome.model.script.ScriptServiceUtil;
 import org.osgi.framework.BundleContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,13 @@ public class RuleRuntimeActivator implements ModelParser {
     @Override
     public String getExtension() {
         return "rules";
+    }
+
+    protected void setScriptServiceUtil(ScriptServiceUtil scriptServiceUtil) {
+        // noop - only make sure ScriptServiceUtil gets "used", hence activated
+    }
+
+    protected void unsetScriptServiceUtil(ScriptServiceUtil scriptServiceUtil) {
     }
 
 }

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
@@ -43,6 +43,7 @@ import org.eclipse.smarthome.model.rule.jvmmodel.RulesJvmModelInferrer;
 import org.eclipse.smarthome.model.rule.rules.Rule;
 import org.eclipse.smarthome.model.rule.rules.RuleModel;
 import org.eclipse.smarthome.model.rule.runtime.RuleEngine;
+import org.eclipse.smarthome.model.rule.runtime.internal.RuleRuntimeActivator;
 import org.eclipse.smarthome.model.script.engine.Script;
 import org.eclipse.smarthome.model.script.engine.ScriptEngine;
 import org.eclipse.smarthome.model.script.engine.ScriptExecutionException;
@@ -171,6 +172,13 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
 
     public void unsetThingRegistry(ThingRegistry thingRegistry) {
         this.thingRegistry = null;
+    }
+
+    protected void setRuleRuntimeActivator(RuleRuntimeActivator ruleRuntimeActivator) {
+        // noop - only make sure RuleRuntimeActivator gets "used", hence activated
+    }
+
+    protected void unsetRuleRuntimeActivator(RuleRuntimeActivator ruleRuntimeActivator) {
     }
 
     @Override

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/OSGI-INF/scriptengine.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/OSGI-INF/scriptengine.xml
@@ -15,5 +15,5 @@
       <provide interface="org.eclipse.smarthome.model.core.ModelParser"/>
    </service>
    <!-- we must depend on ScriptServiceUtil, because the activate() of this component will trigger Guice startup, which needs the all services (such as the ItemRegistry) to be in place already -->
-   <reference cardinality="1..1" interface="org.eclipse.smarthome.model.script.ScriptServiceUtil" name="ScriptServiceUtil" policy="static"/>
+   <reference bind="setScriptServiceUtil" cardinality="1..1" interface="org.eclipse.smarthome.model.script.ScriptServiceUtil" name="ScriptServiceUtil" policy="static" unbind="unsetScriptServiceUtil"/>
 </scr:component>

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptEngineImpl.java
@@ -19,6 +19,7 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.Resource.Diagnostic;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.smarthome.model.core.ModelParser;
+import org.eclipse.smarthome.model.script.ScriptServiceUtil;
 import org.eclipse.smarthome.model.script.engine.Script;
 import org.eclipse.smarthome.model.script.engine.ScriptEngine;
 import org.eclipse.smarthome.model.script.engine.ScriptExecutionException;
@@ -79,6 +80,13 @@ public class ScriptEngineImpl implements ScriptEngine, ModelParser {
     }
 
     protected void unsetScriptRuntime(final ScriptRuntime scriptRuntime) {
+    }
+
+    protected void setScriptServiceUtil(ScriptServiceUtil scriptServiceUtil) {
+        // noop - only make sure ScriptServiceUtil gets "used", hence activated
+    }
+
+    protected void unsetScriptServiceUtil(ScriptServiceUtil scriptServiceUtil) {
     }
 
     @Override


### PR DESCRIPTION
...as without actually using them, their activate() method never gets called.

In the logs, we could see that ScriptServiceUtil is there and has all its dependencies satisfied, but still did not get activated early enough:

```
2017-06-08 13:29:48.190 [DEBUG] [thome.model.script.ScriptServiceUtil] - ScriptServiceUtil is not initialized!
  ThingRegistry: {org.eclipse.smarthome.core.thing.ThingRegistry}={component.name=org.eclipse.smarthome.core.thing.ThingRegistry, component.id=78, service.id=166, service.bundleid=106, service.scope=bundle}
  ItemRegistry: {org.eclipse.smarthome.core.items.ItemRegistry}={component.name=org.eclipse.smarthome.core.itemregistry, component.id=50, service.id=132, service.bundleid=99, service.scope=bundle}
  EventPublisher: {org.osgi.service.event.EventHandler, org.eclipse.smarthome.core.events.EventPublisher}={event.topics=smarthome, component.name=org.eclipse.smarthome.core.internal.events.OSGiEventManager, component.id=45, service.id=125, service.bundleid=99, service.scope=bundle}
  ModelRepository: {org.eclipse.smarthome.model.core.ModelRepository}={component.name=org.eclipse.smarthome.model.core.repository, component.id=20, service.id=95, service.bundleid=123, service.scope=bundle}
```

The activation actually happened at a later point in time:

```
2017-06-08 13:29:48.309 [DEBUG] [thome.model.script.ScriptServiceUtil] - ScriptServiceUtil started
```

So this together with together with #3608 hopefully finally will fix #3562. At least I cannot reproduce it anymore by cleaning the karaf's cache & tmp folders.

fixes #3562
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>