### PR TITLE
Removing unnecessary repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -471,32 +471,4 @@
     </profile>
   </profiles>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>tycho-snapshots</id>
-      <url>https://oss.sonatype.org/content/groups/public/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>cbi-releases</id>
-      <url>https://repo.eclipse.org/content/repositories/cbi-releases/</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>buchen-maven-repo</id>
-      <url>http://buchen.github.io/maven-repo</url>
-      <layout>default</layout>
-    </pluginRepository>
-  </pluginRepositories>
-
-  <repositories>
-    <repository>
-      <id>eclipse</id>
-      <name>Eclipse Snapshot Repository</name>
-      <layout>default</layout>
-      <url>https://repo.eclipse.org/content/repositories/snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
 </project>


### PR DESCRIPTION
Our build is continuously failing with timeouts on weird remote repos and it is also generally terribly slow.
I just checked the additional repos that we include in our pom.xml and it seems that we do not require any of them anymore. We e.g. do not use snapshots from Tycho and the buchen-maven-repo is only required by the Designer RCP build, which is not part of this repo anymore.

Signed-off-by: Kai Kreuzer <kai@openhab.org>