### PR TITLE
Implemented two fixes/improvements for the Tradfri binding

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -145,6 +146,17 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
             
             logger.debug("Updating thing for lightId {} to state {dimmer: {}, colorTemp: {}, devicefirmware: {}, modelId: {}, vendor: {}}"
                     , state.getLightId(), dimmer, colorTemp, devicefirmware, modelId, vendor);
+        }
+    }
+    
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        super.bridgeStatusChanged(bridgeStatusInfo);
+
+        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
+            scheduler.schedule(() -> {
+                coapClient.startObserve(this);
+            }, 0, TimeUnit.SECONDS);
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -48,6 +48,7 @@ public class TradfriDiscoveryService extends AbstractDiscoveryService implements
 
     @Override
     protected void startScan() {
+        removeOlderResults(getTimestampOfLastScan());
         handler.startScan();
     }
 


### PR DESCRIPTION
1. **`TradfriDiscoveryService.java`** - Removal of older discovery results implemented for `TradfriDiscoveryService#startScan()`, so that devices are instantaneously retrieved in inbox after deletion (e.g. if pairing process is invoked directly afterwards).
2. **`TradfriLightHandler.java`** - Fixed bulb channels not receiving updates applied to the physical device from remote control (fixes #3869, but the issue should be also reproduced with bridge remaining `ONLINE`). 
The problem was that, when at some point the bridge goes `OFFLINE` for some reason, after it and the bulb become `ONLINE` again, `coapClient.startObserve(this)` was not called for the bulb while the observe relation, on the other hand, has timed out. This is why this logic is implemented in `public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo)` for the light handler.

Signed-off-by: Alexander Kostadinov <alexander.g.kostadinov@gmail.com>