### PR TITLE
PaperUI: Allow thing-type name column to grow as needed

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/css/components.css
@@ -1457,7 +1457,8 @@ md-progress-circular.firmware {
 
 .binding :not(md-expansion-panel) .md-title {
 	padding-bottom: 10px;
-	flex-grow: 2
+	flex-grow: 2;
+	max-width: none;
 }
 .binding .things .search {
 	padding: 0 0 10px 0;


### PR DESCRIPTION
For thing-types with long names (like openHAB z-wave binding) this allows the name column to grow as much as needed in the binding details view.

Signed-off-by: Henning Treu <henning.treu@telekom.de>