### PR TITLE
Make IncreaseDecrease implement State and add to Dimmer

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/DimmerItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/items/DimmerItemTest.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.types.State;
 import org.junit.Test;
@@ -66,6 +67,17 @@ public class DimmerItemTest {
         final DimmerItem item = createDimmerItem(new PercentType(origin));
         final BigDecimal result = getState(item, DecimalType.class);
         assertEquals(origin.divide(new BigDecimal(100)).compareTo(result), 0);
+    }
+
+    @Test
+    public void getAsPercentFromIncreaseDecrease() {
+        DimmerItem item = createDimmerItem(IncreaseDecreaseType.DECREASE);
+        BigDecimal result = getState(item, PercentType.class);
+        assertEquals(new BigDecimal(0).compareTo(result), 0);
+
+        item = createDimmerItem(IncreaseDecreaseType.INCREASE);
+        result = getState(item, PercentType.class);
+        assertEquals(new BigDecimal(100).compareTo(result), 0);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/DimmerItem.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.types.UnDefType;
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Markus Rathgeb - Support more types for getStateAs
+ * @author Chris Jackson - Add IncreaseDecreaseType as state
  *
  */
 public class DimmerItem extends SwitchItem {
@@ -36,6 +37,7 @@ public class DimmerItem extends SwitchItem {
     static {
         acceptedDataTypes.add(PercentType.class);
         acceptedDataTypes.add(OnOffType.class);
+        acceptedDataTypes.add(IncreaseDecreaseType.class);
         acceptedDataTypes.add(UnDefType.class);
 
         acceptedCommandTypes.add(PercentType.class);
@@ -50,6 +52,10 @@ public class DimmerItem extends SwitchItem {
 
     /* package */ DimmerItem(String type, String name) {
         super(type, name);
+    }
+
+    public void send(IncreaseDecreaseType command) {
+        internalSend(command);
     }
 
     public void send(PercentType command) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
@@ -9,8 +9,9 @@ package org.eclipse.smarthome.core.library.types;
 
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
+import org.eclipse.smarthome.core.types.State;
 
-public enum IncreaseDecreaseType implements PrimitiveType, Command {
+public enum IncreaseDecreaseType implements PrimitiveType, State, Command {
     INCREASE,
     DECREASE;
 


### PR DESCRIPTION
This allows DimmerType to use IncreaseDecrease as a State which is needed for "valueless" commands - ie the user presses a dimmer and the dimmer sends up/down rather than an actual level.

https://github.com/openhab/org.openhab.binding.zwave/issues/598

Signed-off-by: Chris Jackson <chris@cd-jackson.com>