### PR TITLE
MQTT broker reconnect and close cleanup

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/reconnect/AbstractReconnectStrategy.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/reconnect/AbstractReconnectStrategy.java
@@ -7,6 +7,8 @@
  */
 package org.eclipse.smarthome.io.transport.mqtt.reconnect;
 
+import java.io.Closeable;
+
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionObserver;
 
@@ -16,7 +18,7 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionObserver;
  *
  * @author David Graeff - Initial contribution
  */
-public abstract class AbstractReconnectStrategy {
+public abstract class AbstractReconnectStrategy implements Closeable {
     protected MqttBrokerConnection brokerConnection;
 
     /**
@@ -52,4 +54,10 @@ public abstract class AbstractReconnectStrategy {
      * resources.
      */
     public abstract void connectionEstablished();
+
+    /**
+     * This will be called if your reconnect strategy should no longer try to handle a reconnect.
+     */
+    @Override
+    public abstract void close();
 }


### PR DESCRIPTION
Fixes:
If the MQTT broker connection is closed the reconnect strategy is still
hold alive and a reconnect is not stopped.
If the MQTT broker could not be reached all the time there will be
multiple reconnect tasks been started / running.
