### PR TITLE
Renamed a package in the org.eclipse.smarthome.config.core bundle to internal.

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/normalization/NormalizerTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/normalization/NormalizerTest.groovy
@@ -15,6 +15,8 @@ import java.text.MessageFormat
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type
+import org.eclipse.smarthome.config.core.internal.normalization.Normalizer
+import org.eclipse.smarthome.config.core.internal.normalization.NormalizerFactory
 import org.junit.Test
 
 public class NormalizerTest {

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigUtil.java
@@ -16,8 +16,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.eclipse.smarthome.config.core.normalization.Normalizer;
-import org.eclipse.smarthome.config.core.normalization.NormalizerFactory;
+import org.eclipse.smarthome.config.core.internal.normalization.Normalizer;
+import org.eclipse.smarthome.config.core.internal.normalization.NormalizerFactory;
 import org.eclipse.smarthome.config.core.validation.ConfigDescriptionValidator;
 
 /**

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/AbstractNormalizer.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/AbstractNormalizer.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.config.core.normalization;
+package org.eclipse.smarthome.config.core.internal.normalization;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/BooleanNormalizer.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/BooleanNormalizer.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.config.core.normalization;
+package org.eclipse.smarthome.config.core.internal.normalization;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/DecimalNormalizer.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/DecimalNormalizer.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.config.core.normalization;
+package org.eclipse.smarthome.config.core.internal.normalization;
 
 import java.math.BigDecimal;
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/IntNormalizer.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/IntNormalizer.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.config.core.normalization;
+package org.eclipse.smarthome.config.core.internal.normalization;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/ListNormalizer.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/ListNormalizer.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.config.core.normalization;
+package org.eclipse.smarthome.config.core.internal.normalization;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/Normalizer.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/Normalizer.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.config.core.normalization;
+package org.eclipse.smarthome.config.core.internal.normalization;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/NormalizerFactory.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/NormalizerFactory.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.config.core.normalization;
+package org.eclipse.smarthome.config.core.internal.normalization;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/TextNormalizer.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/normalization/TextNormalizer.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.config.core.normalization;
+package org.eclipse.smarthome.config.core.internal.normalization;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 


### PR DESCRIPTION
See openhab/static-code-analysis#100

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>