### PR TITLE
fixed license headers

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/i18n/TranslationProviderOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/i18n/TranslationProviderOSGiTest.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.smarthome.core.internal.i18n;
 
 import static org.hamcrest.CoreMatchers.*;

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/GroupItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/GroupItemTest.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.smarthome.core.items;
 
 import static org.hamcrest.CoreMatchers.*;

--- a/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/MagicColorLightHandlerTest.java
+++ b/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/MagicColorLightHandlerTest.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/MagicDimmableLightHandlerTest.java
+++ b/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/MagicDimmableLightHandlerTest.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/MagicOnOffLightHandlerTest.java
+++ b/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/MagicOnOffLightHandlerTest.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactoryTest.java
+++ b/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactoryTest.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImplTest.java
+++ b/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImplTest.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/OSGI-INF/MagicHandlerFactory.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/OSGI-INF/MagicHandlerFactory.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010-2017 by the respective copyright holders.
-
+    Copyright (c) 2014-2017 by the respective copyright holders.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/MagicBindingConstants.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/MagicBindingConstants.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/MagicService.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/MagicService.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicColorLightHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicColorLightHandler.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicContactHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicContactHandler.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicDimmableLightHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicDimmableLightHandler.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicOnOffLightHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicOnOffLightHandler.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImpl.java
@@ -1,6 +1,5 @@
 /**
- * Copyright (c) 2010-2017 by the respective copyright holders.
- *
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/src/main/java/org/eclipse/smarthome/binding/fsinternetradio/internal/radio/FrontierSiliconRadioConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/src/main/java/org/eclipse/smarthome/binding/fsinternetradio/internal/radio/FrontierSiliconRadioConstants.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.smarthome.binding.fsinternetradio.internal.radio;
 
 /**


### PR DESCRIPTION
* a few were missing
* some did not comply to mvn license:format again

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>