### PR TITLE
Parameter assignment warnings

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/AutomationResourceBundlesTracker.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/AutomationResourceBundlesTracker.java
@@ -253,13 +253,11 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
      */
     @SuppressWarnings({ "rawtypes" })
     protected void addEvent(Bundle bundle, BundleEvent event) {
-        if (event == null) {
-            event = initializeEvent(bundle);
-        }
+        BundleEvent e = event != null ? event : initializeEvent(bundle);
         synchronized (queue) {
-            queue.add(event);
+            queue.add(e);
             for (AutomationResourceBundlesEventQueue queue : providerEventsQueue) {
-                queue.addEvent(bundle, event);
+                queue.addEvent(bundle, e);
             }
         }
     }

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/Configuration.java
@@ -112,9 +112,10 @@ public class Configuration {
     private List<Field> getAllFields(Class<?> clazz) {
         List<Field> fields = new ArrayList<Field>();
 
-        while (clazz != null) {
-            fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
-            clazz = clazz.getSuperclass();
+        Class<?> currentClass = clazz;
+        while (currentClass != null) {
+            fields.addAll(Arrays.asList(currentClass.getDeclaredFields()));
+            currentClass = currentClass.getSuperclass();
         }
 
         return fields;

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
@@ -310,12 +310,11 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      */
     protected void removeOlderResults(long timestamp, Collection<ThingTypeUID> thingTypeUIDs) {
         Collection<ThingUID> removedThings = null;
-        if (thingTypeUIDs == null) {
-            thingTypeUIDs = getSupportedThingTypes();
-        }
+
+        Collection<ThingTypeUID> toBeRemoved = thingTypeUIDs != null ? thingTypeUIDs : getSupportedThingTypes();
         for (DiscoveryListener discoveryListener : discoveryListeners) {
             try {
-                removedThings = discoveryListener.removeOlderResults(this, timestamp, thingTypeUIDs);
+                removedThings = discoveryListener.removeOlderResults(this, timestamp, toBeRemoved);
             } catch (Exception e) {
                 logger.error("An error occurred while calling the discovery listener {}.",
                         discoveryListener.getClass().getName(), e);

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/util/ConverterValueMap.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/util/ConverterValueMap.java
@@ -52,14 +52,9 @@ public class ConverterValueMap {
      */
     public ConverterValueMap(HierarchicalStreamReader reader, int numberOfValues, UnmarshallingContext context)
             throws ConversionException {
-
-        if (numberOfValues < -1) {
-            numberOfValues = -1;
-        }
-
         this.reader = reader;
         this.context = context;
-        this.valueMap = readValueMap(this.reader, numberOfValues, this.context);
+        this.valueMap = readValueMap(this.reader, numberOfValues >= -1 ? numberOfValues : -1, this.context);
     }
 
     /**

--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/util/NodeList.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/util/NodeList.java
@@ -104,8 +104,9 @@ public class NodeList implements NodeName {
         if (this.list != null) {
             attributes = new ArrayList<>(this.list.size());
 
-            if ((formattedText == null) || (formattedText.isEmpty())) {
-                formattedText = "%s";
+            String format = formattedText;
+            if ((format == null) || (format.isEmpty())) {
+                format = "%s";
             }
 
             for (NodeAttributes node : (List<NodeAttributes>) this.list) {
@@ -113,10 +114,10 @@ public class NodeList implements NodeName {
                     String attributeValue = node.getAttribute(attributeName);
 
                     if (attributeValue != null) {
-                        attributes.add(String.format(formattedText, attributeValue));
+                        attributes.add(String.format(format, attributeValue));
                     } else {
-                        throw new ConversionException("Missing attribute '" + attributeName + "' in '" + nodeName
-                                + "'!");
+                        throw new ConversionException(
+                                "Missing attribute '" + attributeName + "' in '" + nodeName + "'!");
                     }
                 } else {
                     throw new ConversionException("Invalid attribute in '" + nodeName + "'!");

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/XmlHelper.java
@@ -26,9 +26,12 @@ public class XmlHelper {
      * @return system uid (e.g. "system:test")
      */
     public static String getSystemUID(String typeId) {
+        String type;
         if (typeId.startsWith(SYSTEM_NAMESPACE_PREFIX)) {
-            typeId = typeId.substring(SYSTEM_NAMESPACE_PREFIX.length());
+            type = typeId.substring(SYSTEM_NAMESPACE_PREFIX.length());
+        } else {
+            type = typeId;
         }
-        return String.format("%s:%s", SYSTEM_NAMESPACE, typeId);
+        return String.format("%s:%s", SYSTEM_NAMESPACE, type);
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
@@ -249,12 +249,10 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
     @Override
     public Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration, ThingUID thingUID,
             ThingUID bridgeUID) {
-        if (thingUID == null) {
-            thingUID = ThingFactory.generateRandomThingUID(thingTypeUID);
-        }
+        ThingUID effectiveUID = thingUID != null ? thingUID : ThingFactory.generateRandomThingUID(thingTypeUID);
         ThingType thingType = getThingTypeByUID(thingTypeUID);
         if (thingType != null) {
-            Thing thing = ThingFactory.createThing(thingType, thingUID, configuration, bridgeUID,
+            Thing thing = ThingFactory.createThing(thingType, effectiveUID, configuration, bridgeUID,
                     getConfigDescriptionRegistry());
             return thing;
         } else {

--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceManagerImpl.java
@@ -126,22 +126,23 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
     }
 
     @Override
-    public void say(String text, String voiceId, String sinkId) {
+    public void say(String text, String voiceIda, String sinkId) {
         try {
             TTSService tts = null;
             Voice voice = null;
-            if (voiceId == null) {
+            String selectedVoiceId = voiceIda;
+            if (selectedVoiceId == null) {
                 // use the configured default, if set
-                voiceId = defaultVoice;
+                selectedVoiceId = defaultVoice;
             }
-            if (voiceId == null) {
+            if (selectedVoiceId == null) {
                 tts = getTTS();
                 if (tts != null) {
                     voice = getPreferredVoice(tts.getAvailableVoices());
                 }
-            } else if (voiceId.contains(":")) {
+            } else if (selectedVoiceId.contains(":")) {
                 // it is a fully qualified unique id
-                String[] segments = voiceId.split(":");
+                String[] segments = selectedVoiceId.split(":");
                 tts = getTTS(segments[0]);
                 if (tts != null) {
                     voice = getVoice(tts.getAvailableVoices(), segments[1]);
@@ -150,11 +151,11 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
                 // voiceId is not fully qualified
                 tts = getTTS();
                 if (tts != null) {
-                    voice = getVoice(tts.getAvailableVoices(), voiceId);
+                    voice = getVoice(tts.getAvailableVoices(), selectedVoiceId);
                 }
             }
             if (tts == null) {
-                throw new TTSException("No TTS service can be found for voice " + voiceId);
+                throw new TTSException("No TTS service can be found for voice " + selectedVoiceId);
             }
             if (voice == null) {
                 throw new TTSException(
@@ -369,24 +370,25 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
     }
 
     @Override
-    public void startDialog(KSService ks, STTService stt, TTSService tts, HumanLanguageInterpreter hli,
-            AudioSource source, AudioSink sink, Locale locale, String keyword, String listeningItem) {
+    public void startDialog(KSService ksService, STTService sttService, TTSService ttsService,
+            HumanLanguageInterpreter interpreter, AudioSource audioSource, AudioSink audioSink, Locale locale,
+            String keyword, String listeningItem) {
 
         // use defaults, if null
-        ks = (ks == null) ? getKS() : ks;
-        stt = (stt == null) ? getSTT() : stt;
-        tts = (tts == null) ? getTTS() : tts;
-        hli = (hli == null) ? getHLI() : hli;
-        source = (source == null) ? audioManager.getSource() : source;
-        sink = (sink == null) ? audioManager.getSink() : sink;
-        locale = (locale == null) ? localeProvider.getLocale() : locale;
-        keyword = (keyword == null) ? this.keyword : keyword;
-        listeningItem = (listeningItem == null) ? this.listeningItem : listeningItem;
+        KSService ks = (ksService == null) ? getKS() : ksService;
+        STTService stt = (sttService == null) ? getSTT() : sttService;
+        TTSService tts = (ttsService == null) ? getTTS() : ttsService;
+        HumanLanguageInterpreter hli = (interpreter == null) ? getHLI() : interpreter;
+        AudioSource source = (audioSource == null) ? audioManager.getSource() : audioSource;
+        AudioSink sink = (audioSink == null) ? audioManager.getSink() : audioSink;
+        Locale loc = (locale == null) ? localeProvider.getLocale() : locale;
+        String kw = (keyword == null) ? this.keyword : keyword;
+        String item = (listeningItem == null) ? this.listeningItem : listeningItem;
 
-        if (ks != null && stt != null && tts != null && hli != null && source != null && sink != null && locale != null
-                && keyword != null) {
-            DialogProcessor processor = new DialogProcessor(ks, stt, tts, hli, source, sink, locale, keyword,
-                    listeningItem, this.eventPublisher);
+        if (ks != null && stt != null && tts != null && hli != null && source != null && sink != null && loc != null
+                && kw != null) {
+            DialogProcessor processor = new DialogProcessor(ks, stt, tts, hli, source, sink, loc, kw, item,
+                    this.eventPublisher);
             processor.start();
         } else {
             String msg = "Cannot start dialog as services are missing.";

--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -660,10 +660,11 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         }
 
         private Expression unwrapLet(Expression expression) {
-            while (expression instanceof ExpressionLet) {
-                expression = ((ExpressionLet) expression).getSubExpression();
+            Expression exp = expression;
+            while (exp instanceof ExpressionLet) {
+                exp = ((ExpressionLet) expression).getSubExpression();
             }
-            return expression;
+            return exp;
         }
 
         private void emit(Object obj) {
@@ -701,17 +702,17 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
         }
 
         private void emitExpression(Expression expression) {
-            expression = unwrapLet(expression);
-            if (expression instanceof ExpressionMatch) {
-                emitMatchExpression((ExpressionMatch) expression);
-            } else if (expression instanceof ExpressionSequence) {
-                emitSequenceExpression((ExpressionSequence) expression);
-            } else if (expression instanceof ExpressionAlternatives) {
-                emitAlternativesExpression((ExpressionAlternatives) expression);
-            } else if (expression instanceof ExpressionCardinality) {
-                emitCardinalExpression((ExpressionCardinality) expression);
-            } else if (expression instanceof ExpressionIdentifier) {
-                emitItemIdentifierExpression((ExpressionIdentifier) expression);
+            Expression unwrappedExpression = unwrapLet(expression);
+            if (unwrappedExpression instanceof ExpressionMatch) {
+                emitMatchExpression((ExpressionMatch) unwrappedExpression);
+            } else if (unwrappedExpression instanceof ExpressionSequence) {
+                emitSequenceExpression((ExpressionSequence) unwrappedExpression);
+            } else if (unwrappedExpression instanceof ExpressionAlternatives) {
+                emitAlternativesExpression((ExpressionAlternatives) unwrappedExpression);
+            } else if (unwrappedExpression instanceof ExpressionCardinality) {
+                emitCardinalExpression((ExpressionCardinality) unwrappedExpression);
+            } else if (unwrappedExpression instanceof ExpressionIdentifier) {
+                emitItemIdentifierExpression((ExpressionIdentifier) unwrappedExpression);
             }
         }
 

--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/text/ExpressionCardinality.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/text/ExpressionCardinality.java
@@ -41,7 +41,8 @@ public final class ExpressionCardinality extends Expression {
     }
 
     @Override
-    ASTNode parse(ResourceBundle language, TokenList list) {
+    ASTNode parse(ResourceBundle language, TokenList tokenList) {
+        TokenList list = tokenList;
         ASTNode node = new ASTNode(), cr;
         ArrayList<ASTNode> nodes = new ArrayList<ASTNode>();
         ArrayList<Object> values = new ArrayList<Object>();

--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/text/ExpressionSequence.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/text/ExpressionSequence.java
@@ -35,7 +35,8 @@ public final class ExpressionSequence extends Expression {
     }
 
     @Override
-    ASTNode parse(ResourceBundle language, TokenList list) {
+    ASTNode parse(ResourceBundle language, TokenList tokenList) {
+        TokenList list = tokenList;
         int l = subExpressions.size();
         ASTNode node = new ASTNode(), cr;
         ASTNode[] children = new ASTNode[l];

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/LanguageResourceBundleManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/LanguageResourceBundleManager.java
@@ -132,15 +132,14 @@ public class LanguageResourceBundleManager {
      */
     public String getText(String resource, String key, Locale locale) {
         if ((key != null) && (!key.isEmpty())) {
-            if (locale == null) {
-                locale = localeProvider.getLocale();
-            }
+
+            Locale effectiveLocale = locale != null ? locale : localeProvider.getLocale();
 
             if (resource != null) {
-                return getTranslatedText(resource, key, locale);
+                return getTranslatedText(resource, key, effectiveLocale);
             } else {
                 for (String resourceName : this.resourceNames) {
-                    String text = getTranslatedText(resourceName, key, locale);
+                    String text = getTranslatedText(resourceName, key, effectiveLocale);
 
                     if (text != null) {
                         return text;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/RecurrenceExpression.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/RecurrenceExpression.java
@@ -832,7 +832,7 @@ public class RecurrenceExpression extends AbstractExpression<RecurrenceExpressio
             cal.setLenient(false);
             cal.setTime(getStartDate());
 
-            candidates = new ArrayList<Date>();
+            ArrayList<Date> ret = new ArrayList<>();
             ArrayList<Date> newCandidates = new ArrayList<Date>();
             newCandidates.add(cal.getTime());
 
@@ -843,8 +843,8 @@ public class RecurrenceExpression extends AbstractExpression<RecurrenceExpressio
                 newCandidates.add(cal.getTime());
             }
 
-            candidates.addAll(newCandidates);
-            return candidates;
+            ret.addAll(newCandidates);
+            return ret;
         }
 
         @Override

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/persistence/PersistenceResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/persistence/PersistenceResource.java
@@ -198,20 +198,19 @@ public class PersistenceResource implements RESTResource {
 
         // If serviceId is null, then use the default service
         PersistenceService service = null;
-        if (serviceId == null) {
-            serviceId = persistenceServiceRegistry.getDefaultId();
-        }
-        service = persistenceServiceRegistry.get(serviceId);
+        String effectiveServiceId = serviceId != null ? serviceId : persistenceServiceRegistry.getDefaultId();
+        service = persistenceServiceRegistry.get(effectiveServiceId);
 
         if (service == null) {
-            logger.debug("Persistence service not found '{}'.", serviceId);
-            return JSONResponse.createErrorResponse(Status.BAD_REQUEST, "Persistence service not found: " + serviceId);
+            logger.debug("Persistence service not found '{}'.", effectiveServiceId);
+            return JSONResponse.createErrorResponse(Status.BAD_REQUEST,
+                    "Persistence service not found: " + effectiveServiceId);
         }
 
         if (!(service instanceof QueryablePersistenceService)) {
-            logger.debug("Persistence service not queryable '{}'.", serviceId);
+            logger.debug("Persistence service not queryable '{}'.", effectiveServiceId);
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST,
-                    "Persistence service not queryable: " + serviceId);
+                    "Persistence service not queryable: " + effectiveServiceId);
         }
 
         QueryablePersistenceService qService = (QueryablePersistenceService) service;
@@ -421,14 +420,12 @@ public class PersistenceResource implements RESTResource {
     private Response putItemState(String serviceId, String itemName, String value, String time) {
         // If serviceId is null, then use the default service
         PersistenceService service = null;
-        if (serviceId == null) {
-            serviceId = persistenceServiceRegistry.getDefaultId();
-        }
-        service = persistenceServiceRegistry.get(serviceId);
+        String effectiveServiceId = serviceId != null ? serviceId : persistenceServiceRegistry.getDefaultId();
+        service = persistenceServiceRegistry.get(effectiveServiceId);
 
         if (service == null) {
-            logger.warn("Persistence service not found '{}'.", serviceId);
-            return JSONResponse.createErrorResponse(Status.BAD_REQUEST, "Persistence service not found: " + serviceId);
+            logger.warn("Persistence service not found '{}'.", effectiveServiceId);
+            return JSONResponse.createErrorResponse(Status.BAD_REQUEST, "Persistence service not found: " + effectiveServiceId);
         }
 
         Item item;
@@ -461,9 +458,9 @@ public class PersistenceResource implements RESTResource {
         }
 
         if (!(service instanceof ModifiablePersistenceService)) {
-            logger.warn("Persistence service not modifiable '{}'.", serviceId);
+            logger.warn("Persistence service not modifiable '{}'.", effectiveServiceId);
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST,
-                    "Persistence service not modifiable: " + serviceId);
+                    "Persistence service not modifiable: " + effectiveServiceId);
         }
 
         ModifiablePersistenceService mService = (ModifiablePersistenceService) service;

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
@@ -84,18 +84,21 @@ public class LogHandler implements RESTResource {
             return Response.ok("[]").build();
         }
 
+        int effectiveLimit;
         if (limit == null || limit <= 0 || limit > LogConstants.LOG_BUFFER_LIMIT) {
-            limit = LOG_BUFFER.size();
+            effectiveLimit = LOG_BUFFER.size();
+        } else {
+            effectiveLimit = limit;
         }
 
-        if (limit >= LOG_BUFFER.size()) {
+        if (effectiveLimit >= LOG_BUFFER.size()) {
             return Response.ok(LOG_BUFFER.toArray()).build();
         } else {
             final List<LogMessage> result = new ArrayList<>();
             Iterator<LogMessage> iter = LOG_BUFFER.descendingIterator();
             do {
                 result.add(iter.next());
-            } while (iter.hasNext() && result.size() < limit);
+            } while (iter.hasNext() && result.size() < effectiveLimit);
             Collections.reverse(result);
             return Response.ok(result).build();
         }

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -300,10 +300,9 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
                             logger.debug("Received HTTP GET request at '{}' for the unknown page id '{}'.", uri,
                                     pageId);
                         } else {
-                            logger.debug(
-                                    "Received HTTP GET request at '{}' for the page id '{}'. "
-                                            + "This id refers to a non-linkable widget and is therefore no valid page id.",
-                                    uri, pageId);
+                            logger.debug("Received HTTP GET request at '{}' for the page id '{}'. "
+                                    + "This id refers to a non-linkable widget and is therefore no valid page id.", uri,
+                                    pageId);
                         }
                     }
                     throw new WebApplicationException(404);
@@ -413,9 +412,10 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
             EList<Widget> children = itemUIRegistry.getChildren(linkableWidget);
             if (widget instanceof Frame) {
                 int cntWidget = 0;
+                String wID = widgetId;
                 for (Widget child : children) {
-                    widgetId += "_" + cntWidget;
-                    WidgetDTO subWidget = createWidgetBean(sitemapName, child, drillDown, uri, widgetId, locale);
+                    wID += "_" + cntWidget;
+                    WidgetDTO subWidget = createWidgetBean(sitemapName, child, drillDown, uri, wID, locale);
                     if (subWidget != null) {
                         bean.widgets.add(subWidget);
                         cntWidget++;

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactory.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactory.java
@@ -78,21 +78,22 @@ public class TestHueThingHandlerFactory extends BaseThingHandlerFactory {
     }
 
     private ThingUID getBridgeThingUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration) {
-        if (thingUID == null) {
+        if (thingUID != null) {
+            return thingUID;
+        } else {
             String serialNumber = (String) configuration.get(SERIAL_NUMBER);
-            thingUID = new ThingUID(thingTypeUID, serialNumber);
+            return new ThingUID(thingTypeUID, serialNumber);
         }
-        return thingUID;
     }
 
     private ThingUID getLightUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration,
             ThingUID bridgeUID) {
-        String lightId = (String) configuration.get(LIGHT_ID);
-
-        if (thingUID == null) {
-            thingUID = new ThingUID(thingTypeUID, lightId, bridgeUID.getId());
+        if (thingUID != null) {
+            return thingUID;
+        } else {
+            String lightId = (String) configuration.get(LIGHT_ID);
+            return new ThingUID(thingTypeUID, lightId, bridgeUID.getId());
         }
-        return thingUID;
     }
 
     @Override

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactoryX.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/test/hue/TestHueThingHandlerFactoryX.java
@@ -50,11 +50,10 @@ public class TestHueThingHandlerFactoryX extends BaseThingHandlerFactory {
     public static final String LIGHT_ID = "XlightId";
 
     public TestHueThingHandlerFactoryX(ComponentContext componentContext) {
-    	
-		super.activate(componentContext);
-	}
-    
-    
+
+        super.activate(componentContext);
+    }
+
     @Override
     public Thing createThing(ThingTypeUID thingTypeUID, Configuration configuration, ThingUID thingUID,
             ThingUID bridgeUID) {
@@ -75,21 +74,22 @@ public class TestHueThingHandlerFactoryX extends BaseThingHandlerFactory {
     }
 
     private ThingUID getBridgeThingUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration) {
-        if (thingUID == null) {
+        if (thingUID != null) {
+            return thingUID;
+        } else {
             String serialNumber = (String) configuration.get(SERIAL_NUMBER);
-            thingUID = new ThingUID(thingTypeUID, serialNumber);
+            return new ThingUID(thingTypeUID, serialNumber);
         }
-        return thingUID;
     }
 
     private ThingUID getLightUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration,
             ThingUID bridgeUID) {
-        String lightId = (String) configuration.get(LIGHT_ID);
-
-        if (thingUID == null) {
-            thingUID = new ThingUID(thingTypeUID, lightId, bridgeUID.getId());
+        if (thingUID != null) {
+            return thingUID;
+        } else {
+            String lightId = (String) configuration.get(LIGHT_ID);
+            return new ThingUID(thingTypeUID, lightId, bridgeUID.getId());
         }
-        return thingUID;
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/calc/MoonCalc.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/calc/MoonCalc.java
@@ -217,13 +217,16 @@ public class MoonCalc {
             return riseSet;
         }
         double riseMinute = (riseSet - Math.floor(riseSet)) * 60.0 / 100.0;
+        double rounded;
         if (riseMinute >= .595) {
             riseMinute = 0;
-            riseSet += 1;
+            rounded = riseSet + 1;
+        } else {
+            rounded = riseSet;
         }
-        riseSet = Math.floor(riseSet) + riseMinute;
+        rounded = Math.floor(rounded) + riseMinute;
 
-        BigDecimal bd = new BigDecimal(Double.toString(riseSet));
+        BigDecimal bd = new BigDecimal(Double.toString(rounded));
         bd = bd.setScale(2, BigDecimal.ROUND_HALF_UP);
         return bd.doubleValue();
     }
@@ -232,14 +235,14 @@ public class MoonCalc {
      * Calculates the moon phase.
      */
     private double calcMoonPhase(double k, double mode) {
-        k = Math.floor(k) + mode;
-        double t = k / 1236.85;
+        double k_mod = Math.floor(k) + mode;
+        double t = k_mod / 1236.85;
         double e = var_e(t);
-        double m = var_m(k, t);
-        double m1 = var_m1(k, t);
-        double f = var_f(k, t);
-        double o = var_o(k, t);
-        double jd = var_jde(k, t);
+        double m = var_m(k_mod, t);
+        double m1 = var_m1(k_mod, t);
+        double f = var_f(k_mod, t);
+        double o = var_o(k_mod, t);
+        double jd = var_jde(k_mod, t);
         if (mode == NEW_MOON) {
             jd += -.4072 * SN(m1) + .17241 * e * SN(m) + .01608 * SN(2 * m1) + .01039 * SN(2 * f)
                     + .00739 * e * SN(m1 - m) - .00514 * e * SN(m1 + m) + .00208 * e * e * SN(2 * m)
@@ -277,32 +280,32 @@ public class MoonCalc {
                     + .00002 * CS(2 * f);
             jd += (mode == FIRST_QUARTER) ? w : -w;
         }
-        return moonCorrection(jd, t, k);
+        return moonCorrection(jd, t, k_mod);
     }
 
     /**
      * Calculates the eclipse.
      */
     private double getEclipse(double k, double typ, int mode) {
-        k = Math.floor(k) + typ;
-        double t = k / 1236.85;
-        double f = var_f(k, t);
+        double k_mod = Math.floor(k) + typ;
+        double t = k_mod / 1236.85;
+        double f = var_f(k_mod, t);
         double jd = 0;
         double ringTest = 0;
         if (SN(Math.abs(f)) <= .36) {
-            double o = var_o(k, t);
+            double o = var_o(k_mod, t);
             double f1 = f - .02665 * SN(o);
-            double a1 = 299.77 + .107408 * k - .009173 * t * t;
+            double a1 = 299.77 + .107408 * k_mod - .009173 * t * t;
             double e = var_e(t);
-            double m = var_m(k, t);
-            double m1 = var_m1(k, t);
+            double m = var_m(k_mod, t);
+            double m1 = var_m1(k_mod, t);
             double p = .207 * e * SN(m) + .0024 * e * SN(2 * m) - .0392 * SN(m1) + .0116 * SN(2 * m1)
                     - .0073 * e * SN(m1 + m) + .0067 * e * SN(m1 - m) + .0118 * SN(2 * f1);
             double q = 5.2207 - .0048 * e * CS(m) + .002 * e * CS(2 * m) - .3299 * CS(m1) - .006 * e * CS(m1 + m)
                     + .0041 * e * CS(m1 - m);
             double g = (p * CS(f1) + q * SN(f1)) * (1 - .0048 * CS(Math.abs(f1)));
             double u = .0059 + .0046 * e * CS(m) - .0182 * CS(m1) + .0004 * CS(2 * m1) - .0005 * CS(m + m1);
-            jd = var_jde(k, t);
+            jd = var_jde(k_mod, t);
             jd += (typ == ECLIPSE_TYPE_MOON) ? -.4065 * SN(m1) + .1727 * e * SN(m)
                     : -.4075 * SN(m1) + .1721 * e * SN(m);
 
@@ -542,11 +545,11 @@ public class MoonCalc {
     }
 
     private double FRAK(double x) {
-        x = x - (int) (x);
-        if (x < 0) {
-            x += 1;
+        double ret = x - (int) (x);
+        if (ret < 0) {
+            ret += 1;
         }
-        return x;
+        return ret;
     }
 
     private double[] QUAD(double yminus, double yo, double yplus) {
@@ -606,15 +609,16 @@ public class MoonCalc {
     }
 
     private double moonCorrection(double jd, double t, double k) {
-        jd += .000325 * SN(299.77 + .107408 * k - .009173 * t * t) + .000165 * SN(251.88 + .016321 * k)
+        double ret = jd;
+        ret += .000325 * SN(299.77 + .107408 * k - .009173 * t * t) + .000165 * SN(251.88 + .016321 * k)
                 + .000164 * SN(251.83 + 26.651886 * k) + .000126 * SN(349.42 + 36.412478 * k)
                 + .00011 * SN(84.66 + 18.206239 * k);
-        jd += .000062 * SN(141.74 + 53.303771 * k) + .00006 * SN(207.14 + 2.453732 * k)
+        ret += .000062 * SN(141.74 + 53.303771 * k) + .00006 * SN(207.14 + 2.453732 * k)
                 + .000056 * SN(154.84 + 7.30686 * k) + .000047 * SN(34.52 + 27.261239 * k)
                 + .000042 * SN(207.19 + .121824 * k) + .00004 * SN(291.34 + 1.844379 * k);
-        jd += .000037 * SN(161.72 + 24.198154 * k) + .000035 * SN(239.56 + 25.513099 * k)
+        ret += .000037 * SN(161.72 + 24.198154 * k) + .000035 * SN(239.56 + 25.513099 * k)
                 + .000023 * SN(331.55 + 3.592518 * k);
-        return jd;
+        return ret;
     }
 
     private double getCoefficient(double d, double m, double m1, double f) {
@@ -776,8 +780,8 @@ public class MoonCalc {
      */
     private double toGMST(double jd) {
         double ut = (jd - 0.5 - Math.floor(jd - 0.5)) * 24.;
-        jd = Math.floor(jd - 0.5) + 0.5;
-        double t = (jd - 2451545.0) / 36525.0;
+        double jd_mod = Math.floor(jd - 0.5) + 0.5;
+        double t = (jd_mod - 2451545.0) / 36525.0;
         double t0 = 6.697374558 + t * (2400.051336 + t * 0.000025862);
         return (mod(t0 + ut * 1.002737909, 24.));
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/util/PropertyUtils.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/util/PropertyUtils.java
@@ -27,7 +27,7 @@ import org.eclipse.smarthome.core.types.UnDefType;
  * @author Gerhard Riegler - Initial contribution
  */
 public class PropertyUtils {
-    
+
     /** Constructor */
     private PropertyUtils() {
         throw new IllegalAccessError("Non-instantiable");
@@ -70,8 +70,8 @@ public class PropertyUtils {
         String propertyName = properties[nestedIndex];
         Method m = instance.getClass().getMethod(toGetterString(propertyName), null);
         Object result = m.invoke(instance, (Object[]) null);
-        if (++nestedIndex < properties.length) {
-            return getPropertyValue(result, properties, nestedIndex);
+        if (nestedIndex + 1 < properties.length) {
+            return getPropertyValue(result, properties, nestedIndex + 1);
         }
         return result;
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/SceneManagerImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/SceneManagerImpl.java
@@ -145,10 +145,11 @@ public class SceneManagerImpl implements SceneManager {
 
     private boolean isEcho(String dsid, short sceneId) {
         // sometimes the dS-event have a dSUID saved in the dSID
+        String dsidReal = dsid;
         if (structureManager.getDeviceByDSUID(dsid) != null) {
-            dsid = structureManager.getDeviceByDSUID(dsid).getDSID().getValue();
+            dsidReal = structureManager.getDeviceByDSUID(dsid).getDSID().getValue();
         }
-        String echo = dsid + "-" + sceneId;
+        String echo = dsidReal + "-" + sceneId;
         return isEcho(echo);
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
@@ -665,9 +665,9 @@ public class HueBridge {
                 if (requestMethod.equals("GET")) {
                     return super.doNetwork(address, requestMethod, body);
                 } else {
-                    address = Util.quickMatch("^http://[^/]+(.+)$", address);
+                    String extractedAddress = Util.quickMatch("^http://[^/]+(.+)$", address);
                     JsonElement commandBody = new JsonParser().parse(body);
-                    scheduleCommand = new ScheduleCommand(address, requestMethod, commandBody);
+                    scheduleCommand = new ScheduleCommand(extractedAddress, requestMethod, commandBody);
 
                     // Return a fake result that will cause an exception and the callback to end
                     return new Result(null, 405);

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueThingHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueThingHandlerFactory.java
@@ -64,12 +64,12 @@ public class HueThingHandlerFactory extends BaseThingHandlerFactory {
 
     private ThingUID getLightUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration,
             ThingUID bridgeUID) {
-        String lightId = (String) configuration.get(LIGHT_ID);
-
-        if (thingUID == null) {
-            thingUID = new ThingUID(thingTypeUID, lightId, bridgeUID.getId());
+        if (thingUID != null) {
+            return thingUID;
+        } else {
+            String lightId = (String) configuration.get(LIGHT_ID);
+            return new ThingUID(thingTypeUID, lightId, bridgeUID.getId());
         }
-        return thingUID;
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.lirc/src/main/java/org/eclipse/smarthome/binding/lirc/internal/connector/LIRCConnector.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lirc/src/main/java/org/eclipse/smarthome/binding/lirc/internal/connector/LIRCConnector.java
@@ -108,12 +108,15 @@ public class LIRCConnector {
      */
     public void transmit(String remote, String button) {
         int timesToSend = 1;
+        String buttonName;
         String[] parts = button.split(" ");
         if (parts.length > 1) {
-            button = parts[0];
+            buttonName = parts[0];
             timesToSend = Integer.parseInt(parts[1]);
+        } else {
+            buttonName = button;
         }
-        transmit(remote, button, timesToSend);
+        transmit(remote, buttonName, timesToSend);
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/handler/ZonePlayerHandler.java
@@ -1747,7 +1747,8 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
 
     public Boolean isShuffleActive() {
         return ((stateMap.get("CurrentPlayMode") != null) && stateMap.get("CurrentPlayMode").startsWith("SHUFFLE"))
-                ? true : false;
+                ? true
+                : false;
     }
 
     public String getRepeatMode() {
@@ -2839,11 +2840,12 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
         if (sleepSeconds == 0) {
             return "";
         } else if (sleepSeconds < 68400) {
-            long hours = TimeUnit.SECONDS.toHours(sleepSeconds);
-            sleepSeconds -= TimeUnit.HOURS.toSeconds(hours);
-            long minutes = TimeUnit.SECONDS.toMinutes(sleepSeconds);
-            sleepSeconds -= TimeUnit.MINUTES.toSeconds(minutes);
-            long seconds = TimeUnit.SECONDS.toSeconds(sleepSeconds);
+            long remainingSeconds = sleepSeconds;
+            long hours = TimeUnit.SECONDS.toHours(remainingSeconds);
+            remainingSeconds -= TimeUnit.HOURS.toSeconds(hours);
+            long minutes = TimeUnit.SECONDS.toMinutes(remainingSeconds);
+            remainingSeconds -= TimeUnit.MINUTES.toSeconds(minutes);
+            long seconds = TimeUnit.SECONDS.toSeconds(remainingSeconds);
             return String.format("%02d:%02d:%02d", hours, minutes, seconds);
         } else {
             logger.error("Sonos SleepTimer: Invalid sleep time set. sleep time must be >=0 and < 68400s (24h)");

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosHandlerFactory.java
@@ -143,14 +143,12 @@ public class SonosHandlerFactory extends BaseThingHandlerFactory {
     }
 
     private ThingUID getPlayerUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration) {
-
-        String udn = (String) configuration.get(UDN);
-
-        if (thingUID == null) {
-            thingUID = new ThingUID(thingTypeUID, udn);
+        if (thingUID != null) {
+            return thingUID;
+        } else {
+            String udn = (String) configuration.get(UDN);
+            return new ThingUID(thingTypeUID, udn);
         }
-
-        return thingUID;
     }
 
     @Reference

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
@@ -910,15 +910,15 @@ public class SonosXMLParser {
      * @return the extracted players model name without column (:) character used for ThingType creation
      */
     public static String extractModelName(String sonosModelName) {
-        //
-        Matcher matcher = Pattern.compile("\\s(.*)").matcher(sonosModelName);
+        String ret = sonosModelName;
+        Matcher matcher = Pattern.compile("\\s(.*)").matcher(ret);
         if (matcher.find()) {
-            sonosModelName = matcher.group(1);
+            ret = matcher.group(1);
         }
-        if (sonosModelName.contains(":")) {
-            sonosModelName = sonosModelName.replace(":", "");
+        if (ret.contains(":")) {
+            ret = ret.replace(":", "");
         }
-        return sonosModelName;
+        return ret;
     }
 
     public static String compileMetadataString(SonosEntry entry) {

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/json/WeatherUndergroundJsonUtils.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/json/WeatherUndergroundJsonUtils.java
@@ -43,8 +43,8 @@ public class WeatherUndergroundJsonUtils {
         String fieldName = fields[index];
         Method method = data.getClass().getMethod(toGetterString(fieldName), null);
         Object result = method.invoke(data, (Object[]) null);
-        if (++index < fields.length) {
-            result = getValue(result, fields, index);
+        if (index + 1 < fields.length) {
+            result = getValue(result, fields, index + 1);
         }
         return result;
     }

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/src/main/java/org/eclipse/smarthome/transform/exec/internal/ExecTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/src/main/java/org/eclipse/smarthome/transform/exec/internal/ExecTransformationService.java
@@ -25,7 +25,7 @@ public class ExecTransformationService implements TransformationService {
 
     /**
      * Transforms the input <code>source</code> by the command line.
-     * 
+     *
      * @param commandLine
      *            the command to execute. Command line should contain %s string,
      *            which will be replaced by the input data.
@@ -43,8 +43,8 @@ public class ExecTransformationService implements TransformationService {
 
         long startTime = System.currentTimeMillis();
 
-        commandLine = String.format(commandLine, source);
-        String result = ExecUtil.executeCommandLineAndWaitResponse(commandLine, 5000);
+        String formattedCommandLine = String.format(commandLine, source);
+        String result = ExecUtil.executeCommandLineAndWaitResponse(formattedCommandLine, 5000);
         logger.trace("command line execution elapsed {} ms", System.currentTimeMillis() - startTime);
 
         return result;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/AbstractWidgetRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/AbstractWidgetRenderer.java
@@ -79,7 +79,8 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
      * @param w corresponding widget
      * @return
      */
-    protected String preprocessSnippet(String snippet, Widget w) {
+    protected String preprocessSnippet(String originalSnippet, Widget w) {
+        String snippet = originalSnippet;
         snippet = StringUtils.replace(snippet, "%widget_id%", itemUIRegistry.getWidgetId(w));
         snippet = StringUtils.replace(snippet, "%icon_type%", config.getIconType());
         snippet = StringUtils.replace(snippet, "%item%", w.getItem() != null ? w.getItem() : "");
@@ -108,20 +109,20 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
      * @throws RenderException if snippet could not be read
      */
     protected synchronized String getSnippet(String elementType) throws RenderException {
-        elementType = elementType.toLowerCase();
-        String snippet = snippetCache.get(elementType);
+        String lowerTypeElementType = elementType.toLowerCase();
+        String snippet = snippetCache.get(lowerTypeElementType);
         if (snippet == null) {
-            String snippetLocation = SNIPPET_LOCATION + elementType + SNIPPET_EXT;
+            String snippetLocation = SNIPPET_LOCATION + lowerTypeElementType + SNIPPET_EXT;
             URL entry = WebAppActivator.getContext().getBundle().getEntry(snippetLocation);
             if (entry != null) {
                 try {
                     snippet = IOUtils.toString(entry.openStream());
-                    snippetCache.put(elementType, snippet);
+                    snippetCache.put(lowerTypeElementType, snippet);
                 } catch (IOException e) {
-                    logger.warn("Cannot load snippet for element type '{}'", elementType, e);
+                    logger.warn("Cannot load snippet for element type '{}'", lowerTypeElementType, e);
                 }
             } else {
-                throw new RenderException("Cannot find a snippet for element type '" + elementType + "'");
+                throw new RenderException("Cannot find a snippet for element type '" + lowerTypeElementType + "'");
             }
         }
         return snippet;
@@ -147,10 +148,10 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
         int index = text.indexOf('[');
 
         if (index != -1) {
-            text = text.substring(0, index);
+            return escapeHtml(text.substring(0, index));
+        } else {
+            return escapeHtml(text);
         }
-
-        return escapeHtml(text);
     }
 
     /**
@@ -228,9 +229,10 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
      *            The snippet to translate
      * @return The updated snippet
      */
-    protected String processColor(Widget w, String snippet) {
+    protected String processColor(Widget w, String originalSnippet) {
         String style = "";
         String color = "";
+        String snippet = originalSnippet;
 
         color = itemUIRegistry.getLabelColor(w);
 

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/PageRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/PageRenderer.java
@@ -74,10 +74,11 @@ public class PageRenderer extends AbstractWidgetRenderer {
         // Note: we can have a span here, if the parent widget had a label
         // with some value defined (e.g. "Windows [%d]"), which getLabel()
         // will convert into a "Windows <span>5</span>".
-        if (label.contains("[") && label.endsWith("]")) {
-            label = label.replace("[", "").replace("]", "");
+        String labelPlain = label;
+        if (labelPlain.contains("[") && labelPlain.endsWith("]")) {
+            labelPlain = labelPlain.replace("[", "").replace("]", "");
         }
-        snippet = StringUtils.replace(snippet, "%label%", escapeHtml(label));
+        snippet = StringUtils.replace(snippet, "%label%", escapeHtml(labelPlain));
         snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_NAME);
         snippet = StringUtils.replace(snippet, "%sitemap%", sitemap);
         snippet = StringUtils.replace(snippet, "%htmlclass%", config.getCssClassList());

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/AbstractWidgetRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/AbstractWidgetRenderer.java
@@ -83,22 +83,22 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
      * @throws RenderException if snippet could not be read
      */
     protected synchronized String getSnippet(String elementType) throws RenderException {
-        elementType = elementType.toLowerCase();
-        String snippet = snippetCache.get(elementType);
+        String lowerCaseElementType = elementType.toLowerCase();
+        String snippet = snippetCache.get(lowerCaseElementType);
         if (snippet == null) {
-            String snippetLocation = SNIPPET_LOCATION + elementType + SNIPPET_EXT;
+            String snippetLocation = SNIPPET_LOCATION + lowerCaseElementType + SNIPPET_EXT;
             URL entry = WebAppActivator.getContext().getBundle().getEntry(snippetLocation);
             if (entry != null) {
                 try {
                     snippet = IOUtils.toString(entry.openStream());
                     if (!config.isHtmlCacheDisabled()) {
-                        snippetCache.put(elementType, snippet);
+                        snippetCache.put(lowerCaseElementType, snippet);
                     }
                 } catch (IOException e) {
-                    logger.warn("Cannot load snippet for element type '{}'", elementType, e);
+                    logger.warn("Cannot load snippet for element type '{}'", lowerCaseElementType, e);
                 }
             } else {
-                throw new RenderException("Cannot find a snippet for element type '" + elementType + "'");
+                throw new RenderException("Cannot find a snippet for element type '" + lowerCaseElementType + "'");
             }
         }
         return snippet;
@@ -184,16 +184,16 @@ abstract public class AbstractWidgetRenderer implements WidgetRenderer {
         if (color != null) {
             style = "color:" + color;
         }
-        snippet = StringUtils.replace(snippet, "%labelstyle%", style);
+        String ret = StringUtils.replace(snippet, "%labelstyle%", style);
 
         style = "";
         color = itemUIRegistry.getValueColor(w);
         if (color != null) {
             style = "color:" + color;
         }
-        snippet = StringUtils.replace(snippet, "%valuestyle%", style);
+        ret = StringUtils.replace(ret, "%valuestyle%", style);
 
-        return snippet;
+        return ret;
     }
 
     protected String getFormat() {

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/PageRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/PageRenderer.java
@@ -70,11 +70,12 @@ public class PageRenderer extends AbstractWidgetRenderer {
         // Note: we can have a span here, if the parent widget had a label
         // with some value defined (e.g. "Windows [%d]"), which getLabel()
         // will convert into a "Windows <span>5</span>".
-        if (label.contains("[") && label.endsWith("]")) {
-            label = label.replace("[", "").replace("]", "");
+        String labelPlain = label;
+        if (labelPlain.contains("[") && labelPlain.endsWith("]")) {
+            labelPlain = labelPlain.replace("[", "").replace("]", "");
         }
         snippet = StringUtils.replace(snippet, "%labelstyle%", "");
-        snippet = StringUtils.replace(snippet, "%label%", StringEscapeUtils.escapeHtml(label));
+        snippet = StringUtils.replace(snippet, "%label%", StringEscapeUtils.escapeHtml(labelPlain));
         snippet = StringUtils.replace(snippet, "%servletname%", WebAppServlet.SERVLET_NAME);
         snippet = StringUtils.replace(snippet, "%sitemap%", sitemap);
 

--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -111,6 +111,10 @@
           value="error"/>
       <setupTask
           xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.parameterAssignment"
+          value="warning"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment"
           value="error"/>
       <setupTask


### PR DESCRIPTION
* switched on WARNINGS for parameter assignments
* fixed majority of parameter assignments (only automation & digitalstrom missing)

As it turned out, many of the classes generated by Xtext violate this rule, therefore I set it to WARNING level only for the moment. Maybe somebody has a good idea what to do about them (except maintaining project specific JDT settings there)?


fixes #4221
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>