### PR TITLE
Improve Sonos notification timeout handling

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/config/config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/config/config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd"
+>
+	<config-description uri="config:sonos:zoneplayer">
+		<parameter name="udn" type="text">
+			<label>Unique Device Name</label>
+			<description>The UDN identifies the Zone Player.</description>
+			<required>true</required>
+		</parameter>
+		<parameter name="notificationTimeout" type="integer">
+			<label>Notification Timeout</label>
+			<description>Specifies the amount of time for which the notification sound will be played</description>
+			<default>40</default>
+			<required>true</required>
+		</parameter>
+		<parameter name="refresh" type="integer">
+			<label>Refresh interval</label>
+			<description>Specifies the refresh interval in seconds</description>
+			<default>60</default>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
@@ -62,18 +62,6 @@
 			<property name="modelId"></property>
 		</properties>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the Zone Player.</description>
-				<required>true</required>
-			</parameter>
-
-			<parameter name="refresh" type="integer">
-				<label>Refresh interval</label>
-				<description>Specifies the refresh interval in seconds</description>
-				<default>60</default>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="config:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
@@ -63,18 +63,6 @@
 			<property name="modelId">CONNECT:AMP</property>
 		</properties>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the Zone Player.</description>
-				<required>true</required>
-			</parameter>
-
-			<parameter name="refresh" type="integer">
-				<label>Refresh interval</label>
-				<description>Specifies the refresh interval in seconds</description>
-				<default>60</default>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="config:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
@@ -60,18 +60,6 @@
 			<property name="modelId">PLAY:1</property>
 		</properties>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the Zone Player.</description>
-				<required>true</required>
-			</parameter>
-
-			<parameter name="refresh" type="integer">
-				<label>Refresh interval</label>
-				<description>Specifies the refresh interval in seconds</description>
-				<default>60</default>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="config:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
@@ -60,18 +60,6 @@
 			<property name="modelId">PLAY:3</property>
 		</properties>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the Zone Player.</description>
-				<required>true</required>
-			</parameter>
-
-			<parameter name="refresh" type="integer">
-				<label>Refresh interval</label>
-				<description>Specifies the refresh interval in seconds</description>
-				<default>60</default>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="config:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
@@ -63,18 +63,6 @@
 			<property name="modelId">PLAY:5</property>
 		</properties>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the Zone Player.</description>
-				<required>true</required>
-			</parameter>
-
-			<parameter name="refresh" type="integer">
-				<label>Refresh interval</label>
-				<description>Specifies the refresh interval in seconds</description>
-				<default>60</default>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="config:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
@@ -62,18 +62,6 @@
 			<property name="modelId">PLAYBAR</property>
 		</properties>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the Zone Player.</description>
-				<required>true</required>
-			</parameter>
-
-			<parameter name="refresh" type="integer">
-				<label>Refresh interval</label>
-				<description>Specifies the refresh interval in seconds</description>
-				<default>60</default>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="config:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
@@ -60,18 +60,6 @@
 			<property name="modelId">ZonePlayer</property>
 		</properties>
 
-		<config-description>
-			<parameter name="udn" type="text">
-				<label>Unique Device Name</label>
-				<description>The UDN identifies the Zone Player.</description>
-				<required>true</required>
-			</parameter>
-
-			<parameter name="refresh" type="integer">
-				<label>Refresh interval</label>
-				<description>Specifies the refresh interval in seconds</description>
-				<default>60</default>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="config:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/config/ZonePlayerConfiguration.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/config/ZonePlayerConfiguration.java
@@ -11,8 +11,10 @@ public class ZonePlayerConfiguration {
 
     public static final String UDN = "udn";
     public static final String REFRESH = "refresh";
+    public static final String NOTIFICATION_TIMEOUT = "notificationTimeout";
 
     public String udn;
     public Integer refresh;
+    public Integer notificationTimeout;
 
 }


### PR DESCRIPTION
1. Extract the notification timeout as a thing configuration parameter
2. Increase the default notification timeout to 40 sec. (as 20 s is too short time)