### PR TITLE
Remove braces from method names.

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueBridgeHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/groovy/org/eclipse/smarthome/binding/hue/test/HueBridgeHandlerOSGiTest.groovy
@@ -197,7 +197,7 @@ class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
     }
 
     @Test
-    void 'assert that a status configuration message for missing bridge IP is properly returned (IP is null)'() {
+    void 'assert that a status configuration message for missing bridge IP is properly returned - IP is null'() {
         Configuration configuration = new Configuration().with {
             put(HOST, null)
             put(SERIAL_NUMBER, "testSerialNumber")
@@ -218,7 +218,7 @@ class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
     }
 
     @Test
-    void 'assert that a status configuration message for missing bridge IP is properly returned (IP is an empty string)'() {
+    void 'assert that a status configuration message for missing bridge IP is properly returned - IP is an empty string'() {
         Configuration configuration = new Configuration().with {
             put(HOST, "")
             put(SERIAL_NUMBER, "testSerialNumber")


### PR DESCRIPTION
The braces in method names cause FindBugs to throw IllegalArgumentException and to fail the build

See https://github.com/eclipse/smarthome/pull/3995#discussion_r132170322

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>