### PR TITLE
static-code-analyzer use directory realtive to root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,23 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.commonjava.maven.plugins</groupId>
+        <artifactId>directory-maven-plugin</artifactId>
+        <version>0.2</version>
+        <executions>
+          <execution>
+            <id>directories</id>
+            <goals>
+              <goal>highest-basedir</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <property>basedirRoot</property>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
         <version>${tycho-version}</version>
@@ -168,7 +185,7 @@
               <arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot</arg>
               <arg>-warn:+null,+inheritNullAnnot,+nullAnnotConflict,+nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
             </compilerArgs>
-          </configuration>          
+          </configuration>
         </plugin>
         <plugin>
           <groupId>${tycho-groupid}</groupId>
@@ -497,9 +514,9 @@
                 </execution>
               </executions>
               <configuration>
-                <checkstyleProperties>tools/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
-                <checkstyleFilter>tools/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
-                <findbugsExclude>tools/static-code-analysis/findbugs/suppressions.xml</findbugsExclude>
+                <checkstyleProperties>${basedirRoot}/tools/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
+                <checkstyleFilter>${basedirRoot}/tools/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
+                <findbugsExclude>${basedirRoot}/tools/static-code-analysis/findbugs/suppressions.xml</findbugsExclude>
               </configuration>
             </plugin>
           </plugins>
@@ -516,9 +533,9 @@
       <build>
         <plugins>
           <plugin>
-              <groupId>org.openhab.tools</groupId>
-              <artifactId>static-code-analysis</artifactId>
-              <version>${sat.version}</version>
+            <groupId>org.openhab.tools</groupId>
+            <artifactId>static-code-analysis</artifactId>
+            <version>${sat.version}</version>
           </plugin>
         </plugins>
       </build>
@@ -543,7 +560,7 @@
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        </snapshots>
+      </snapshots>
     </repository>
   </repositories>
 


### PR DESCRIPTION
```sh
pushd extensions/binding/org.eclipse.smarthome.binding.astro/; mvn clean install; popd
```

before:
```text
[INFO] BUILD FAILURE
...
[ERROR] Failed to execute goal org.openhab.tools:static-code-analysis:0.3.0:checkstyle (default) on project org.eclipse.smarthome.binding.astro: Unable to execute mojo: An error has occurred in Checkstyle report generation. Failed during checkstyle execution: Unable to find suppressions file at location: /home/rathgeb/bin/pkgs/eclipse/esh/git/smarthome/extensions/binding/org.eclipse.smarthome.binding.astro/tools/static-code-analysis/checkstyle/suppressions.xml: Could not find resource '/home/rathgeb/bin/pkgs/eclipse/esh/git/smarthome/extensions/binding/org.eclipse.smarthome.binding.astro/tools/static-code-analysis/checkstyle/suppressions.xml'. -> [Help 1]
```

after:
```text
[INFO] BUILD SUCCESS
```

Fixes: https://github.com/eclipse/smarthome/issues/4230