### PR TITLE
export more packages of rest.core

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -54,7 +54,9 @@ Import-Package: com.google.common.base,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.slf4j
-Export-Package: org.eclipse.smarthome.io.rest.core.item,
+Export-Package: org.eclipse.smarthome.io.rest.core.config,
+ org.eclipse.smarthome.io.rest.core.service,
+ org.eclipse.smarthome.io.rest.core.item,
  org.eclipse.smarthome.io.rest.core.thing
 Service-Component: OSGI-INF/*.xml
 Bundle-Activator: org.eclipse.smarthome.io.rest.core.internal.RESTCoreActivator


### PR DESCRIPTION
The rest.core bundle already exports:
* org.eclipse.smarthome.io.rest.core.item
* org.eclipse.smarthome.io.rest.core.thing

I assume the packages are exported so other implementations can make use
of the DTO classes without the need to implement and maintain that
classes themselves.

The same should be true for e.g. ConfigurationService and
ConfigurableServiceDTO.
