### PR TITLE
Fixed broken <ul> on concepts/items.md page

### DIFF
--- a/docs/documentation/concepts/items.md
+++ b/docs/documentation/concepts/items.md
@@ -78,6 +78,6 @@ Here is a short table demonstrating conversions for the examples above:
 
 | Itemname | Main data type | Additional data types conversions |
 | --- | --- | --- |
-| Color | `HSBType` | <ul><li>`OnOffType` - `OFF` if the brightness level in the `HSBType` equals 0, `ON` otherwise</li><li>`PercentType` - the value for the brightness level in the `HSBType`</li></ul> |
+| Color | `HSBType` | &bull; `OnOffType` - `OFF` if the brightness level in the `HSBType` equals 0, `ON` otherwise <br/> &bull; `PercentType` - the value for the brightness level in the `HSBType` |
 | Dimmer | `PercentType` | `OnOffType` - `OFF` if the brightness level indicated by the percent type equals 0, `ON` otherwise |
 | Rollershutter | `PercentType` | `UpDownType` - `UP` if the shutter level indicated by the percent type equals 0, `DOWN` if it equals 100, and `UnDefType.UNDEF` for any other value|


### PR DESCRIPTION
The `<ul><li>` elements were displayed as plain text. Fixed by substituting them with a break tag and bullet entity code.

Local build of the docs performed to verify change is properly visualized.