### PR TITLE
Added Null check on Representation Property

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ThingType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ThingType.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -309,7 +310,7 @@ public class ThingType extends AbstractDescriptionType {
      *
      * @return representation property name or {@code null}
      */
-    public String getRepresentationProperty() {
+    public @Nullable String getRepresentationProperty() {
         return representationProperty;
     }
 


### PR DESCRIPTION
`org.eclipse.smarthome.core.thing.type.ThingType.getRepresentationProperty()` javadoc says that representation property of this thing type can be null. Without any representation property results in NPE.