### PR TITLE
fix potential CME

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -9,11 +9,11 @@ package org.eclipse.smarthome.core.thing.internal;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -69,13 +69,13 @@ public class ChannelItemProvider implements ItemProvider {
         } else {
             synchronized (this) {
                 if (items == null) {
-                    items = new HashMap<>();
+                    items = new ConcurrentHashMap<>();
                     for (ItemChannelLink link : linkRegistry.getAll()) {
                         createItemForLink(link);
                     }
                 }
             }
-            return items.values();
+            return new HashSet<>(items.values());
         }
     }
 


### PR DESCRIPTION
The items member are used internally as expected and additionally by the
internal item registry change listener.
The items are iterated and the map could be modified at the same time.

The getAll function currently returns a view of the map values. So, the
caller could run into trouble using the returned set if the internal map
is changed.

Fixes: https://github.com/eclipse/smarthome/issues/3956