### PR TITLE
configurable initial delay of ChannelItemProvider

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
@@ -71,8 +71,8 @@ public class ChannelItemProviderTest {
 
         Map<String, Object> props = new HashMap<>();
         props.put("enable", "true");
+        props.put("initialDelay", "false");
         provider.activate(props);
-        Thread.sleep(2500);
 
         when(thingRegistry.getChannel(same(CHANNEL_UID))).thenReturn(new Channel(CHANNEL_UID, "Number"));
         when(itemFactory.createItem("Number", ITEM_NAME)).thenReturn(ITEM);


### PR DESCRIPTION
It's been a pain for tests (see https://hudson.eclipse.org/smarthome/job/SmartHomeDistribution-Nightly/1936), but I think it also cannot hurt to have it switched off configurable (on remains the default).

Alternatively we could add an `isInitialized()`method. I don't mind.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>