### PR TITLE
Initial contribution of Trådfri binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bundles/storage/org.eclipse.smarthome.storage.mapdb.test/userdata/mapdb/storage.
 bundles/storage/org.eclipse.smarthome.storage.mapdb.test/userdata/mapdb/storage.mapdb.t
 features/karaf/*/src/main/history
 
+Californium.properties

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/.classpath
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/.project
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.binding.tradfri.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
@@ -1,0 +1,25 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name:  Tradfri Binding Tests
+Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri.test;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Fragment-Host: org.eclipse.smarthome.binding.tradfri
+Import-Package: org.eclipse.smarthome.binding.tradfri,
+ org.eclipse.smarthome.binding.tradfri.handler,
+ org.eclipse.smarthome.core.common.registry,
+ org.eclipse.smarthome.core.events,
+ org.eclipse.smarthome.core.thing.util,
+ org.eclipse.smarthome.test.java,
+ org.eclipse.smarthome.test.storage,
+ org.hamcrest;core=split,
+ org.junit;version="4.0.0",
+ org.mockito,
+ org.osgi.framework,
+ org.osgi.service.device,
+ org.slf4j
+Require-Bundle: org.junit,org.mockito,org.hamcrest
+Export-Package: org.eclipse.smarthome.binding.tradfri.internal;x-internal:=true,
+ org.eclipse.smarthome.binding.tradfri;uses:="org.eclipse.smarthome.test"
+

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/build.properties
@@ -1,0 +1,4 @@
+source.. = src/test/java/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/build.properties
@@ -1,4 +1,4 @@
 source.. = src/test/java/
 output.. = target/classes
 bin.includes = META-INF/,\
-               .,
+               .

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/pom.xml
@@ -1,0 +1,124 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.smarthome.binding</groupId>
+    <artifactId>pom</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.eclipse.smarthome.archetype</groupId>
+  <artifactId>org.eclipse.smarthome.binding.tradfri.test</artifactId>
+  <version>0.9.0-SNAPSHOT</version>
+  <packaging>eclipse-test-plugin</packaging>
+
+  <name>Tradfri Binding Tests</name>
+
+  <properties>
+    <bundle.symbolicName>org.eclipse.smarthome.binding.tradfri.test</bundle.symbolicName>
+    <bundle.namespace>org.eclipse.smarthome.binding.tradfri</bundle.namespace>
+  </properties>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <environments combine.self="override"></environments>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.config.xml</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core.binding.xml</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core.thing.xml</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.config.discovery</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <bundleStartLevel>
+            <bundle>
+              <id>org.eclipse.equinox.ds</id>
+              <level>1</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.equinox.event</id>
+              <level>2</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core.thing</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.config.core</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.config.xml</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core.thing.xml</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+                <id>org.eclipse.smarthome.config.discovery</id>
+                <level>4</level>
+                <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core.binding.xml</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+          </bundleStartLevel>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/TradfriHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/TradfriHandlerTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.smarthome.binding.tradfri.handler.TradfriGatewayHandler;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ManagedThingProvider;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingProvider;
+import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder;
+import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
+import org.eclipse.smarthome.test.java.JavaOSGiTest;
+import org.eclipse.smarthome.test.storage.VolatileStorageService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests cases for {@link TradfriGatewayHandler}.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriHandlerTest extends JavaOSGiTest {
+
+    private ManagedThingProvider managedThingProvider;
+    private VolatileStorageService volatileStorageService = new VolatileStorageService();
+    private Bridge bridge;
+    private Thing thing;
+
+    @Before
+    public void setUp() {
+        registerService(volatileStorageService);
+        managedThingProvider = getService(ThingProvider.class, ManagedThingProvider.class);
+        assertThat(managedThingProvider, is(notNullValue()));
+
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(GatewayConfig.HOST, "1.2.3.4");
+        properties.put(GatewayConfig.CODE, "abc");
+        bridge = BridgeBuilder.create(TradfriBindingConstants.GATEWAY_TYPE_UID, "1").withLabel("My Gateway")
+                .withConfiguration(new Configuration(properties)).build();
+        properties = new HashMap<>();
+        properties.put(DeviceConfig.ID, "65537");
+        thing = ThingBuilder.create(TradfriBindingConstants.THING_TYPE_DIMMABLE_LIGHT, "1").withLabel("My Bulb")
+                .withBridge(bridge.getUID()).withConfiguration(new Configuration(properties)).build();
+    }
+
+    @After
+    public void tearDown() {
+        managedThingProvider.remove(thing.getUID());
+        managedThingProvider.remove(bridge.getUID());
+        unregisterService(volatileStorageService);
+    }
+
+    @Test
+    public void creationOfTradfriGatewayHandler() {
+        assertThat(bridge.getHandler(), is(nullValue()));
+        managedThingProvider.add(bridge);
+        waitForAssert(() -> assertThat(bridge.getHandler(), notNullValue()));
+    }
+
+    @Test
+    public void creationOfTradfriLightHandler() {
+        assertThat(thing.getHandler(), is(nullValue()));
+        managedThingProvider.add(bridge);
+        managedThingProvider.add(thing);
+        waitForAssert(() -> assertThat(thing.getHandler(), notNullValue()));
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/discovery/TradfriDiscoveryParticipantOSGITest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/discovery/TradfriDiscoveryParticipantOSGITest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.discovery;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import javax.jmdns.ServiceInfo;
+
+import org.eclipse.smarthome.binding.tradfri.GatewayConfig;
+import org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants;
+import org.eclipse.smarthome.binding.tradfri.internal.discovery.TradfriDiscoveryParticipant;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant;
+import org.eclipse.smarthome.test.java.JavaOSGiTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/**
+ * Tests for {@link TradfriDiscoveryParticipant}.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriDiscoveryParticipantOSGITest extends JavaOSGiTest {
+
+    MDNSDiscoveryParticipant discoveryParticipant;
+
+    @Mock
+    ServiceInfo tradfriGateway;
+
+    @Mock
+    ServiceInfo otherDevice;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        discoveryParticipant = getService(MDNSDiscoveryParticipant.class, TradfriDiscoveryParticipant.class);
+        assertThat(discoveryParticipant, is(notNullValue()));
+
+        when(tradfriGateway.getType()).thenReturn("_coap._udp.local.");
+        when(tradfriGateway.getName()).thenReturn("gw:12-34-56-78-90-ab");
+        when(tradfriGateway.getHostAddresses()).thenReturn(new String[] { "192.168.0.5" });
+        when(tradfriGateway.getPort()).thenReturn(1234);
+        when(tradfriGateway.getPropertyString("version")).thenReturn("1.1");
+
+        when(otherDevice.getType()).thenReturn("_coap._udp.local.");
+        when(otherDevice.getName()).thenReturn("something");
+        when(otherDevice.getHostAddresses()).thenReturn(new String[] { "192.168.0.5" });
+        when(otherDevice.getPort()).thenReturn(1234);
+        when(otherDevice.getPropertyString("version")).thenReturn("1.1");
+    }
+
+    @After
+    public void cleanUp() {
+    }
+
+    @Test
+    public void correctSupportedTypes() {
+        assertThat(discoveryParticipant.getSupportedThingTypeUIDs().size(), is(1));
+        assertThat(discoveryParticipant.getSupportedThingTypeUIDs().iterator().next(),
+                is(TradfriBindingConstants.GATEWAY_TYPE_UID));
+    }
+
+    @Test
+    public void correctThingUID() {
+        assertThat(discoveryParticipant.getThingUID(tradfriGateway),
+                is(new ThingUID("tradfri:gateway:gw1234567890ab")));
+    }
+
+    @Test
+    public void validDiscoveryResult() {
+        DiscoveryResult result = discoveryParticipant.createResult(tradfriGateway);
+
+        assertNotNull(result);
+        assertThat(result.getProperties().get("firmware"), is("1.1"));
+        assertThat(result.getFlag(), is(DiscoveryResultFlag.NEW));
+        assertThat(result.getThingUID(), is(new ThingUID("tradfri:gateway:gw1234567890ab")));
+        assertThat(result.getThingTypeUID(), is(TradfriBindingConstants.GATEWAY_TYPE_UID));
+        assertThat(result.getBridgeUID(), is(nullValue()));
+        assertThat(result.getProperties().get("vendor"), is("IKEA"));
+        assertThat(result.getProperties().get(GatewayConfig.HOST), is("192.168.0.5"));
+        assertThat(result.getProperties().get(GatewayConfig.PORT), is(1234));
+        assertThat(result.getRepresentationProperty(), is(GatewayConfig.HOST));
+    }
+
+    @Test
+    public void noThingUIDForUnknownDevice() {
+        assertThat(discoveryParticipant.getThingUID(otherDevice), is(nullValue()));
+    }
+
+    @Test
+    public void noDiscoveryResultForUnknownDevice() {
+        assertThat(discoveryParticipant.createResult(otherDevice), is(nullValue()));
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/discovery/TradfriDiscoveryServiceTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/discovery/TradfriDiscoveryServiceTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.discovery;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collection;
+
+import org.eclipse.smarthome.binding.tradfri.DeviceConfig;
+import org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants;
+import org.eclipse.smarthome.binding.tradfri.handler.TradfriGatewayHandler;
+import org.eclipse.smarthome.binding.tradfri.internal.discovery.TradfriDiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryListener;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * Tests for {@link TradfriDiscoveryService}.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriDiscoveryServiceTest {
+
+    @Mock
+    TradfriGatewayHandler handler;
+
+    DiscoveryListener listener;
+    DiscoveryResult discoveryResult;
+
+    TradfriDiscoveryService discovery;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        when(handler.getThing())
+                .thenReturn(BridgeBuilder.create(TradfriBindingConstants.GATEWAY_TYPE_UID, "1").build());
+        discovery = new TradfriDiscoveryService(handler);
+
+        listener = new DiscoveryListener() {
+            @Override
+            public void thingRemoved(DiscoveryService source, ThingUID thingUID) {
+            }
+
+            @Override
+            public void thingDiscovered(DiscoveryService source, DiscoveryResult result) {
+                discoveryResult = result;
+            }
+
+            @Override
+            public Collection<ThingUID> removeOlderResults(DiscoveryService source, long timestamp,
+                    Collection<ThingTypeUID> thingTypeUIDs) {
+                return null;
+            }
+        };
+        discovery.addDiscoveryListener(listener);
+    }
+
+    @After
+    public void cleanUp() {
+        discoveryResult = null;
+    }
+
+    @Test
+    public void correctSupportedTypes() {
+        assertThat(discovery.getSupportedThingTypes().size(), is(2));
+        assertTrue(discovery.getSupportedThingTypes().contains(TradfriBindingConstants.THING_TYPE_DIMMABLE_LIGHT));
+        assertTrue(discovery.getSupportedThingTypes().contains(TradfriBindingConstants.THING_TYPE_COLOR_TEMP_LIGHT));
+    }
+
+    @Test
+    public void validDiscoveryResult() {
+
+        String json = "{\"9054\":0,\"9001\":\"LR\",\"5750\":2,\"9002\":1490983446,\"9020\":1491055861,\"9003\":65537,\"9019\":1,\"3\":{\"1\":\"TRADFRI bulb E27 WS opal 980lm\",\"0\":\"IKEA of Sweden\",\"2\":\"\",\"3\":\"1.1.1.1-5.7.2.0\",\"6\":1},\"3311\":[{\"5850\":1,\"5851\":254,\"5707\":0,\"5708\":0,\"5709\":33135,\"5710\":27211,\"9003\":0,\"5711\":0,\"5706\":\"efd275\"}]}";
+        JsonObject data = new JsonParser().parse(json).getAsJsonObject();
+
+        discovery.onUpdate("65537", data);
+
+        assertNotNull(discoveryResult);
+        assertThat(discoveryResult.getFlag(), is(DiscoveryResultFlag.NEW));
+        assertThat(discoveryResult.getThingUID(), is(new ThingUID("tradfri:0220:1:65537")));
+        assertThat(discoveryResult.getThingTypeUID(), is(TradfriBindingConstants.THING_TYPE_COLOR_TEMP_LIGHT));
+        assertThat(discoveryResult.getBridgeUID(), is(new ThingUID("tradfri:gateway:1")));
+        assertThat(discoveryResult.getProperties().get(DeviceConfig.ID), is(65537));
+        assertThat(discoveryResult.getRepresentationProperty(), is(DeviceConfig.ID));
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/.classpath
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/.project
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.binding.tradfri</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/binding/binding.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="tradfri"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+    <name>Trådfri Binding</name>
+    <description>This binding supports IKEA Trådfri lighting devices through the IKEA gateway.</description>
+
+</binding:binding>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="tradfri"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+    <bridge-type id="gateway">
+        <label>Trådfri Gateway</label>
+
+        <config-description>
+            <parameter name="host" type="text" required="true">
+                <context>network-address</context>
+                <label>Host</label>
+                <description>Hostname or IP address of the IKEA Trådfri gateway</description>
+            </parameter>
+            <parameter name="port" type="integer" required="false">
+                <label>Port</label>
+                <description>Port for accessing the gateway</description>
+                <advanced>true</advanced>
+                <default>5684</default>
+            </parameter>
+            <parameter name="code" type="text" required="true">
+                <context>password</context>
+                <label>Security Code</label>
+                <description>Security code printed on the label underneath the gateway.</description>
+            </parameter>
+        </config-description>
+    </bridge-type>
+
+    <!-- thing types for devices -->
+    <!-- their IDs refer to the Zigbee Lightlink device ids (see chapter 2.2 in https://www.nxp.com/documents/user_manual/JN-UG-3091.pdf) -->
+    <thing-type id="0100">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="gateway"/>
+        </supported-bridge-type-refs>
+
+        <label>Dimmable Light</label>
+
+        <channels>
+            <channel id="brightness" typeId="brightness"/>
+        </channels>
+
+        <config-description>
+            <parameter name="id" type="text" required="true">
+                <label>ID</label>
+                <description>The identifier of the light on the gateway</description>
+            </parameter>
+        </config-description>
+    </thing-type>
+
+    <thing-type id="0220">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="gateway"/>
+        </supported-bridge-type-refs>
+
+        <label>Color Temperature Light</label>
+
+        <channels>
+            <channel id="brightness" typeId="brightness"/>
+            <channel id="colorTemperature" typeId="colorTemperature"/>
+        </channels>
+
+        <config-description>
+            <parameter name="id" type="text" required="true">
+                <label>ID</label>
+                <description>The identifier of the light on the gateway</description>
+            </parameter>
+        </config-description>
+    </thing-type>
+
+    <!-- note that this isn't yet supported by the code as we do not receive any data from the gateway for it -->
+    <thing-type id="0820" listed="false">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="gateway"/>
+        </supported-bridge-type-refs>
+
+        <label>Non-Color Control Unit</label>
+
+        <channels>
+            <channel id="brightness" typeId="brightness"/>
+        </channels>
+
+        <config-description>
+            <parameter name="id" type="text" required="true">
+                <label>ID</label>
+                <description>The identifier of the controller on the gateway</description>
+            </parameter>
+        </config-description>
+    </thing-type>
+
+    <channel-type id="brightness">
+        <item-type>Dimmer</item-type>
+        <label>Brightness</label>
+        <description>
+            The brightness channel allows to control the brightness of a light.
+            It is also possible to switch the light on and off.
+        </description>
+        <category>DimmableLight</category>
+        <tags>
+            <tag>Lighting</tag>
+        </tags>
+    </channel-type>
+
+    <channel-type id="color">
+        <item-type>Color</item-type>
+        <label>Color</label>
+        <description>Control the color of light.</description>
+        <category>ColorLight</category>
+        <tags>
+            <tag>Lighting</tag>
+        </tags>
+    </channel-type>
+
+    <channel-type id="colorTemperature">
+        <item-type>Dimmer</item-type>
+        <label>Color Temperature</label>
+        <description>Allows to control the color temperature of light.</description>
+        <tags>
+            <tag>ColorTemperature</tag>
+        </tags>
+    </channel-type>
+
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
@@ -35,6 +35,7 @@
         </supported-bridge-type-refs>
 
         <label>Dimmable Light</label>
+        <description>A light that has continuous brightness control.</description>
 
         <channels>
             <channel id="brightness" typeId="brightness"/>
@@ -54,10 +55,11 @@
         </supported-bridge-type-refs>
 
         <label>Color Temperature Light</label>
+        <description>A dimmable light that supports different color temperature settings.</description>
 
         <channels>
             <channel id="brightness" typeId="brightness"/>
-            <channel id="colorTemperature" typeId="colorTemperature"/>
+            <channel id="color_temperature" typeId="color_temperature"/>
         </channels>
 
         <config-description>
@@ -101,23 +103,11 @@
         </tags>
     </channel-type>
 
-    <channel-type id="color">
-        <item-type>Color</item-type>
-        <label>Color</label>
-        <description>Control the color of light.</description>
-        <category>ColorLight</category>
-        <tags>
-            <tag>Lighting</tag>
-        </tags>
-    </channel-type>
-
-    <channel-type id="colorTemperature">
+    <channel-type id="color_temperature">
         <item-type>Dimmer</item-type>
         <label>Color Temperature</label>
         <description>Allows to control the color temperature of light.</description>
-        <tags>
-            <tag>ColorTemperature</tag>
-        </tags>
+        <category>ColorLight</category>
     </channel-type>
 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
@@ -1,0 +1,37 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tradfri Binding
+Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Import-Package: 
+ com.google.common.collect,
+ com.google.gson,
+ javax.jmdns,
+ org.eclipse.californium.core,
+ org.eclipse.californium.core.coap,
+ org.eclipse.californium.core.network,
+ org.eclipse.californium.core.network.config,
+ org.eclipse.californium.elements,
+ org.eclipse.californium.scandium,
+ org.eclipse.californium.scandium.config,
+ org.eclipse.californium.scandium.dtls.pskstore,
+ org.eclipse.smarthome.binding.tradfri,
+ org.eclipse.smarthome.binding.tradfri.handler,
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.thing,
+ org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.thing.binding.builder,
+ org.eclipse.smarthome.core.thing.type,
+ org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.io.transport.mdns.discovery,
+ org.osgi.framework,
+ org.slf4j
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.eclipse.smarthome.binding.tradfri,
+ org.eclipse.smarthome.binding.tradfri.handler
+Bundle-ActivationPolicy: lazy

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/OSGI-INF/TradfriDiscoveryParticipant.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/OSGI-INF/TradfriDiscoveryParticipant.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2017 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.binding.tradfri.internal.discovery.TradfriDiscoveryParticipant">
+ <implementation class="org.eclipse.smarthome.binding.tradfri.internal.discovery.TradfriDiscoveryParticipant"/>
+ <service>
+    <provide interface="org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant"/>
+ </service>
+</scr:component>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/OSGI-INF/TradfriHandlerFactory.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/OSGI-INF/TradfriHandlerFactory.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2010-2017 by the respective copyright holders.
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="binding.tradfri">
+
+	<implementation class="org.eclipse.smarthome.binding.tradfri.internal.TradfriHandlerFactory"/>
+
+	<service>
+		<provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+	</service>
+
+</scr:component>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
@@ -13,7 +13,6 @@ The thing type ids are defined according to the lighting devices defined for Zig
 | Dimmable Light           | 0x0100           | 0100       |
 | Colour Temperature Light | 0x0220           | 0220       |
 
-
 ## Thing Configuration
 
 The gateway requires a `host` parameter for the hostname or IP address and a `code`, which is the security code that is printed on the bottom of the gateway. Optionally, a `port` can be configured, but any standard gateway uses the default port 5684.
@@ -24,10 +23,10 @@ The devices require only a single parameter, which is their instance id. Unfortu
 
 All devices support the `brightness` channel, while the white spectrum bulbs additionally also support the `colorTemperature` channel.
 
-| Channel Type ID | Item Type     | Description                           |
-|-----------------|---------------|---------------------------------------|
-| brightness      | Percent       | The brightness of the bulb in percent |
-| colorTemperature| Percent       | color temperature from 0%=cold to 100%=warm |
+| Channel Type ID   | Item Type | Description                                 |
+|-------------------|-----------|---------------------------------------------|
+| brightness        | Dimmer    | The brightness of the bulb in percent       |
+| color_temperature | Dimmer    | color temperature from 0%=cold to 100%=warm |
 
 ## Full Example
 

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
@@ -1,0 +1,58 @@
+# Trådfri Binding
+
+This binding integrates the IKEA Trådfri gateway and devices connected to it (such as dimmable LED bulbs).
+
+## Supported Things
+
+Besides the gateway (thing type "gateway"), the binding currently supports dimmable warm white bulbs as well as white spectrum bulbs.
+
+The thing type ids are defined according to the lighting devices defined for ZigBee LightLink ([see page 24, table 2](https://www.nxp.com/documents/user_manual/JN-UG-3091.pdf). These are:
+
+| Device type              | ZigBee Device ID | Thing type |
+|--------------------------|------------------|------------|
+| Dimmable Light           | 0x0100           | 0100       |
+| Colour Temperature Light | 0x0220           | 0220       |
+
+
+## Thing Configuration
+
+The gateway requires a `host` parameter for the hostname or IP address and a `code`, which is the security code that is printed on the bottom of the gateway. Optionally, a `port` can be configured, but any standard gateway uses the default port 5684.
+
+The devices require only a single parameter, which is their instance id. Unfortunately, this is not displayed anywhere in the IKEA app, but it seems that they are sequentially numbered starting with 65537 for the first device. If in doubt, use the auto-discovered things to find out the correct instance ids.
+
+## Channels
+
+All devices support the `brightness` channel, while the white spectrum bulbs additionally also support the `colorTemperature` channel.
+
+| Channel Type ID | Item Type     | Description                           |
+|-----------------|---------------|---------------------------------------|
+| brightness      | Percent       | The brightness of the bulb in percent |
+| colorTemperature| Percent       | color temperature from 0%=cold to 100%=warm |
+
+## Full Example
+
+demo.things:
+
+```
+Bridge tradfri:gateway:mygateway [ host="192.168.0.177", code="EHPW5rIJKyXFgjH3" ] {
+    0100 myDimmableBulb [ id=65537 ]    
+    0220 myColorTempBulb [ id=65538 ]    
+}
+```
+
+demo.items:
+
+```
+Dimmer Light { channel="tradfri:0100:mygateway:myDimmableBulb:brightness" } 
+```
+
+demo.sitemap:
+
+```
+sitemap demo label="Main Menu"
+{
+    Frame {
+    	Slider item=Light label="Brightness [%.1f %%]"
+	}
+}
+```

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/about.html
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/about.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+<p>June 5, 2006</p>
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;). Unless otherwise
+    indicated below, the Content is provided to you under the terms and conditions of the
+    Eclipse Public License Version 1.0 (&quot;EPL&quot;). A copy of the EPL is available
+    at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
+    being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the Redistributor's license that was
+    provided with the Content. If no such license exists, contact the Redistributor. Unless otherwise
+    indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+    and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/build.properties
@@ -1,0 +1,7 @@
+source..=src/main/java/
+output..=target/classes
+bin.includes=META-INF/,\
+             .,\
+             OSGI-INF/,\
+             ESH-INF/,\
+             about.html

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.smarthome.binding</groupId>
+		<artifactId>pom</artifactId>
+		<version>0.9.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>org.eclipse.smarthome.binding.tradfri</artifactId>
+	<version>0.9.0-SNAPSHOT</version>
+
+	<name>Tradfri Binding</name>
+	<packaging>eclipse-plugin</packaging>
+
+</project>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/DeviceConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/DeviceConfig.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri;
+
+/**
+ * The {@link DeviceConfig} holds the
+ * configuration information needed to access single bulbs on the gateway.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class DeviceConfig {
+
+    public static final String ID = "id";
+
+    public Integer id;
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/GatewayConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/GatewayConfig.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri;
+
+/**
+ * Configuration class for the gateway.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class GatewayConfig {
+
+    public static final String HOST = "host";
+    public static final String PORT = "port";
+    public static final String CODE = "code";
+
+    public String host;
+    public int port = 5684; // default port
+    public String code;
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
@@ -33,11 +33,13 @@ public class TradfriBindingConstants {
 
     public static final Set<ThingTypeUID> SUPPORTED_LIGHT_TYPES_UIDS = ImmutableSet.of(THING_TYPE_DIMMABLE_LIGHT,
             THING_TYPE_COLOR_TEMP_LIGHT);
+
+    // Not yet used - included for future support
     public static final Set<ThingTypeUID> SUPPORTED_CONTROLLER_TYPES_UIDS = ImmutableSet.of(THING_TYPE_DIMMER);
 
     // List of all Channel IDs
     public static final String CHANNEL_BRIGHTNESS = "brightness";
-    public static final String CHANNEL_COLOR_TEMPERATURE = "colorTemperature";
+    public static final String CHANNEL_COLOR_TEMPERATURE = "color_temperature";
 
     // IPSO Objects
     public static final String DEVICES = "15001";

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
@@ -145,4 +145,7 @@ public class TradfriBindingConstants {
 
     public static final String TYPE_LIGHT = "2";
     public static final String TYPE_SWITCH = "0";
+    public static final String DEVICE_VENDOR = "0";
+    public static final String DEVICE_MODEL = "1";
+    public static final String DEVICE_FIRMWARE = "3";
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri;
+
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * The {@link TradfriBindingConstants} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriBindingConstants {
+
+    private static final String BINDING_ID = "tradfri";
+
+    // List of all Thing Type UIDs
+    public static final ThingTypeUID GATEWAY_TYPE_UID = new ThingTypeUID(BINDING_ID, "gateway");
+
+    public final static ThingTypeUID THING_TYPE_DIMMABLE_LIGHT = new ThingTypeUID(BINDING_ID, "0100");
+    public final static ThingTypeUID THING_TYPE_COLOR_TEMP_LIGHT = new ThingTypeUID(BINDING_ID, "0220");
+    public final static ThingTypeUID THING_TYPE_DIMMER = new ThingTypeUID(BINDING_ID, "0820");
+
+    public static final Set<ThingTypeUID> SUPPORTED_LIGHT_TYPES_UIDS = ImmutableSet.of(THING_TYPE_DIMMABLE_LIGHT,
+            THING_TYPE_COLOR_TEMP_LIGHT);
+    public static final Set<ThingTypeUID> SUPPORTED_CONTROLLER_TYPES_UIDS = ImmutableSet.of(THING_TYPE_DIMMER);
+
+    // List of all Channel IDs
+    public static final String CHANNEL_BRIGHTNESS = "brightness";
+    public static final String CHANNEL_COLOR_TEMPERATURE = "colorTemperature";
+
+    // IPSO Objects
+    public static final String DEVICES = "15001";
+    public static final String AUTH_PATH = "9063";
+    public static final String CLIENT_IDENTITY_PROPOSED = "9090";
+    public static final String COLOR = "5706";
+    public static final String COLOR_X = "5709";
+    public static final String COLOR_Y = "5710";
+    public static final String COMMISSIONING_MODE = "9061";
+    public static final String CREATED_AT = "9002";
+    public static final String CUM_ACTIVE_POWER = "5805";
+    public static final String CURRENT_TIMESTAMP = "9059";
+    public static final int DEFAULT_DIMMER_TRANSITION_TIME = 5;
+    public static final String DEVICE = "3";
+    public static final String DIMMER = "5851";
+    public static final int DIMMER_MAX = 254;
+    public static final int DIMMER_MIN = 0;
+    public static final String END_ACTION = "9043";
+    public static final String END_TIME_HR = "9048";
+    public static final String END_TIME_MN = "9049";
+    public static final String ERROR_TAG = "errorcode";
+    public static final String FORCE_CHECK_OTA_UPDATE = "9032";
+    public static final String GATEWAY = "15011";
+    public static final String GATEWAY_DETAILS = "15012";
+    public static final String GATEWAY_NAME = "9035";
+    public static final int GATEWAY_REBOOT_NOTIFICATION = 1003;
+    public static final String GATEWAY_REBOOT_NOTIFICATION_TYPE = "9052";
+    public static final String GATEWAY_TIME_SOURCE = "9071";
+    public static final String GATEWAY_UPDATE_DETAILS_URL = "9056";
+    public static final String GATEWAY_UPDATE_PROGRESS = "9055";
+    public static final String GROUPS = "15004";
+    public static final String GROUP_ID = "9038";
+    public static final String GROUP_LINK_ARRAY = "9995";
+    public static final String GROUP_SETTINGS = "9045";
+    public static final String HS_ACCESSORY_LINK = "9018";
+    public static final String HS_LINK = "15002";
+    public static final String IKEA_MOODS = "9068";
+    public static final String INSTANCE_ID = "9003";
+    public static final String LAST_SEEN = "9020";
+    public static final String LIGHT = "3311";
+    public static final int LIGHTS_OFF_SMART_TASK = 2;
+    public static final String LIGHT_SETTING = "15013";
+    public static final int LOSS_OF_INTERNET_CONNECTIVITY = 5001;
+    public static final String MASTER_TOKEN_TAG = "9036";
+    public static final String MAX_MSR_VALUE = "5602";
+    public static final String MAX_RNG_VALUE = "5604";
+    public static final String MIN_MSR_VALUE = "5601";
+    public static final String MIN_RNG_VALUE = "5603";
+    public static final String NAME = "9001";
+    public static final int NEW_FIRMWARE_AVAILABLE = 1001;
+    public static final String NEW_PSK_BY_GW = "9091";
+    public static final String NOTIFICATION_EVENT = "9015";
+    public static final String NOTIFICATION_NVPAIR = "9017";
+    public static final String NOTIFICATION_STATE = "9014";
+    public static final int NOT_AT_HOME_SMART_TASK = 1;
+    public static final String NTP_SERVER = "9023";
+    public static final String ONOFF = "5850";
+    public static final String ON_TIME = "5852";
+    public static final String OPEN = "1";
+    public static final int OPTION_APP_TOKEN = 2051;
+    public static final int OTA_CRITICAL = 1;
+    public static final int OTA_FORCED = 5;
+    public static final int OTA_NORMAL = 0;
+    public static final int OTA_REQUIRED = 2;
+    public static final String OTA_TYPE = "9066";
+    public static final String OTA_UPDATE = "9037";
+    public static final String OTA_UPDATE_STATE = "9054";
+    public static final String PLUG = "3312";
+    public static final String POWER_FACTOR = "5820";
+    public static final String REACHABILITY_STATE = "9019";
+    public static final String REBOOT = "9030";
+    public static final String REPEAT_DAYS = "9041";
+    public static final String RESET = "9031";
+    public static final String RESET_MIN_MAX_MSR = "5605";
+    public static final String SCENE = "15005";
+    public static final String SCENE_ACTIVATE_FLAG = "9058";
+    public static final String SCENE_ID = "9039";
+    public static final String SCENE_INDEX = "9057";
+    public static final String SCENE_LINK = "9009";
+    public static final String SENSOR = "3300";
+    public static final String SENSOR_TYPE = "5751";
+    public static final String SENSOR_VALUE = "5700";
+    public static final String SESSION_ID = "9033";
+    public static final String SESSION_LENGTH = "9064";
+    public static final String SHORTCUT_ICON_REFERENCE_TYPE = "9051";
+    public static final String SMART_TASK_ACTION = "9050";
+    public static final String SMART_TASK_TEMPLATE = "9016";
+    public static final int SMART_TASK_TRIGGERED_EVENT = 1002;
+    public static final String SMART_TASK_TYPE = "9040";
+    public static final String START_ACTION = "9042";
+    public static final String START_TIME_HR = "9046";
+    public static final String START_TIME_MN = "9047";
+    public static final String SWITCH = "15009";
+    public static final String TIME_ARRAY = "9994";
+    public static final String TIME_REMAINING_IN_SECONDS = "9024";
+    public static final String TRANSITION_TIME = "5712";
+    public static final String TRIGGER_TIME_INTERVAL = "9044";
+    public static final String TYPE = "5750";
+    public static final String UNIT = "5701";
+    public static final String UPDATE_ACCEPTED_TIMESTAMP = "9069";
+    public static final String UPDATE_FIRMWARE = "9034";
+    public static final String USE_CURRENT_LIGHT_SETTINGS = "9070";
+    public static final String VERSION = "9029";
+    public static final int WAKE_UP_SMART_TASK = 3;
+
+    public static final String TYPE_LIGHT = "2";
+    public static final String TYPE_SWITCH = "0";
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
@@ -1,0 +1,183 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.handler;
+
+import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.DEVICES;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.eclipse.californium.core.network.CoapEndpoint;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.scandium.DTLSConnector;
+import org.eclipse.californium.scandium.config.DtlsConnectorConfig;
+import org.eclipse.californium.scandium.dtls.pskstore.StaticPskStore;
+import org.eclipse.smarthome.binding.tradfri.GatewayConfig;
+import org.eclipse.smarthome.binding.tradfri.internal.CoapCallback;
+import org.eclipse.smarthome.binding.tradfri.internal.DeviceUpdateListener;
+import org.eclipse.smarthome.binding.tradfri.internal.TradfriCoapClient;
+import org.eclipse.smarthome.binding.tradfri.internal.TradfriCoapHandler;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * The {@link TradfriGatewayHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCallback {
+
+    private final Logger logger = LoggerFactory.getLogger(TradfriGatewayHandler.class);
+
+    private TradfriCoapClient deviceClient;
+    private String gatewayURI;
+    private DTLSConnector dtlsConnector;
+    private CoapEndpoint endPoint;
+
+    private Set<DeviceUpdateListener> deviceUpdateListeners = new CopyOnWriteArraySet<>();
+
+    public TradfriGatewayHandler(Bridge bridge) {
+        super(bridge);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // there are no channels on the gateway yet
+    }
+
+    @Override
+    public void initialize() {
+        GatewayConfig configuration = getConfigAs(GatewayConfig.class);
+        if (configuration.host == null || configuration.host.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Host must be specified in the configuration!");
+            return;
+        }
+        if (configuration.code == null || configuration.code.isEmpty()) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
+                    "Security code must be provided in the configuration!");
+            return;
+        }
+
+        this.gatewayURI = "coaps://" + configuration.host + ":" + configuration.port + "//" + DEVICES;
+        try {
+            URI uri = new URI(gatewayURI);
+            deviceClient = new TradfriCoapClient(uri);
+        } catch (URISyntaxException e) {
+            logger.debug("Illegal gateway URI `{}`: {}", gatewayURI, e.getMessage());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+            return;
+        }
+
+        DtlsConnectorConfig.Builder builder = new DtlsConnectorConfig.Builder(new InetSocketAddress(0));
+        builder.setPskStore(new StaticPskStore("", configuration.code.getBytes()));
+        dtlsConnector = new DTLSConnector(builder.build());
+        endPoint = new CoapEndpoint(dtlsConnector, NetworkConfig.getStandard());
+        deviceClient.setEndpoint(endPoint);
+        startScan();
+        updateStatus(ThingStatus.UNKNOWN);
+    }
+
+    /**
+     * Does a request to the gateway to list all available devices/services.
+     * The response is received and processed by the method {@link onUpdate(JsonElement data)}.
+     */
+    public void startScan() {
+        deviceClient.get(new TradfriCoapHandler(this));
+    }
+
+    /**
+     * Returns the root URI of the gateway.
+     *
+     * @return root URI of the gateway with coaps scheme
+     */
+    public String getGatewayURI() {
+        return gatewayURI;
+    }
+
+    /**
+     * Returns the coap endpoint that can be used within coap clients.
+     *
+     * @return the coap endpoint
+     */
+    public CoapEndpoint getEndpoint() {
+        return endPoint;
+    }
+
+    @Override
+    public void onUpdate(JsonElement data) {
+        logger.trace("Response: {}", data);
+
+        if (endPoint != null) {
+            try {
+                JsonArray array = data.getAsJsonArray();
+                for (int i = 0; i < array.size(); i++) {
+                    requestDeviceDetails(array.get(i).getAsString());
+                }
+            } catch (JsonSyntaxException e) {
+                logger.debug("JSON error: {}", e.getMessage());
+                setStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+            }
+        }
+    }
+
+    private void requestDeviceDetails(String instanceId) {
+        // we are reusing our coap client and merely temporarily set a sub-URI to call
+        deviceClient.setURI(gatewayURI + "/" + instanceId);
+        deviceClient.asyncGet().thenAccept(data -> {
+            logger.debug("Response: {}", data);
+            JsonObject json = new JsonParser().parse(data).getAsJsonObject();
+            deviceUpdateListeners.forEach(listener -> listener.onUpdate(instanceId, json));
+        });
+        // restore root URI
+        deviceClient.setURI(gatewayURI);
+    }
+
+    @Override
+    public void setStatus(ThingStatus status, ThingStatusDetail statusDetail) {
+        // are we still connected at all?
+        if (endPoint != null) {
+            updateStatus(status, statusDetail);
+        }
+    }
+
+    /**
+     * Registers a listener, which is informed about device details.
+     *
+     * @param listener the listener to register
+     */
+    public void registerDeviceUpdateListener(DeviceUpdateListener listener) {
+        this.deviceUpdateListeners.add(listener);
+    }
+
+    /**
+     * Unregisters a given listener.
+     *
+     * @param listener the listener to unregister
+     */
+    public void unregisterDeviceUpdateListener(DeviceUpdateListener listener) {
+        this.deviceUpdateListeners.remove(listener);
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.californium.core.network.CoapEndpoint;
 import org.eclipse.californium.core.network.config.NetworkConfig;
@@ -96,8 +97,12 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
         dtlsConnector = new DTLSConnector(builder.build());
         endPoint = new CoapEndpoint(dtlsConnector, NetworkConfig.getStandard());
         deviceClient.setEndpoint(endPoint);
-        startScan();
         updateStatus(ThingStatus.UNKNOWN);
+
+        // schedule a new scan every minute
+        scheduler.scheduleWithFixedDelay(() -> {
+            startScan();
+        }, 0, 1, TimeUnit.MINUTES);
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
@@ -105,12 +105,27 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
         }, 0, 1, TimeUnit.MINUTES);
     }
 
+    @Override
+    public void dispose() {
+        if (deviceClient != null) {
+            deviceClient.shutdown();
+            deviceClient = null;
+        }
+        if (endPoint != null) {
+            endPoint.destroy();
+            endPoint = null;
+        }
+        super.dispose();
+    }
+
     /**
      * Does a request to the gateway to list all available devices/services.
      * The response is received and processed by the method {@link onUpdate(JsonElement data)}.
      */
     public void startScan() {
-        deviceClient.get(new TradfriCoapHandler(this));
+        if (endPoint != null) {
+            deviceClient.get(new TradfriCoapHandler(this));
+        }
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
@@ -244,8 +244,8 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
         }
 
         public boolean getReachabilityStatus() {
-            if (attributes.get(REACHABILITY_STATE) != null) {
-                return attributes.get(REACHABILITY_STATE).getAsInt() == 1;
+            if (root.get(REACHABILITY_STATE) != null) {
+                return root.get(REACHABILITY_STATE).getAsInt() == 1;
             } else {
                 return false;
             }

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.handler;
+
+import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.eclipse.smarthome.binding.tradfri.DeviceConfig;
+import org.eclipse.smarthome.binding.tradfri.internal.CoapCallback;
+import org.eclipse.smarthome.binding.tradfri.internal.TradfriCoapClient;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * The {@link TradfriLightHandler} is responsible for handling commands for
+ * individual lights.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriLightHandler extends BaseThingHandler implements CoapCallback {
+
+    private final Logger logger = LoggerFactory.getLogger(TradfriLightHandler.class);
+
+    // step size for increase/decrease commands
+    private static final int STEP = 10;
+
+    // keeps track of the current state for handling of increase/decrease
+    private LightData state = null;
+
+    // the unique instance id of the light
+    private Integer id;
+
+    // used to check whether we have already been disposed when receiving data asynchronously
+    private volatile boolean active = false;
+
+    private TradfriCoapClient coapClient;
+
+    public TradfriLightHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        this.id = getConfigAs(DeviceConfig.class).id;
+        TradfriGatewayHandler handler = (TradfriGatewayHandler) getBridge().getHandler();
+        String uriString = handler.getGatewayURI() + "/" + id;
+        try {
+            URI uri = new URI(uriString);
+            coapClient = new TradfriCoapClient(uri);
+            coapClient.setEndpoint(handler.getEndpoint());
+        } catch (URISyntaxException e) {
+            logger.debug("Illegal device URI `{}`: {}", uriString, e.getMessage());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, e.getMessage());
+            return;
+        }
+        updateStatus(ThingStatus.UNKNOWN);
+        active = true;
+        coapClient.startObserve(this);
+    }
+
+    @Override
+    public void dispose() {
+        active = false;
+        if (coapClient != null) {
+            coapClient.shutdown();
+        }
+        super.dispose();
+    }
+
+    @Override
+    public void setStatus(ThingStatus status, ThingStatusDetail statusDetail) {
+        if (active && getBridge().getStatus() != ThingStatus.OFFLINE && status != ThingStatus.ONLINE) {
+            updateStatus(status, statusDetail);
+        }
+    }
+
+    @Override
+    public void onUpdate(JsonElement data) {
+        if (active && !(data.isJsonNull())) {
+            state = new LightData(data);
+            updateStatus(state.getReachabilityStatus() ? ThingStatus.ONLINE : ThingStatus.OFFLINE);
+
+            if (!state.getOnOffState()) {
+                logger.debug("Setting state to OFF");
+                updateState(CHANNEL_BRIGHTNESS, PercentType.ZERO);
+                // if we are turned off, we do not set any brightness value
+                return;
+            }
+
+            PercentType dimmer = state.getBrightness();
+            if (dimmer != null) {
+                logger.debug("Updating brightness to {}", dimmer);
+                updateState(CHANNEL_BRIGHTNESS, dimmer);
+            }
+
+            PercentType colorTemp = state.getColorTemperature();
+            if (colorTemp != null) {
+                logger.debug("Updating color temperature to {} ", colorTemp);
+                updateState(CHANNEL_COLOR_TEMPERATURE, colorTemp);
+            }
+        }
+    }
+
+    private void set(String payload) {
+        logger.debug("Sending payload: {}", payload);
+        coapClient.asyncPut(payload, this);
+    }
+
+    private void setBrightness(PercentType percent) {
+        LightData data = new LightData();
+        data.setBrightness(percent).setTransitionTime(DEFAULT_DIMMER_TRANSITION_TIME);
+        set(data.getJsonString());
+    }
+
+    private void setState(OnOffType onOff) {
+        LightData data = new LightData();
+        data.setOnOffState(onOff == OnOffType.ON);
+        set(data.getJsonString());
+    }
+
+    private void setColorTemperature(PercentType percent) {
+        LightData data = new LightData();
+        data.setColorTemperature(percent).setTransitionTime(DEFAULT_DIMMER_TRANSITION_TIME);
+        set(data.getJsonString());
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command instanceof RefreshType) {
+            logger.debug("Refreshing channel {}", channelUID);
+            coapClient.asyncGet(this);
+            return;
+        }
+
+        switch (channelUID.getId()) {
+            case CHANNEL_BRIGHTNESS:
+                if (command instanceof PercentType) {
+                    setBrightness((PercentType) command);
+                } else if (command instanceof OnOffType) {
+                    setState(((OnOffType) command));
+                } else if (command instanceof IncreaseDecreaseType) {
+                    if (state != null) {
+                        int current = state.getBrightness().intValue();
+                        if (IncreaseDecreaseType.INCREASE.equals(command)) {
+                            setBrightness(new PercentType(Math.min(current + STEP, PercentType.HUNDRED.intValue())));
+                        } else {
+                            setBrightness(new PercentType(Math.max(current - STEP, PercentType.ZERO.intValue())));
+                        }
+                    } else {
+                        logger.debug("Cannot handle inc/dec as current state is not known.");
+                    }
+                } else {
+                    logger.debug("Cannot handle command {} for channel {}", command, channelUID);
+                }
+                break;
+            case CHANNEL_COLOR_TEMPERATURE:
+                if (command instanceof PercentType) {
+                    setColorTemperature((PercentType) command);
+                } else if (command instanceof IncreaseDecreaseType) {
+                    if (state != null) {
+                        int current = state.getColorTemperature().intValue();
+                        if (IncreaseDecreaseType.INCREASE.equals(command)) {
+                            setColorTemperature(
+                                    new PercentType(Math.min(current + STEP, PercentType.HUNDRED.intValue())));
+                        } else {
+                            setColorTemperature(new PercentType(Math.max(current - STEP, PercentType.ZERO.intValue())));
+                        }
+                    } else {
+                        logger.debug("Cannot handle inc/dec as current state is not known.");
+                    }
+                } else {
+                    logger.debug("Can't handle command {} on channel {}", command, channelUID);
+                }
+                break;
+            default:
+                logger.error("Unknown channel UID {}", channelUID);
+        }
+    }
+
+    /**
+     * This class is a Java wrapper for the raw JSON data about the light state.
+     */
+    private static class LightData {
+
+        private final Logger logger = LoggerFactory.getLogger(LightData.class);
+
+        JsonObject root;
+        JsonArray array;
+        JsonObject attributes;
+
+        public LightData() {
+            root = new JsonObject();
+            array = new JsonArray();
+            attributes = new JsonObject();
+            array.add(attributes);
+            root.add(LIGHT, array);
+        }
+
+        public LightData(JsonElement json) {
+            try {
+                root = json.getAsJsonObject();
+                array = root.getAsJsonArray(LIGHT);
+                attributes = array.get(0).getAsJsonObject();
+            } catch (JsonSyntaxException e) {
+                logger.error("JSON error: {}", e.getMessage(), e);
+            }
+        }
+
+        public LightData setBrightness(PercentType brightness) {
+            attributes.add(DIMMER, new JsonPrimitive(Math.round(brightness.floatValue() / 100.0f * 254)));
+            return this;
+        }
+
+        public PercentType getBrightness() {
+            int b = attributes.get(DIMMER).getAsInt();
+            if (b == 1) {
+                return new PercentType(1);
+            }
+            return new PercentType((int) Math.round(b / 2.54));
+        }
+
+        public boolean getReachabilityStatus() {
+            if (attributes.get(REACHABILITY_STATE) != null) {
+                return attributes.get(REACHABILITY_STATE).getAsInt() == 1;
+            } else {
+                return false;
+            }
+        }
+
+        public LightData setTransitionTime(int seconds) {
+            attributes.add(TRANSITION_TIME, new JsonPrimitive(seconds));
+            return this;
+        }
+
+        @SuppressWarnings("unused")
+        public int getTransitionTime() {
+            return attributes.get(TRANSITION_TIME).getAsInt();
+        }
+
+        private final static double[] X = new double[] { 33137.0, 30138.0, 24933.0 };
+        private final static double[] Y = new double[] { 27211.0, 26909.0, 24691.0 };
+
+        public LightData setColorTemperature(PercentType c) {
+            double percent = c.doubleValue();
+
+            long x, y;
+            if (percent < 50.0) {
+                double p = percent / 50.0;
+                x = Math.round(X[0] + p * (X[1] - X[0]));
+                y = Math.round(Y[0] + p * (Y[1] - Y[0]));
+            } else {
+                double p = (percent - 50) / 50.0;
+                x = Math.round(X[1] + p * (X[2] - X[1]));
+                y = Math.round(Y[1] + p * (Y[2] - Y[1]));
+            }
+            logger.debug("New color temperature: {},{} ({} %)", x, y, percent);
+
+            attributes.add(COLOR_X, new JsonPrimitive(x));
+            attributes.add(COLOR_Y, new JsonPrimitive(y));
+            return this;
+        }
+
+        PercentType getColorTemperature() {
+            JsonElement colorX = attributes.get(COLOR_X);
+            if (colorX != null) {
+                double x = attributes.get(COLOR_X).getAsInt();
+                double value = 0.0;
+                if (x > X[1]) {
+                    value = (x - X[0]) / (X[1] - X[0]) / 2.0;
+                } else {
+                    value = (x - X[1]) / (X[2] - X[1]) / 2.0 + 0.5;
+                }
+                return new PercentType((int) Math.round(value * 100.0));
+            } else {
+                return null;
+            }
+        }
+
+        LightData setOnOffState(boolean on) {
+            attributes.add(ONOFF, new JsonPrimitive(on ? 1 : 0));
+            return this;
+        }
+
+        boolean getOnOffState() {
+            JsonElement onOff = attributes.get(ONOFF);
+            if (onOff != null) {
+                return attributes.get(ONOFF).getAsInt() == 1;
+            } else {
+                return false;
+            }
+        }
+
+        String getJsonString() {
+            return root.toString();
+        }
+    }
+
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/CoapCallback.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/CoapCallback.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal;
+
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+
+import com.google.gson.JsonElement;
+
+/**
+ * The {@link CoapCallback} is receives coap response data asynchronously.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public interface CoapCallback {
+
+    /**
+     * This is being called, if new data is received from a CoAP request.
+     *
+     * @param data the received json structure
+     */
+    public void onUpdate(JsonElement data);
+
+    /**
+     * Tells the listener to set the Thing status.
+     * Should usually be directly passed on to updateStatus() on the ThingHandler.
+     *
+     * @param status The thing status
+     * @param statusDetail the status detail
+     */
+    public void setStatus(ThingStatus status, ThingStatusDetail statusDetail);
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/DeviceUpdateListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/DeviceUpdateListener.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal;
+
+import org.eclipse.smarthome.binding.tradfri.handler.TradfriGatewayHandler;
+
+import com.google.gson.JsonObject;
+
+/**
+ * {@link DeviceUpdateListener} can register on the {@link TradfriGatewayHandler} to be
+ * informed about details about devices.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public interface DeviceUpdateListener {
+
+    /**
+     * This method is called when new device information is received.
+     *
+     * @param instanceId The instance id of the device
+     * @param data the json data describing the device
+     */
+    public void onUpdate(String instanceId, JsonObject data);
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapClient.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.californium.core.CoapClient;
+import org.eclipse.californium.core.coap.MediaTypeRegistry;
+
+/**
+ * The {@link TradfriCoapClient} provides some convenience features over the
+ * plain {@link CoapClient} from californium.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriCoapClient extends CoapClient {
+
+    private static final int TIMEOUT = 5000;
+
+    public TradfriCoapClient(URI uri) {
+        super(uri);
+        setTimeout(TIMEOUT);
+    }
+
+    /**
+     * Starts observation of the resource and uses the given callback to provide updates.
+     *
+     * @param callback the callback to use for updates
+     */
+    public void startObserve(CoapCallback callback) {
+        observe(new TradfriCoapHandler(callback));
+    }
+
+    /**
+     * Asynchronously executes a GET on the resource and provides the result through a {@link CompletableFuture}.
+     *
+     * @return the future that will hold the result
+     */
+    public CompletableFuture<String> asyncGet() {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        get(new TradfriCoapHandler(future));
+        return future;
+    }
+
+    /**
+     * Asynchronously executes a GET on the resource and provides the result to a given callback.
+     *
+     * @param callback the callback to use for the response
+     */
+    public void asyncGet(CoapCallback callback) {
+        get(new TradfriCoapHandler(callback));
+    }
+
+    /**
+     * Asynchronously executes a PUT on the resource with a payload and provides the result to a given callback.
+     *
+     * @param payload the payload to send with the PUT request
+     * @param callback the callback to use for the response
+     */
+    public void asyncPut(String payload, CoapCallback callback) {
+        put(new TradfriCoapHandler(callback), payload, MediaTypeRegistry.TEXT_PLAIN);
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapClient.java
@@ -22,7 +22,7 @@ import org.eclipse.californium.core.coap.MediaTypeRegistry;
  */
 public class TradfriCoapClient extends CoapClient {
 
-    private static final int TIMEOUT = 5000;
+    private static final int TIMEOUT = 2000;
 
     public TradfriCoapClient(URI uri) {
         super(uri);

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapHandler.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.californium.core.CoapHandler;
+import org.eclipse.californium.core.CoapResponse;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+
+/**
+ * The {@link TradfriCoapHandler} is used to handle the asynchronous coap reponses.
+ * It can either be used with a callback class or with a future.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriCoapHandler implements CoapHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(CoapHandler.class);
+    private final JsonParser parser = new JsonParser();
+
+    private CoapCallback callback;
+    private CompletableFuture<String> future;
+
+    /**
+     * Constructor for using a callback
+     *
+     * @param callback the callback to use for responses
+     */
+    public TradfriCoapHandler(CoapCallback callback) {
+        this.callback = callback;
+    }
+
+    /**
+     * Constructor for using a future
+     *
+     * @param future the future to use for responses
+     */
+    public TradfriCoapHandler(CompletableFuture<String> future) {
+        this.future = future;
+    }
+
+    @Override
+    public void onLoad(CoapResponse response) {
+        logger.debug("CoAP response\noptions: {}\npayload: {} ", response.getOptions(), response.getResponseText());
+        if (response.isSuccess()) {
+            if (callback != null) {
+                try {
+                    callback.onUpdate(parser.parse(response.getResponseText()));
+                    callback.setStatus(ThingStatus.ONLINE, ThingStatusDetail.NONE);
+                } catch (JsonParseException e) {
+                    logger.warn("Observed value is no valid json: {}, {}", response.getResponseText(), e.getMessage());
+                }
+            }
+            if (future != null) {
+                String data = response.getResponseText();
+                future.complete(data);
+            }
+        } else {
+            logger.debug("CoAP error {}", response.getCode());
+            if (callback != null) {
+                callback.setStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+            }
+            if (future != null) {
+                future.completeExceptionally(new RuntimeException("Response " + response.getCode().toString()));
+            }
+        }
+    }
+
+    @Override
+    public void onError() {
+        logger.debug("CoAP error");
+        if (callback != null) {
+            callback.setStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+        }
+        if (future != null) {
+            future.completeExceptionally(new RuntimeException("CoAP GET resulted in an error."));
+        }
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapHandler.java
@@ -28,7 +28,7 @@ import com.google.gson.JsonParser;
  */
 public class TradfriCoapHandler implements CoapHandler {
 
-    private final Logger logger = LoggerFactory.getLogger(CoapHandler.class);
+    private final Logger logger = LoggerFactory.getLogger(TradfriCoapHandler.class);
     private final JsonParser parser = new JsonParser();
 
     private CoapCallback callback;

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriHandlerFactory.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal;
+
+import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.smarthome.binding.tradfri.handler.TradfriGatewayHandler;
+import org.eclipse.smarthome.binding.tradfri.handler.TradfriLightHandler;
+import org.eclipse.smarthome.binding.tradfri.internal.discovery.TradfriDiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryService;
+import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.osgi.framework.ServiceRegistration;
+
+import com.google.common.collect.Sets;
+
+/**
+ * The {@link TradfriHandlerFactory} is responsible for creating things and thing handlers.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriHandlerFactory extends BaseThingHandlerFactory {
+
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets
+            .union(Collections.singleton(GATEWAY_TYPE_UID), SUPPORTED_LIGHT_TYPES_UIDS);
+
+    private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected ThingHandler createHandler(Thing thing) {
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (thingTypeUID.equals(GATEWAY_TYPE_UID)) {
+            TradfriGatewayHandler handler = new TradfriGatewayHandler((Bridge) thing);
+            registerDiscoveryService(handler);
+            return handler;
+        } else if (SUPPORTED_LIGHT_TYPES_UIDS.contains(thingTypeUID)) {
+            return new TradfriLightHandler(thing);
+        }
+        return null;
+    }
+
+    @Override
+    protected synchronized void removeHandler(ThingHandler thingHandler) {
+        if (thingHandler instanceof TradfriGatewayHandler) {
+            unregisterDiscoveryService((TradfriGatewayHandler) thingHandler);
+        }
+        super.removeHandler(thingHandler);
+    }
+
+    private void registerDiscoveryService(TradfriGatewayHandler bridgeHandler) {
+        TradfriDiscoveryService discoveryService = new TradfriDiscoveryService(bridgeHandler);
+        discoveryService.activate();
+        this.discoveryServiceRegs.put(bridgeHandler.getThing().getUID(), bundleContext
+                .registerService(DiscoveryService.class.getName(), discoveryService, new Hashtable<String, Object>()));
+    }
+
+    private void unregisterDiscoveryService(TradfriGatewayHandler bridgeHandler) {
+        ServiceRegistration<?> serviceReg = this.discoveryServiceRegs.get(bridgeHandler.getThing().getUID());
+        if (serviceReg != null) {
+            TradfriDiscoveryService service = (TradfriDiscoveryService) bundleContext
+                    .getService(serviceReg.getReference());
+            service.deactivate();
+            serviceReg.unregister();
+            discoveryServiceRegs.remove(bridgeHandler.getThing().getUID());
+        }
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryParticipant.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal.discovery;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jmdns.ServiceInfo;
+
+import org.eclipse.smarthome.binding.tradfri.GatewayConfig;
+import org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.io.transport.mdns.discovery.MDNSDiscoveryParticipant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class identifies Tradfri gateways by their mDNS service information.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriDiscoveryParticipant implements MDNSDiscoveryParticipant {
+
+    private Logger logger = LoggerFactory.getLogger(TradfriDiscoveryParticipant.class);
+
+    private static final String SERVICE_TYPE = "_coap._udp.local.";
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypeUIDs() {
+        return Collections.singleton(TradfriBindingConstants.GATEWAY_TYPE_UID);
+    }
+
+    @Override
+    public String getServiceType() {
+        return SERVICE_TYPE;
+    }
+
+    @Override
+    public ThingUID getThingUID(ServiceInfo service) {
+        if (service != null) {
+            String name = service.getName();
+            if ((service.getType() != null) && service.getType().equals(getServiceType())
+                    && (name.matches("gw:([a-f0-9]{2}[-]?){6}"))) {
+                return new ThingUID(TradfriBindingConstants.GATEWAY_TYPE_UID, name.replaceAll("[^A-Za-z0-9_]", ""));
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public DiscoveryResult createResult(ServiceInfo service) {
+
+        if (service.getHostAddresses() != null && service.getHostAddresses().length > 0
+                && !service.getHostAddresses()[0].isEmpty()) {
+            String ip = service.getHostAddresses()[0];
+
+            ThingUID thingUID = getThingUID(service);
+            if (thingUID != null) {
+                logger.debug("Discovered Tradfri gateway: {}", service);
+                Map<String, Object> properties = new HashMap<>(4);
+                properties.put("vendor", "IKEA");
+                properties.put(GatewayConfig.HOST, ip);
+                properties.put(GatewayConfig.PORT, service.getPort());
+                String fwVersion = service.getPropertyString("version");
+                if (fwVersion != null) {
+                    properties.put("firmware", fwVersion);
+                }
+                return DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel("Trådfri Gateway")
+                        .withRepresentationProperty(GatewayConfig.HOST).build();
+            }
+        }
+        return null;
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -89,12 +89,7 @@ public class TradfriDiscoveryService extends AbstractDiscoveryService implements
                     return;
                 }
 
-                String label = "Unknown device"; // this is only a default as an unlikely fallback situation
-                try {
-                    label = data.get(NAME).getAsString();
-                } catch (JsonSyntaxException e) {
-                    logger.error("JSON error: {}", e.getMessage());
-                }
+                String label = data.get(NAME).getAsString();
 
                 Map<String, Object> properties = new HashMap<>(1);
                 properties.put("id", id);
@@ -107,7 +102,7 @@ public class TradfriDiscoveryService extends AbstractDiscoveryService implements
                 thingDiscovered(discoveryResult);
             }
         } catch (JsonSyntaxException e) {
-            logger.error("JSON error: {}", e.getMessage());
+            logger.debug("JSON error during discovery: {}", e.getMessage());
         }
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal.discovery;
+
+import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants;
+import org.eclipse.smarthome.binding.tradfri.handler.TradfriGatewayHandler;
+import org.eclipse.smarthome.binding.tradfri.internal.DeviceUpdateListener;
+import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+
+/**
+ * This class identifies devices that are available on the gateway and adds discovery results for them.
+ *
+ * @author Kai Kreuzer - Initial contribution
+ */
+public class TradfriDiscoveryService extends AbstractDiscoveryService implements DeviceUpdateListener {
+
+    private Logger logger = LoggerFactory.getLogger(TradfriDiscoveryService.class);
+
+    private TradfriGatewayHandler handler;
+
+    public TradfriDiscoveryService(TradfriGatewayHandler bridgeHandler) {
+        super(TradfriBindingConstants.SUPPORTED_LIGHT_TYPES_UIDS, 10, true);
+        this.handler = bridgeHandler;
+    }
+
+    @Override
+    protected void startScan() {
+        handler.startScan();
+    }
+
+    public void activate() {
+        handler.registerDeviceUpdateListener(this);
+    }
+
+    @Override
+    public void deactivate() {
+        handler.unregisterDeviceUpdateListener(this);
+    }
+
+    @Override
+    public void onUpdate(String instanceId, JsonObject data) {
+        ThingUID bridge = handler.getThing().getUID();
+        try {
+            if (data.has(INSTANCE_ID)) {
+                int id = data.get(INSTANCE_ID).getAsInt();
+                String type = data.get(TYPE).getAsString();
+                ThingUID thingId = null;
+
+                if (type.equals(TYPE_LIGHT) && data.has(LIGHT)) {
+                    JsonObject state = data.get(LIGHT).getAsJsonArray().get(0).getAsJsonObject();
+
+                    // Color temperature light
+                    if (state.has(COLOR)) {
+                        thingId = new ThingUID(THING_TYPE_COLOR_TEMP_LIGHT, bridge, Integer.toString(id));
+                    } else {
+                        thingId = new ThingUID(THING_TYPE_DIMMABLE_LIGHT, bridge, Integer.toString(id));
+                    }
+                }
+
+                if (thingId == null) {
+                    // we didn't identify any device, so let's quit
+                    return;
+                }
+
+                String label = "Unknown device"; // this is only a default as an unlikely fallback situation
+                try {
+                    label = data.get(NAME).getAsString();
+                } catch (JsonSyntaxException e) {
+                    logger.error("JSON error: {}", e.getMessage());
+                }
+
+                Map<String, Object> properties = new HashMap<>(1);
+                properties.put("id", id);
+                logger.debug("Adding device {} to inbox", thingId);
+                DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingId).withBridge(bridge)
+                        .withLabel(label).withProperties(properties).withRepresentationProperty("id").build();
+                thingDiscovered(discoveryResult);
+            }
+        } catch (JsonSyntaxException e) {
+            logger.error("JSON error: {}", e.getMessage());
+        }
+    }
+}

--- a/extensions/binding/pom.xml
+++ b/extensions/binding/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
@@ -27,6 +27,8 @@
     <module>org.eclipse.smarthome.binding.ntp</module>
     <module>org.eclipse.smarthome.binding.ntp.test</module>
     <module>org.eclipse.smarthome.binding.sonos</module>
+    <module>org.eclipse.smarthome.binding.tradfri</module>
+    <module>org.eclipse.smarthome.binding.tradfri.test</module>
     <module>org.eclipse.smarthome.binding.wemo</module>
     <module>org.eclipse.smarthome.binding.wemo.test</module>
     <module>org.eclipse.smarthome.binding.yahooweather</module>

--- a/features/karaf/esh-core/src/main/feature/feature.xml
+++ b/features/karaf/esh-core/src/main/feature/feature.xml
@@ -194,6 +194,11 @@
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.rest.mdns/${project.version}</bundle>
   </feature>
 
+  <feature name="esh-io-transport-coap" version="${project.version}">
+    <feature>esh-base</feature>
+    <requirement>esh.tp;filter:="(feature=coap)"</requirement>
+  </feature>
+
   <feature name="esh-io-transport-dbus" version="${project.version}">
     <feature>esh-base</feature>
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.transport.dbus/${project.version}</bundle>

--- a/features/karaf/esh-ext/src/main/feature/feature.xml
+++ b/features/karaf/esh-ext/src/main/feature/feature.xml
@@ -52,6 +52,7 @@
   <feature name="esh-binding-tradfri" version="${project.version}">
     <feature>esh-base</feature>
     <feature>esh-io-transport-coap</feature>
+    <feature>esh-io-transport-mdns</feature>
     <bundle>mvn:org.eclipse.smarthome.binding/org.eclipse.smarthome.binding.tradfri/${project.version}</bundle>
   </feature>
 

--- a/features/karaf/esh-ext/src/main/feature/feature.xml
+++ b/features/karaf/esh-ext/src/main/feature/feature.xml
@@ -49,6 +49,12 @@
     <bundle>mvn:org.eclipse.smarthome.binding/org.eclipse.smarthome.binding.sonos/${project.version}</bundle>
   </feature>
 
+  <feature name="esh-binding-tradfri" version="${project.version}">
+    <feature>esh-base</feature>
+    <feature>esh-io-transport-coap</feature>
+    <bundle>mvn:org.eclipse.smarthome.binding/org.eclipse.smarthome.binding.tradfri/${project.version}</bundle>
+  </feature>
+
   <feature name="esh-binding-wemo" version="${project.version}">
     <feature>esh-base</feature>
     <feature>esh-io-transport-upnp</feature>

--- a/features/karaf/esh-tp/src/main/feature/feature.xml
+++ b/features/karaf/esh-tp/src/main/feature/feature.xml
@@ -40,6 +40,13 @@
     <bundle dependency="true">mvn:commons-net/commons-net/3.2</bundle>
   </feature>
 
+  <feature name="esh-tp-coap" description="Californium CoAP library" version="${project.version}">
+    <capability>esh.tp;feature=coap;version=1.0.5</capability>
+    <bundle>mvn:org.eclipse.californium/californium-osgi/1.0.5</bundle>
+    <bundle>mvn:org.eclipse.californium/element-connector/1.0.5</bundle>
+    <bundle>mvn:org.eclipse.californium/scandium/1.0.5</bundle>
+  </feature>
+
   <feature name="esh-tp-httpclient" version="${project.version}">
     <capability>esh.tp;feature=httpclient;version=4.2.3</capability>
     <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/4.2.3</bundle>
@@ -147,7 +154,7 @@
     <bundle>mvn:org.jupnp/org.jupnp/2.2.0</bundle>
   </feature>
 
-  <feature name="esh-tp-jmdns" description="An implemenation of multi-cast DNS in Java." version="${project.version}">
+  <feature name="esh-tp-jmdns" description="An implementation of multi-cast DNS in Java." version="${project.version}">
     <capability>esh.tp;feature=jmdns;version=3.5.1</capability>
 
     <bundle>mvn:org.jmdns/jmdns/3.5.1</bundle>

--- a/features/karaf/esh-tp/src/main/feature/feature.xml
+++ b/features/karaf/esh-tp/src/main/feature/feature.xml
@@ -15,6 +15,7 @@
     <feature>eventadmin</feature>
 
     <feature dependency="true">esh-tp-apache-commons</feature>
+    <feature dependency="true">esh-tp-coap</feature>
     <feature dependency="true">esh-tp-httpclient</feature>
     <feature dependency="true">esh-tp-measurement</feature>
     <feature dependency="true">esh-tp-jax-rs</feature>

--- a/features/org.eclipse.smarthome.feature.runtime.binding/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.binding/feature.xml
@@ -69,6 +69,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.smarthome.binding.tradfri"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.smarthome.binding.wemo"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
Initial implementation for IKEA Trådfri support:
- discovers gateway through mDNS
- supports dimmable and color temp bulbs
- receives immediate state updates, no need for polling
- sets the bulb Thing status according to info on the gateway

Signed-off-by: Kai Kreuzer <kai@openhab.org>