### PR TITLE
PaperUI: Prevent duplicate things during digest cycle

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -99,7 +99,7 @@ angular.module('PaperUI.controllers.control', []) //
                             })
                             $timeout.cancel(redraw)
                             redraw = $timeout(function() {
-                                $scope.things.push.apply($scope.things, renderedThings);
+                                $scope.things = renderedThings;
                                 masonry()
                             }, 0, true)
                         }


### PR DESCRIPTION
This fixes an error when rendered things got pushed multiple times to the digest cycle.

Since things/channels/items are tracked by angularjs already rendered things will not be rendered again.

Signed-off-by: Henning Treu <henning.treu@telekom.de>