### PR TITLE
relax transaction enforcement in GenericItemChannelLinkProvider

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericItemChannelLinkProviderJavaTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericItemChannelLinkProviderJavaTest.java
@@ -125,25 +125,6 @@ public class GenericItemChannelLinkProviderJavaTest extends JavaOSGiTest {
         assertThat(itemChannelLinkRegistry.getAll().size(), is(1));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testTransaction_requiredStart() {
-        GenericItemChannelLinkProvider provider = new GenericItemChannelLinkProvider();
-        provider.stopConfigurationUpdate(ITEMS_TESTMODEL_NAME);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testTransaction_requiredProcess() throws Exception {
-        GenericItemChannelLinkProvider provider = new GenericItemChannelLinkProvider();
-        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, "Number", ITEM, CHANNEL);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testTransaction_duplicate() {
-        GenericItemChannelLinkProvider provider = new GenericItemChannelLinkProvider();
-        provider.startConfigurationUpdate(ITEMS_TESTMODEL_NAME);
-        provider.startConfigurationUpdate(ITEMS_TESTMODEL_NAME);
-    }
-
     @SuppressWarnings("unchecked")
     @Test
     public void testNoAmnesia() throws Exception {


### PR DESCRIPTION
...in order to enable the entry points from service again.
As they are currently built in an add-only way, they don't
require the remval capability at the end anyway.

fixes #3686
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>