### PR TITLE
add missing import to MQTT transport manifest

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.smarthome.io.transport.mqtt
-Import-Package: javax.net,
+Import-Package: javax.naming,
+ javax.net,
  javax.net.ssl,
  org.apache.commons.lang,
  org.eclipse.paho.client.mqttv3,


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/3856
