### PR TITLE
POC: Encrypted credentials

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
@@ -9,6 +9,8 @@ Import-Package: org.apache.commons.io;version="2.2.0",
  org.apache.commons.lang;version="2.6.0",
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.service,
+ org.eclipse.smarthome.io.crypto,
  org.osgi.service.cm;version="1.5.0",
  org.slf4j;version="1.7.2"
 Service-Component: OSGI-INF/*.xml
+Require-Bundle: org.eclipse.smarthome.io.crypto

--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -63,3 +63,4 @@ Export-Package: org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.util
 Service-Component: OSGI-INF/*.xml
 Bundle-Activator: org.eclipse.smarthome.core.thing.internal.Activator
+Require-Bundle: org.eclipse.smarthome.io.crypto

--- a/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingManager.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/OSGI-INF/ThingManager.xml
@@ -22,4 +22,5 @@
    <reference bind="setThingTypeRegistry" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.type.ThingTypeRegistry" name="ThingTypeRegistry" policy="static" unbind="unsetThingTypeRegistry"/>
    <reference bind="setThingStatusInfoI18nLocalizationService" cardinality="1..1" interface="org.eclipse.smarthome.core.thing.i18n.ThingStatusInfoI18nLocalizationService" name="ThingStatusInfoI18nLocalizationService" policy="static" unbind="unsetThingStatusInfoI18nLocalizationService"/>
    <reference bind="addReadyMarker" cardinality="0..n" interface="org.eclipse.smarthome.core.service.ReadyMarker" name="ReadyMarker" policy="dynamic" unbind="removeReadyMarker"/>
+   <reference bind="setCryptoModule" cardinality="1..1" interface="org.eclipse.smarthome.io.crypto.Crypto" name="CryptoModule" policy="static" unbind="unsetCryptoModule"/>
 </scr:component>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -531,7 +531,7 @@ public class ThingManager extends AbstractItemEventSubscriber implements ThingTr
                     thing.setHandler(thingHandler);
                 }
 
-                decryptConfiguration(thing.getConfiguration());
+                // decryptConfiguration(thing.getConfiguration());
 
                 if (ThingHandlerHelper.isHandlerInitialized(thing) || isInitializing(thing)) {
                     try {
@@ -697,7 +697,7 @@ public class ThingManager extends AbstractItemEventSubscriber implements ThingTr
         if (thingType != null) {
             ThingFactoryHelper.applyDefaultConfiguration(thing.getConfiguration(), thingType,
                     configDescriptionRegistry);
-            decryptConfiguration(thing.getConfiguration());
+            // decryptConfiguration(thing.getConfiguration());
         }
     }
 

--- a/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Import-Package: org.apache.commons.lang,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.console,
  org.eclipse.smarthome.io.console.extensions,
+ org.eclipse.smarthome.io.crypto,
  org.osgi.framework,
  org.osgi.util.tracker,
  org.slf4j
@@ -22,3 +23,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.smarthome.io.console,
  org.eclipse.smarthome.io.console.extensions
 Bundle-ActivationPolicy: lazy
+Require-Bundle: org.eclipse.smarthome.io.crypto

--- a/bundles/io/org.eclipse.smarthome.io.console/OSGI-INF/EncryptConsoleCommandExtension.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console/OSGI-INF/EncryptConsoleCommandExtension.xml
@@ -8,10 +8,10 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.eclipse.smarthome.config.dispatch">
-   <implementation class="org.eclipse.smarthome.config.dispatch.internal.ConfigDispatcher"/>
-   
-   <reference bind="setConfigurationAdmin" cardinality="1..1" interface="org.osgi.service.cm.ConfigurationAdmin" name="ConfigurationAdmin" policy="static" unbind="unsetConfigurationAdmin"/>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.io.console.internal.extension.CryptoConsoleCommandExtension">
+   <implementation class="org.eclipse.smarthome.io.console.internal.extension.CryptoConsoleCommandExtension"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.io.console.extensions.ConsoleCommandExtension"/>
+   </service>
    <reference bind="setCryptoModule" cardinality="1..1" interface="org.eclipse.smarthome.io.crypto.Crypto" name="CryptoModule" policy="static" unbind="unsetCryptoModule"/>
-
 </scr:component>

--- a/bundles/io/org.eclipse.smarthome.io.console/src/main/java/org/eclipse/smarthome/io/console/internal/extension/CryptoConsoleCommandExtension.java
+++ b/bundles/io/org.eclipse.smarthome.io.console/src/main/java/org/eclipse/smarthome/io/console/internal/extension/CryptoConsoleCommandExtension.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.console.internal.extension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.smarthome.io.console.Console;
+import org.eclipse.smarthome.io.console.extensions.AbstractConsoleCommandExtension;
+import org.eclipse.smarthome.io.crypto.Crypto;
+
+/**
+ * Console command extension for crypto module functions.
+ *
+ * @author Pauli Anttila - Initial contribution
+ *
+ */
+public class CryptoConsoleCommandExtension extends AbstractConsoleCommandExtension {
+
+    private Crypto crypto;
+
+    private static final String SUBCMD_ENCRYPT = "encrypt";
+    private static final String SUBCMD_SET_PASSPHRASE = "setpassphrase";
+
+    public CryptoConsoleCommandExtension() {
+        super("crypto", "Crypto utils");
+    }
+
+    protected void setCryptoModule(Crypto crypto) {
+        this.crypto = crypto;
+    }
+
+    protected void unsetCryptoModule(Crypto crypto) {
+        this.crypto = null;
+    }
+
+    @Override
+    public List<String> getUsages() {
+        return Arrays
+                .asList(new String[] { buildCommandUsage(SUBCMD_ENCRYPT + " <plaintext>", "Encrypt plain text value"),
+                        buildCommandUsage(SUBCMD_SET_PASSPHRASE + " <passphrase>", "Set encryption passphrase") });
+    }
+
+    @Override
+    public void execute(String[] args, Console console) {
+        if (args.length > 0) {
+            String subCommand = args[0];
+            switch (subCommand) {
+                case SUBCMD_ENCRYPT:
+                    if (args.length > 1) {
+                        String value = args[1];
+                        try {
+                            String encryptedText = crypto.encrypt(value);
+                            console.println("Encrypted value: " + encryptedText);
+                        } catch (Exception e) {
+                            console.println("Error occured during value encryption: " + e.getMessage());
+                        }
+                    } else {
+                        console.println("Specify the plaintext to encrypt: " + this.getCommand() + " " + SUBCMD_ENCRYPT
+                                + " <plaintext>");
+                    }
+                    break;
+                case SUBCMD_SET_PASSPHRASE:
+                    if (args.length > 1) {
+                        String key = args[1];
+                        crypto.setEncPassphrase(key.getBytes());
+                    } else {
+                        console.println("Specify the passphrase: " + this.getCommand() + " " + SUBCMD_SET_PASSPHRASE
+                                + " <passphrase>");
+                    }
+                    break;
+                default:
+                    console.println("Unknown command '" + subCommand + "'");
+                    printUsage(console);
+                    break;
+            }
+        } else {
+            printUsage(console);
+        }
+    }
+
+}

--- a/bundles/io/org.eclipse.smarthome.io.encryption/.classpath
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/bundles/io/org.eclipse.smarthome.io.encryption/.project
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.io.crypto</name>
+	<comment>This is the crypto module of Eclipse SmartHome</comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/io/org.eclipse.smarthome.io.encryption/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/bundles/io/org.eclipse.smarthome.io.encryption/.settings/org.maven.ide.eclipse.prefs
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/.settings/org.maven.ide.eclipse.prefs
@@ -1,0 +1,9 @@
+#Fri Feb 19 22:30:18 CET 2010
+activeProfiles=
+eclipse.preferences.version=1
+fullBuildGoals=process-test-resources
+includeModules=false
+resolveWorkspaceProjects=true
+resourceFilterGoals=process-resources resources\:testResources
+skipCompilerPlugin=true
+version=1

--- a/bundles/io/org.eclipse.smarthome.io.encryption/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/META-INF/MANIFEST.MF
@@ -1,0 +1,15 @@
+Manifest-Version: 1.0
+Bundle-Name: Eclipse SmartHome Crypto Module
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-ManifestVersion: 2
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Import-Package: org.osgi.framework,
+ org.osgi.util.tracker,
+ org.slf4j
+Bundle-SymbolicName: org.eclipse.smarthome.io.crypto
+Originally-Created-By: Apache Maven Bundle Plugin
+Service-Component: OSGI-INF/*.xml
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: org.eclipse.smarthome.io.crypto
+Bundle-Activator: org.eclipse.smarthome.io.crypto.internal.CryptoActivator

--- a/bundles/io/org.eclipse.smarthome.io.encryption/OSGI-INF/CryptoModule.xml
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/OSGI-INF/CryptoModule.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014-2017 by the respective copyright holders.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.io.crypto.internal.CryptoModule">
+   <implementation class="org.eclipse.smarthome.io.crypto.internal.CryptoModule"/>
+   <service>
+      <provide interface="org.eclipse.smarthome.io.crypto.Crypto"/>
+   </service>
+</scr:component>

--- a/bundles/io/org.eclipse.smarthome.io.encryption/about.html
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/about.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 5, 2006</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+</body>
+</html>

--- a/bundles/io/org.eclipse.smarthome.io.encryption/build.properties
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/,src/main/resources/
+output.. = target/classes/
+bin.includes = META-INF/,\
+               OSGI-INF/,\
+               .,\
+               about.html

--- a/bundles/io/org.eclipse.smarthome.io.encryption/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.eclipse.smarthome.bundles</groupId>
+    <artifactId>io</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
+
+  <properties>
+    <bundle.symbolicName>org.eclipse.smarthome.io.crypto</bundle.symbolicName>
+    <bundle.namespace>org.eclipse.smarthome.io.crypto</bundle.namespace>
+  </properties>
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eclipse.smarthome.io</groupId>
+  <artifactId>org.eclipse.smarthome.io.crypto</artifactId>
+
+  <name>Eclipse SmartHome Crypto Module</name>
+
+  <packaging>eclipse-plugin</packaging>
+</project>

--- a/bundles/io/org.eclipse.smarthome.io.encryption/src/main/java/org/eclipse/smarthome/io/crypto/Crypto.java
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/src/main/java/org/eclipse/smarthome/io/crypto/Crypto.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.crypto;
+
+import java.security.InvalidKeyException;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+
+/**
+ * Crypto module API.
+ *
+ * @author Pauli Anttila - Initial contribution
+ *
+ */
+public interface Crypto {
+
+    public String encrypt(String plainText) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException;
+
+    public String decrypt(String encryptedText)
+            throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException;
+
+    void setEncPassphrase(byte[] secret);
+}

--- a/bundles/io/org.eclipse.smarthome.io.encryption/src/main/java/org/eclipse/smarthome/io/crypto/internal/CryptoActivator.java
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/src/main/java/org/eclipse/smarthome/io/crypto/internal/CryptoActivator.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.crypto.internal;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+
+/**
+ * Extension of the default OSGi bundle activator
+ *
+ * @author Pauli Anttila - Intial contribution
+ */
+public final class CryptoActivator implements BundleActivator {
+
+    private static byte[] encKey;
+
+    /**
+     * Called whenever the OSGi framework starts our bundle
+     */
+    @Override
+    public void start(BundleContext bc) throws Exception {
+
+        String key = System.getenv(CryptoModule.ENV_VARIABLE_ENC_PASSPHRASE);
+        if ("ASK".equalsIgnoreCase(key)) {
+            while (true) {
+                System.out.println("Give secret key to continue: ");
+                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                String line = br.readLine();
+                if (!line.isEmpty()) {
+                    // System.out.println("secret key: " + line);
+                    encKey = line.getBytes();
+                    break;
+                }
+            }
+
+        } else {
+            encKey = key.getBytes();
+        }
+    }
+
+    /**
+     * Called whenever the OSGi framework stops our bundle
+     */
+    @Override
+    public void stop(BundleContext bc) throws Exception {
+    }
+
+    public static byte[] getKey() {
+        return encKey;
+    }
+
+    public static void clearKey() {
+        Arrays.fill(encKey, (byte) 0);
+        encKey = null;
+    }
+}

--- a/bundles/io/org.eclipse.smarthome.io.encryption/src/main/java/org/eclipse/smarthome/io/crypto/internal/CryptoModule.java
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/src/main/java/org/eclipse/smarthome/io/crypto/internal/CryptoModule.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.io.crypto.internal;
+
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.PBEParameterSpec;
+import javax.xml.bind.DatatypeConverter;
+
+import org.eclipse.smarthome.io.crypto.Crypto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ *
+ * @author Pauli Anttila - Initial contribution
+ *
+ */
+public class CryptoModule implements Crypto {
+    public final static String ENV_VARIABLE_ENC_PASSPHRASE = "CFG_ENCRYPTION_PASSPHRASE";
+
+    private final Logger logger = LoggerFactory.getLogger(CryptoModule.class);
+
+    private byte[] salt = { (byte) 0xB8, (byte) 0x62, (byte) 0xF2, (byte) 0x29, (byte) 0x85, (byte) 0xE8, (byte) 0x11,
+            (byte) 0x96 };
+
+    private int iterationCount = 2000;
+    private Cipher dcipher;
+    private Cipher ecipher;
+    private SecretKey secretKey;
+
+    public CryptoModule() {
+        initEnc();
+    }
+
+    private void initEnc() {
+        try {
+            byte[] encodedKey = CryptoActivator.getKey();
+            if (encodedKey != null) {
+                setEncPassphrase(encodedKey);
+                CryptoActivator.clearKey();
+            }
+        } catch (IllegalArgumentException e) {
+            logger.warn("Secret key initialization failed. ", e);
+        }
+    }
+
+    @Override
+    public String encrypt(String plainText) throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+        if (ecipher != null) {
+            try {
+                AlgorithmParameterSpec paramSpec = new PBEParameterSpec(salt, iterationCount);
+                ecipher.init(Cipher.ENCRYPT_MODE, secretKey, paramSpec);
+                byte[] plainTextBytes = plainText.getBytes("UTF-8");
+                byte[] encryptedBytes = ecipher.doFinal(plainTextBytes);
+                Base64.Encoder encoder = Base64.getEncoder();
+                String encryptedText = encoder.encodeToString(encryptedBytes);
+                return encryptedText;
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            } catch (InvalidAlgorithmParameterException e) {
+                e.printStackTrace();
+            }
+            return null;
+
+        } else {
+            throw new IllegalStateException("Secret key not initialized");
+        }
+    }
+
+    @Override
+    public String decrypt(String encryptedText)
+            throws InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+
+        if (dcipher != null) {
+            try {
+                AlgorithmParameterSpec paramSpec = new PBEParameterSpec(salt, iterationCount);
+                dcipher.init(Cipher.DECRYPT_MODE, secretKey, paramSpec);
+                Base64.Decoder decoder = Base64.getDecoder();
+                byte[] encryptedTextBytes = decoder.decode(encryptedText);
+                byte[] decryptedBytes = dcipher.doFinal(encryptedTextBytes);
+                String decryptedText = new String(decryptedBytes, "UTF8");
+                return decryptedText;
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            } catch (InvalidAlgorithmParameterException e) {
+                e.printStackTrace();
+            }
+            return null;
+        } else {
+            throw new IllegalStateException("Secret key not initialized");
+        }
+    }
+
+    @Override
+    public void setEncPassphrase(byte[] secret) {
+        try {
+            String text = new String(secret, "UTF-8");
+            KeySpec keySpec = new PBEKeySpec(text.toCharArray(), salt, iterationCount);
+            secretKey = SecretKeyFactory.getInstance("PBEWithMD5AndDES").generateSecret(keySpec);
+            ecipher = Cipher.getInstance(secretKey.getAlgorithm());
+            dcipher = Cipher.getInstance(secretKey.getAlgorithm());
+        } catch (InvalidKeySpecException e) {
+            logger.warn("Error occured during encryption key initialization. ", e);
+        } catch (NoSuchPaddingException e) {
+            logger.warn("Error occured during encryption key initialization. ", e);
+        } catch (NoSuchAlgorithmException e) {
+            logger.warn("Error occured during encryption key initialization. ", e);
+        } catch (UnsupportedEncodingException e) {
+            logger.warn("Error occured during encryption key initialization. ", e);
+        }
+    }
+
+    public static byte[] toByteArray(String s) {
+        return DatatypeConverter.parseHexBinary(s);
+    }
+}

--- a/bundles/io/org.eclipse.smarthome.io.encryption/src/main/resources/readme.txt
+++ b/bundles/io/org.eclipse.smarthome.io.encryption/src/main/resources/readme.txt
@@ -1,0 +1,1 @@
+Bundle resources go in here!


### PR DESCRIPTION
I quickly tested idea to have encrypted credentials on property files. Idea was to store passphrase in the ENV variable. Or even make it more secure and ask passphrase during startup (currently from karaf console), then passphrase is not stored on target system disk at all but only in RAM. Karaf console command extension can be used to encrypt credentials which can be then stored in property files.

I also implemented simple crypto action in openHAB side, which could be used to decrypt credentials from rules. In fact, rules was my motivation for this as I use some rules to fetch iPhone location info, but I don't like to have my apple id credentials in plain text format in rule files.

This PR is just a POC and starting point for the discussion around the topic.

Signed-off-by: Pauli Anttila <pauli.anttila@gmail.com>