### PR TITLE
the reconnect timing should be constant after object creation

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/reconnect/PeriodicReconnectStrategy.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/reconnect/PeriodicReconnectStrategy.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
  */
 public class PeriodicReconnectStrategy extends AbstractReconnectStrategy {
     private final Logger logger = LoggerFactory.getLogger(PeriodicReconnectStrategy.class);
-    private int reconnectFrequency = 60000;
-    private int firstReconnectAfter = 10000;
+    private final int reconnectFrequency;
+    private final int firstReconnectAfter;
 
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
     private ScheduledFuture<?> scheduledTask;
@@ -38,6 +38,7 @@ public class PeriodicReconnectStrategy extends AbstractReconnectStrategy {
      * Use a default 60s reconnect frequency and try the first reconnect after 10s.
      */
     public PeriodicReconnectStrategy() {
+        this(10000, 60000);
     }
 
     /**
@@ -94,16 +95,8 @@ public class PeriodicReconnectStrategy extends AbstractReconnectStrategy {
         return reconnectFrequency;
     }
 
-    public void setReconnectFrequency(int reconnectFrequency) {
-        this.reconnectFrequency = reconnectFrequency;
-    }
-
     public int getFirstReconnectAfter() {
         return firstReconnectAfter;
-    }
-
-    public void setFirstReconnectAfter(int firstReconnectAfter) {
-        this.firstReconnectAfter = firstReconnectAfter;
     }
 
     @Override


### PR DESCRIPTION
The reconnect timing should not be changed after the periodic reconnect strategy has been connected.
Using unmodifiable members will make that values thread safe.
The caller also does the internal state the reconnect strategy currently is using, so it make IMHO no sense to change some timing without knowing at which time it will affect the
current behavior.
If the MQTT broker connection should use another timed strategy you could create a new reconnect strategy and set it for the existing connection.
