### PR TITLE
Fix Eclipse Oxygen Installer

### DIFF
--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -2350,7 +2350,7 @@
       <repository
           url="http://download.eclipse.org/modeling/emf/emf/updates/milestones/"/>
       <repository
-          url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.6/"/>
+          url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.7/"/>
     </setupTask>
     <setupTask
         xsi:type="projects:ProjectsImportTask">


### PR DESCRIPTION
GREclipse in 4.6 is pulling in
org.eclipse.jdt.core_3.12.3.xx-201707192352-e46.jar which
is incompatible with Eclipse Oxygen using jdt 3.13

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>