### PR TITLE
Changed logger message instantiating NPE

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemUtil.java
@@ -78,7 +78,7 @@ public class ItemUtil {
 
     public static State convertToAcceptedState(State state, Item item) {
         if (state == null) {
-            LOGGER.error("A conversion of null was requested", new NullPointerException("state should not be null"));
+            LOGGER.error("A conversion of null was requested: state should not be null");
             return UnDefType.NULL;
         }
 


### PR DESCRIPTION
This was marked by PMD as error by the AvoidThrowingNullPointerException rule. Obviously the NPE is not thrown :), but anyway the instance here seems to be unnecessary.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>