### PR TITLE
Expose command line delimiter in org.eclipse.smarthome.io.net.exec.Ex…

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/exec/ExecUtil.java
@@ -30,7 +30,10 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecUtil {
 
-    private static final String CMD_LINE_DELIMITER = "@@";
+    /**
+     * Use this to separate between command and parameter, and also between parameters.
+     */
+    public static final String CMD_LINE_DELIMITER = "@@";
 
     /**
      * <p>


### PR DESCRIPTION
Expose command line delimiter in org.eclipse.smarthome.io.net.exec.ExecUtil for reference

Signed-off-by: Gary Tse <gary.garytse@gmail.com>