### PR TITLE
adapt ConfigOptionProvider javadoc to reality

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigOptionProvider.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigOptionProvider.java
@@ -28,8 +28,7 @@ public interface ConfigOptionProvider {
      *            the parameter name for which the requested options shall be returned
      * @param locale
      *            locale
-     * @return the configuration options provided by this provider (not
-     *         null, could be empty)
+     * @return the configuration options provided by this provider if any or {@code null} otherwise
      */
     Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale);
 }

--- a/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/internal/PersistenceServiceRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/internal/PersistenceServiceRegistryImpl.java
@@ -89,13 +89,14 @@ public class PersistenceServiceRegistryImpl implements ConfigOptionProvider, Per
 
     @Override
     public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
-        Set<ParameterOption> options = new HashSet<>();
         if (uri.toString().equals("system:persistence") && param.equals("default")) {
+            Set<ParameterOption> options = new HashSet<>();
             for (PersistenceService service : getAll()) {
                 options.add(new ParameterOption(service.getId(), service.getLabel(locale)));
             }
+            return options;
         }
-        return options;
+        return null;
     }
 
 }

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImpl.java
@@ -11,7 +11,6 @@ package org.eclipse.smarthome.magic.binding.internal;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Locale;
 
 import org.eclipse.smarthome.config.core.ParameterOption;
@@ -26,7 +25,7 @@ public class MagicServiceImpl implements MagicService {
     @Override
     public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
         if (!uri.equals(CONFIG_URI)) {
-            return Collections.emptyList();
+            return null;
         }
 
         if (param.equals(PARAMETER_BACKEND_DECIMAL)) {
@@ -35,7 +34,7 @@ public class MagicServiceImpl implements MagicService {
                     new ParameterOption(BigDecimal.valueOf(21d).toPlainString(), "21"));
         }
 
-        return Collections.emptyList();
+        return null;
     }
 
 }


### PR DESCRIPTION
...as several implementations return null. Also, it does not make
much sense to instantiate empty collections all the time, as the
majority of call will be returned with no results.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>