### PR TITLE
Renamed a package in the org.eclipse.smarthome.automation.module…

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/CompareConditionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/CompareConditionHandler.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import org.eclipse.smarthome.automation.Condition;
 import org.eclipse.smarthome.automation.handler.BaseModuleHandler;
 import org.eclipse.smarthome.automation.handler.ConditionHandler;
-import org.eclipse.smarthome.automation.module.core.handler.exception.UncomparableException;
+import org.eclipse.smarthome.automation.module.core.internal.exception.UncomparableException;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.TypeParser;
 import org.slf4j.Logger;

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/internal/exception/UncomparableException.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/internal/exception/UncomparableException.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.automation.module.core.handler.exception;
+package org.eclipse.smarthome.automation.module.core.internal.exception;
 
 /**
  * This Exception is used as an indicator for not matching types during comparation


### PR DESCRIPTION
….core bundle to internal.

See openhab/static-code-analysis#100

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>