### PR TITLE
Added time zone in the PaperUI and in the I18ProviderImpl 

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/i18n/I18nConfigOptionsProvider.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/i18n/I18nConfigOptionsProvider.java
@@ -8,10 +8,16 @@
 package org.eclipse.smarthome.config.core.internal.i18n;
 
 import java.net.URI;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -23,29 +29,64 @@ import org.osgi.service.component.annotations.Component;
  * {@link ConfigOptionProvider} that provides a list of
  *
  * @author Simon Kaufmann - initial contribution and API
+ * @author Erdoan Hadzhiyusein - Added time zone
  *
  */
 @Component(immediate = true)
 public class I18nConfigOptionsProvider implements ConfigOptionProvider {
 
+    private static final String NO_OFFSET_FORMAT = "(GMT) %s";
+    private static final String NEGATIVE_OFFSET_FORMAT = "%s (GMT%d:%02d)";
+    private static final String POSITIVE_OFFSET_FORMAT = "%s (GMT+%d:%02d)";
+
     @Override
     public Collection<ParameterOption> getParameterOptions(URI uri, String param, Locale locale) {
         if (uri.toString().equals("system:i18n")) {
             Locale translation = locale != null ? locale : Locale.getDefault();
-            if (param.equals("language")) {
-                return getAvailable(locale, l -> new ParameterOption(l.getLanguage(), l.getDisplayLanguage(translation)));
-            } else if (param.equals("region")) {
-                return getAvailable(locale, l -> new ParameterOption(l.getCountry(), l.getDisplayCountry(translation)));
-            } else if (param.equals("variant")) {
-                return getAvailable(locale, l -> new ParameterOption(l.getVariant(), l.getDisplayVariant(translation)));
-            }
+            return processParamType(param, locale, translation);
         }
         return null;
+    }
+
+    private Collection<ParameterOption> processParamType(String param, Locale locale, Locale translation) {
+        switch (param) {
+            case "language":
+                return getAvailable(locale,
+                        l -> new ParameterOption(l.getLanguage(), l.getDisplayLanguage(translation)));
+            case "region":
+                return getAvailable(locale,
+                        l -> new ParameterOption(l.getCountry(), l.getDisplayCountry(translation)));
+            case "variant":
+                return getAvailable(locale,
+                        l -> new ParameterOption(l.getVariant(), l.getDisplayVariant(translation)));
+            case "timezone":
+                return ZoneId.getAvailableZoneIds().stream().map(TimeZone::getTimeZone).sorted((tz1, tz2) -> {
+                    return tz2.getRawOffset() - tz2.getRawOffset();
+                }).map(tz -> {
+                    return new ParameterOption(tz.getID(), getTimeZoneRepresentation(tz));
+                }).collect(Collectors.toList());
+            default:
+                return null;
+        }
+    }
+
+    private static String getTimeZoneRepresentation(TimeZone tz) {
+        long hours = TimeUnit.MILLISECONDS.toHours(tz.getRawOffset());
+        long minutes = TimeUnit.MILLISECONDS.toMinutes(tz.getRawOffset()) - TimeUnit.HOURS.toMinutes(hours);
+        minutes = Math.abs(minutes);
+        final String result;
+        if (hours > 0) {
+            result = String.format(POSITIVE_OFFSET_FORMAT, tz.getID(), hours, minutes);
+        } else if (hours < 0) {
+            result = String.format(NEGATIVE_OFFSET_FORMAT, tz.getID(), hours, minutes);
+        } else {
+            result = String.format(NO_OFFSET_FORMAT, tz.getDisplayName(Locale.getDefault()));
+        }
+        return result;
     }
 
     private Collection<ParameterOption> getAvailable(Locale locale, Function<Locale, ParameterOption> mapFunction) {
         return Arrays.stream(Locale.getAvailableLocales()).map(l -> mapFunction.apply(l)).distinct()
                 .sorted(Comparator.comparing(a -> a.getLabel())).collect(Collectors.toList());
     }
-
 }

--- a/bundles/core/org.eclipse.smarthome.core/ESH-INF/config/i18n.xml
+++ b/bundles/core/org.eclipse.smarthome.core/ESH-INF/config/i18n.xml
@@ -43,6 +43,15 @@
 			</description>
 			<advanced>true</advanced>
 		</parameter>
+		<parameter name="timezone" type="text" required="false">
+			<label>Time Zone</label>
+			<description><![CDATA[
+				<p>A time zone can be set from the user interface.</p>
+				<p>The underlying system's time zone is the default.</p>
+				<p>Example: Asia/Tokyo, Europe/Berlin</p>
+			]]>
+			</description>
+		</parameter>
 		<parameter name="location" type="text" required="false">
 			<context>location</context>
 			<label>Location</label>

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TimeZoneProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TimeZoneProvider.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.i18n;
+
+import java.time.ZoneId;
+
+/**
+ * This interface describes a provider for time zone.
+ *
+ * @author Erdoan Hadzhiyusein - Initial contribution and API
+ */
+public interface TimeZoneProvider {
+
+    /**
+     * Provides access to the time zone property.
+     *
+     * @return the time zone set in the user interface and if there isn't one, the default time zone of the operating system
+     */
+    ZoneId getTimeZone();
+}


### PR DESCRIPTION




 Querying the underlying OS for a timezone and setting this as a default in the LocationProvider. A user could then choose a different one via a drop down list in **Paper UI**.
![timezonesnimka1](https://user-images.githubusercontent.com/17512690/30366149-cc72a75c-9872-11e7-8c14-62ec0bd83dd1.PNG)
![yee](https://user-images.githubusercontent.com/17512690/30366143-c4071a94-9872-11e7-839f-42137b82a7c4.PNG)


Fixes #3936 

Signed-off-by: Erdoan Hadzhiyusein <3rdoan@gmail.com>