### PR TITLE
Ignore final fields in config/core/Configuration

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -8,6 +8,7 @@
 package org.eclipse.smarthome.config.core;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,6 +67,10 @@ public class Configuration {
 
             List<Field> fields = getAllFields(configurationClass);
             for (Field field : fields) {
+                // Don't try to write to final fields
+                if (Modifier.isFinal(field.getModifiers())) {
+                    continue;
+                }
                 String fieldName = field.getName();
                 String typeName = field.getType().getSimpleName();
                 Object value = properties.get(fieldName);


### PR DESCRIPTION
If a configuration-values class contain final fields (for example for defining constants related to configuration field names etc), the core.Configuration parser still try to write to those fields. This is fixed.

Signed-off-by: David Gräff <david.graeff@web.de>