### PR TITLE
Use the proper version and groupId parameter values for test fragment…

### DIFF
--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/pom.xml
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>${namespace}.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>${version}</version>
+    <version>@${version}</version>
   </parent>
 
-  <groupId>${groupId}</groupId>
+  <groupId>@${groupId}</groupId>
   <artifactId>${rootArtifactId}</artifactId>
-  <version>${version}</version>
+  <version>@${version}</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <name>${bindingIdCamelCase} Binding Tests</name>


### PR DESCRIPTION
… creation

Otherwise the version and groupId of the archetype are used. Resulting on openHAB binding test fragments to have 0.9.0-SNAPSHOT instead of the given 2.2.0-SNAPSHOT values (same for groupId).

Signed-off-by: Henning Treu <henning.treu@telekom.de>