### PR TITLE
[Tradfri] Avoid NPE if response doesn't contain needed JSON elements

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
@@ -21,7 +21,7 @@ The devices require only a single (integer) parameter, which is their instance i
 
 ## Channels
 
-All devices support the `brightness` channel, while the white spectrum bulbs additionally also support the `colorTemperature` channel.
+All devices support the `brightness` channel, while the white spectrum bulbs additionally also support the `color_temperature` channel.
 
 | Channel Type ID   | Item Type | Description                                 |
 |-------------------|-----------|---------------------------------------------|
@@ -51,7 +51,7 @@ demo.sitemap:
 sitemap demo label="Main Menu"
 {
     Frame {
-    	Slider item=Light label="Brightness [%.1f %%]"
-	}
+        Slider item=Light label="Brightness [%.1f %%]"
+    }
 }
 ```

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
@@ -256,11 +256,16 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
         }
 
         public PercentType getBrightness() {
-            int b = attributes.get(DIMMER).getAsInt();
-            if (b == 1) {
-                return new PercentType(1);
+            JsonElement dimmer = attributes.get(DIMMER);
+            if (dimmer != null) {
+                int b = dimmer.getAsInt();
+                if (b == 1) {
+                    return new PercentType(1);
+                }
+                return new PercentType((int) Math.round(b / 2.54));
+            } else {
+                return null;
             }
-            return new PercentType((int) Math.round(b / 2.54));
         }
 
         public boolean getReachabilityStatus() {
@@ -278,7 +283,12 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
 
         @SuppressWarnings("unused")
         public int getTransitionTime() {
-            return attributes.get(TRANSITION_TIME).getAsInt();
+            JsonElement transitionTime = attributes.get(TRANSITION_TIME);
+            if (transitionTime != null) {
+                return transitionTime.getAsInt();
+            } else {
+                return 0;
+            }
         }
 
         public LightData setColorTemperature(PercentType c) {
@@ -307,7 +317,7 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
             // we only need to check one of the coordinates and figure out where between the presets we are
             JsonElement colorX = attributes.get(COLOR_X);
             if (colorX != null) {
-                double x = attributes.get(COLOR_X).getAsInt();
+                double x = colorX.getAsInt();
                 double value = 0.0;
                 if (x > X[1]) {
                     // is it between preset 1 and 2?

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -37,7 +37,8 @@ public class TradfriDiscoveryService extends AbstractDiscoveryService implements
 
     private TradfriGatewayHandler handler;
 
-    private String[] COLOR_TEMP_MODELS = new String[] { "TRADFRI bulb E27 WS opal 980lm" };
+    private String[] COLOR_TEMP_MODELS = new String[] { "TRADFRI bulb E27 WS opal 980lm",
+            "TRADFRI bulb GU10 WS 400lm" };
 
     public TradfriDiscoveryService(TradfriGatewayHandler bridgeHandler) {
         super(TradfriBindingConstants.SUPPORTED_LIGHT_TYPES_UIDS, 10, true);


### PR DESCRIPTION
* NPE safeguard
* Added "TRADFRI bulb GU10 WS 400lm" bulb to `COLOR_TEMP_MODELS`
* Minor fixes in README.md

Closes #3683 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>