### PR TITLE
implemented get in abstract class

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -63,18 +63,6 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
     }
 
     @Override
-    public Thing get(final ThingUID uid) {
-        for (final Map.Entry<Provider<Thing>, Collection<Thing>> entry : elementMap.entrySet()) {
-            for (final Thing thing : entry.getValue()) {
-                if (uid.equals(thing.getUID())) {
-                    return thing;
-                }
-            }
-        }
-        return null;
-    }
-
-    @Override
     public Channel getChannel(ChannelUID channelUID) {
         ThingUID thingUID = channelUID.getThingUID();
         Thing thing = get(thingUID);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/AbstractLinkRegistry.java
@@ -7,9 +7,7 @@
  */
 package org.eclipse.smarthome.core.thing.link;
 
-import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
@@ -83,18 +81,6 @@ public abstract class AbstractLinkRegistry<L extends AbstractLink, P extends Pro
             }
         }
         return links;
-    }
-
-    @Override
-    public L get(final String key) {
-        for (final Map.Entry<Provider<L>, Collection<L>> entry : elementMap.entrySet()) {
-            for (final L link : entry.getValue()) {
-                if (key.equals(link.getUID())) {
-                    return link;
-                }
-            }
-        }
-        return null;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
@@ -186,6 +186,18 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
     }
 
     @Override
+    public E get(K key) {
+        for (final Map.Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
+            for (final E element : entry.getValue()) {
+                if (key.equals(element.getUID())) {
+                    return element;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
     public E add(E element) {
         if (this.managedProvider != null) {
             this.managedProvider.add(element);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -12,10 +12,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
-import org.eclipse.smarthome.core.common.registry.Provider;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupItem;
@@ -29,8 +27,6 @@ import org.eclipse.smarthome.core.items.ManagedItemProvider;
 import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.types.StateDescriptionProvider;
 import org.osgi.service.component.ComponentContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This is the main implementing class of the {@link ItemRegistry} interface. It
@@ -43,8 +39,6 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvider> implements ItemRegistry {
-
-    private final Logger logger = LoggerFactory.getLogger(ItemRegistryImpl.class);
 
     private List<StateDescriptionProvider> stateDescriptionProviders = Collections
             .synchronizedList(new ArrayList<StateDescriptionProvider>());
@@ -61,18 +55,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         } else {
             return item;
         }
-    }
-
-    @Override
-    public Item get(final String itemName) {
-        for (final Map.Entry<Provider<Item>, Collection<Item>> entry : elementMap.entrySet()) {
-            for (final Item item : entry.getValue()) {
-                if (itemName.equals(item.getName())) {
-                    return item;
-                }
-            }
-        }
-        return null;
     }
 
     @Override


### PR DESCRIPTION
Since we introduced `Identifiable`, it is now possible to implement the `get()` method in the abstract registry and thus remove the (identical) implementations in the different registries.

Note: All automation registries have a similar logic, but then return a copy of the entity at the end.
I wonder whether we should better streamline the implementations across the registry implementations...

Signed-off-by: Kai Kreuzer <kai@openhab.org>