### PR TITLE
fix config admin usage in tests

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/groovy/org/eclipse/smarthome/core/binding/xml/test/BindingInfoI18nTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/groovy/org/eclipse/smarthome/core/binding/xml/test/BindingInfoI18nTest.groovy
@@ -104,7 +104,7 @@ class BindingInfoI18nTest extends OSGiTest {
     void 'assert using default locale'() {
         // Set german locale
         ConfigurationAdmin configAdmin = getService(ConfigurationAdmin.class);
-        Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.core.i18nprovider");
+        Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.core.i18nprovider", null);
         Dictionary<String, String> localeCfg = new Hashtable<String, String>();
         localeCfg.put("language", "de");
         localeCfg.put("country", "DE");

--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.groovy
@@ -270,7 +270,7 @@ abstract class OSGiTest {
         def localeProvider = getService(Class.forName("org.eclipse.smarthome.core.i18n.LocaleProvider"))
         assertThat localeProvider, is(notNullValue())
 
-        def config = configAdmin.getConfiguration("org.eclipse.smarthome.core.i18nprovider")
+        def config = configAdmin.getConfiguration("org.eclipse.smarthome.core.i18nprovider", null)
         assertThat config, is(notNullValue())
 
         def properties = config.getProperties()


### PR DESCRIPTION
In order to alter the configuration of another bundle, the `ConfigurationAdmin.getConfiguration(String, String)` method must be used (also already in OSGi 4.2). 

For some reasons our current equinox version does not seem to care, so this did not fail so far. But it will with a newer version (which is a prerequisite for the Xtext upgrade with in turn is required for #3898).

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>