### PR TITLE
Renamed a package in the org.eclipse.smarthome.io.rest.log bundle to internal.

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogConstants.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogConstants.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.io.rest.log;
+package org.eclipse.smarthome.io.rest.log.internal;
 
 /**
  * The {@link LogConstants} class defines common constants, which are

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
@@ -28,7 +28,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.smarthome.io.rest.RESTResource;
-import org.eclipse.smarthome.io.rest.log.LogConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
See openhab/static-code-analysis#100

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>