### PR TITLE
Hue binding: remove lightId property

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/bridge.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/bridge.xml
@@ -29,7 +29,7 @@
                 </description>
                 <required>false</required>
             </parameter>
-            <parameter name="pollingInterval" type="integer" min="1" step="1">
+            <parameter name="pollingInterval" type="integer" min="1" step="1" unit="s">
                 <label>Polling Interval</label>
                 <description>Seconds between fetching values from the Bridge.</description>
                 <required>true</required>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
@@ -133,7 +133,6 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
                 if (vendor != null) {
                     updateProperty(Thing.PROPERTY_VENDOR, vendor);
                 }
-                updateProperty(LIGHT_ID, fullLight.getId());
                 updateProperty(LIGHT_UNIQUE_ID, fullLight.getUniqueID());
                 isOsramPar16 = OSRAM_PAR16_50_TW_MODEL_ID.equals(modelId);
                 propertiesInitializedSuccessfully = true;


### PR DESCRIPTION
Fix issue #3965

Also add unit to pollingInterval configuration setting

Signed-off-by: Laurent Garnier <lg.hc@free.fr>