### PR TITLE
Add missing about.html files.

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/about.html
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/build.properties
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/build.properties
@@ -1,5 +1,6 @@
 bin.includes = .,\
                META-INF/,\
-               OSGI-INF/
+               OSGI-INF/,\
+               about.html
 source.. = src/test/groovy/
 output.. = target/classes/

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/about.html
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/build.properties
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/build.properties
@@ -2,4 +2,5 @@ source.. = src/main/java/
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\
-               OSGI-INF/
+               OSGI-INF/,\
+               about.html

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/about.html
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/build.properties
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/build.properties
@@ -1,4 +1,5 @@
 source.. = src/test/groovy/
 output.. = target/classes/
 bin.includes = META-INF/,\
-               .
+               .,\
+               about.html

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/build.properties
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/build.properties
@@ -2,4 +2,5 @@ source.. = src/main/java
 output.. = target/classes
 bin.includes = META-INF/,\
                .,\
-               OSGI-INF/
+               OSGI-INF/,\
+               about.html

--- a/bundles/model/org.eclipse.smarthome.model.core.test/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/build.properties
@@ -1,3 +1,4 @@
 source.. = src/test/java
 bin.includes = META-INF/,\
-               .
+               .,\
+               about.html

--- a/bundles/test/org.eclipse.smarthome.magic.test/about.html
+++ b/bundles/test/org.eclipse.smarthome.magic.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/bundles/test/org.eclipse.smarthome.magic.test/build.properties
+++ b/bundles/test/org.eclipse.smarthome.magic.test/build.properties
@@ -1,4 +1,6 @@
 source.. = src/test/java/
 output.. = target/classes
 bin.includes = META-INF/,\
-               .,
+               .,\
+               about.html
+

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/about.html
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/build.properties
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/build.properties
@@ -1,4 +1,5 @@
 source.. = src/test/groovy/
 output.. = target/test-classes/
 bin.includes = META-INF/,\
-               .
+               .,\
+               about.html

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/build.properties
@@ -3,4 +3,6 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
-               ESH-INF/
+               ESH-INF/,\
+               about.html
+

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/about.html
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/build.properties
@@ -1,5 +1,6 @@
 source.. = src/test/java/
 bin.includes = META-INF/,\
-               .
+               .,\
+               about.html
 output.. = bin/,\
            target/test-classes/

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/about.html
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/build.properties
@@ -1,4 +1,5 @@
 source.. = src/test/java/
 output.. = target/test-classes/
 bin.includes = META-INF/,\
-               .
+               .,\
+               about.html

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/about.html
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/build.properties
@@ -3,4 +3,5 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
-               ESH-INF/
+               ESH-INF/,\
+               about.html

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/build.properties
@@ -3,4 +3,6 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
-               ESH-INF/
+               ESH-INF/,\
+               about.html
+

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/about.html
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/build.properties
@@ -1,4 +1,5 @@
 source.. = src/test/java/
 output.. = target/classes
 bin.includes = META-INF/,\
-               .
+               .,\
+               about.html

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/about.html
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/build.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/build.properties
@@ -1,4 +1,5 @@
 source.. = src/main/groovy/
 output.. = target/classes/
 bin.includes = META-INF/,\
-               .
+               .,\
+               about.html

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/about.html
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>July 24, 2017</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/build.properties
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/build.properties
@@ -3,5 +3,6 @@ bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
                icons/,\
-               ESH-INF/
+               ESH-INF/,\
+               about.html
 source.. = src/main/java/


### PR DESCRIPTION
About.hmtl added to build.properties

Found by https://github.com/openhab/static-code-analysis.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>