### PR TITLE
Return status '204: no content' if Thing has no firmware details

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -587,7 +587,7 @@ public class ThingResource implements RESTResource {
     @Path("/{thingUID}/firmware/status")
     @ApiOperation(value = "Gets thing's firmware status.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 204, message = "Firmware status info not found.") })
+            @ApiResponse(code = 204, message = "No firmware status provided by this Thing.") })
     public Response getFirmwareStatus(@HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) String language,
             @PathParam("thingUID") @ApiParam(value = "thing") String thingUID) throws IOException {
         ThingUID thingUIDObject = new ThingUID(thingUID);

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/thing/ThingResource.java
@@ -587,14 +587,14 @@ public class ThingResource implements RESTResource {
     @Path("/{thingUID}/firmware/status")
     @ApiOperation(value = "Gets thing's firmware status.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 404, message = "Firmware status info not found.") })
+            @ApiResponse(code = 204, message = "Firmware status info not found.") })
     public Response getFirmwareStatus(@HeaderParam(HttpHeaders.ACCEPT_LANGUAGE) String language,
             @PathParam("thingUID") @ApiParam(value = "thing") String thingUID) throws IOException {
         ThingUID thingUIDObject = new ThingUID(thingUID);
 
         FirmwareStatusInfo info = firmwareUpdateService.getFirmwareStatusInfo(thingUIDObject);
         if (info == null) {
-            return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Firmware status info not found.");
+            return Response.status(Status.NO_CONTENT).build();
         }
 
         return Response.ok().entity(buildFirmwareStatusDTO(info)).build();

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.firmware.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.firmware.html
@@ -3,12 +3,12 @@
     <div>
         Current firmware version:
         <span class="current-firmware">{{thing.properties['firmwareVersion']}}</span>
-        <span class="badge firmware-status" ng-class="firmwareStatus.status | firmwareStatusClass">
+        <span ng-if="firmwareStatus.status" class="badge firmware-status" ng-class="firmwareStatus.status | firmwareStatusClass">
            <span>{{firmwareStatus.status | firmwareStatusFormat}}</span>
            <span ng-if="isFirmwareUpdateable(firmwareStatus)"> {{firmwareStatus.updatableVersion}}</span>
         </span>
     </div>
-    <div>
+    <div ng-if="firmwareStatus.status">
         <span>
 	        <md-button ng-if="isFirmwareUpdateable(firmwareStatus)" aria-label="Install" ng-click="installFirmware(firmwareStatus.updatableVersion)">
 	           <span>Install</span>
@@ -22,7 +22,7 @@
             <span>Update step: {{updateStep | firmwareUpdateStep}}</span>
         </div>
     </div>
-    <md-button ng-show="thing.properties['firmwareVersion']" ng-click="fvdetails=!fvdetails">{{fvdetails?'hide':'show'}} firmware details</md-button>
+    <md-button ng-show="firmwares.length > 0" ng-click="fvdetails=!fvdetails">{{fvdetails?'hide':'show'}} firmware details</md-button>
     <div ng-show="fvdetails" class="thing-properties">
         <table class="table firmware-table middle-aligned"> 
             <tr>


### PR DESCRIPTION
Also: adopt PaperUI to not show FW details or an empty list of firmwares if nothing is found for the Thing.

Fixes #3791.