### PR TITLE
remove apache commons http client from target platform

### DIFF
--- a/features/karaf/esh-tp/src/main/feature/feature.xml
+++ b/features/karaf/esh-tp/src/main/feature/feature.xml
@@ -34,7 +34,6 @@
     <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.1</bundle>
     <bundle dependency="true">mvn:org.apache.commons/commons-collections4/4.1</bundle>
     <bundle dependency="true">mvn:org.apache.commons/commons-exec/1.1</bundle>
-    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.commons-httpclient/3.1_7</bundle>
     <bundle dependency="true">mvn:commons-io/commons-io/2.2</bundle>
     <bundle dependency="true">mvn:commons-lang/commons-lang/2.6</bundle>
     <bundle dependency="true">mvn:org.apache.commons/commons-lang3/3.4</bundle>

--- a/targetplatform/smarthome.target
+++ b/targetplatform/smarthome.target
@@ -34,8 +34,6 @@
 <unit id="org.apache.commons.codec.source" version="1.6.0.v201305230611"/>
 <unit id="org.apache.commons.collections.source" version="3.2.0.v2013030210310"/>
 <unit id="org.apache.commons.collections" version="3.2.0.v2013030210310"/>
-<unit id="org.apache.commons.httpclient" version="3.1.0.v201012070820"/>
-<unit id="org.apache.commons.httpclient.source" version="3.1.0.v201012070820"/>
 <unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
 <unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
 <unit id="org.apache.commons.net" version="3.2.0.v201305141515"/>


### PR DESCRIPTION
Afair, we do not have any dependency on the Apache Commons HTTP client anymore.

Signed-off-by: Kai Kreuzer <kai@openhab.org>