### PR TITLE
Switch DS annotation processor to openhab/felix fork.

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -60,7 +60,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.felix</groupId>
+      <groupId>org.openhab</groupId>
       <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
       <version>${ds-annotations.version}</version>
       <optional>true</optional>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -56,7 +56,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.felix</groupId>
+      <groupId>org.openhab</groupId>
       <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
       <version>${ds-annotations.version}</version>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <tycho-groupid>org.eclipse.tycho</tycho-groupid>
     <xtext-version>2.12.0</xtext-version>
     <karaf.version>4.0.3</karaf.version>
-    <ds-annotations.version>1.2.8</ds-annotations.version>
+    <ds-annotations.version>1.2.9-AG1</ds-annotations.version>
     <jdt-annotations.version>2.1.0</jdt-annotations.version>
     <build.helper.maven.plugin.version>1.8</build.helper.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -154,7 +154,7 @@
           <configuration>
             <extraClasspathElements>
               <extraClasspathElement>
-                <groupId>org.apache.felix</groupId>
+                <groupId>org.openhab</groupId>
                 <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
                 <version>${ds-annotations.version}</version>
               </extraClasspathElement>


### PR DESCRIPTION
Fixes #4179.

This should be applied as soon as org.openhab:org.apache.felix.scr.ds-annotations:1.2.9-AG1 is available from the openHAB maven repo.

Signed-off-by: Henning Treu <henning.treu@telekom.de>