### PR TITLE
Expose the command line delimiter

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
@@ -30,9 +30,10 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecUtil {
 
-	/**
-	 * Use this to separate between command and parameter, and also between parameters
-	 */
+    /**
+     * Use this to separate between command and parameter, and also between
+     * parameters
+     */
     public static final String CMD_LINE_DELIMITER = "@@";
 
     /**

--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
@@ -30,7 +30,10 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecUtil {
 
-    private static final String CMD_LINE_DELIMITER = "@@";
+	/**
+	 * Use this to separate between command and parameter, and also between parameters
+	 */
+    public static final String CMD_LINE_DELIMITER = "@@";
 
     /**
      * <p>


### PR DESCRIPTION
The javadoc in method executeCommandLineAndWaitResponse mentions @@ as the command line delimiter.  It is easier to expose it for external reference.