### PR TITLE
Small fix on the logger name binding for ThingFactoryHelper

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingFactoryHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingFactoryHelper.java
@@ -43,7 +43,7 @@ import com.google.common.collect.Lists;
  */
 public class ThingFactoryHelper {
 
-    private static Logger logger = LoggerFactory.getLogger(ThingFactory.class);
+    private static Logger logger = LoggerFactory.getLogger(ThingFactoryHelper.class);
 
     /**
      * Create {@link Channel} instances for the given Thing.


### PR DESCRIPTION
Changed from ThingFactory to ThingFactoryHelper.
Signed-off-by: Dimitar Ivanov <dstivanov@gmail.com>