### PR TITLE
Export the package org.eclipse.smarthome.core.thing.link.events

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -60,6 +60,7 @@ Export-Package: org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.i18n,
  org.eclipse.smarthome.core.thing.link,
  org.eclipse.smarthome.core.thing.link.dto,
+ org.eclipse.smarthome.core.thing.link.events,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.thing.util
 Service-Component: OSGI-INF/*.xml


### PR DESCRIPTION
Currently, the package org.eclipse.smarthome.core.thing.link.events is not exported.
In consequence, one cannot use the ItemChannelLinkXXXEvent classes in that package
to listen to those events. Moreover, this is unlike for other events packages, like, e.g.,
the package org.eclipse.smarthome.core.items.events which is exported.

This is why I suggest to export org.eclipse.smarthome.core.thing.link.events.
Or is there a reason why it should not be exported?

Signed-off-by: Henning Sudbrock <henning.sudbrock@telekom.de>