### PR TITLE
removed getKey() method from AbstractManagedProvider

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/ManagedRuleProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/ManagedRuleProvider.java
@@ -7,8 +7,6 @@
  */
 package org.eclipse.smarthome.automation;
 
-import org.eclipse.smarthome.automation.Rule;
-import org.eclipse.smarthome.automation.RuleProvider;
 import org.eclipse.smarthome.core.common.registry.DefaultAbstractManagedProvider;
 
 /**
@@ -19,11 +17,6 @@ import org.eclipse.smarthome.core.common.registry.DefaultAbstractManagedProvider
  * @author Kai Kreuzer - refactored (managed) provider and registry implementation
  */
 public class ManagedRuleProvider extends DefaultAbstractManagedProvider<Rule, String> implements RuleProvider {
-
-    @Override
-    protected String getKey(Rule element) {
-        return element.getUID();
-    }
 
     @Override
     protected String getStorageName() {

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/storage/ManagedItemProviderOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/storage/ManagedItemProviderOSGiTest.groovy
@@ -21,11 +21,11 @@ import org.eclipse.smarthome.core.items.ManagedItemProvider.PersistedItem
 import org.eclipse.smarthome.core.library.items.NumberItem
 import org.eclipse.smarthome.core.library.items.StringItem
 import org.eclipse.smarthome.core.library.items.SwitchItem
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.StringType
 import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction.And
 import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction.Avg
 import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction.Sum
-import org.eclipse.smarthome.core.library.types.OnOffType;
-import org.eclipse.smarthome.core.library.types.StringType
 import org.eclipse.smarthome.core.types.Command
 import org.eclipse.smarthome.core.types.State
 import org.eclipse.smarthome.test.OSGiTest
@@ -216,7 +216,7 @@ class ManagedItemProviderOSGiTest extends OSGiTest {
 
         Storage storage = storageService.getStorage(Item.class.getName())
         StrangeItem item = new StrangeItem('SomeStrangeItem')
-        String key = itemProvider.keyToString(itemProvider.getKey(item))
+        String key = itemProvider.keyToString(item.getUID())
 
         // put an item into the storage that cannot be handled (yet)
         PersistedItem persistableElement = storage.put(key, itemProvider.toPersistableElement(item))
@@ -256,8 +256,8 @@ class ManagedItemProviderOSGiTest extends OSGiTest {
         GroupItem groupItem = new GroupItem('SomeGroupItem')
         item.addGroupName(groupItem.getName())
         groupItem.addMember(item)
-        String itemKey = itemProvider.keyToString(itemProvider.getKey(item))
-        String groupKey = itemProvider.keyToString(itemProvider.getKey(groupItem))
+        String itemKey = itemProvider.keyToString(item.getUID())
+        String groupKey = itemProvider.keyToString(groupItem.getUID())
 
         // put items into the storage that cannot be handled (yet)
         PersistedItem persistableElement1 = storage.put(itemKey, itemProvider.toPersistableElement(item))
@@ -316,7 +316,7 @@ class ManagedItemProviderOSGiTest extends OSGiTest {
 
 
     @Test
-	void 'assert group functions are stored and retrieved as well'() {
+    void 'assert group functions are stored and retrieved as well'() {
 
         assertThat itemProvider.getAll().size(), is(0)
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ManagedThingProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ManagedThingProvider.java
@@ -22,11 +22,6 @@ import org.eclipse.smarthome.core.common.registry.DefaultAbstractManagedProvider
 public class ManagedThingProvider extends DefaultAbstractManagedProvider<Thing, ThingUID> implements ThingProvider {
 
     @Override
-    protected ThingUID getKey(Thing thing) {
-        return thing.getUID();
-    }
-
-    @Override
     protected String getStorageName() {
         return Thing.class.getName();
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemChannelLinkProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemChannelLinkProvider.java
@@ -19,8 +19,8 @@ import org.eclipse.smarthome.core.thing.ThingUID;
  * @author Dennis Nobel - Initial contribution
  *
  */
-public class ManagedItemChannelLinkProvider extends DefaultAbstractManagedProvider<ItemChannelLink, String> implements
-        ItemChannelLinkProvider {
+public class ManagedItemChannelLinkProvider extends DefaultAbstractManagedProvider<ItemChannelLink, String>
+        implements ItemChannelLinkProvider {
 
     @Override
     protected String getStorageName() {
@@ -30,11 +30,6 @@ public class ManagedItemChannelLinkProvider extends DefaultAbstractManagedProvid
     @Override
     protected String keyToString(String key) {
         return key;
-    }
-
-    @Override
-    protected String getKey(ItemChannelLink element) {
-        return element.getUID();
     }
 
     public void removeLinksForThing(ThingUID thingUID) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemThingLinkProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemThingLinkProvider.java
@@ -16,13 +16,8 @@ import org.eclipse.smarthome.core.common.registry.DefaultAbstractManagedProvider
  * @author Dennis Nobel - Initial contribution
  *
  */
-public class ManagedItemThingLinkProvider extends DefaultAbstractManagedProvider<ItemThingLink, String> implements
-        ItemThingLinkProvider {
-
-    @Override
-    protected String getKey(ItemThingLink element) {
-        return element.getUID();
-    }
+public class ManagedItemThingLinkProvider extends DefaultAbstractManagedProvider<ItemThingLink, String>
+        implements ItemThingLinkProvider {
 
     @Override
     protected String getStorageName() {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
@@ -143,17 +143,8 @@ public abstract class AbstractManagedProvider<E extends Identifiable<K>, K, PE> 
     }
 
     private String getKeyAsString(E element) {
-        return keyToString(getKey(element));
+        return keyToString(element.getUID());
     }
-
-    /**
-     * Returns the key for a given element
-     *
-     * @param element
-     *            element
-     * @return key (must not be null)
-     */
-    protected abstract K getKey(E element);
 
     /**
      * Returns the name of storage, that is used to persist the elements.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
@@ -161,11 +161,6 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
     }
 
     @Override
-    protected String getKey(Item element) {
-        return element.getName();
-    }
-
-    @Override
     protected String getStorageName() {
         return Item.class.getName();
     }

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/automation/internal/MarketplaceRuleTemplateProvider.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/automation/internal/MarketplaceRuleTemplateProvider.java
@@ -47,11 +47,6 @@ public class MarketplaceRuleTemplateProvider extends DefaultAbstractManagedProvi
     }
 
     @Override
-    protected String getKey(RuleTemplate element) {
-        return element.getUID();
-    }
-
-    @Override
     protected String getStorageName() {
         return "org.eclipse.smarthome.extensionservice.marketplace.RuleTemplates";
     }


### PR DESCRIPTION
This is superfluous since we now have identifiable entities.

Signed-off-by: Kai Kreuzer <kai@openhab.org>