### PR TITLE
Fix NPE when EnrichedItemDTOMapper considers transforming null Strings

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -45,7 +45,7 @@ public class EnrichedItemDTOMapper {
 
         String state = item.getState().toFullString();
         String transformedState = considerTransformation(state, item.getStateDescription(locale));
-        if (transformedState.equals(state)) {
+        if (transformedState != null && transformedState.equals(state)) {
             transformedState = null;
         }
         StateDescription stateDescription = considerTransformation(item.getStateDescription(locale));
@@ -90,7 +90,7 @@ public class EnrichedItemDTOMapper {
     }
 
     private static String considerTransformation(String state, StateDescription stateDescription) {
-        if (stateDescription != null && stateDescription.getPattern() != null) {
+        if (stateDescription != null && stateDescription.getPattern() != null && state != null) {
             try {
                 return TransformationHelper.transform(RESTCoreActivator.getBundleContext(),
                         stateDescription.getPattern(), state.toString());


### PR DESCRIPTION
This NPE occurred when showing the Thing Control page in Paper UI while testing the new Nest Binding. The Nest Binding had [updated](https://github.com/openhab/openhab2-addons/blob/1987aecc480cb48700ca0fb6584a0ba3327a1e6e/addons/binding/org.openhab.binding.nest/src/main/java/org/openhab/binding/nest/handler/NestCameraHandler.java#L75) the public camera URL with a `new StringType(null)` because public sharing was not enabled for the respective camera.

As a result `/rest/items?recursive=false` returned a 500 response code and the whole Paper UI Control page stopped working.

Perhaps the Nest Binding should not post such updates. But ESH should be able to handle such item states when it does not immediately reject such updates.

With this fix such items do not have a "state" property in the resulting JSON and Paper UI shows "undefined" for such states.
