### PR TITLE
[tradfri] restart transport layer on error

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
@@ -10,6 +10,7 @@ package org.eclipse.smarthome.binding.tradfri.handler;
 
 import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.DEVICES;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -187,6 +188,14 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
         // are we still connected at all?
         if (endPoint != null) {
             updateStatus(status, statusDetail);
+            if (dtlsConnector != null && status == ThingStatus.OFFLINE) {
+                try {
+                    dtlsConnector.stop();
+                    dtlsConnector.start();
+                } catch (IOException e) {
+                    logger.debug("Error restarting the DTLS connector: {}", e.getMessage());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Restarting the transport layer causes all CoAP connections to create a new TCP connection with a new SSL handshake. While this for sure is required if the Gateway has been restarted, I'm not really sure whether it is the right way of doing it when using the Californium APIs. I would have expected californium to take care of such aspects and also doing it only when necessary. This is brute-force right now: Whenever there is an error, renew all sockets. 

So big disclaimer: I have no clue what I'm doing here, please help if you have a better idea!

fixes #3672
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>