### PR TITLE
BaseThingHandler initialize() now abstract, does not set Thing to ONLINE anymore

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
@@ -116,6 +116,8 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
             // check getBridge works
             assertThat getBridge().getUID().toString(), is("bindingId:type1:bridgeId")
         }
+
+        void initialize() {}
     }
 
     class SimpleBridgeHandler extends BaseBridgeHandler {
@@ -131,6 +133,8 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
         public void updateBridgetatus(ThingStatus status) {
             updateStatus(status)
         }
+
+        void initialize() {}
     }
 
 
@@ -313,6 +317,8 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
         public void handleCommand(ChannelUID channelUID, Command command) {
             // not implemented
         }
+
+        void initialize() {}
 
         @Override
         public Collection<ConfigStatusMessage> getConfigStatus() {

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
@@ -117,7 +117,10 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
             assertThat getBridge().getUID().toString(), is("bindingId:type1:bridgeId")
         }
 
-        void initialize() {}
+        @Override
+        void initialize() {
+            updateStatus(ThingStatus.ONLINE);
+        }
     }
 
     class SimpleBridgeHandler extends BaseBridgeHandler {
@@ -134,7 +137,10 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
             updateStatus(status)
         }
 
-        void initialize() {}
+        @Override
+        void initialize() {
+            updateStatus(ThingStatus.ONLINE);
+        }
     }
 
 
@@ -318,7 +324,10 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
             // not implemented
         }
 
-        void initialize() {}
+        @Override
+        void initialize() {
+            updateStatus(ThingStatus.ONLINE);
+        }
 
         @Override
         public Collection<ConfigStatusMessage> getConfigStatus() {
@@ -350,12 +359,12 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
 
         @Override
         public void initialize() {
-            super.initialize()
             ThingBuilder thingBuilder = editThing()
             thingBuilder.withChannels([
                 new Channel(new ChannelUID("bindingId:type:thingId:1"), "String")
             ])
             updateThing(thingBuilder.build())
+            updateStatus(ThingStatus.ONLINE)
         }
 
         @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ChangeThingTypeOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ChangeThingTypeOSGiTest.groovy
@@ -209,7 +209,7 @@ class ChangeThingTypeOSGiTest extends OSGiTest {
         @Override
         public void initialize() {
             println "[ChangeThingTypeOSGiTest] GenericThingHandler.initialize"
-            super.initialize()
+            updateStatus(ThingStatus.ONLINE)
             genericInits++;
             if (selfChanging) {
                 changeThingType(THING_TYPE_SPECIFIC_UID, new Configuration(['providedspecific':'there']))
@@ -233,7 +233,7 @@ class ChangeThingTypeOSGiTest extends OSGiTest {
         public void initialize() {
             println "[ChangeThingTypeOSGiTest] SpecificThingHandler.initialize"
             specificInits++;
-            super.initialize();
+            updateStatus(ThingStatus.ONLINE);
         }
 
         @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServiceOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServiceOSGiTest.groovy
@@ -1223,5 +1223,7 @@ final class FirmwareUpdateServiceOSGiTest extends OSGiTest {
         @Override
         public void handleCommand(ChannelUID channelUID, Command command) {
         }
+
+        void initialize() {}
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServiceOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServiceOSGiTest.groovy
@@ -210,7 +210,7 @@ final class FirmwareUpdateServiceOSGiTest extends OSGiTest {
             managedThingProvider = getService ManagedThingProvider
             assertThat managedThingProvider, is(notNullValue())
         }
-        
+
         thingRegistry = getService(ThingRegistry)
         assertThat thingRegistry, is(notNullValue())
 
@@ -1099,7 +1099,7 @@ final class FirmwareUpdateServiceOSGiTest extends OSGiTest {
         @Override
         public void initialize() {
             sleep wait
-            super.initialize();
+            updateStatus(ThingStatus.ONLINE)
         }
 
         @Override
@@ -1172,7 +1172,7 @@ final class FirmwareUpdateServiceOSGiTest extends OSGiTest {
         @Override
         public void initialize() {
             sleep wait
-            super.initialize()
+            updateStatus(ThingStatus.ONLINE)
         }
 
         @Override
@@ -1224,6 +1224,9 @@ final class FirmwareUpdateServiceOSGiTest extends OSGiTest {
         public void handleCommand(ChannelUID channelUID, Command command) {
         }
 
-        void initialize() {}
+        @Override
+        public void initialize() {
+            updateStatus(ThingStatus.ONLINE)
+        }
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.groovy
@@ -201,6 +201,8 @@ class ThingStatusInfoI18nLocalizationServiceOSGiTest extends OSGiTest {
             //do nothing
         }
 
+        public void initialize() {}
+
         void setThingStatusInfo(ThingStatusInfo thingStatusInfo) {
             updateStatus(thingStatusInfo.getStatus(), thingStatusInfo.getStatusDetail(), thingStatusInfo.getDescription())
         }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/i18n/ThingStatusInfoI18nLocalizationServiceOSGiTest.groovy
@@ -201,7 +201,10 @@ class ThingStatusInfoI18nLocalizationServiceOSGiTest extends OSGiTest {
             //do nothing
         }
 
-        public void initialize() {}
+        @Override
+        public void initialize() {
+            updateStatus(ThingStatus.ONLINE);
+        }
 
         void setThingStatusInfo(ThingStatusInfo thingStatusInfo) {
             updateStatus(thingStatusInfo.getStatus(), thingStatusInfo.getStatusDetail(), thingStatusInfo.getDescription())

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingLinkManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingLinkManagerOSGiTest.groovy
@@ -20,6 +20,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID
 import org.eclipse.smarthome.core.thing.ManagedThingProvider
 import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingRegistry
+import org.eclipse.smarthome.core.thing.ThingStatus
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler
@@ -175,7 +176,11 @@ class ThingLinkManagerOSGiTest extends OSGiTest {
         protected ThingHandler createHandler(Thing thing) {
             return new BaseThingHandler(thing) {
                         public void handleCommand(ChannelUID channelUID, Command command) { }
-                        public void initialize() {}
+
+                        @Override
+                        public void initialize() {
+                            updateStatus(ThingStatus.ONLINE);
+                        }
 
                         void channelLinked(ChannelUID channelUID) {
                             putContext("linkedChannel", channelUID)

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingLinkManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingLinkManagerOSGiTest.groovy
@@ -175,6 +175,7 @@ class ThingLinkManagerOSGiTest extends OSGiTest {
         protected ThingHandler createHandler(Thing thing) {
             return new BaseThingHandler(thing) {
                         public void handleCommand(ChannelUID channelUID, Command command) { }
+                        public void initialize() {}
 
                         void channelLinked(ChannelUID channelUID) {
                             putContext("linkedChannel", channelUID)

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -32,6 +32,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
@@ -299,6 +300,7 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
 
                 @Override
                 public void initialize() {
+                    updateStatus(ThingStatus.ONLINE);
                 }
             };
         }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -296,6 +296,10 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
                 @Override
                 public void handleCommand(ChannelUID channelUID, Command command) {
                 }
+
+                @Override
+                public void initialize() {
+                }
             };
         }
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -178,12 +178,7 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     @Override
-    public void initialize() {
-        // can be overridden by subclasses
-        // standard behavior is to set the thing to ONLINE,
-        // assuming no further initialization is necessary.
-        updateStatus(ThingStatus.ONLINE);
-    }
+    public abstract void initialize();
 
     @Override
     public void thingUpdated(Thing thing) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -178,7 +178,13 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     @Override
-    public abstract void initialize();
+    @Deprecated
+    public void initialize() {
+        // should be overridden by subclasses!
+        updateStatus(ThingStatus.ONLINE);
+        logger.warn(
+                "BaseThingHandler.initialize() will be removed soon, ThingStatus can be set manually via updateStatus(ThingStatus.ONLINE)");
+    }
 
     @Override
     public void thingUpdated(Thing thing) {

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactory.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactory.java
@@ -13,6 +13,7 @@ import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
@@ -104,6 +105,7 @@ public class TestHueThingHandlerFactory extends BaseThingHandlerFactory {
 
                 @Override
                 public void initialize() {
+                    updateStatus(ThingStatus.ONLINE);
                 }
             };
         } else {
@@ -114,6 +116,7 @@ public class TestHueThingHandlerFactory extends BaseThingHandlerFactory {
 
                 @Override
                 public void initialize() {
+                    updateStatus(ThingStatus.ONLINE);
                 }
             };
         }

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactory.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactory.java
@@ -101,11 +101,19 @@ public class TestHueThingHandlerFactory extends BaseThingHandlerFactory {
                 @Override
                 public void handleCommand(ChannelUID channelUID, Command command) {
                 }
+
+                @Override
+                public void initialize() {
+                }
             };
         } else {
             return new BaseThingHandler(thing) {
                 @Override
                 public void handleCommand(ChannelUID channelUID, Command command) {
+                }
+
+                @Override
+                public void initialize() {
                 }
             };
         }

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest4.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest4.groovy
@@ -118,6 +118,7 @@ class GenericThingProviderTest4 extends OSGiTest{
                         } else {
                             return new BaseThingHandler(thing) {
                                         void handleCommand(ChannelUID arg0, Command arg1) {};
+                                        void initialize() {}
                                     }
                         }
                     }

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest4.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest4.groovy
@@ -118,7 +118,10 @@ class GenericThingProviderTest4 extends OSGiTest{
                         } else {
                             return new BaseThingHandler(thing) {
                                         void handleCommand(ChannelUID arg0, Command arg1) {};
-                                        void initialize() {}
+                                        @Override
+                                        void initialize() {
+                                            updateState(ThingStatus.ONLINE);
+                                        }
                                     }
                         }
                     }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
@@ -216,8 +216,6 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
             if (this.notificationTimeout == null) {
                 this.notificationTimeout = DEFAULT_NOTIFICATION_TIMEOUT;
             }
-
-            updateStatus(ThingStatus.ONLINE);
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
             logger.warn("Cannot initalize the zoneplayer. UDN not set.");

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoBridgeHandler.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseBridgeHandler;
 import org.eclipse.smarthome.core.types.Command;
@@ -46,7 +47,7 @@ public class WemoBridgeHandler extends BaseBridgeHandler {
 
         if (configuration.get(UDN) != null) {
             logger.trace("Initializing WemoBridgeHandler for UDN '{}'", configuration.get(UDN));
-            super.initialize();
+            updateStatus(ThingStatus.ONLINE);
         } else {
             logger.debug("Cannot initalize WemoBridgeHandler. UDN not set.");
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoCoffeeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoCoffeeHandler.java
@@ -127,7 +127,7 @@ public class WemoCoffeeHandler extends BaseThingHandler implements UpnpIOPartici
             logger.debug("Initializing WemoCoffeeHandler for UDN '{}'", configuration.get("udn"));
             onSubscription();
             onUpdate();
-            super.initialize();
+            updateStatus(ThingStatus.ONLINE);
         } else {
             logger.debug("Cannot initalize WemoCoffeeHandler. UDN not set.");
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoHandler.java
@@ -119,7 +119,7 @@ public class WemoHandler extends BaseThingHandler implements UpnpIOParticipant, 
             logger.debug("Initializing WemoHandler for UDN '{}'", configuration.get("udn"));
             onSubscription();
             onUpdate();
-            super.initialize();
+            updateStatus(ThingStatus.ONLINE);
         } else {
             logger.debug("Cannot initalize WemoHandler. UDN not set.");
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoMakerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoMakerHandler.java
@@ -105,7 +105,7 @@ public class WemoMakerHandler extends BaseThingHandler implements UpnpIOParticip
         if (configuration.get("udn") != null) {
             logger.debug("Initializing WemoMakerHandler for UDN '{}'", configuration.get("udn"));
             onUpdate();
-            super.initialize();
+            updateStatus(ThingStatus.ONLINE);
         } else {
             logger.debug("Cannot initalize WemoMakerHandler. UDN not set.");
         }


### PR DESCRIPTION
The background for this PR is that a lot of new binding developers do the super call and "accidentally" set their thing to online.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>