### PR TITLE
Retain item order in group items

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.item.tests/src/org/eclipse/smarthome/model/item/tests/GenericItemProvider2Test.java
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/src/org/eclipse/smarthome/model/item/tests/GenericItemProvider2Test.java
@@ -78,4 +78,48 @@ public class GenericItemProvider2Test extends JavaOSGiTest {
         }
     }
 
+    @Test
+    public void testStableReloadOrder() {
+        assertThat(itemRegistry.getAll().size(), is(0));
+
+        String model = "Group testGroup " + //
+                "Number number1 (testGroup) " + //
+                "Number number2 (testGroup) " + //
+                "Number number3 (testGroup) " + //
+                "Number number4 (testGroup) " + //
+                "Number number5 (testGroup) " + //
+                "Number number6 (testGroup) " + //
+                "Number number7 (testGroup) " + //
+                "Number number8 (testGroup) " + //
+                "Number number9 (testGroup) ";
+
+        modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.getBytes()));
+        assertThat(itemRegistry.getAll().size(), is(10));
+
+        model = "Group testGroup " + //
+                "Number number1 (testGroup) " + //
+                "Number number2 (testGroup) " + //
+                "Number number3 (testGroup) " + //
+                "Number number4 (testGroup) " + //
+                "Number number5 (testGroup) " + //
+                "Number number6 (testGroup) " + //
+                "Number number7 \"Number Seven\" (testGroup) " + //
+                "Number number8 (testGroup) " + //
+                "Number number9 (testGroup) ";
+
+        modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.getBytes()));
+        GroupItem groupItem = (GroupItem) itemRegistry.get("testGroup");
+        assertNotNull(groupItem);
+
+        int number = 0;
+        Iterator<Item> it = groupItem.getMembers().iterator();
+        while (it.hasNext()) {
+            Item item = it.next();
+            assertEquals("number" + (++number), item.getName());
+            if (number == 7) {
+                assertEquals("Number Seven", item.getLabel());
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
...by replacing existing ones instead of removing & adding them.

FTR: 

* In order to keep the `GroupItem` API compatible, I internally changed the `members` from a `Set` to a `List`, but kept the method signatures as they are. In fact that's more or less what the `LinkedHashSet` did before anyway...

* As the `GroupItem` cannot expose it is using a `List` internally, I had to extend it with a `replaceMember()`-Method. Better suggestions are welcome.

fixes #3321
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>