### PR TITLE
WU binding: example updated in the documentation

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/README.md
@@ -131,7 +131,7 @@ demo.items:
 String Conditions "Conditions [%s]" {channel="weatherunderground:weather:CDG:current#conditions"}
 Image Icon "Icon" {channel="weatherunderground:weather:CDG:current#icon"}
 DateTime ObservationTime "Observation time [%1$tH:%1$tM]" <clock>  {channel="weatherunderground:weather:CDG:current#observationTime"}
-String Location "Location [%s]" {channel="weatherunderground:weather:CDG:current#location"}
+String ObservationLocation "Location [%s]" {channel="weatherunderground:weather:CDG:current#location"}
 String Station "Station [%s]" {channel="weatherunderground:weather:CDG:current#stationId"}
 
 Number Temperature "Current temperature [%.1f °C]" <temperature> {channel="weatherunderground:weather:CDG:current#temperature"}


### PR DESCRIPTION
It is not allowed to use "Location" as an item name.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>