### PR TITLE
Performed documentation changes

### DIFF
--- a/docs/_includes/documentation-menu.html
+++ b/docs/_includes/documentation-menu.html
@@ -18,18 +18,19 @@
 			<li><a href="{{docu}}/features/internationalization.html">Internationalization</a></li>
 			<li><a href="{{docu}}/features/frameworkUtilities.html">Framework Utilities</a></li>
 			<li><a href="{{docu}}/features/rules.html">Rules</a></li>
-			<li><a href="{{docu}}/features/bindings/hue/readme.html">Bindings</a>
+			<li><a href="{{docu}}/features/bindings/astro/readme.html">Bindings</a>
 				<ul>
 					<li><a href="{{docu}}/features/bindings/astro/readme.html">Astro</a></li>
+					<li><a href="{{docu}}/features/bindings/wemo/readme.html">Belkin Wemo</a></li>
 					<li><a href="{{docu}}/features/bindings/digitalstrom/readme.html">digitalSTROM</a></li>
-					<li><a href="{{docu}}/features/bindings/hue/readme.html">Philips Hue</a></li>
 					<li><a href="{{docu}}/features/bindings/fsinternetradio/readme.html">FS Internet Radio</a></li>
 					<li><a href="{{docu}}/features/bindings/lifx/readme.html">LIFX</a></li>
 					<li><a href="{{docu}}/features/bindings/lirc/readme.html">LIRC</a></li>
 					<li><a href="{{docu}}/features/bindings/ntp/readme.html">NTP Time Server</a></li>
+					<li><a href="{{docu}}/features/bindings/hue/readme.html">Philips Hue</a></li>
 					<li><a href="{{docu}}/features/bindings/sonos/readme.html">Sonos</a></li>
+					<li><a href="{{docu}}/features/bindings/tradfri/readme.html">IKEA Trådfri</a></li>
 					<li><a href="{{docu}}/features/bindings/weatherunderground/readme.html">Weather Underground</a></li>
-					<li><a href="{{docu}}/features/bindings/wemo/readme.html">Belkin Wemo</a></li>
 					<li><a href="{{docu}}/features/bindings/yahooweather/readme.html">Yahoo Weather</a></li>
 				</ul></li>
 			<li><a href="{{docu}}/features/icons.html">User Interfaces</a>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
@@ -13,6 +13,14 @@ The thing type ids are defined according to the lighting devices defined for Zig
 | Dimmable Light           | 0x0100           | 0100       |
 | Colour Temperature Light | 0x0220           | 0220       |
 
+
+The following matrix lists the capabilities (channels) for each of the supported lighting device types:
+
+| Thing type  | On/Off | Brightness | Color | Color Temperature |
+|-------------|:------:|:----------:|:-----:|:-----------------:|   
+|  0100       |    X   |     X      |       |                   |
+|  0220       |    X   |     X      |       |          X        |
+
 ## Thing Configuration
 
 The gateway requires a `host` parameter for the hostname or IP address and a `code`, which is the security code that is printed on the bottom of the gateway. Optionally, a `port` can be configured, but any standard gateway uses the default port 5684.
@@ -21,7 +29,7 @@ The devices require only a single (integer) parameter, which is their instance i
 
 ## Channels
 
-All devices support the `brightness` channel, while the white spectrum bulbs additionally also support the `color_temperature` channel.
+All devices support the `brightness` channel, while the white spectrum bulbs additionally also support the `color_temperature` channel (refer to the matrix above).
 
 | Channel Type ID   | Item Type | Description                                 |
 |-------------------|-----------|---------------------------------------------|


### PR DESCRIPTION
- Extended a little bit the Tradfri readme (in order to conform with the docs style created for HUE).
- Added the Tradfri readme to the documentation menu (Bindings section).
- Re-organized the "Bindings" section so that all bindings are listed in an alphabetical order (this used to be partially done).
- Changed the link of the "Bindings" section button so that it leads to the first binding in the list, not Philips HUE (which before also used to not be in the first position).

Local documentation builds performed in order to verify there are no visual issues.

Signed-off-by: Alexander Kostadinov <alexander.g.kostadinov@gmail.com>