### PR TITLE
Change for the automatic inbox processor 

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
@@ -92,7 +92,8 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
 
     private String getRepresentationValue(DiscoveryResult result) {
         return result.getRepresentationProperty() != null
-                ? (String) result.getProperties().get(result.getRepresentationProperty()) : null;
+                ? (String) result.getProperties().get(result.getRepresentationProperty())
+                : null;
     }
 
     @Override
@@ -140,7 +141,8 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
 
     private String getRepresentationPropertyValueForThing(Thing thing) {
         ThingType thingType = thingTypeRegistry.getThingType(thing.getThingTypeUID());
-        return thing.getProperties().get(thingType.getRepresentationProperty());
+        String value = thing.getProperties().get(thingType.getRepresentationProperty());
+        return value != null ? value : (String) thing.getConfiguration().get(thingType.getRepresentationProperty());
     }
 
     private void removeFromInbox(String representationValue) {


### PR DESCRIPTION
Compare the value of the representation property not only to a value of a property but also of a configuration parameter

Signed-off-by: Andre Fuechsel <andre.fuechsel@telekom.de>