### PR TITLE
Synchronous Execution of Astro Startup Jobs and minor fixes

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/AbstractJob.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/job/AbstractJob.java
@@ -21,36 +21,6 @@ public abstract class AbstractJob implements Job {
         return thingUID;
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (thingUID == null ? 0 : thingUID.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        AbstractJob other = (AbstractJob) obj;
-        if (thingUID == null) {
-            if (other.thingUID != null) {
-                return false;
-            }
-        } else if (!thingUID.equals(other.thingUID)) {
-            return false;
-        }
-        return true;
-    }
-
     /**
      * Ensures the truth of an expression involving one or more parameters to the
      * calling method.


### PR DESCRIPTION
The scheduling operations schedules few jobs and executes 2 specific jobs immediately. These two jobs are executed in a different thread to prevent blocking the thread that spawns it. 

In addition, during handler initialize, channel linking and unlinking, we reschedule the jobs. And every time, before we reschedule the jobs, we remove the jobs from the ESH Core scheduler that are associated with the current thing.

As the jobs that execute immediately are handled by different threads, it is sometime noticed that while rescheduling, removal of jobs did occur after the jobs got rescheduled. This created unexpected issues in ESH Core scheduler. In this PR, we have rendered the asynchronous operations of executing immediate jobs in different threads to synchronous execution so that we can make sure the removal always happens before rescheduling.

Another note is that previously we required `equals` and `hashcode` to be overriden by `AbstractJob` but currently it is not used anymore. These `equals` and `hashcode` affected normal executions of scheduled jobs as well. Hence, the methods have been removed.