### PR TITLE
Revert Generics Null Annotation in Binding API due to Eclipse Bug

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -137,7 +137,7 @@ public abstract class BaseThingHandler implements ThingHandler {
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<@NonNull String, Object> configurationParameters) {
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
         validateConfigurationParameters(configurationParameters);
 
         // can be overridden by subclasses
@@ -506,9 +506,8 @@ public abstract class BaseThingHandler implements ThingHandler {
      * @param properties
      *            properties map, that was updated
      */
-    protected void updateProperties(Map<@NonNull String, String> properties) {
-        for (Entry<@NonNull String, String> property : properties.entrySet()) {
-            @SuppressWarnings("null")
+    protected void updateProperties(Map<String, String> properties) {
+        for (Entry<String, String> property : properties.entrySet()) {
             String propertyName = property.getKey();
             String propertyValue = property.getValue();
             String existingPropertyValue = thing.getProperties().get(propertyName);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ConfigStatusBridgeHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ConfigStatusBridgeHandler.java
@@ -53,7 +53,7 @@ public abstract class ConfigStatusBridgeHandler extends BaseBridgeHandler implem
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<@NonNull String, Object> configurationParameters) {
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
         super.handleConfigurationUpdate(configurationParameters);
         if (configStatusCallback != null) {
             configStatusCallback.configUpdated(new ThingConfigStatusSource(getThing().getUID().getAsString()));

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ConfigStatusThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ConfigStatusThingHandler.java
@@ -54,7 +54,7 @@ public abstract class ConfigStatusThingHandler extends BaseThingHandler implemen
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<@NonNull String, Object> configurationParameters) {
+    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
         super.handleConfigurationUpdate(configurationParameters);
         if (configStatusCallback != null) {
             configStatusCallback.configUpdated(new ThingConfigStatusSource(getThing().getUID().getAsString()));

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
@@ -113,7 +113,7 @@ public interface ThingHandler {
      * @throws ConfigValidationException if one or more of the given configuration parameters do not match
      *             their declarations in the configuration description
      */
-    void handleConfigurationUpdate(Map<@NonNull String, Object> configurationParameters);
+    void handleConfigurationUpdate(Map<String, Object> configurationParameters);
 
     /**
      * Notifies the handler about an updated {@link Thing}.

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
@@ -18,7 +18,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.binding.digitalstrom.DigitalSTROMBindingConstants;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.listener.DeviceStatusListener;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.Device;
@@ -142,7 +141,7 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<@NonNull String, Object> configurationParmeters) {
+    public void handleConfigurationUpdate(Map<String, Object> configurationParmeters) {
         Configuration configuration = editConfiguration();
         for (Entry<String, Object> configurationParmeter : configurationParmeters.entrySet()) {
             configuration.put(configurationParmeter.getKey(), configurationParmeter.getValue());


### PR DESCRIPTION
The Eclipse JDT compiler is not yet able to handle inherited null annotations on generics.

See: https://bugs.eclipse.org/bugs/show_bug.cgi?id=463359

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>