### PR TITLE
[LIFX] Update ThingStatus at most once a second

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/handler/LifxLightHandler.java
@@ -47,6 +47,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -82,9 +83,11 @@ public class LifxLightHandler extends BaseThingHandler implements LifxProperties
 
     private final ReentrantLock lock = new ReentrantLock();
 
-    private Map<String, State> channelStates;
     private CurrentLightState currentLightState;
     private LifxLightState pendingLightState;
+
+    private Map<String, State> channelStates;
+    private ThingStatusInfo statusInfo;
 
     private LifxLightCommunicationHandler communicationHandler;
     private LifxLightCurrentStateUpdater currentStateUpdater;
@@ -103,15 +106,15 @@ public class LifxLightHandler extends BaseThingHandler implements LifxProperties
         }
 
         public void setOnline() {
-            updateStatus(ThingStatus.ONLINE);
+            updateStatusIfChanged(ThingStatus.ONLINE);
         }
 
         public void setOffline() {
-            updateStatus(ThingStatus.OFFLINE);
+            updateStatusIfChanged(ThingStatus.OFFLINE);
         }
 
         public void setOfflineByCommunicationError() {
-            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
+            updateStatusIfChanged(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
         }
 
         @Override
@@ -570,6 +573,18 @@ public class LifxLightHandler extends BaseThingHandler implements LifxProperties
         if (oldState == null || !oldState.equals(newState)) {
             updateState(channel, newState);
             channelStates.put(channel, newState);
+        }
+    }
+
+    private void updateStatusIfChanged(ThingStatus status) {
+        updateStatusIfChanged(status, ThingStatusDetail.NONE);
+    }
+
+    private void updateStatusIfChanged(ThingStatus status, ThingStatusDetail statusDetail) {
+        ThingStatusInfo newStatusInfo = new ThingStatusInfo(status, statusDetail, null);
+        if (statusInfo == null || !statusInfo.equals(newStatusInfo)) {
+            statusInfo = newStatusInfo;
+            updateStatus(status, statusDetail);
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
@@ -9,6 +9,8 @@ package org.eclipse.smarthome.binding.lifx.internal;
 
 import static org.eclipse.smarthome.binding.lifx.LifxBindingConstants.DEFAULT_COLOR;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -33,7 +35,7 @@ public class LifxLightState {
     private PercentType infrared;
     private SignalStrength signalStrength;
 
-    private long lastChange;
+    private LocalDateTime lastChange = LocalDateTime.MIN;
 
     private List<LifxLightStateListener> listeners = new CopyOnWriteArrayList<>();
 
@@ -184,11 +186,11 @@ public class LifxLightState {
     }
 
     private void updateLastChange() {
-        lastChange = System.currentTimeMillis();
+        lastChange = LocalDateTime.now();
     }
 
-    public long getMillisSinceLastChange() {
-        return System.currentTimeMillis() - lastChange;
+    public Duration getDurationSinceLastChange() {
+        return Duration.between(lastChange, LocalDateTime.now());
     }
 
     public void addListener(LifxLightStateListener listener) {


### PR DESCRIPTION
With this PR the `LifxLightHandler` will only update the ThingStatus when there is a change.

Each received message currently always results in a `ThingStatus.ONLINE` update. This causes a lot of unnecessary `ThingStatusInfoEvent` s, logging etc. which generate unnecessary CPU load.

