### PR TITLE
Scheduler: Detect time jumps and reschedule jobs

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Fragment-Host: org.eclipse.smarthome.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: groovy.lang,
+ org.apache.commons.lang.time,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolExecutorTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/scheduler/ExpressionThreadPoolExecutorTest.java
@@ -8,16 +8,46 @@
 package org.eclipse.smarthome.core.scheduler;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Date;
 
+import org.apache.commons.lang.time.DateUtils;
 import org.eclipse.smarthome.core.scheduler.ExpressionThreadPoolManager.ExpressionThreadPoolExecutor;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExpressionThreadPoolExecutorTest {
 
-    private ExpressionThreadPoolExecutor scheduler = ExpressionThreadPoolManager.getExpressionScheduledPool("test");
+    private ExpressionThreadPoolExecutor scheduler;
     protected boolean success;
+
+    private final Logger logger = LoggerFactory.getLogger(ExpressionThreadPoolExecutorTest.class);
+
+    protected boolean fakeOn = false;
+
+    @Mock
+    DateWrapper dw;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        scheduler = ExpressionThreadPoolManager.getExpressionScheduledPool("test");
+    }
+
+    @After
+    public void after() {
+        scheduler = null;
+    }
 
     @Test
     public void testScheduleAndRemove() throws ParseException, InterruptedException {
@@ -47,7 +77,7 @@ public class ExpressionThreadPoolExecutorTest {
     }
 
     @Test
-    public void testScheduleAndRemoveRunnable() throws ParseException, InterruptedException {
+    public void testScheduleAndRemoveRunstaticnable() throws ParseException, InterruptedException {
 
         Runnable runnable = new Runnable() {
             @Override
@@ -71,6 +101,96 @@ public class ExpressionThreadPoolExecutorTest {
         assertFalse(success);
 
         assertEquals(0, scheduler.getQueue().size());
+    }
+
+    private Date createDate(int offset) {
+        if (fakeOn) {
+            return DateUtils.addMilliseconds(new Date(), offset);
+        } else {
+            return new Date();
+        }
+    }
+
+    @Test
+    public void testTimeJumpBackwards() throws ParseException, InterruptedException {
+
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                success = true;
+            }
+        };
+
+        when(dw.getDate()).thenAnswer(new Answer<Date>() {
+            @Override
+            public Date answer(InvocationOnMock invocation) throws Throwable {
+                return createDate(-2500);
+            }
+        });
+
+        success = false;
+        scheduler.setDateWrapper(dw);
+        scheduler.setMonitorSleep(500);
+        scheduler.setMonitorAllowedDrift(100);
+
+        Date date = new Date();
+        Date futureDate = DateUtils.addSeconds(date, 1);
+
+        // adding future job
+        Calendar futureCalender = DateUtils.toCalendar(futureDate);
+        CronExpression expression = new CronExpression(futureCalender.get(Calendar.SECOND) + " * * * * ?");
+        scheduler.schedule(runnable, expression);
+
+        Thread.sleep(1500);
+        assertTrue(success);
+
+        // reset the time into the past
+        fakeOn = true;
+        success = false;
+
+        Thread.sleep(2000);
+        assertTrue(success);
+    }
+
+    @Test
+    public void testTimeJumpForward() throws ParseException, InterruptedException {
+
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                success = true;
+            }
+        };
+
+        when(dw.getDate()).thenAnswer(new Answer<Date>() {
+            @Override
+            public Date answer(InvocationOnMock invocation) throws Throwable {
+                return createDate(57000);
+            }
+        });
+
+        success = false;
+        scheduler.setDateWrapper(dw);
+        scheduler.setMonitorSleep(500);
+        scheduler.setMonitorAllowedDrift(100);
+
+        Date date = new Date();
+        Date futureDate = DateUtils.addSeconds(date, 1);
+
+        // adding future job
+        Calendar futureCalender = DateUtils.toCalendar(futureDate);
+        CronExpression expression = new CronExpression(futureCalender.get(Calendar.SECOND) + " * * * * ?");
+        scheduler.schedule(runnable, expression);
+
+        Thread.sleep(1500);
+        assertTrue(success);
+
+        // reset the time into the future
+        fakeOn = true;
+        success = false;
+
+        Thread.sleep(2500);
+        assertTrue(success);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  * The created thread pools have named threads, so that it is easy to find them in the debugger. Additionally, it is
  * possible to configure the pool sizes through the configuration admin service, so that solutions have the chance to
  * tweak the pool sizes according to their needs.
- * 
+ *
  * <p>
  * The configuration can be done as
  * <br/>
@@ -48,7 +48,6 @@ public class ThreadPoolManager {
     protected static final int DEFAULT_THREAD_POOL_SIZE = 5;
 
     protected static final long THREAD_TIMEOUT = 65L;
-    protected static final long THREAD_MONITOR_SLEEP = 60000;
 
     static protected Map<String, ExecutorService> pools = new WeakHashMap<>();
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/AbstractExpression.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/AbstractExpression.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractExpression<E extends AbstractExpressionPart> implements Expression {
 
-    private final Logger logger = LoggerFactory.getLogger(AbstractExpression.class);
+    private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
 
     private int minimumCandidates = 1;
     private int maximumCandidates = 100;
@@ -71,6 +71,9 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
             throw new IllegalArgumentException("The start date of the rule must not be null");
         }
         setStartDate(startDate);
+
+        setTimeZone(timeZone);
+        parseExpression(expression);
     }
 
     @Override
@@ -168,7 +171,7 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
         validateExpression();
 
         if (startDate == null) {
-            startDate = Calendar.getInstance().getTime();
+            setStartDate(Calendar.getInstance().getTime());
         }
 
         applyExpressionParts(searchMode);
@@ -257,6 +260,8 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
     @Override
     public Date getTimeAfter(Date afterTime) {
 
+        Date currentStartDate = getStartDate();
+
         if (hasFloatingStartDate()) {
             try {
                 clearCandidates();
@@ -287,6 +292,7 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
                         for (Date candidate : getCandidates()) {
                             newStartDate = candidate;
                             if (candidate.after(afterTime)) {
+                                setStartDate(currentStartDate);
                                 return candidate;
                             }
                         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/AbstractExpression.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/AbstractExpression.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractExpression<E extends AbstractExpressionPart> implements Expression {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass().getName());
+    private final Logger logger = LoggerFactory.getLogger(AbstractExpression.class);
 
     private int minimumCandidates = 1;
     private int maximumCandidates = 100;
@@ -71,9 +71,6 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
             throw new IllegalArgumentException("The start date of the rule must not be null");
         }
         setStartDate(startDate);
-
-        setTimeZone(timeZone);
-        parseExpression(expression);
     }
 
     @Override
@@ -171,7 +168,7 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
         validateExpression();
 
         if (startDate == null) {
-            setStartDate(Calendar.getInstance().getTime());
+            startDate = Calendar.getInstance().getTime();
         }
 
         applyExpressionParts(searchMode);
@@ -260,8 +257,6 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
     @Override
     public Date getTimeAfter(Date afterTime) {
 
-        Date currentStartDate = getStartDate();
-
         if (hasFloatingStartDate()) {
             try {
                 clearCandidates();
@@ -292,7 +287,6 @@ public abstract class AbstractExpression<E extends AbstractExpressionPart> imple
                         for (Date candidate : getCandidates()) {
                             newStartDate = candidate;
                             if (candidate.after(afterTime)) {
-                                setStartDate(currentStartDate);
                                 return candidate;
                             }
                         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/DateWrapper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/DateWrapper.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.scheduler;
+
+import java.util.Date;
+
+/**
+ * Wraps an instance of Date for testing purposes
+ *
+ * @author Stefan Triller - initial contribution
+ *
+ */
+public class DateWrapper {
+
+    /**
+     * Provides the current date
+     *
+     * @return the current date
+     */
+    public Date getDate() {
+        return new Date();
+    }
+}


### PR DESCRIPTION
The ExpressionThreadPoolExecutor now calculates the time when he plans to wake up next. If this time is exceeded by 3 seconds, all jobs will be rescheduled.

Fixes #3185

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>