### PR TITLE
[Discussion] ConfigDispatcher: Notify services of altered/removed configuration

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
@@ -10,5 +10,6 @@ Import-Package: org.apache.commons.io;version="2.2.0",
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.service,
  org.osgi.service.cm;version="1.5.0",
+ org.osgi.framework;version="1.5.0",
  org.slf4j;version="1.7.2"
 Service-Component: OSGI-INF/*.xml

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/src/main/java/org/eclipse/smarthome/config/dispatch/internal/ConfigDispatcher.java
@@ -29,6 +29,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.service.AbstractWatchService;
+import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.cm.ManagedService;
@@ -47,18 +48,18 @@ import org.slf4j.LoggerFactory;
  * <p>
  * The format of the configuration file is similar to a standard property file, with the exception that the property
  * name can be prefixed by the service pid of the {@link ManagedService}:
- * 
+ *
  * <p>
  * &lt;service-pid&gt;:&lt;property&gt;=&lt;value&gt;
- * 
+ *
  * <p>
  * In case the pid does not contain any ".", the default service pid namespace is prefixed, which can be defined by the
  * program argument "smarthome.servicepid" (default is "org.eclipse.smarthome").
- * 
+ *
  * <p>
  * If no pid is defined in the property line, the default pid namespace will be used together with the filename. E.g. if
  * you have a file "security.cfg", the pid that will be used is "org.eclipse.smarthome.security".
- * 
+ *
  * <p>
  * Last but not least, a pid can be defined in the first line of a cfg file by prefixing it with "pid:", e.g.
  * "pid: com.acme.smarthome.security".
@@ -68,6 +69,20 @@ import org.slf4j.LoggerFactory;
  * @author Ana Dimova - reduce to a single watch thread for all class instances
  */
 public class ConfigDispatcher extends AbstractWatchService {
+    /**
+     * Represents a result of parseLine().
+     */
+    private class ParseLineResult {
+        public String pid;
+        public String property;
+        public String value;
+
+        public ParseLineResult(String pid, String property, String value) {
+            this.pid = pid;
+            this.property = property;
+            this.value = value;
+        }
+    }
 
     private static String getPathToWatch() {
         String progArg = System.getProperty(SERVICEDIR_PROG_ARGUMENT);
@@ -151,6 +166,22 @@ public class ConfigDispatcher extends AbstractWatchService {
             } catch (IOException e) {
                 logger.warn("Could not process config file '{}': {}", path, e);
             }
+        } else if (kind == ENTRY_DELETE) {
+            // Detect if a service specific configuration file was removed. We want to
+            // notify the service in this case with an updated empty configuration.
+            File configFile = path.toFile();
+            if (configFile.isHidden() || configFile.isDirectory() || !configFile.getName().endsWith(".cfg")) {
+                return;
+            }
+            String pid = pidFromFilename(configFile);
+            try {
+                Configuration configs[] = configAdmin.listConfigurations("(service.pid=" + pid + ")");
+                if (configs.length > 0) {
+                    configs[0].update((Dictionary) new Properties());
+                }
+            } catch (IOException | InvalidSyntaxException ignored) {
+                return;
+            }
         }
     }
 
@@ -205,6 +236,23 @@ public class ConfigDispatcher extends AbstractWatchService {
         }
     }
 
+    /**
+     * The filename of a given configuration file is assumed to be the service PID. If the filename
+     * without extension contains ".", we assume it is the fully qualified name.
+     *
+     * @param configFile The configuration file
+     * @return The PID
+     */
+    private String pidFromFilename(File configFile) {
+        String filenameWithoutExt = StringUtils.substringBeforeLast(configFile.getName(), ".");
+        if (filenameWithoutExt.contains(".")) {
+            // it is a fully qualified namespace
+            return filenameWithoutExt;
+        } else {
+            return getServicePidNamespace() + "." + filenameWithoutExt;
+        }
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private void processConfigFile(File configFile) throws IOException, FileNotFoundException {
         if (configFile.isDirectory() || !configFile.getName().endsWith(".cfg")) {
@@ -220,14 +268,7 @@ public class ConfigDispatcher extends AbstractWatchService {
         // also cache the already retrieved configurations for each pid
         Map<Configuration, Dictionary> configMap = new HashMap<Configuration, Dictionary>();
 
-        String pid;
-        String filenameWithoutExt = StringUtils.substringBeforeLast(configFile.getName(), ".");
-        if (filenameWithoutExt.contains(".")) {
-            // it is a fully qualified namespace
-            pid = filenameWithoutExt;
-        } else {
-            pid = getServicePidNamespace() + "." + filenameWithoutExt;
-        }
+        String pid = pidFromFilename(configFile);
 
         // configuration file contains a PID Marker
         List<String> lines = IOUtils.readLines(new FileInputStream(configFile));
@@ -235,60 +276,102 @@ public class ConfigDispatcher extends AbstractWatchService {
             pid = lines.get(0).substring(PID_MARKER.length()).trim();
         }
 
+        /**
+         * Services are also interested if a configuration file is cleared.
+         * This is necessary to clean up resources, that were configured before.
+         * It only works with configuration files dedicated to a service though.
+         */
+        boolean isMultiPidConfigFile = false;
+        /**
+         * Record if we have valid configuration lines in the file
+         */
+        int changes = 0;
+
+        Configuration configuration = null;
+
         for (String line : lines) {
-            String[] contents = parseLine(configFile.getPath(), line);
+            ParseLineResult contents = parseLine(configFile.getPath(), line);
             // no valid configuration line, so continue
             if (contents == null) {
                 continue;
             }
 
-            if (contents[0] != null) {
-                pid = contents[0];
-                // PID is not fully qualified, so prefix with namespace
-                if (!pid.contains(".")) {
-                    pid = getServicePidNamespace() + "." + pid;
-                }
+            if (contents.pid != null) {
+                isMultiPidConfigFile = true;
+                pid = contents.pid;
+                configuration = configAdmin.getConfiguration(pid, null);
+            } else if (configuration == null) {
+                configuration = configAdmin.getConfiguration(pid, null);
             }
 
-            String property = contents[1];
-            String value = contents[2];
-            Configuration configuration = configAdmin.getConfiguration(pid, null);
-            if (configuration != null) {
-                Dictionary configProperties = configMap.get(configuration);
-                if (configProperties == null) {
-                    configProperties = configuration.getProperties() != null ? configuration.getProperties()
-                            : new Properties();
-                    configMap.put(configuration, configProperties);
-                }
-                if (!value.equals(configProperties.get(property))) {
-                    configProperties.put(property, value);
-                    configsToUpdate.put(configuration, configProperties);
-                }
+            if (configuration == null) {
+                continue;
             }
+
+            // Combine all configurations for one service in the same configuration object.
+            // If it doesn't exist yet, create it.
+            Dictionary configProperties = configMap.get(configuration);
+            if (configProperties == null) {
+                configProperties = new Properties();
+                configMap.put(configuration, configProperties);
+            }
+
+            // Do not bother services if the configuration tuple key=value hasn't changed
+            Object oldValue = configProperties.get(contents.property);
+            if (contents.value.equals(oldValue)) {
+                continue;
+            }
+
+            ++changes;
+            configProperties.put(contents.property, contents.value);
+            configsToUpdate.put(configuration, configProperties);
         }
 
-        for (Entry<Configuration, Dictionary> entry : configsToUpdate.entrySet()) {
-            entry.getKey().update(entry.getValue());
+        if (!isMultiPidConfigFile) {
+            configuration = configAdmin.getConfiguration(pid, null);
+            if (configuration == null) {
+                return;
+            }
+
+            int oldSize = configuration.getProperties() == null ? 0 : configuration.getProperties().size();
+
+            // If the old service configuration has more entries than the new one, it has changed as well
+            // We want to inform the services about this, even if the configuration is empty
+            // (for example to clean up what was configured before)
+            if (changes > 0) {
+                // There is only one configuration in the file, just take the first entry therefore
+                configuration.update(configsToUpdate.values().iterator().next());
+            } else if (oldSize > 0) {
+                configuration.update((Dictionary) new Properties());
+            }
+        } else {
+            for (Entry<Configuration, Dictionary> entry : configsToUpdate.entrySet()) {
+                entry.getKey().update(entry.getValue());
+            }
         }
     }
 
-    private String[] parseLine(final String filePath, final String line) {
+    private ParseLineResult parseLine(final String filePath, final String line) {
         String trimmedLine = line.trim();
         if (trimmedLine.startsWith("#") || trimmedLine.isEmpty()) {
             return null;
         }
 
-        String pid = null; // no override of the pid
+        String pid = null; // no override of the pid is default
         String key = StringUtils.substringBefore(trimmedLine, "=");
         if (key.contains(":")) {
             pid = StringUtils.substringBefore(key, ":");
             trimmedLine = trimmedLine.substring(pid.length() + 1);
             pid = pid.trim();
+            // PID is not fully qualified, so prefix with namespace
+            if (!pid.contains(".")) {
+                pid = getServicePidNamespace() + "." + pid;
+            }
         }
         if (!trimmedLine.isEmpty() && trimmedLine.substring(1).contains("=")) {
             String property = StringUtils.substringBefore(trimmedLine, "=");
             String value = trimmedLine.substring(property.length() + 1);
-            return new String[] { pid, property.trim(), value.trim() };
+            return new ParseLineResult(pid, property.trim(), value.trim());
         } else {
             logger.warn("Could not parse line '{}'", line);
             return null;


### PR DESCRIPTION
## Config.Dispatch:
Until now the config dispatcher didn't notify services if a configuration tuple was removed or the entire configuration files was removed.
The MqttService needs this information though, to remove old configured broker connections.

This works only if the configuration file is dedicated to the service (no multiple service pids
in one file), but this is the recommended way anyway.

Discussion can be found [here](https://github.com/openhab/openhab-distro/issues/396#issuecomment-321021872)

Signed-off-by: David Gräff <david.graeff@web.de>