### PR TITLE
storage: add containsKey method

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/storage/Storage.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/storage/Storage.java
@@ -41,6 +41,16 @@ public interface Storage<T> {
     T remove(@NonNull String key);
 
     /**
+     * Check if the storage contains a key.
+     *
+     * @param key the key
+     * @return true if the storage contains the key, otherwise false
+     */
+    default boolean containsKey(@NonNull String key) {
+        return getKeys().contains(key);
+    }
+
+    /**
      * Gets the value mapped to the key specified.
      *
      * @param key the key

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/storage/Storage.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/storage/Storage.java
@@ -46,9 +46,7 @@ public interface Storage<T> {
      * @param key the key
      * @return true if the storage contains the key, otherwise false
      */
-    default boolean containsKey(@NonNull String key) {
-        return getKeys().contains(key);
-    }
+    boolean containsKey(@NonNull String key);
 
     /**
      * Gets the value mapped to the key specified.

--- a/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/JsonStorage.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/JsonStorage.java
@@ -20,6 +20,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.storage.Storage;
 import org.slf4j.Logger;
@@ -75,8 +76,9 @@ public class JsonStorage<T> implements Storage<T> {
         this.writeDelay = writeDelay;
         this.maxDeferredPeriod = maxDeferredPeriod;
 
-        this.internalMapper = new GsonBuilder().registerTypeHierarchyAdapter(Map.class, new StorageEntryMapDeserializer())
-                .setPrettyPrinting().create();
+        this.internalMapper = new GsonBuilder()
+                .registerTypeHierarchyAdapter(Map.class, new StorageEntryMapDeserializer()).setPrettyPrinting()
+                .create();
         this.entityMapper = new GsonBuilder().registerTypeAdapter(Configuration.class, new ConfigurationDeserializer())
                 .setPrettyPrinting().create();
 
@@ -137,6 +139,11 @@ public class JsonStorage<T> implements Storage<T> {
         StorageEntry removedElement = map.remove(key);
         deferredCommit();
         return deserialize(removedElement);
+    }
+
+    @Override
+    public boolean containsKey(final @NonNull String key) {
+        return map.containsKey(key);
     }
 
     @Override

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/src/main/java/org/eclipse/smarthome/storage/mapdb/MapDbStorage.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/src/main/java/org/eclipse/smarthome/storage/mapdb/MapDbStorage.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.storage.DeletableStorage;
 import org.eclipse.smarthome.core.storage.Storage;
 import org.mapdb.DB;
@@ -74,6 +75,11 @@ public class MapDbStorage<T> implements DeletableStorage<T> {
         String removedElement = map.remove(key);
         db.commit();
         return deserialize(removedElement);
+    }
+
+    @Override
+    public boolean containsKey(final @NonNull String key) {
+        return map.containsKey(key);
     }
 
     @Override

--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/storage/VolatileStorage.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/storage/VolatileStorage.java
@@ -11,11 +11,12 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.storage.Storage;
 
 /**
  * A {@link Storage} implementation which stores it's data in-memory.
- * 
+ *
  * @author Thomas.Eichstaedt-Engelen - Initial Contribution and API
  * @author Kai Kreuzer - improved return values
  */
@@ -31,6 +32,11 @@ public class VolatileStorage<T> implements Storage<T> {
     @Override
     public T remove(String key) {
         return storage.remove(key);
+    }
+
+    @Override
+    public boolean containsKey(final @NonNull String key) {
+        return storage.containsKey(key);
     }
 
     @Override


### PR DESCRIPTION
The storage interface returns null if you call get for a key that is not
present in the storage.
If you want to check if a key is present (and differ between non-present
or present but an assigned null value) you currently need to call
`storage.getKeys().contains(key)`.
Normally there exist better implementation that does not require to
create a collection of all keys first and then check that collection.
