### PR TITLE
fix NPEs in cases where ModelRepository returns null

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
@@ -444,13 +444,14 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                 case org.eclipse.smarthome.model.core.EventType.MODIFIED: {
                     val oldThings = thingsMap.get(modelName) ?: newArrayList
                     val model = modelRepository.getModel(modelName) as ThingModel
-                    val newThingUIDs = model.allThingUIDs
-                    val removedThings = oldThings.filter[!newThingUIDs.contains(it.UID)]
-                    removedThings.forEach [
-                        notifyListenersAboutRemovedElement
-                    ]
-
-                    createThingsFromModel(modelName)
+                    if (model != null) {
+                        val newThingUIDs = model.allThingUIDs
+                        val removedThings = oldThings.filter[!newThingUIDs.contains(it.UID)]
+                        removedThings.forEach [
+                            notifyListenersAboutRemovedElement
+                        ]
+                        createThingsFromModel(modelName)
+                    }
                 }
                 case org.eclipse.smarthome.model.core.EventType.REMOVED: {
                     val things = thingsMap.remove(modelName) ?: newArrayList

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/GenericItemUIProvider.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/GenericItemUIProvider.java
@@ -65,9 +65,12 @@ public class GenericItemUIProvider implements ItemUIProvider {
         if (itemName != null && modelRepository != null) {
             for (String modelName : modelRepository.getAllModelNamesOfType("items")) {
                 ItemModel model = (ItemModel) modelRepository.getModel(modelName);
-                for (ModelItem item : model.getItems()) {
-                    if (itemName.equals(item.getName()))
-                        return item;
+                if (model != null) {
+                    for (ModelItem item : model.getItems()) {
+                        if (itemName.equals(item.getName())) {
+                            return item;
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
The `ModelRepository.getModel()` method _can_ return null. Almost all callers have a null-guard. Here I added the two missing ones which I could find.

fixes #3636
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>