### PR TITLE
move I18nProviderImpl into the internal.i18n package

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImplTest.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.core.internal;
+package org.eclipse.smarthome.core.internal.i18n;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/i18n/TranslationProviderOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/i18n/TranslationProviderOSGiTest.java
@@ -1,4 +1,4 @@
-package org.eclipse.smarthome.core.internal;
+package org.eclipse.smarthome.core.internal.i18n;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;

--- a/bundles/core/org.eclipse.smarthome.core/OSGI-INF/i18nprovider.xml
+++ b/bundles/core/org.eclipse.smarthome.core/OSGI-INF/i18nprovider.xml
@@ -9,7 +9,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" modified="modified" name="org.eclipse.smarthome.core.i18nprovider">
-   <implementation class="org.eclipse.smarthome.core.internal.I18nProviderImpl"/>
+   <implementation class="org.eclipse.smarthome.core.internal.i18n.I18nProviderImpl"/>
    <service>
       <provide interface="org.eclipse.smarthome.core.i18n.TranslationProvider"/>
       <provide interface="org.eclipse.smarthome.core.i18n.LocaleProvider"/>

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.core.internal;
+package org.eclipse.smarthome.core.internal.i18n;
 
 import java.text.MessageFormat;
 import java.util.Locale;
@@ -16,8 +16,6 @@ import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.i18n.LocaleProvider;
 import org.eclipse.smarthome.core.i18n.LocationProvider;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
-import org.eclipse.smarthome.core.internal.i18n.LanguageResourceBundleManager;
-import org.eclipse.smarthome.core.internal.i18n.ResourceBundleTracker;
 import org.eclipse.smarthome.core.library.types.PointType;
 import org.osgi.framework.Bundle;
 import org.osgi.service.component.ComponentContext;


### PR DESCRIPTION
...in order to not pollute the "root" internal package and to make it symmetric to the interfaces (which are located in the i18n package as well).


Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>