### PR TITLE
Add spotbugs to target platform

### DIFF
--- a/targetplatform/smarthome.target
+++ b/targetplatform/smarthome.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="SmartHome" sequenceNumber="115">
+<?pde version="3.8"?><target name="SmartHome" sequenceNumber="116">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.inject" version="3.0.0.v201312141243"/>
@@ -171,6 +171,10 @@
 <unit id="org.eclipse.jetty.webapp" version="0.0.0"/>
 <unit id="org.eclipse.jetty.xml" version="0.0.0"/>
 <repository location="http://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.2.12.v20150709"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.github.spotbugs.plugin.eclipse.feature.group" version="0.0.0"/>
+<repository location="https://spotbugs.github.io/eclipse/"/>
 </location>
 <location path="${project_loc:targetplatform}/third-party" type="Directory"/>
 </locations>


### PR DESCRIPTION
The plugin exports annotations for FindBugs(SpotBugs).

See https://github.com/eclipse/smarthome/pull/4016#discussion_r132476289
See #3995

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>