### PR TITLE
[Classic Iconset] Add figcaptions

### DIFF
--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/README.md
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/README.md
@@ -1,383 +1,1523 @@
 # Classic Icon Set
 
-This is a modernized version of the original icon set of openHAB 1. The set is provided with the distribution in both the PNG and SVG file format. Move your mouse over an icon to learn its name.<br/><br/>
+This is a modernized version of the original icon set from openHAB 1.x.
+The set is provided with the distribution in both the PNG and SVG file format.
 
-![alarm](icons/alarm.png "alarm")
-![attic](icons/attic.png "attic")
-![baby_1](icons/baby_1.png "baby_1")
-![baby_2](icons/baby_2.png "baby_2")
-![baby_3](icons/baby_3.png "baby_3")
-![baby_4](icons/baby_4.png "baby_4")
-![baby_5](icons/baby_5.png "baby_5")
-![baby_6](icons/baby_6.png "baby_6")
-![bath](icons/bath.png "bath")
-![battery](icons/battery.png "battery")
-![battery-0](icons/battery-0.png "battery-0")
-![battery-10](icons/battery-10.png "battery-10")
-![battery-20](icons/battery-20.png "battery-20")
-![battery-30](icons/battery-30.png "battery-30")
-![battery-40](icons/battery-40.png "battery-40")
-![battery-50](icons/battery-50.png "battery-50")
-![battery-60](icons/battery-60.png "battery-60")
-![battery-70](icons/battery-70.png "battery-70")
-![battery-80](icons/battery-80.png "battery-80")
-![battery-90](icons/battery-90.png "battery-90")
-![battery-100](icons/battery-100.png "battery-100")
-![battery-off](icons/battery-off.png "battery-off")
-![battery-on](icons/battery-on.png "battery-on")
-![bedroom](icons/bedroom.png "bedroom")
-![bedroom_blue](icons/bedroom_blue.png "bedroom_blue")
-![bedroom_orange](icons/bedroom_orange.png "bedroom_orange")
-![bedroom_red](icons/bedroom_red.png "bedroom_red")
-![blinds](icons/blinds.png "blinds")
-![blinds-0](icons/blinds-0.png "blinds-0")
-![blinds-10](icons/blinds-10.png "blinds-10")
-![blinds-20](icons/blinds-20.png "blinds-20")
-![blinds-30](icons/blinds-30.png "blinds-30")
-![blinds-40](icons/blinds-40.png "blinds-40")
-![blinds-50](icons/blinds-50.png "blinds-50")
-![blinds-60](icons/blinds-60.png "blinds-60")
-![blinds-70](icons/blinds-70.png "blinds-70")
-![blinds-80](icons/blinds-80.png "blinds-80")
-![blinds-90](icons/blinds-90.png "blinds-90")
-![blinds-100](icons/blinds-100.png "blinds-100")
-![bluetooth](icons/bluetooth.png "bluetooth")
-![boiler_viessmann](icons/boiler_viessmann.png "boiler_viessmann")
-![boy_1](icons/boy_1.png "boy_1")
-![boy_2](icons/boy_2.png "boy_2")
-![boy_3](icons/boy_3.png "boy_3")
-![boy_4](icons/boy_4.png "boy_4")
-![boy_5](icons/boy_5.png "boy_5")
-![boy_6](icons/boy_6.png "boy_6")
-![calendar](icons/calendar.png "calendar")
-![camera](icons/camera.png "camera")
-![carbondioxide](icons/carbondioxide.png "carbondioxide")
-![cellar](icons/cellar.png "cellar")
-![chart](icons/chart.png "chart")
-![cinema](icons/cinema.png "cinema")
-![cinemascreen](icons/cinemascreen.png "cinemascreen")
-![cinemascreen-0](icons/cinemascreen-0.png "cinemascreen-0")
-![cinemascreen-10](icons/cinemascreen-10.png "cinemascreen-10")
-![cinemascreen-20](icons/cinemascreen-20.png "cinemascreen-20")
-![cinemascreen-30](icons/cinemascreen-30.png "cinemascreen-30")
-![cinemascreen-40](icons/cinemascreen-40.png "cinemascreen-40")
-![cinemascreen-50](icons/cinemascreen-50.png "cinemascreen-50")
-![cinemascreen-60](icons/cinemascreen-60.png "cinemascreen-60")
-![cinemascreen-70](icons/cinemascreen-70.png "cinemascreen-70")
-![cinemascreen-80](icons/cinemascreen-80.png "cinemascreen-80")
-![cinemascreen-90](icons/cinemascreen-90.png "cinemascreen-90")
-![cinemascreen-100](icons/cinemascreen-100.png "cinemascreen-100")
-![cistern](icons/cistern.png "cistern")
-![cistern-0](icons/cistern-0.png "cistern-0")
-![cistern-10](icons/cistern-10.png "cistern-10")
-![cistern-20](icons/cistern-20.png "cistern-20")
-![cistern-30](icons/cistern-30.png "cistern-30")
-![cistern-40](icons/cistern-40.png "cistern-40")
-![cistern-50](icons/cistern-50.png "cistern-50")
-![cistern-60](icons/cistern-60.png "cistern-60")
-![cistern-70](icons/cistern-70.png "cistern-70")
-![cistern-80](icons/cistern-80.png "cistern-80")
-![cistern-90](icons/cistern-90.png "cistern-90")
-![cistern-100](icons/cistern-100.png "cistern-100")
-![climate](icons/climate.png "climate")
-![climate-on](icons/climate-on.png "climate-on")
-![clock](icons/clock.png "clock")
-![clock-on](icons/clock-on.png "clock-on")
-![colorlight](icons/colorlight.png "colorlight")
-![colorpicker](icons/colorpicker.png "colorpicker")
-![colorwheel](icons/colorwheel.png "colorwheel")
-![contact](icons/contact.png "contact")
-![contact-ajar](icons/contact-ajar.png "contact-ajar")
-![contact-closed](icons/contact-closed.png "contact-closed")
-![contact-open](icons/contact-open.png "contact-open")
-![corridor](icons/corridor.png "corridor")
-![dimmablelight](icons/dimmablelight.png "dimmablelight")
-![dimmablelight-0](icons/dimmablelight-0.png "dimmablelight-0")
-![dimmablelight-10](icons/dimmablelight-10.png "dimmablelight-10")
-![dimmablelight-20](icons/dimmablelight-20.png "dimmablelight-20")
-![dimmablelight-30](icons/dimmablelight-30.png "dimmablelight-30")
-![dimmablelight-40](icons/dimmablelight-40.png "dimmablelight-40")
-![dimmablelight-50](icons/dimmablelight-50.png "dimmablelight-50")
-![dimmablelight-60](icons/dimmablelight-60.png "dimmablelight-60")
-![dimmablelight-70](icons/dimmablelight-70.png "dimmablelight-70")
-![dimmablelight-80](icons/dimmablelight-80.png "dimmablelight-80")
-![dimmablelight-90](icons/dimmablelight-90.png "dimmablelight-90")
-![dimmablelight-100](icons/dimmablelight-100.png "dimmablelight-100")
-![door](icons/door.png "door")
-![door-closed](icons/door-closed.png "door-closed")
-![door-open](icons/door-open.png "door-open")
-![dryer](icons/dryer.png "dryer")
-![dryer-0](icons/dryer-0.png "dryer-0")
-![dryer-1](icons/dryer-1.png "dryer-1")
-![dryer-2](icons/dryer-2.png "dryer-2")
-![dryer-3](icons/dryer-3.png "dryer-3")
-![dryer-4](icons/dryer-4.png "dryer-4")
-![dryer-5](icons/dryer-5.png "dryer-5")
-![energy](icons/energy.png "energy")
-![error](icons/error.png "error")
-![fan](icons/fan.png "fan")
-![fan_box](icons/fan_box.png "fan_box")
-![fan_ceiling](icons/fan_ceiling.png "fan_ceiling")
-![faucet](icons/faucet.png "faucet")
-![fire](icons/fire.png "fire")
-![fire-off](icons/fire-off.png "fire-off")
-![fire-on](icons/fire-on.png "fire-on")
-![firstfloor](icons/firstfloor.png "firstfloor")
-![flow](icons/flow.png "flow")
-![flowpipe](icons/flowpipe.png "flowpipe")
-![frontdoor](icons/frontdoor.png "frontdoor")
-![frontdoor-closed](icons/frontdoor-closed.png "frontdoor-closed")
-![frontdoor-open](icons/frontdoor-open.png "frontdoor-open")
-![garage](icons/garage.png "garage")
-![garagedoor](icons/garagedoor.png "garagedoor")
-![garagedoor-0](icons/garagedoor-0.png "garagedoor-0")
-![garagedoor-10](icons/garagedoor-10.png "garagedoor-10")
-![garagedoor-20](icons/garagedoor-20.png "garagedoor-20")
-![garagedoor-30](icons/garagedoor-30.png "garagedoor-30")
-![garagedoor-40](icons/garagedoor-40.png "garagedoor-40")
-![garagedoor-50](icons/garagedoor-50.png "garagedoor-50")
-![garagedoor-60](icons/garagedoor-60.png "garagedoor-60")
-![garagedoor-70](icons/garagedoor-70.png "garagedoor-70")
-![garagedoor-80](icons/garagedoor-80.png "garagedoor-80")
-![garagedoor-90](icons/garagedoor-90.png "garagedoor-90")
-![garagedoor-100](icons/garagedoor-100.png "garagedoor-100")
-![garagedoor-ajar](icons/garagedoor-ajar.png "garagedoor-ajar")
-![garagedoor-closed](icons/garagedoor-closed.png "garagedoor-closed")
-![garagedoor-open](icons/garagedoor-open.png "garagedoor-open")
-![garage_detached](icons/garage_detached.png "garage_detached")
-![garage_detached_selected](icons/garage_detached_selected.png "garage_detached_selected")
-![garden](icons/garden.png "garden")
-![gas](icons/gas.png "gas")
-![girl_1](icons/girl_1.png "girl_1")
-![girl_2](icons/girl_2.png "girl_2")
-![girl_3](icons/girl_3.png "girl_3")
-![girl_4](icons/girl_4.png "girl_4")
-![girl_5](icons/girl_5.png "girl_5")
-![girl_6](icons/girl_6.png "girl_6")
-![grass](icons/grass.png "grass")
-![greenhouse](icons/greenhouse.png "greenhouse")
-![groundfloor](icons/groundfloor.png "groundfloor")
-![group](icons/group.png "group")
-![heating](icons/heating.png "heating")
-![heating-0](icons/heating-0.png "heating-0")
-![heating-20](icons/heating-20.png "heating-20")
-![heating-40](icons/heating-40.png "heating-40")
-![heating-60](icons/heating-60.png "heating-60")
-![heating-80](icons/heating-80.png "heating-80")
-![heating-100](icons/heating-100.png "heating-100")
-![heating-off](icons/heating-off.png "heating-off")
-![heating-on](icons/heating-on.png "heating-on")
-![house](icons/house.png "house")
-![humidity](icons/humidity.png "humidity")
-![humidity-0](icons/humidity-0.png "humidity-0")
-![humidity-10](icons/humidity-10.png "humidity-10")
-![humidity-20](icons/humidity-20.png "humidity-20")
-![humidity-30](icons/humidity-30.png "humidity-30")
-![humidity-40](icons/humidity-40.png "humidity-40")
-![humidity-50](icons/humidity-50.png "humidity-50")
-![humidity-60](icons/humidity-60.png "humidity-60")
-![humidity-70](icons/humidity-70.png "humidity-70")
-![humidity-80](icons/humidity-80.png "humidity-80")
-![humidity-90](icons/humidity-90.png "humidity-90")
-![humidity-100](icons/humidity-100.png "humidity-100")
-![incline](icons/incline.png "incline")
-![keyring](icons/keyring.png "keyring")
-![kitchen](icons/kitchen.png "kitchen")
-![light](icons/light.png "light")
-![light-off](icons/light-off.png "light-off")
-![light-on](icons/light-on.png "light-on")
-![line](icons/line.png "line")
-![line-decline](icons/line-decline.png "line-decline")
-![line-incline](icons/line-incline.png "line-incline")
-![line-stagnation](icons/line-stagnation.png "line-stagnation")
-![lock](icons/lock.png "lock")
-![lock-closed](icons/lock-closed.png "lock-closed")
-![lock-open](icons/lock-open.png "lock-open")
-![man_1](icons/man_1.png "man_1")
-![man_2](icons/man_2.png "man_2")
-![man_3](icons/man_3.png "man_3")
-![man_4](icons/man_4.png "man_4")
-![man_5](icons/man_5.png "man_5")
-![man_6](icons/man_6.png "man_6")
-![microphone](icons/microphone.png "microphone")
-![moon](icons/moon.png "moon")
-![motion](icons/motion.png "motion")
-![movecontrol](icons/movecontrol.png "movecontrol")
-![network](icons/network.png "network")
-![network-off](icons/network-off.png "network-off")
-![network-on](icons/network-on.png "network-on")
-![niveau](icons/niveau.png "niveau")
-![office](icons/office.png "office")
-![oil](icons/oil.png "oil")
-![outdoorlight](icons/outdoorlight.png "outdoorlight")
-![pantry](icons/pantry.png "pantry")
-![parents-off](icons/parents-off.png "parents-off")
-![parents_1_1](icons/parents_1_1.png "parents_1_1")
-![parents_1_2](icons/parents_1_2.png "parents_1_2")
-![parents_1_3](icons/parents_1_3.png "parents_1_3")
-![parents_1_4](icons/parents_1_4.png "parents_1_4")
-![parents_1_5](icons/parents_1_5.png "parents_1_5")
-![parents_1_6](icons/parents_1_6.png "parents_1_6")
-![parents_2_1](icons/parents_2_1.png "parents_2_1")
-![parents_2_2](icons/parents_2_2.png "parents_2_2")
-![parents_2_3](icons/parents_2_3.png "parents_2_3")
-![parents_2_4](icons/parents_2_4.png "parents_2_4")
-![parents_2_5](icons/parents_2_5.png "parents_2_5")
-![parents_2_6](icons/parents_2_6.png "parents_2_6")
-![parents_3_1](icons/parents_3_1.png "parents_3_1")
-![parents_3_2](icons/parents_3_2.png "parents_3_2")
-![parents_3_3](icons/parents_3_3.png "parents_3_3")
-![parents_3_4](icons/parents_3_4.png "parents_3_4")
-![parents_3_5](icons/parents_3_5.png "parents_3_5")
-![parents_3_6](icons/parents_3_6.png "parents_3_6")
-![parents_4_1](icons/parents_4_1.png "parents_4_1")
-![parents_4_2](icons/parents_4_2.png "parents_4_2")
-![parents_4_3](icons/parents_4_3.png "parents_4_3")
-![parents_4_4](icons/parents_4_4.png "parents_4_4")
-![parents_4_5](icons/parents_4_5.png "parents_4_5")
-![parents_4_6](icons/parents_4_6.png "parents_4_6")
-![parents_5_1](icons/parents_5_1.png "parents_5_1")
-![parents_5_2](icons/parents_5_2.png "parents_5_2")
-![parents_5_3](icons/parents_5_3.png "parents_5_3")
-![parents_5_4](icons/parents_5_4.png "parents_5_4")
-![parents_5_5](icons/parents_5_5.png "parents_5_5")
-![parents_5_6](icons/parents_5_6.png "parents_5_6")
-![parents_6_1](icons/parents_6_1.png "parents_6_1")
-![parents_6_2](icons/parents_6_2.png "parents_6_2")
-![parents_6_3](icons/parents_6_3.png "parents_6_3")
-![parents_6_4](icons/parents_6_4.png "parents_6_4")
-![parents_6_5](icons/parents_6_5.png "parents_6_5")
-![parents_6_6](icons/parents_6_6.png "parents_6_6")
-![party](icons/party.png "party")
-![pie](icons/pie.png "pie")
-![piggybank](icons/piggybank.png "piggybank")
-![player](icons/player.png "player")
-![poweroutlet](icons/poweroutlet.png "poweroutlet")
-![poweroutlet-off](icons/poweroutlet-off.png "poweroutlet-off")
-![poweroutlet-on](icons/poweroutlet-on.png "poweroutlet-on")
-![poweroutlet_au](icons/poweroutlet_au.png "poweroutlet_au")
-![poweroutlet_eu](icons/poweroutlet_eu.png "poweroutlet_eu")
-![poweroutlet_uk](icons/poweroutlet_uk.png "poweroutlet_uk")
-![poweroutlet_us](icons/poweroutlet_us.png "poweroutlet_us")
-![present](icons/present.png "present")
-![present-off](icons/present-off.png "present-off")
-![pressure](icons/pressure.png "pressure")
-![projector_benq](icons/projector_benq.png "projector_benq")
-![pump](icons/pump.png "pump")
-![qualityofservice](icons/qualityofservice.png "qualityofservice")
-![qualityofservice-0](icons/qualityofservice-0.png "qualityofservice-0")
-![qualityofservice-1](icons/qualityofservice-1.png "qualityofservice-1")
-![qualityofservice-2](icons/qualityofservice-2.png "qualityofservice-2")
-![qualityofservice-3](icons/qualityofservice-3.png "qualityofservice-3")
-![qualityofservice-4](icons/qualityofservice-4.png "qualityofservice-4")
-![radiator](icons/radiator.png "radiator")
-![rain](icons/rain.png "rain")
-![receiver](icons/receiver.png "receiver")
-![receiver-off](icons/receiver-off.png "receiver-off")
-![receiver-on](icons/receiver-on.png "receiver-on")
-![recorder](icons/recorder.png "recorder")
-![returnpipe](icons/returnpipe.png "returnpipe")
-![rgb](icons/rgb.png "rgb")
-![rollershutter](icons/rollershutter.png "rollershutter")
-![rollershutter-0](icons/rollershutter-0.png "rollershutter-0")
-![rollershutter-10](icons/rollershutter-10.png "rollershutter-10")
-![rollershutter-20](icons/rollershutter-20.png "rollershutter-20")
-![rollershutter-30](icons/rollershutter-30.png "rollershutter-30")
-![rollershutter-40](icons/rollershutter-40.png "rollershutter-40")
-![rollershutter-50](icons/rollershutter-50.png "rollershutter-50")
-![rollershutter-60](icons/rollershutter-60.png "rollershutter-60")
-![rollershutter-70](icons/rollershutter-70.png "rollershutter-70")
-![rollershutter-80](icons/rollershutter-80.png "rollershutter-80")
-![rollershutter-90](icons/rollershutter-90.png "rollershutter-90")
-![rollershutter-100](icons/rollershutter-100.png "rollershutter-100")
-![settings](icons/settings.png "settings")
-![sewerage](icons/sewerage.png "sewerage")
-![sewerage-0](icons/sewerage-0.png "sewerage-0")
-![sewerage-10](icons/sewerage-10.png "sewerage-10")
-![sewerage-20](icons/sewerage-20.png "sewerage-20")
-![sewerage-30](icons/sewerage-30.png "sewerage-30")
-![sewerage-40](icons/sewerage-40.png "sewerage-40")
-![sewerage-50](icons/sewerage-50.png "sewerage-50")
-![sewerage-60](icons/sewerage-60.png "sewerage-60")
-![sewerage-70](icons/sewerage-70.png "sewerage-70")
-![sewerage-80](icons/sewerage-80.png "sewerage-80")
-![sewerage-90](icons/sewerage-90.png "sewerage-90")
-![sewerage-100](icons/sewerage-100.png "sewerage-100")
-![shield](icons/shield.png "shield")
-![shield-0](icons/shield-0.png "shield-0")
-![shield-1](icons/shield-1.png "shield-1")
-![signal](icons/signal.png "signal")
-![signal-0](icons/signal-0.png "signal-0")
-![signal-1](icons/signal-1.png "signal-1")
-![signal-2](icons/signal-2.png "signal-2")
-![signal-3](icons/signal-3.png "signal-3")
-![signal-4](icons/signal-4.png "signal-4")
-![siren](icons/siren.png "siren")
-![siren-off](icons/siren-off.png "siren-off")
-![siren-on](icons/siren-on.png "siren-on")
-![slider](icons/slider.png "slider")
-![slider-0](icons/slider-0.png "slider-0")
-![slider-10](icons/slider-10.png "slider-10")
-![slider-20](icons/slider-20.png "slider-20")
-![slider-30](icons/slider-30.png "slider-30")
-![slider-40](icons/slider-40.png "slider-40")
-![slider-50](icons/slider-50.png "slider-50")
-![slider-60](icons/slider-60.png "slider-60")
-![slider-70](icons/slider-70.png "slider-70")
-![slider-80](icons/slider-80.png "slider-80")
-![slider-90](icons/slider-90.png "slider-90")
-![slider-100](icons/slider-100.png "slider-100")
-![smiley](icons/smiley.png "smiley")
-![smoke](icons/smoke.png "smoke")
-![sofa](icons/sofa.png "sofa")
-![softener](icons/softener.png "softener")
-![solarplant](icons/solarplant.png "solarplant")
-![soundvolume](icons/soundvolume.png "soundvolume")
-![soundvolume-0](icons/soundvolume-0.png "soundvolume-0")
-![soundvolume-33](icons/soundvolume-33.png "soundvolume-33")
-![soundvolume-66](icons/soundvolume-66.png "soundvolume-66")
-![soundvolume-100](icons/soundvolume-100.png "soundvolume-100")
-![soundvolume_mute](icons/soundvolume_mute.png "soundvolume_mute")
-![status](icons/status.png "status")
-![suitcase](icons/suitcase.png "suitcase")
-![sun](icons/sun.png "sun")
-![sunrise](icons/sunrise.png "sunrise")
-![sunset](icons/sunset.png "sunset")
-![sun_clouds](icons/sun_clouds.png "sun_clouds")
-![switch](icons/switch.png "switch")
-![switch-off](icons/switch-off.png "switch-off")
-![switch-on](icons/switch-on.png "switch-on")
-![television](icons/television.png "television")
-![television-off](icons/television-off.png "television-off")
-![television-on](icons/television-on.png "television-on")
-![temperature](icons/temperature.png "temperature")
-![temperature_cold](icons/temperature_cold.png "temperature_cold")
-![temperature_hot](icons/temperature_hot.png "temperature_hot")
-![terrace](icons/terrace.png "terrace")
-![text](icons/text.png "text")
-![toilet](icons/toilet.png "toilet")
-![vacation](icons/vacation.png "vacation")
-![video](icons/video.png "video")
-![wallswitch](icons/wallswitch.png "wallswitch")
-![wallswitch-off](icons/wallswitch-off.png "wallswitch-off")
-![wallswitch-on](icons/wallswitch-on.png "wallswitch-on")
-![wardrobe](icons/wardrobe.png "wardrobe")
-![washingmachine](icons/washingmachine.png "washingmachine")
-![washingmachine_2](icons/washingmachine_2.png "washingmachine_2")
-![washingmachine_2-0](icons/washingmachine_2-0.png "washingmachine_2-0")
-![washingmachine_2-1](icons/washingmachine_2-1.png "washingmachine_2-1")
-![washingmachine_2-2](icons/washingmachine_2-2.png "washingmachine_2-2")
-![washingmachine_2-3](icons/washingmachine_2-3.png "washingmachine_2-3")
-![water](icons/water.png "water")
-![wind](icons/wind.png "wind")
-![window](icons/window.png "window")
-![window-ajar](icons/window-ajar.png "window-ajar")
-![window-closed](icons/window-closed.png "window-closed")
-![window-open](icons/window-open.png "window-open")
-![woman_1](icons/woman_1.png "woman_1")
-![woman_2](icons/woman_2.png "woman_2")
-![woman_3](icons/woman_3.png "woman_3")
-![woman_4](icons/woman_4.png "woman_4")
-![woman_5](icons/woman_5.png "woman_5")
-![woman_6](icons/woman_6.png "woman_6")
-![zoom](icons/zoom.png "zoom")
+<div id="iconset-preview">
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/alarm.png" alt="alarm" title="alarm">
+    <figcaption>alarm</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/attic.png" alt="attic" title="attic">
+    <figcaption>attic</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/baby_1.png" alt="baby_1" title="baby_1">
+    <figcaption>baby_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/baby_2.png" alt="baby_2" title="baby_2">
+    <figcaption>baby_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/baby_3.png" alt="baby_3" title="baby_3">
+    <figcaption>baby_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/baby_4.png" alt="baby_4" title="baby_4">
+    <figcaption>baby_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/baby_5.png" alt="baby_5" title="baby_5">
+    <figcaption>baby_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/baby_6.png" alt="baby_6" title="baby_6">
+    <figcaption>baby_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/bath.png" alt="bath" title="bath">
+    <figcaption>bath</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery.png" alt="battery" title="battery">
+    <figcaption>battery</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-0.png" alt="battery-0" title="battery-0">
+    <figcaption>battery-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-10.png" alt="battery-10" title="battery-10">
+    <figcaption>battery-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-20.png" alt="battery-20" title="battery-20">
+    <figcaption>battery-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-30.png" alt="battery-30" title="battery-30">
+    <figcaption>battery-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-40.png" alt="battery-40" title="battery-40">
+    <figcaption>battery-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-50.png" alt="battery-50" title="battery-50">
+    <figcaption>battery-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-60.png" alt="battery-60" title="battery-60">
+    <figcaption>battery-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-70.png" alt="battery-70" title="battery-70">
+    <figcaption>battery-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-80.png" alt="battery-80" title="battery-80">
+    <figcaption>battery-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-90.png" alt="battery-90" title="battery-90">
+    <figcaption>battery-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-100.png" alt="battery-100" title="battery-100">
+    <figcaption>battery-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-off.png" alt="battery-off" title="battery-off">
+    <figcaption>battery-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/battery-on.png" alt="battery-on" title="battery-on">
+    <figcaption>battery-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/bedroom.png" alt="bedroom" title="bedroom">
+    <figcaption>bedroom</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/bedroom_blue.png" alt="bedroom_blue" title="bedroom_blue">
+    <figcaption>bedroom_blue</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/bedroom_orange.png" alt="bedroom_orange" title="bedroom_orange">
+    <figcaption>bedroom_orange</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/bedroom_red.png" alt="bedroom_red" title="bedroom_red">
+    <figcaption>bedroom_red</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds.png" alt="blinds" title="blinds">
+    <figcaption>blinds</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-0.png" alt="blinds-0" title="blinds-0">
+    <figcaption>blinds-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-10.png" alt="blinds-10" title="blinds-10">
+    <figcaption>blinds-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-20.png" alt="blinds-20" title="blinds-20">
+    <figcaption>blinds-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-30.png" alt="blinds-30" title="blinds-30">
+    <figcaption>blinds-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-40.png" alt="blinds-40" title="blinds-40">
+    <figcaption>blinds-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-50.png" alt="blinds-50" title="blinds-50">
+    <figcaption>blinds-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-60.png" alt="blinds-60" title="blinds-60">
+    <figcaption>blinds-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-70.png" alt="blinds-70" title="blinds-70">
+    <figcaption>blinds-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-80.png" alt="blinds-80" title="blinds-80">
+    <figcaption>blinds-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-90.png" alt="blinds-90" title="blinds-90">
+    <figcaption>blinds-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/blinds-100.png" alt="blinds-100" title="blinds-100">
+    <figcaption>blinds-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/bluetooth.png" alt="bluetooth" title="bluetooth">
+    <figcaption>bluetooth</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/boiler_viessmann.png" alt="boiler_viessmann" title="boiler_viessmann">
+    <figcaption>boiler_viessmann</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/boy_1.png" alt="boy_1" title="boy_1">
+    <figcaption>boy_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/boy_2.png" alt="boy_2" title="boy_2">
+    <figcaption>boy_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/boy_3.png" alt="boy_3" title="boy_3">
+    <figcaption>boy_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/boy_4.png" alt="boy_4" title="boy_4">
+    <figcaption>boy_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/boy_5.png" alt="boy_5" title="boy_5">
+    <figcaption>boy_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/boy_6.png" alt="boy_6" title="boy_6">
+    <figcaption>boy_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/calendar.png" alt="calendar" title="calendar">
+    <figcaption>calendar</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/camera.png" alt="camera" title="camera">
+    <figcaption>camera</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/carbondioxide.png" alt="carbondioxide" title="carbondioxide">
+    <figcaption>carbondioxide</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cellar.png" alt="cellar" title="cellar">
+    <figcaption>cellar</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/chart.png" alt="chart" title="chart">
+    <figcaption>chart</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinema.png" alt="cinema" title="cinema">
+    <figcaption>cinema</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen.png" alt="cinemascreen" title="cinemascreen">
+    <figcaption>cinemascreen</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-0.png" alt="cinemascreen-0" title="cinemascreen-0">
+    <figcaption>cinemascreen-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-10.png" alt="cinemascreen-10" title="cinemascreen-10">
+    <figcaption>cinemascreen-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-20.png" alt="cinemascreen-20" title="cinemascreen-20">
+    <figcaption>cinemascreen-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-30.png" alt="cinemascreen-30" title="cinemascreen-30">
+    <figcaption>cinemascreen-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-40.png" alt="cinemascreen-40" title="cinemascreen-40">
+    <figcaption>cinemascreen-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-50.png" alt="cinemascreen-50" title="cinemascreen-50">
+    <figcaption>cinemascreen-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-60.png" alt="cinemascreen-60" title="cinemascreen-60">
+    <figcaption>cinemascreen-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-70.png" alt="cinemascreen-70" title="cinemascreen-70">
+    <figcaption>cinemascreen-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-80.png" alt="cinemascreen-80" title="cinemascreen-80">
+    <figcaption>cinemascreen-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-90.png" alt="cinemascreen-90" title="cinemascreen-90">
+    <figcaption>cinemascreen-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cinemascreen-100.png" alt="cinemascreen-100" title="cinemascreen-100">
+    <figcaption>cinemascreen-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern.png" alt="cistern" title="cistern">
+    <figcaption>cistern</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-0.png" alt="cistern-0" title="cistern-0">
+    <figcaption>cistern-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-10.png" alt="cistern-10" title="cistern-10">
+    <figcaption>cistern-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-20.png" alt="cistern-20" title="cistern-20">
+    <figcaption>cistern-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-30.png" alt="cistern-30" title="cistern-30">
+    <figcaption>cistern-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-40.png" alt="cistern-40" title="cistern-40">
+    <figcaption>cistern-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-50.png" alt="cistern-50" title="cistern-50">
+    <figcaption>cistern-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-60.png" alt="cistern-60" title="cistern-60">
+    <figcaption>cistern-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-70.png" alt="cistern-70" title="cistern-70">
+    <figcaption>cistern-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-80.png" alt="cistern-80" title="cistern-80">
+    <figcaption>cistern-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-90.png" alt="cistern-90" title="cistern-90">
+    <figcaption>cistern-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/cistern-100.png" alt="cistern-100" title="cistern-100">
+    <figcaption>cistern-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/climate.png" alt="climate" title="climate">
+    <figcaption>climate</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/climate-on.png" alt="climate-on" title="climate-on">
+    <figcaption>climate-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/clock.png" alt="clock" title="clock">
+    <figcaption>clock</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/clock-on.png" alt="clock-on" title="clock-on">
+    <figcaption>clock-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/colorlight.png" alt="colorlight" title="colorlight">
+    <figcaption>colorlight</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/colorpicker.png" alt="colorpicker" title="colorpicker">
+    <figcaption>colorpicker</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/colorwheel.png" alt="colorwheel" title="colorwheel">
+    <figcaption>colorwheel</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/contact.png" alt="contact" title="contact">
+    <figcaption>contact</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/contact-ajar.png" alt="contact-ajar" title="contact-ajar">
+    <figcaption>contact-ajar</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/contact-closed.png" alt="contact-closed" title="contact-closed">
+    <figcaption>contact-closed</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/contact-open.png" alt="contact-open" title="contact-open">
+    <figcaption>contact-open</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/corridor.png" alt="corridor" title="corridor">
+    <figcaption>corridor</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight.png" alt="dimmablelight" title="dimmablelight">
+    <figcaption>dimmablelight</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-0.png" alt="dimmablelight-0" title="dimmablelight-0">
+    <figcaption>dimmablelight-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-10.png" alt="dimmablelight-10" title="dimmablelight-10">
+    <figcaption>dimmablelight-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-20.png" alt="dimmablelight-20" title="dimmablelight-20">
+    <figcaption>dimmablelight-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-30.png" alt="dimmablelight-30" title="dimmablelight-30">
+    <figcaption>dimmablelight-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-40.png" alt="dimmablelight-40" title="dimmablelight-40">
+    <figcaption>dimmablelight-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-50.png" alt="dimmablelight-50" title="dimmablelight-50">
+    <figcaption>dimmablelight-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-60.png" alt="dimmablelight-60" title="dimmablelight-60">
+    <figcaption>dimmablelight-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-70.png" alt="dimmablelight-70" title="dimmablelight-70">
+    <figcaption>dimmablelight-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-80.png" alt="dimmablelight-80" title="dimmablelight-80">
+    <figcaption>dimmablelight-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-90.png" alt="dimmablelight-90" title="dimmablelight-90">
+    <figcaption>dimmablelight-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dimmablelight-100.png" alt="dimmablelight-100" title="dimmablelight-100">
+    <figcaption>dimmablelight-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/door.png" alt="door" title="door">
+    <figcaption>door</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/door-closed.png" alt="door-closed" title="door-closed">
+    <figcaption>door-closed</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/door-open.png" alt="door-open" title="door-open">
+    <figcaption>door-open</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dryer.png" alt="dryer" title="dryer">
+    <figcaption>dryer</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dryer-0.png" alt="dryer-0" title="dryer-0">
+    <figcaption>dryer-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dryer-1.png" alt="dryer-1" title="dryer-1">
+    <figcaption>dryer-1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dryer-2.png" alt="dryer-2" title="dryer-2">
+    <figcaption>dryer-2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dryer-3.png" alt="dryer-3" title="dryer-3">
+    <figcaption>dryer-3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dryer-4.png" alt="dryer-4" title="dryer-4">
+    <figcaption>dryer-4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/dryer-5.png" alt="dryer-5" title="dryer-5">
+    <figcaption>dryer-5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/energy.png" alt="energy" title="energy">
+    <figcaption>energy</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/error.png" alt="error" title="error">
+    <figcaption>error</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/fan.png" alt="fan" title="fan">
+    <figcaption>fan</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/fan_box.png" alt="fan_box" title="fan_box">
+    <figcaption>fan_box</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/fan_ceiling.png" alt="fan_ceiling" title="fan_ceiling">
+    <figcaption>fan_ceiling</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/faucet.png" alt="faucet" title="faucet">
+    <figcaption>faucet</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/fire.png" alt="fire" title="fire">
+    <figcaption>fire</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/fire-off.png" alt="fire-off" title="fire-off">
+    <figcaption>fire-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/fire-on.png" alt="fire-on" title="fire-on">
+    <figcaption>fire-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/firstfloor.png" alt="firstfloor" title="firstfloor">
+    <figcaption>firstfloor</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/flow.png" alt="flow" title="flow">
+    <figcaption>flow</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/flowpipe.png" alt="flowpipe" title="flowpipe">
+    <figcaption>flowpipe</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/frontdoor.png" alt="frontdoor" title="frontdoor">
+    <figcaption>frontdoor</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/frontdoor-closed.png" alt="frontdoor-closed" title="frontdoor-closed">
+    <figcaption>frontdoor-closed</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/frontdoor-open.png" alt="frontdoor-open" title="frontdoor-open">
+    <figcaption>frontdoor-open</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garage.png" alt="garage" title="garage">
+    <figcaption>garage</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor.png" alt="garagedoor" title="garagedoor">
+    <figcaption>garagedoor</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-0.png" alt="garagedoor-0" title="garagedoor-0">
+    <figcaption>garagedoor-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-10.png" alt="garagedoor-10" title="garagedoor-10">
+    <figcaption>garagedoor-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-20.png" alt="garagedoor-20" title="garagedoor-20">
+    <figcaption>garagedoor-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-30.png" alt="garagedoor-30" title="garagedoor-30">
+    <figcaption>garagedoor-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-40.png" alt="garagedoor-40" title="garagedoor-40">
+    <figcaption>garagedoor-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-50.png" alt="garagedoor-50" title="garagedoor-50">
+    <figcaption>garagedoor-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-60.png" alt="garagedoor-60" title="garagedoor-60">
+    <figcaption>garagedoor-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-70.png" alt="garagedoor-70" title="garagedoor-70">
+    <figcaption>garagedoor-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-80.png" alt="garagedoor-80" title="garagedoor-80">
+    <figcaption>garagedoor-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-90.png" alt="garagedoor-90" title="garagedoor-90">
+    <figcaption>garagedoor-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-100.png" alt="garagedoor-100" title="garagedoor-100">
+    <figcaption>garagedoor-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-ajar.png" alt="garagedoor-ajar" title="garagedoor-ajar">
+    <figcaption>garagedoor-ajar</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-closed.png" alt="garagedoor-closed" title="garagedoor-closed">
+    <figcaption>garagedoor-closed</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garagedoor-open.png" alt="garagedoor-open" title="garagedoor-open">
+    <figcaption>garagedoor-open</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garage_detached.png" alt="garage_detached" title="garage_detached">
+    <figcaption>garage_detached</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garage_detached_selected.png" alt="garage_detached_selected" title="garage_detached_selected">
+    <figcaption>garage_detached_selected</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/garden.png" alt="garden" title="garden">
+    <figcaption>garden</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/gas.png" alt="gas" title="gas">
+    <figcaption>gas</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/girl_1.png" alt="girl_1" title="girl_1">
+    <figcaption>girl_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/girl_2.png" alt="girl_2" title="girl_2">
+    <figcaption>girl_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/girl_3.png" alt="girl_3" title="girl_3">
+    <figcaption>girl_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/girl_4.png" alt="girl_4" title="girl_4">
+    <figcaption>girl_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/girl_5.png" alt="girl_5" title="girl_5">
+    <figcaption>girl_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/girl_6.png" alt="girl_6" title="girl_6">
+    <figcaption>girl_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/grass.png" alt="grass" title="grass">
+    <figcaption>grass</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/greenhouse.png" alt="greenhouse" title="greenhouse">
+    <figcaption>greenhouse</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/groundfloor.png" alt="groundfloor" title="groundfloor">
+    <figcaption>groundfloor</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/group.png" alt="group" title="group">
+    <figcaption>group</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating.png" alt="heating" title="heating">
+    <figcaption>heating</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating-0.png" alt="heating-0" title="heating-0">
+    <figcaption>heating-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating-20.png" alt="heating-20" title="heating-20">
+    <figcaption>heating-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating-40.png" alt="heating-40" title="heating-40">
+    <figcaption>heating-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating-60.png" alt="heating-60" title="heating-60">
+    <figcaption>heating-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating-80.png" alt="heating-80" title="heating-80">
+    <figcaption>heating-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating-100.png" alt="heating-100" title="heating-100">
+    <figcaption>heating-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating-off.png" alt="heating-off" title="heating-off">
+    <figcaption>heating-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/heating-on.png" alt="heating-on" title="heating-on">
+    <figcaption>heating-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/house.png" alt="house" title="house">
+    <figcaption>house</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity.png" alt="humidity" title="humidity">
+    <figcaption>humidity</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-0.png" alt="humidity-0" title="humidity-0">
+    <figcaption>humidity-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-10.png" alt="humidity-10" title="humidity-10">
+    <figcaption>humidity-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-20.png" alt="humidity-20" title="humidity-20">
+    <figcaption>humidity-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-30.png" alt="humidity-30" title="humidity-30">
+    <figcaption>humidity-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-40.png" alt="humidity-40" title="humidity-40">
+    <figcaption>humidity-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-50.png" alt="humidity-50" title="humidity-50">
+    <figcaption>humidity-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-60.png" alt="humidity-60" title="humidity-60">
+    <figcaption>humidity-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-70.png" alt="humidity-70" title="humidity-70">
+    <figcaption>humidity-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-80.png" alt="humidity-80" title="humidity-80">
+    <figcaption>humidity-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-90.png" alt="humidity-90" title="humidity-90">
+    <figcaption>humidity-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/humidity-100.png" alt="humidity-100" title="humidity-100">
+    <figcaption>humidity-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/incline.png" alt="incline" title="incline">
+    <figcaption>incline</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/keyring.png" alt="keyring" title="keyring">
+    <figcaption>keyring</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/kitchen.png" alt="kitchen" title="kitchen">
+    <figcaption>kitchen</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/light.png" alt="light" title="light">
+    <figcaption>light</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/light-off.png" alt="light-off" title="light-off">
+    <figcaption>light-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/light-on.png" alt="light-on" title="light-on">
+    <figcaption>light-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/line.png" alt="line" title="line">
+    <figcaption>line</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/line-decline.png" alt="line-decline" title="line-decline">
+    <figcaption>line-decline</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/line-incline.png" alt="line-incline" title="line-incline">
+    <figcaption>line-incline</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/line-stagnation.png" alt="line-stagnation" title="line-stagnation">
+    <figcaption>line-stagnation</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/lock.png" alt="lock" title="lock">
+    <figcaption>lock</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/lock-closed.png" alt="lock-closed" title="lock-closed">
+    <figcaption>lock-closed</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/lock-open.png" alt="lock-open" title="lock-open">
+    <figcaption>lock-open</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/man_1.png" alt="man_1" title="man_1">
+    <figcaption>man_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/man_2.png" alt="man_2" title="man_2">
+    <figcaption>man_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/man_3.png" alt="man_3" title="man_3">
+    <figcaption>man_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/man_4.png" alt="man_4" title="man_4">
+    <figcaption>man_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/man_5.png" alt="man_5" title="man_5">
+    <figcaption>man_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/man_6.png" alt="man_6" title="man_6">
+    <figcaption>man_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/microphone.png" alt="microphone" title="microphone">
+    <figcaption>microphone</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/moon.png" alt="moon" title="moon">
+    <figcaption>moon</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/motion.png" alt="motion" title="motion">
+    <figcaption>motion</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/movecontrol.png" alt="movecontrol" title="movecontrol">
+    <figcaption>movecontrol</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/network.png" alt="network" title="network">
+    <figcaption>network</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/network-off.png" alt="network-off" title="network-off">
+    <figcaption>network-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/network-on.png" alt="network-on" title="network-on">
+    <figcaption>network-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/niveau.png" alt="niveau" title="niveau">
+    <figcaption>niveau</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/office.png" alt="office" title="office">
+    <figcaption>office</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/oil.png" alt="oil" title="oil">
+    <figcaption>oil</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/outdoorlight.png" alt="outdoorlight" title="outdoorlight">
+    <figcaption>outdoorlight</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/pantry.png" alt="pantry" title="pantry">
+    <figcaption>pantry</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents-off.png" alt="parents-off" title="parents-off">
+    <figcaption>parents-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_1_1.png" alt="parents_1_1" title="parents_1_1">
+    <figcaption>parents_1_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_1_2.png" alt="parents_1_2" title="parents_1_2">
+    <figcaption>parents_1_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_1_3.png" alt="parents_1_3" title="parents_1_3">
+    <figcaption>parents_1_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_1_4.png" alt="parents_1_4" title="parents_1_4">
+    <figcaption>parents_1_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_1_5.png" alt="parents_1_5" title="parents_1_5">
+    <figcaption>parents_1_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_1_6.png" alt="parents_1_6" title="parents_1_6">
+    <figcaption>parents_1_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_2_1.png" alt="parents_2_1" title="parents_2_1">
+    <figcaption>parents_2_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_2_2.png" alt="parents_2_2" title="parents_2_2">
+    <figcaption>parents_2_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_2_3.png" alt="parents_2_3" title="parents_2_3">
+    <figcaption>parents_2_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_2_4.png" alt="parents_2_4" title="parents_2_4">
+    <figcaption>parents_2_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_2_5.png" alt="parents_2_5" title="parents_2_5">
+    <figcaption>parents_2_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_2_6.png" alt="parents_2_6" title="parents_2_6">
+    <figcaption>parents_2_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_3_1.png" alt="parents_3_1" title="parents_3_1">
+    <figcaption>parents_3_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_3_2.png" alt="parents_3_2" title="parents_3_2">
+    <figcaption>parents_3_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_3_3.png" alt="parents_3_3" title="parents_3_3">
+    <figcaption>parents_3_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_3_4.png" alt="parents_3_4" title="parents_3_4">
+    <figcaption>parents_3_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_3_5.png" alt="parents_3_5" title="parents_3_5">
+    <figcaption>parents_3_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_3_6.png" alt="parents_3_6" title="parents_3_6">
+    <figcaption>parents_3_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_4_1.png" alt="parents_4_1" title="parents_4_1">
+    <figcaption>parents_4_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_4_2.png" alt="parents_4_2" title="parents_4_2">
+    <figcaption>parents_4_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_4_3.png" alt="parents_4_3" title="parents_4_3">
+    <figcaption>parents_4_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_4_4.png" alt="parents_4_4" title="parents_4_4">
+    <figcaption>parents_4_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_4_5.png" alt="parents_4_5" title="parents_4_5">
+    <figcaption>parents_4_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_4_6.png" alt="parents_4_6" title="parents_4_6">
+    <figcaption>parents_4_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_5_1.png" alt="parents_5_1" title="parents_5_1">
+    <figcaption>parents_5_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_5_2.png" alt="parents_5_2" title="parents_5_2">
+    <figcaption>parents_5_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_5_3.png" alt="parents_5_3" title="parents_5_3">
+    <figcaption>parents_5_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_5_4.png" alt="parents_5_4" title="parents_5_4">
+    <figcaption>parents_5_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_5_5.png" alt="parents_5_5" title="parents_5_5">
+    <figcaption>parents_5_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_5_6.png" alt="parents_5_6" title="parents_5_6">
+    <figcaption>parents_5_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_6_1.png" alt="parents_6_1" title="parents_6_1">
+    <figcaption>parents_6_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_6_2.png" alt="parents_6_2" title="parents_6_2">
+    <figcaption>parents_6_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_6_3.png" alt="parents_6_3" title="parents_6_3">
+    <figcaption>parents_6_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_6_4.png" alt="parents_6_4" title="parents_6_4">
+    <figcaption>parents_6_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_6_5.png" alt="parents_6_5" title="parents_6_5">
+    <figcaption>parents_6_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/parents_6_6.png" alt="parents_6_6" title="parents_6_6">
+    <figcaption>parents_6_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/party.png" alt="party" title="party">
+    <figcaption>party</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/pie.png" alt="pie" title="pie">
+    <figcaption>pie</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/piggybank.png" alt="piggybank" title="piggybank">
+    <figcaption>piggybank</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/player.png" alt="player" title="player">
+    <figcaption>player</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/poweroutlet.png" alt="poweroutlet" title="poweroutlet">
+    <figcaption>poweroutlet</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/poweroutlet-off.png" alt="poweroutlet-off" title="poweroutlet-off">
+    <figcaption>poweroutlet-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/poweroutlet-on.png" alt="poweroutlet-on" title="poweroutlet-on">
+    <figcaption>poweroutlet-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/poweroutlet_au.png" alt="poweroutlet_au" title="poweroutlet_au">
+    <figcaption>poweroutlet_au</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/poweroutlet_eu.png" alt="poweroutlet_eu" title="poweroutlet_eu">
+    <figcaption>poweroutlet_eu</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/poweroutlet_uk.png" alt="poweroutlet_uk" title="poweroutlet_uk">
+    <figcaption>poweroutlet_uk</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/poweroutlet_us.png" alt="poweroutlet_us" title="poweroutlet_us">
+    <figcaption>poweroutlet_us</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/present.png" alt="present" title="present">
+    <figcaption>present</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/present-off.png" alt="present-off" title="present-off">
+    <figcaption>present-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/pressure.png" alt="pressure" title="pressure">
+    <figcaption>pressure</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/projector_benq.png" alt="projector_benq" title="projector_benq">
+    <figcaption>projector_benq</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/pump.png" alt="pump" title="pump">
+    <figcaption>pump</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/qualityofservice.png" alt="qualityofservice" title="qualityofservice">
+    <figcaption>qualityofservice</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/qualityofservice-0.png" alt="qualityofservice-0" title="qualityofservice-0">
+    <figcaption>qualityofservice-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/qualityofservice-1.png" alt="qualityofservice-1" title="qualityofservice-1">
+    <figcaption>qualityofservice-1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/qualityofservice-2.png" alt="qualityofservice-2" title="qualityofservice-2">
+    <figcaption>qualityofservice-2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/qualityofservice-3.png" alt="qualityofservice-3" title="qualityofservice-3">
+    <figcaption>qualityofservice-3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/qualityofservice-4.png" alt="qualityofservice-4" title="qualityofservice-4">
+    <figcaption>qualityofservice-4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/radiator.png" alt="radiator" title="radiator">
+    <figcaption>radiator</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rain.png" alt="rain" title="rain">
+    <figcaption>rain</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/receiver.png" alt="receiver" title="receiver">
+    <figcaption>receiver</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/receiver-off.png" alt="receiver-off" title="receiver-off">
+    <figcaption>receiver-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/receiver-on.png" alt="receiver-on" title="receiver-on">
+    <figcaption>receiver-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/recorder.png" alt="recorder" title="recorder">
+    <figcaption>recorder</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/returnpipe.png" alt="returnpipe" title="returnpipe">
+    <figcaption>returnpipe</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rgb.png" alt="rgb" title="rgb">
+    <figcaption>rgb</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter.png" alt="rollershutter" title="rollershutter">
+    <figcaption>rollershutter</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-0.png" alt="rollershutter-0" title="rollershutter-0">
+    <figcaption>rollershutter-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-10.png" alt="rollershutter-10" title="rollershutter-10">
+    <figcaption>rollershutter-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-20.png" alt="rollershutter-20" title="rollershutter-20">
+    <figcaption>rollershutter-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-30.png" alt="rollershutter-30" title="rollershutter-30">
+    <figcaption>rollershutter-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-40.png" alt="rollershutter-40" title="rollershutter-40">
+    <figcaption>rollershutter-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-50.png" alt="rollershutter-50" title="rollershutter-50">
+    <figcaption>rollershutter-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-60.png" alt="rollershutter-60" title="rollershutter-60">
+    <figcaption>rollershutter-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-70.png" alt="rollershutter-70" title="rollershutter-70">
+    <figcaption>rollershutter-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-80.png" alt="rollershutter-80" title="rollershutter-80">
+    <figcaption>rollershutter-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-90.png" alt="rollershutter-90" title="rollershutter-90">
+    <figcaption>rollershutter-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/rollershutter-100.png" alt="rollershutter-100" title="rollershutter-100">
+    <figcaption>rollershutter-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/settings.png" alt="settings" title="settings">
+    <figcaption>settings</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage.png" alt="sewerage" title="sewerage">
+    <figcaption>sewerage</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-0.png" alt="sewerage-0" title="sewerage-0">
+    <figcaption>sewerage-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-10.png" alt="sewerage-10" title="sewerage-10">
+    <figcaption>sewerage-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-20.png" alt="sewerage-20" title="sewerage-20">
+    <figcaption>sewerage-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-30.png" alt="sewerage-30" title="sewerage-30">
+    <figcaption>sewerage-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-40.png" alt="sewerage-40" title="sewerage-40">
+    <figcaption>sewerage-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-50.png" alt="sewerage-50" title="sewerage-50">
+    <figcaption>sewerage-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-60.png" alt="sewerage-60" title="sewerage-60">
+    <figcaption>sewerage-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-70.png" alt="sewerage-70" title="sewerage-70">
+    <figcaption>sewerage-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-80.png" alt="sewerage-80" title="sewerage-80">
+    <figcaption>sewerage-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-90.png" alt="sewerage-90" title="sewerage-90">
+    <figcaption>sewerage-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sewerage-100.png" alt="sewerage-100" title="sewerage-100">
+    <figcaption>sewerage-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/shield.png" alt="shield" title="shield">
+    <figcaption>shield</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/shield-0.png" alt="shield-0" title="shield-0">
+    <figcaption>shield-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/shield-1.png" alt="shield-1" title="shield-1">
+    <figcaption>shield-1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/signal.png" alt="signal" title="signal">
+    <figcaption>signal</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/signal-0.png" alt="signal-0" title="signal-0">
+    <figcaption>signal-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/signal-1.png" alt="signal-1" title="signal-1">
+    <figcaption>signal-1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/signal-2.png" alt="signal-2" title="signal-2">
+    <figcaption>signal-2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/signal-3.png" alt="signal-3" title="signal-3">
+    <figcaption>signal-3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/signal-4.png" alt="signal-4" title="signal-4">
+    <figcaption>signal-4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/siren.png" alt="siren" title="siren">
+    <figcaption>siren</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/siren-off.png" alt="siren-off" title="siren-off">
+    <figcaption>siren-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/siren-on.png" alt="siren-on" title="siren-on">
+    <figcaption>siren-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider.png" alt="slider" title="slider">
+    <figcaption>slider</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-0.png" alt="slider-0" title="slider-0">
+    <figcaption>slider-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-10.png" alt="slider-10" title="slider-10">
+    <figcaption>slider-10</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-20.png" alt="slider-20" title="slider-20">
+    <figcaption>slider-20</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-30.png" alt="slider-30" title="slider-30">
+    <figcaption>slider-30</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-40.png" alt="slider-40" title="slider-40">
+    <figcaption>slider-40</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-50.png" alt="slider-50" title="slider-50">
+    <figcaption>slider-50</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-60.png" alt="slider-60" title="slider-60">
+    <figcaption>slider-60</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-70.png" alt="slider-70" title="slider-70">
+    <figcaption>slider-70</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-80.png" alt="slider-80" title="slider-80">
+    <figcaption>slider-80</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-90.png" alt="slider-90" title="slider-90">
+    <figcaption>slider-90</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/slider-100.png" alt="slider-100" title="slider-100">
+    <figcaption>slider-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/smiley.png" alt="smiley" title="smiley">
+    <figcaption>smiley</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/smoke.png" alt="smoke" title="smoke">
+    <figcaption>smoke</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sofa.png" alt="sofa" title="sofa">
+    <figcaption>sofa</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/softener.png" alt="softener" title="softener">
+    <figcaption>softener</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/solarplant.png" alt="solarplant" title="solarplant">
+    <figcaption>solarplant</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/soundvolume.png" alt="soundvolume" title="soundvolume">
+    <figcaption>soundvolume</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/soundvolume-0.png" alt="soundvolume-0" title="soundvolume-0">
+    <figcaption>soundvolume-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/soundvolume-33.png" alt="soundvolume-33" title="soundvolume-33">
+    <figcaption>soundvolume-33</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/soundvolume-66.png" alt="soundvolume-66" title="soundvolume-66">
+    <figcaption>soundvolume-66</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/soundvolume-100.png" alt="soundvolume-100" title="soundvolume-100">
+    <figcaption>soundvolume-100</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/soundvolume_mute.png" alt="soundvolume_mute" title="soundvolume_mute">
+    <figcaption>soundvolume_mute</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/status.png" alt="status" title="status">
+    <figcaption>status</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/suitcase.png" alt="suitcase" title="suitcase">
+    <figcaption>suitcase</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sun.png" alt="sun" title="sun">
+    <figcaption>sun</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sunrise.png" alt="sunrise" title="sunrise">
+    <figcaption>sunrise</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sunset.png" alt="sunset" title="sunset">
+    <figcaption>sunset</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/sun_clouds.png" alt="sun_clouds" title="sun_clouds">
+    <figcaption>sun_clouds</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/switch.png" alt="switch" title="switch">
+    <figcaption>switch</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/switch-off.png" alt="switch-off" title="switch-off">
+    <figcaption>switch-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/switch-on.png" alt="switch-on" title="switch-on">
+    <figcaption>switch-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/television.png" alt="television" title="television">
+    <figcaption>television</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/television-off.png" alt="television-off" title="television-off">
+    <figcaption>television-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/television-on.png" alt="television-on" title="television-on">
+    <figcaption>television-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/temperature.png" alt="temperature" title="temperature">
+    <figcaption>temperature</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/temperature_cold.png" alt="temperature_cold" title="temperature_cold">
+    <figcaption>temperature_cold</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/temperature_hot.png" alt="temperature_hot" title="temperature_hot">
+    <figcaption>temperature_hot</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/terrace.png" alt="terrace" title="terrace">
+    <figcaption>terrace</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/text.png" alt="text" title="text">
+    <figcaption>text</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/toilet.png" alt="toilet" title="toilet">
+    <figcaption>toilet</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/vacation.png" alt="vacation" title="vacation">
+    <figcaption>vacation</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/video.png" alt="video" title="video">
+    <figcaption>video</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/wallswitch.png" alt="wallswitch" title="wallswitch">
+    <figcaption>wallswitch</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/wallswitch-off.png" alt="wallswitch-off" title="wallswitch-off">
+    <figcaption>wallswitch-off</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/wallswitch-on.png" alt="wallswitch-on" title="wallswitch-on">
+    <figcaption>wallswitch-on</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/wardrobe.png" alt="wardrobe" title="wardrobe">
+    <figcaption>wardrobe</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/washingmachine.png" alt="washingmachine" title="washingmachine">
+    <figcaption>washingmachine</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/washingmachine_2.png" alt="washingmachine_2" title="washingmachine_2">
+    <figcaption>washingmachine_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/washingmachine_2-0.png" alt="washingmachine_2-0" title="washingmachine_2-0">
+    <figcaption>washingmachine_2-0</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/washingmachine_2-1.png" alt="washingmachine_2-1" title="washingmachine_2-1">
+    <figcaption>washingmachine_2-1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/washingmachine_2-2.png" alt="washingmachine_2-2" title="washingmachine_2-2">
+    <figcaption>washingmachine_2-2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/washingmachine_2-3.png" alt="washingmachine_2-3" title="washingmachine_2-3">
+    <figcaption>washingmachine_2-3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/water.png" alt="water" title="water">
+    <figcaption>water</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/wind.png" alt="wind" title="wind">
+    <figcaption>wind</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/window.png" alt="window" title="window">
+    <figcaption>window</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/window-ajar.png" alt="window-ajar" title="window-ajar">
+    <figcaption>window-ajar</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/window-closed.png" alt="window-closed" title="window-closed">
+    <figcaption>window-closed</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/window-open.png" alt="window-open" title="window-open">
+    <figcaption>window-open</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/woman_1.png" alt="woman_1" title="woman_1">
+    <figcaption>woman_1</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/woman_2.png" alt="woman_2" title="woman_2">
+    <figcaption>woman_2</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/woman_3.png" alt="woman_3" title="woman_3">
+    <figcaption>woman_3</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/woman_4.png" alt="woman_4" title="woman_4">
+    <figcaption>woman_4</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/woman_5.png" alt="woman_5" title="woman_5">
+    <figcaption>woman_5</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/woman_6.png" alt="woman_6" title="woman_6">
+    <figcaption>woman_6</figcaption>
+  </figure>
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="icons/zoom.png" alt="zoom" title="zoom">
+    <figcaption>zoom</figcaption>
+  </figure>
+</div>

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/README.sh
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/README.sh
@@ -1,23 +1,27 @@
 #!/usr/bin/env sh
 
+READMEMD="$(cd "$(dirname "$0")"; pwd)/README.md"
 
-README="$(cd "$(dirname "$0")"; pwd)/README.md"
-
-
-cat <<EOF > "${README}"
+cat <<EOF > "$READMEMD"
 # Classic Icon Set
 
-This is a modernized version of the original icon set of openHAB 1. The set is provided with the distribution in both the PNG and SVG file format. Move your mouse over an icon to learn its name.<br/><br/>
+This is a modernized version of the original icon set from openHAB 1.x.
+The set is provided with the distribution in both the PNG and SVG file format.
 
+<div id="iconset-preview">
 EOF
 
-
 for icon in $(ls icons/*.png | sort -V); do
-
-  name="$(basename "${icon}" | cut -d '.' -f1)"
-
-  if [ "${name}" != 'none' ]; then
-    echo "![${name}](${icon} \"${name}\")" >> "${README}"
-  fi
-
+  name="$(basename "$icon" | cut -d '.' -f1)"
+  echo "Adding icon '$name'"
+  if [ "$name" = "none" ]; then continue; fi
+  cat <<EOF >> "$READMEMD"
+  <figure style="width: 128px; display: inline-block; text-align: center; font-size: 0.8em; margin: 16px 8px;">
+    <img src="$icon" alt="$name" title="$name">
+    <figcaption>$name</figcaption>
+  </figure>
+EOF
 done
+
+echo "</div>" >> "$READMEMD"
+echo "Finished."


### PR DESCRIPTION
Add HTML5 figure and figcaption elements to the iconset preview:

![grafik](https://user-images.githubusercontent.com/2870104/27980865-7e74a54c-6383-11e7-8d58-f5dc67fde2cc.png)

You'll find that the style is inline. I promise to move it to css as soon as style.css is unified between ESH and openhab-docs. If you insist I will look into it now.

Signed-off-by: Thomas Dietrich <Thomas.Dietrich@tu-ilmenau.de>