### PR TITLE
normalize in configuration.put(...)

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigurationTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigurationTest.groovy
@@ -99,4 +99,18 @@ class ConfigurationTest {
         def res = configuration.toString()
         assertThat res.contains("type=?"), is(true)
     }
+
+    @Test
+    void 'assert normalization in setProperties'() {
+        Configuration configuration = new Configuration()
+        configuration.setProperties(["intField" : 1])
+        assertThat configuration.get("intField"), is(equalTo(BigDecimal.ONE))
+    }
+
+    @Test
+    void 'assert normalization in put'() {
+        Configuration configuration = new Configuration()
+        configuration.put("intField", 1)
+        assertThat configuration.get("intField"), is(equalTo(BigDecimal.ONE))
+    }
 }

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -143,7 +143,7 @@ public class Configuration {
 
     public Object put(String key, Object value) {
         synchronized (this) {
-            return properties.put(key, value);
+            return properties.put(key, ConfigUtil.normalizeType(value));
         }
     }
 
@@ -181,7 +181,7 @@ public class Configuration {
 
     public void setProperties(Map<String, Object> properties) {
         for (Entry<String, Object> entrySet : properties.entrySet()) {
-            this.put(entrySet.getKey(), ConfigUtil.normalizeType(entrySet.getValue()));
+            this.put(entrySet.getKey(), entrySet.getValue());
         }
         for (Iterator<String> it = this.properties.keySet().iterator(); it.hasNext();) {
             String entry = it.next();


### PR DESCRIPTION
...as a last resort, if it was not normalized before.
The downside is, that at this point there is no type information available,
i.e. the config description cannot be used. Therefore normalization can
happen only on a "best guess", based on the incoming type.

fixes #3527 (mostly)
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>