### PR TITLE
Fix Astrobinding README (config was not in code tags and thus not shown)

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.astro/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/README.md
@@ -20,7 +20,7 @@ No binding configuration required.
 
 ## Thing Configuration
 
-All Things require the parameter `geolocation` (as "<latitude>,<longitude>,[<altitude in m>]") for which the calculation is done. 
+All Things require the parameter `geolocation` (as `<latitude>,<longitude>,[<altitude in m>]`) for which the calculation is done. 
 The altitude segment is optional and sharpens results provided by the Radiation group.
 Optionally, a refresh `interval` (in seconds) can be defined to also calculate positional data like azimuth and elevation.
 


### PR DESCRIPTION
Users to not see the example on this page:
http://docs.openhab.org/addons/bindings/astro/readme.html#thing-configuration

which leads to confusions here:
https://community.openhab.org/t/problem-setting-altitude-for-astro-binding/32017

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>