### PR TITLE
LIFX: Fix #3745 powerOnBrightness is ignored when empty in the things file

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/config/config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/ESH-INF/config/config.xml
@@ -4,22 +4,21 @@
     xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
     <config-description uri="thing-type:lifx:light">
-            <parameter name="deviceId" type="text" required="true">
-                <label>LIFX device ID</label>
-            </parameter>
-            <parameter name="fadetime" type="integer" required="false">
-                <label>Fade time</label>
-                <description>The time to fade to the new color value (in ms).</description>
-                <default>300</default>
-            </parameter>
+        <parameter name="deviceId" type="text" required="true">
+            <label>LIFX device ID</label>
+        </parameter>
+        <parameter name="fadetime" type="integer" required="false">
+            <label>Fade time</label>
+            <description>The time to fade to the new color value (in ms).</description>
+            <default>300</default>
+        </parameter>
     </config-description>
 
     <config-description uri="channel-type:lifx:brightness">
         <parameter name="powerOnBrightness" type="integer" min="0" max="100" required="false" unit="%">
             <label>Power on brightness</label>
             <description>Brightness level used when switching on the light. Use empty value to leave brightness as is.</description>
-            <default>100</default>
-         </parameter>
+        </parameter>
     </config-description>
 
 </config-description:config-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
@@ -90,14 +90,11 @@ Or create items for each type (*Color*, *Switch*, *Dimmer*) and define the corre
 ### demo.things:
 
 ```
-Thing lifx:colorlight:living [ deviceId="D073D5A1A1A1" ] {
-    Channels:
-        Type color : color [ powerOnBrightness= ]
-}
+Thing lifx:colorlight:living [ deviceId="D073D5A1A1A1" ]
 
 Thing lifx:colorlight:living2 [ deviceId="D073D5A2A2A2" ] {
     Channels:
-        Type color : color [ powerOnBrightness= ]
+        Type color : color [ powerOnBrightness=50 ]
 }
 
 Thing lifx:colorirlight:porch [ deviceId="D073D5B2B2B2", fadetime=0 ] {
@@ -135,7 +132,7 @@ Dimmer Ceiling_Temperature { channel="lifx:colormzlight:ceiling:temperature" }
 Color Ceiling_Color_Zone_0 { channel="lifx:colormzlight:ceiling:colorzone0" }
 Dimmer Ceiling_Temperature_Zone_0 { channel="lifx:colormzlight:ceiling:temperaturezone0" }
 Color Ceiling_Color_Zone_15 { channel="lifx:colormzlight:ceiling:colorzone15" }
-Dimmer Ceiling_Temperature_Zone_15 { channel="lifx:colormzlight:ceiling:colorzone15" }
+Dimmer Ceiling_Temperature_Zone_15 { channel="lifx:colormzlight:ceiling:temperaturezone15" }
 
 // Kitchen
 Switch Kitchen_Toggle { channel="lifx:whitelight:kichen:brightness" }

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightPropertiesUpdater.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightPropertiesUpdater.java
@@ -38,7 +38,7 @@ import com.google.common.collect.Lists;
 
 /**
  * The {@link LifxLightPropertiesUpdater} updates the light properties when a light goes online. When packets get lost
- * the requests are resend when the {@code UPDATE_INTERVAL} elapses.
+ * the requests are resent when the {@code UPDATE_INTERVAL} elapses.
  *
  * @author Wouter Born - Update light properties when online
  */


### PR DESCRIPTION
As reported in #3745 using `powerOnBrightness=` in a .things file no longer works. Such files nowadays fail validation, e.g. the following warning is logged:

```
19:04:22.457 [WARN ] [el.core.internal.ModelRepositoryImpl] - Configuration model 'test.things' has errors, therefore ignoring it: [4,49]: no viable alternative at input ']'
```

After testing it shows that removing the default for the `powerOnBrightness` parameter makes it again possible to switch lights on without changing the brightness when the `powerOnBrightness` parameter in .things files is omitted.