### PR TITLE
allow bind new storage service if it uses a higher service ranking

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/OSGI-INF/ManagedRuleProvider.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/OSGI-INF/ManagedRuleProvider.xml
@@ -10,14 +10,12 @@
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.automation.managedruleprovider">
    <implementation class="org.eclipse.smarthome.automation.ManagedRuleProvider"/>
-   
+
    <service>
       <provide interface="org.eclipse.smarthome.automation.RuleProvider"/>
       <provide interface="org.eclipse.smarthome.automation.ManagedRuleProvider"/>
    </service>
-   
-   <reference bind="setStorageService" cardinality="1..1" 
-      interface="org.eclipse.smarthome.core.storage.StorageService" name="StorageService" 
-      policy="static" unbind="unsetStorageService"/>
-   
+
+<reference bind="setStorageService" cardinality="1..1" interface="org.eclipse.smarthome.core.storage.StorageService" name="StorageService" policy="dynamic" unbind="unsetStorageService"/>
+
 </scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ManagedThingProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ManagedThingProvider.java
@@ -11,6 +11,7 @@ import org.eclipse.smarthome.core.common.registry.DefaultAbstractManagedProvider
 import org.eclipse.smarthome.core.storage.StorageService;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  * {@link ManagedThingProvider} is an OSGi service, that allows to add or remove
@@ -35,7 +36,7 @@ public class ManagedThingProvider extends DefaultAbstractManagedProvider<Thing, 
         return key.toString();
     }
 
-    @Reference
+    @Reference(policy = ReferencePolicy.DYNAMIC)
     @Override
     protected void setStorageService(StorageService storageService) {
         super.setStorageService(storageService);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemChannelLinkProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemChannelLinkProvider.java
@@ -14,6 +14,7 @@ import org.eclipse.smarthome.core.storage.StorageService;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  *
@@ -45,7 +46,7 @@ public class ManagedItemChannelLinkProvider extends DefaultAbstractManagedProvid
         }
     }
 
-    @Reference
+    @Reference(policy = ReferencePolicy.DYNAMIC)
     @Override
     protected void setStorageService(StorageService storageService) {
         super.setStorageService(storageService);

--- a/bundles/core/org.eclipse.smarthome.core/OSGI-INF/manageditemprovider.xml
+++ b/bundles/core/org.eclipse.smarthome.core/OSGI-INF/manageditemprovider.xml
@@ -10,17 +10,13 @@
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.core.manageditemprovider">
    <implementation class="org.eclipse.smarthome.core.items.ManagedItemProvider"/>
-   
+
    <service>
       <provide interface="org.eclipse.smarthome.core.items.ItemProvider"/>
       <provide interface="org.eclipse.smarthome.core.items.ManagedItemProvider"/>
    </service>
-   
-   <reference bind="setStorageService" cardinality="1..1" 
-      interface="org.eclipse.smarthome.core.storage.StorageService" name="StorageService" 
-      policy="static" unbind="unsetStorageService"/>
-   <reference bind="addItemFactory" cardinality="0..n" 
-      interface="org.eclipse.smarthome.core.items.ItemFactory" name="ItemFactory" 
-      policy="dynamic" unbind="removeItemFactory"/>
-   
+
+   <reference bind="setStorageService" cardinality="1..1" interface="org.eclipse.smarthome.core.storage.StorageService" name="StorageService" policy="dynamic" unbind="unsetStorageService"/>
+   <reference bind="addItemFactory" cardinality="0..n" interface="org.eclipse.smarthome.core.items.ItemFactory" name="ItemFactory" policy="dynamic" unbind="removeItemFactory"/>
+
 </scr:component>

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
@@ -42,7 +42,9 @@ import com.google.common.collect.ImmutableList;
 public abstract class AbstractManagedProvider<E extends Identifiable<K>, K, PE> extends AbstractProvider<E>
         implements ManagedProvider<E, K> {
 
-    private Storage<PE> storage;
+    private StorageService storageService;
+    private volatile Storage<PE> storage;
+
     protected final Logger logger = LoggerFactory.getLogger(AbstractManagedProvider.class);
 
     @Override
@@ -152,8 +154,18 @@ public abstract class AbstractManagedProvider<E extends Identifiable<K>, K, PE> 
      */
     protected abstract @NonNull String keyToString(@NonNull K key);
 
-    protected void setStorageService(StorageService storageService) {
-        this.storage = storageService.getStorage(getStorageName(), this.getClass().getClassLoader());
+    protected void setStorageService(final StorageService storageService) {
+        if (this.storageService != storageService) {
+            this.storageService = storageService;
+            storage = storageService.getStorage(getStorageName(), this.getClass().getClassLoader());
+        }
+    }
+
+    protected void unsetStorageService(final StorageService storageService) {
+        if (this.storageService == storageService) {
+            this.storageService = null;
+            this.storage = null;
+        }
     }
 
     /**
@@ -174,9 +186,5 @@ public abstract class AbstractManagedProvider<E extends Identifiable<K>, K, PE> 
      * @return persistable element
      */
     protected abstract PE toPersistableElement(E element);
-
-    protected void unsetStorageService(StorageService storageService) {
-        this.storage = null;
-    }
 
 }

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/OSGI-INF/MarketplaceTemplateProvider.xml
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/OSGI-INF/MarketplaceTemplateProvider.xml
@@ -14,6 +14,6 @@
       <provide interface="org.eclipse.smarthome.extensionservice.marketplace.automation.internal.MarketplaceRuleTemplateProvider"/>
       <provide interface="org.eclipse.smarthome.automation.template.RuleTemplateProvider"/>
    </service>
-   <reference bind="setStorageService" cardinality="1..1" interface="org.eclipse.smarthome.core.storage.StorageService" name="StorageService" policy="static" unbind="unsetStorageService"/>
+   <reference bind="setStorageService" cardinality="1..1" interface="org.eclipse.smarthome.core.storage.StorageService" name="StorageService" policy="dynamic" unbind="unsetStorageService"/>
    <reference bind="setParser" cardinality="1..1" interface="org.eclipse.smarthome.automation.parser.Parser" name="Parser" policy="static" target="(&amp;(format=json)(parser.type=parser.template))" unbind="unsetParser"/>
 </scr:component>


### PR DESCRIPTION
If there are multiple storage service implementations used in the runtime and a component already uses a storage service reference shouldn't the storage service with the highest service ranking be used?
Without force the usage of the highest service ranking one we cannot ensure which one get's injected if a product uses multiple ones.