### PR TITLE
NetUtils: Accomodate for different needs of getInterfaceAddresses()

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/net/internal/NetworkConfigOptionProvider.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/net/internal/NetworkConfigOptionProvider.java
@@ -7,27 +7,18 @@
  */
 package org.eclipse.smarthome.config.core.net.internal;
 
-import java.net.Inet6Address;
-import java.net.InetAddress;
-import java.net.InterfaceAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
+import java.net.Inet4Address;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
-import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.ConfigOptionProvider;
 import org.eclipse.smarthome.config.core.ParameterOption;
+import org.eclipse.smarthome.core.net.CidrAddress;
 import org.eclipse.smarthome.core.net.NetUtil;
 import org.osgi.service.component.annotations.Component;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provides a list of IPv4 addresses of the local machine and shows the user which interface belongs to which IP address
@@ -37,11 +28,8 @@ import org.slf4j.LoggerFactory;
  */
 @Component
 public class NetworkConfigOptionProvider implements ConfigOptionProvider {
-
     static final URI CONFIG_URI = URI.create("system:network");
     static final String PARAM_PRIMARY_ADDRESS = "primaryAddress";
-
-    private final Logger logger = LoggerFactory.getLogger(NetworkConfigOptionProvider.class);
 
     @Override
     public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
@@ -50,55 +38,10 @@ public class NetworkConfigOptionProvider implements ConfigOptionProvider {
         }
 
         if (param.equals(PARAM_PRIMARY_ADDRESS)) {
-            return getIPv4Addresses();
+            Stream<CidrAddress> ipv4Addresses = NetUtil.getAllInterfaceAddresses().stream()
+                    .filter(a -> a.getAddress() instanceof Inet4Address);
+            return ipv4Addresses.map(a -> new ParameterOption(a.toString(), a.toString())).collect(Collectors.toList());
         }
         return null;
     }
-
-    private List<ParameterOption> getIPv4Addresses() {
-        List<ParameterOption> interfaceOptions = new ArrayList<>();
-
-        Set<String> subnets = new HashSet<>();
-
-        try {
-            final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
-            while (interfaces.hasMoreElements()) {
-                final NetworkInterface current = interfaces.nextElement();
-                if (!current.isUp() || current.isLoopback() || current.isVirtual()) {
-                    continue;
-                }
-
-                for (InterfaceAddress ifAddr : current.getInterfaceAddresses()) {
-                    InetAddress addr = ifAddr.getAddress();
-
-                    if (addr.isLoopbackAddress() || (addr instanceof Inet6Address)) {
-                        continue;
-                    }
-
-                    @SuppressWarnings("null")
-                    @NonNull
-                    String ipv4Address = addr.getHostAddress();
-                    try {
-                        String subNetString = NetUtil.getIpv4NetAddress(ipv4Address, ifAddr.getNetworkPrefixLength())
-                                + "/" + String.valueOf(ifAddr.getNetworkPrefixLength());
-                        subnets.add(subNetString);
-                    } catch (IllegalArgumentException ex) {
-                        logger.error("Could not calculate network address: {} Ignoring IP {}", ex.getMessage(),
-                                ipv4Address, ex);
-                    }
-                }
-            }
-        } catch (SocketException ex) {
-            logger.error("Could not retrieve network interface: {}", ex.getMessage(), ex);
-            return null;
-        }
-
-        for (String subnet : subnets) {
-            ParameterOption po = new ParameterOption(subnet, subnet);
-            interfaceOptions.add(po);
-        }
-
-        return interfaceOptions;
-    }
-
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/CidrAddress.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/CidrAddress.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.net;
+
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.util.Objects;
+
+import org.eclipse.jdt.annotation.NonNull;
+
+/**
+ * The CIDR (Class-less interdomain routing) notation is an IP address
+ * and additionally ends with a slash followed by the network prefix length number.
+ *
+ * The toString() method will return a CIRDR representation, but the individual
+ * address and prefix length can be accessed as well.
+ *
+ * Java has a class that exactly provides this {@link InterfaceAddress}, but unfortunately
+ * no public constructor exists.
+ *
+ * @author David Graeff - Initial contribution
+ */
+public class CidrAddress {
+    private final InetAddress address;
+    private final int prefix;
+
+    public CidrAddress(@NonNull InetAddress address, short networkPrefixLength) {
+        this.address = address;
+        this.prefix = networkPrefixLength;
+    }
+
+    @Override
+    public String toString() {
+        if (prefix == 0) {
+            return address.getHostAddress();
+        } else {
+            return address.getHostAddress() + "/" + String.valueOf(prefix);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof CidrAddress)) {
+            return false;
+        }
+        CidrAddress c = (CidrAddress) o;
+        return c.getAddress().equals(getAddress()) && c.getPrefix() == getPrefix();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getAddress().hashCode(), getPrefix());
+    }
+
+    public int getPrefix() {
+        return prefix;
+    }
+
+    public InetAddress getAddress() {
+        return address;
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -198,7 +198,6 @@ public class NetUtil implements NetworkAddressService {
      *
      * @return The collected IPv4 and IPv6 Addresses
      */
-    @SuppressWarnings("null")
     public static Collection<CidrAddress> getAllInterfaceAddresses() {
         Collection<CidrAddress> interfaceIPs = new ArrayList<>();
         Enumeration<NetworkInterface> en;
@@ -221,7 +220,10 @@ public class NetUtil implements NetworkAddressService {
             }
 
             for (InterfaceAddress cidr : networkInterface.getInterfaceAddresses()) {
-                interfaceIPs.add(new CidrAddress(cidr.getAddress(), cidr.getNetworkPrefixLength()));
+                final InetAddress address = cidr.getAddress();
+                assert address != null; // NetworkInterface.getInterfaceAddresses() should return only non-null
+                                        // addresses
+                interfaceIPs.add(new CidrAddress(address, cidr.getNetworkPrefixLength()));
             }
         }
 


### PR DESCRIPTION
I'm sorry for the API break. The method is only in core since a few days but I propose these changes:

* Adapt the name, instead of `getAllInterfaceAddresses` it is `getAllInterfaceAddresses` to be in line with other methods of the class.
* Return a collection instead of a set.
* Introduce a CIDR notation class. The boolean flag is therefore removed from the signture of the method.
* Adapt NetworkConfigOptionProvider to use the API. I thing the advantages of a CIDR class (in this case filter for IPv4 addresses) can be seen.

Signed-off-by: David Gräff <david.graeff@web.de>