### PR TITLE
Extended the zoom channel category to also allow Number and Dimmer

### DIFF
--- a/docs/_data/categories_channel.csv
+++ b/docs/_data/categories_channel.csv
@@ -32,4 +32,4 @@ Temperature,"R, RW",Number,temperature.png
 Water,R,"Switch, Number",water.png
 Wind,R,Number,wind.png
 Window,"R, RW","String, Switch",window.png
-Zoom,RW,String,zoom.png
+Zoom,RW,"String, Dimmer, Number",zoom.png


### PR DESCRIPTION
I just stumbled upon the ZOOM channel category, which is listed as a String type. Maybe I missed something, but wouldn't it rather make sense to be of Numeric type? A quick search on Github didn't bring up an existing binding using it. Is there any particular reason why it needs to be a String? 

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>