### PR TITLE
Always correctly activate MDNS client, even if no networks are available

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
@@ -77,12 +77,8 @@ public class MDNSClientImpl implements MDNSClient {
                 jmdnsInstances.add(jmdns);
                 logger.debug("mDNS service has been started ({} for IP {})", jmdns.getName(), address.getHostAddress());
             } catch (IOException e) {
-                logger.debug("JmDNS instanciation failed ({})!", address.getHostAddress());
+                logger.debug("JmDNS instantiation failed ({})!", address.getHostAddress());
             }
-        }
-        if (jmdnsInstances.isEmpty()) {
-            // we must cancel the activation of this component here
-            throw new IllegalStateException("No mDNS service has been started");
         }
     }
 


### PR DESCRIPTION
It is in general no good idea to end an activate method by throwing an exception.
Imho there is nothing wrong to have the service available, even if no network interfaces were found (and hence `jmdnsInstances` is empty).

Signed-off-by: Kai Kreuzer <kai@openhab.org>