### PR TITLE
use casted type for better readability and code checker

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolManager.java
@@ -111,16 +111,16 @@ public class ExpressionThreadPoolManager extends ThreadPoolManager {
             super.afterExecute(runnable, throwable);
 
             if (runnable instanceof Future) {
+                Future<?> future = (Future<?>) runnable;
                 try {
                     futuresLock.lock();
                     for (Runnable aRunnable : futures.keySet()) {
-                        futures.get(aRunnable).removeIf(future -> future == runnable);
+                        futures.get(aRunnable).removeIf(entry -> entry == future);
                     }
                 } finally {
                     futuresLock.unlock();
                 }
-                timestamps.remove(runnable);
-
+                timestamps.remove(future);
             } else {
                 List<ScheduledFuture<?>> obsoleteFutures = new ArrayList<ScheduledFuture<?>>();
                 try {


### PR DESCRIPTION
We should state that we know the correct type (for the other developers
and for code checking tools):

```
Unlikely argument type Runnable for remove(Object) on a Map<Future<?>,Date>
```
