### PR TITLE
Fix save network service configuration, missing service.pid

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * @author Mark Herwege - Added methods to find broadcast address(es)
  * @author Stefan Triller - Converted to OSGi service with primary ipv4 conf
  */
-@Component(configurationPid = "org.eclipse.smarthome.network", property = {
+@Component(configurationPid = "org.eclipse.smarthome.network", property = { "service.pid=org.eclipse.smarthome.network",
         "service.config.description.uri=system:network", "service.config.label=Network Settings",
         "service.config.category=system" })
 public class NetUtil implements NetworkAddressService {


### PR DESCRIPTION
Without a service.pid the RestRessource defaults to the name of the
service which is auto-generated and doesn't match the service.pid

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>