### PR TITLE
Core/net: Add getInterfaceAddresses.

### DIFF
--- a/docs/documentation/features/frameworkUtilities.md
+++ b/docs/documentation/features/frameworkUtilities.md
@@ -12,3 +12,5 @@ The `NetworkAddressService` is an OSGi service that can be used like any other O
 A user can configure his default network address via Paper UI under `Configuration -> System -> Network Settings`.
 One can obtain the configured address via the `getPrimaryIpv4HostAddress()` method on the service.
 This service is useful for example in the `ThingHandlerFactory` or an `AudioSink` where one needs a specific IP address of the host system to provide something like a `callback` URL.
+
+Some static methods like `getAllBroadcastAddresses()` for retrieving all interface broadcast addresses or `getInterfaceAddresses()` for retrieving all assigned interface addresses might be usefull as well for discovery services.


### PR DESCRIPTION
This completes getAllBroadcastAddresses() and is useful for discovery services.
A usecase is for example to compute the list of all assignable addresses for an interface to scan for a service/device.

This is used by the OH network binding and the Mqtt broker binding. See https://github.com/eclipse/smarthome/pull/3839#discussion_r135989687

The actual list of addresses is computed via:
```
NetUtil.getInterfaceAddresses(true).stream().map(interfaceIP -> Arrays
                .asList(new SubnetUtils(interfaceIP).getInfo().getAllAddresses()))
                .flatMap(List::stream).collect(Collectors.toList());
```

Signed-off-by: David Gräff <david.graeff@web.de>