### PR TITLE
add storage.format property to StorageService implementations

### DIFF
--- a/bundles/storage/org.eclipse.smarthome.storage.json/OSGI-INF/jsonstorage.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/OSGI-INF/jsonstorage.xml
@@ -16,6 +16,7 @@
 	<property name="service.config.description.uri" type="String" value="system:json_storage" />
 	<property name="service.config.label" type="String" value="Json Storage" />
 	<property name="service.config.category" type="String" value="system" />
+	<property name="storage.format" type="String" value="json"/>
 
 	<service>
 		<provide interface="org.eclipse.smarthome.core.storage.StorageService" />

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/OSGI-INF/mapdbstorage.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/OSGI-INF/mapdbstorage.xml
@@ -10,9 +10,11 @@
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.eclipse.smarthome.storage.mapdb">
    <implementation class="org.eclipse.smarthome.storage.mapdb.MapDbStorageService"/>
-   
+
+    <property name="storage.format" type="String" value="mapdb"/>
+
    <service>
       <provide interface="org.eclipse.smarthome.core.storage.StorageService"/>
    </service>
-		   
+
 </scr:component>


### PR DESCRIPTION
This property could be consumed e.g. by a filter to get a specific storage service injected.