### PR TITLE
Fix the  java.lang.RuntimePermission in RuleEngineCallbackImpl #3702

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleEngineCallbackImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleEngineCallbackImpl.java
@@ -7,6 +7,8 @@
  */
 package org.eclipse.smarthome.automation.core.internal;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -87,7 +89,10 @@ public class RuleEngineCallbackImpl implements RuleEngineCallback {
 
     public void dispose() {
         synchronized (this) {
-            executor.shutdownNow();
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                executor.shutdownNow();
+                return null;
+            });
             executor = null;
         }
     }


### PR DESCRIPTION
executor.shutdownNow() is now in privileged call

Signed-off-by: Plamen Veselinov Peev <p.peev@prosyst.bg>