### PR TITLE
Avoid creating stream for null entity in JSON response.

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/ItemResource.java
@@ -215,7 +215,7 @@ public class ItemResource implements RESTResource {
     @Path("/{itemname: [a-zA-Z_0-9]*}/state")
     @Consumes(MediaType.TEXT_PLAIN)
     @ApiOperation(value = "Updates the state of an item.")
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
+    @ApiResponses(value = { @ApiResponse(code = 202, message = "Accepted"),
             @ApiResponse(code = 404, message = "Item not found"),
             @ApiResponse(code = 400, message = "Item state null") })
     public Response putItemState(

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/src/test/java/org/eclipse/smarthome/io/rest/JSONResponseTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/src/test/java/org/eclipse/smarthome/io/rest/JSONResponseTest.java
@@ -82,6 +82,17 @@ public class JSONResponseTest {
     }
 
     @Test
+    public void shouldCreateSuccessResponseWithNullEntity() throws Exception {
+        Response response = JSONResponse.createResponse(Status.ACCEPTED, null, null);
+
+        assertThat(response.getStatus(), is(202));
+        assertThat(response.getMediaType(), is(MediaType.APPLICATION_JSON_TYPE));
+
+        Object entity = response.getEntity();
+        assertThat(entity, is(nullValue()));
+    }
+
+    @Test
     public void shouldCreateSuccessResponseWithLargeStreamEntity() throws IOException {
         Response response = JSONResponse.createResponse(Status.OK, new LargeEntity(), null);
 

--- a/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/JSONResponse.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/JSONResponse.java
@@ -144,6 +144,10 @@ public class JSONResponse {
     private Response createResponse(Status status, Object entity) {
         ResponseBuilder rp = responseBuilder(status);
 
+        if (entity == null) {
+            return rp.build();
+        }
+
         // The PipedOutputStream will only be closed by the writing thread
         // since closing it during this method call would be too early.
         // The receiver of the response will read from the pipe after this method returns.


### PR DESCRIPTION
also: adjust item resource API description to match the actual behavior.