### PR TITLE
Sonos binding: add representation property

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECT.xml
@@ -62,6 +62,8 @@
 			<property name="modelId">CONNECT</property>
 		</properties>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/CONNECTAMP.xml
@@ -63,6 +63,8 @@
 			<property name="modelId">CONNECT:AMP</property>
 		</properties>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY1.xml
@@ -60,6 +60,8 @@
 			<property name="modelId">PLAY:1</property>
 		</properties>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY3.xml
@@ -60,6 +60,8 @@
 			<property name="modelId">PLAY:3</property>
 		</properties>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAY5.xml
@@ -63,6 +63,8 @@
 			<property name="modelId">PLAY:5</property>
 		</properties>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/PLAYBAR.xml
@@ -62,6 +62,8 @@
 			<property name="modelId">PLAYBAR</property>
 		</properties>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/ZonePlayer.xml
@@ -60,6 +60,8 @@
 			<property name="modelId">ZonePlayer</property>
 		</properties>
 
+		<representation-property>udn</representation-property>
+
 		<config-description-ref uri="thing-type:sonos:zoneplayer" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/discovery/ZonePlayerDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/discovery/ZonePlayerDiscoveryParticipant.java
@@ -51,11 +51,12 @@ public class ZonePlayerDiscoveryParticipant implements UpnpDiscoveryParticipant 
                 } catch (Exception e) {
                     // ignore and use default label
                 }
+                label += " (" + roomName + ")";
                 properties.put(ZonePlayerConfiguration.UDN, device.getIdentity().getUdn().getIdentifierString());
                 properties.put(SonosBindingConstants.IDENTIFICATION, roomName);
 
                 DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties).withLabel(label)
-                        .withRepresentationProperty(SonosBindingConstants.IDENTIFICATION).build();
+                        .withRepresentationProperty(ZonePlayerConfiguration.UDN).build();
 
                 logger.debug("Created a DiscoveryResult for device '{}' with UDN '{}'",
                         device.getDetails().getFriendlyName(), device.getIdentity().getUdn().getIdentifierString());


### PR DESCRIPTION
Also add the room name to the label of a discovered Sonos device to help the user distinguishing discovered Sonos of the same kind

Fix issue #4028 

Signed-off-by: Laurent Garnier <lg.hc@free.fr>