### PR TITLE
fixed the type of the id parameter for Tradfri devices

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
@@ -42,7 +42,7 @@
         </channels>
 
         <config-description>
-            <parameter name="id" type="text" required="true">
+            <parameter name="id" type="integer" required="true">
                 <label>ID</label>
                 <description>The identifier of the light on the gateway</description>
             </parameter>
@@ -63,7 +63,7 @@
         </channels>
 
         <config-description>
-            <parameter name="id" type="text" required="true">
+            <parameter name="id" type="integer" required="true">
                 <label>ID</label>
                 <description>The identifier of the light on the gateway</description>
             </parameter>
@@ -83,7 +83,7 @@
         </channels>
 
         <config-description>
-            <parameter name="id" type="text" required="true">
+            <parameter name="id" type="integer" required="true">
                 <label>ID</label>
                 <description>The identifier of the controller on the gateway</description>
             </parameter>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
@@ -17,7 +17,7 @@ The thing type ids are defined according to the lighting devices defined for Zig
 
 The gateway requires a `host` parameter for the hostname or IP address and a `code`, which is the security code that is printed on the bottom of the gateway. Optionally, a `port` can be configured, but any standard gateway uses the default port 5684.
 
-The devices require only a single parameter, which is their instance id. Unfortunately, this is not displayed anywhere in the IKEA app, but it seems that they are sequentially numbered starting with 65537 for the first device. If in doubt, use the auto-discovered things to find out the correct instance ids.
+The devices require only a single (integer) parameter, which is their instance id. Unfortunately, this is not displayed anywhere in the IKEA app, but it seems that they are sequentially numbered starting with 65537 for the first device. If in doubt, use the auto-discovered things to find out the correct instance ids.
 
 ## Channels
 


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/3678

Signed-off-by: Kai Kreuzer <kai@openhab.org>