### PR TITLE
resolving circular dependency by removing SCR from the game

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptEngineImpl.java
@@ -83,10 +83,11 @@ public class ScriptEngineImpl implements ScriptEngine, ModelParser {
     }
 
     protected void setScriptServiceUtil(ScriptServiceUtil scriptServiceUtil) {
-        // noop - only make sure ScriptServiceUtil gets "used", hence activated
+        scriptServiceUtil.setScriptEngine(this);
     }
 
     protected void unsetScriptServiceUtil(ScriptServiceUtil scriptServiceUtil) {
+        scriptServiceUtil.unsetScriptEngine(this);
     }
 
     @Override


### PR DESCRIPTION
As it seems, #3614 made a not-so-well-hidden circular dependency between two services surface. 

The `ScriptEngine` depends on the `ScriptServiceUtil`, which in turn registers a service tracker for `ScriptEngine` during its activation. I assume it is done like this because DS would have complained about the circular dependency if it was declared in the XML.

Therefore I suggest setting it "by foot" at the moment when `ScriptEngine` gets injected the `ScriptServiceUtil` instance.

Hacky hacky, little (less) whacky...

relates to #3614
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>