### PR TITLE
Fix static cast in AutomaticInboxProcessor

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
@@ -94,7 +94,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
 
     private String getRepresentationValue(DiscoveryResult result) {
         return result.getRepresentationProperty() != null
-                ? (String) result.getProperties().get(result.getRepresentationProperty())
+                ? Objects.toString(result.getProperties().get(result.getRepresentationProperty()), null)
                 : null;
     }
 


### PR DESCRIPTION
Use Objects.toString instead of static cast (to prevent possible ClassCastException)

Signed-off-by: Ivaylo Ivanov <ivivanov.bg@gmail.com>