### PR TITLE
[Tradfri] Support for new RGB bulbs #4251

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/discovery/TradfriDiscoveryServiceTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/discovery/TradfriDiscoveryServiceTest.java
@@ -112,7 +112,7 @@ public class TradfriDiscoveryServiceTest {
 
         assertNotNull(discoveryResult);
         assertThat(discoveryResult.getFlag(), is(DiscoveryResultFlag.NEW));
-        assertThat(discoveryResult.getThingUID(), is(new ThingUID("tradfri:0200:1:65550")));
+        assertThat(discoveryResult.getThingUID(), is(new ThingUID("tradfri:0210:1:65550")));
         assertThat(discoveryResult.getThingTypeUID(), is(TradfriBindingConstants.THING_TYPE_COLOR_LIGHT));
         assertThat(discoveryResult.getBridgeUID(), is(new ThingUID("tradfri:gateway:1")));
         assertThat(discoveryResult.getProperties().get(DeviceConfig.ID), is(65550));

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/discovery/TradfriDiscoveryServiceTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/discovery/TradfriDiscoveryServiceTest.java
@@ -81,9 +81,10 @@ public class TradfriDiscoveryServiceTest {
 
     @Test
     public void correctSupportedTypes() {
-        assertThat(discovery.getSupportedThingTypes().size(), is(2));
+        assertThat(discovery.getSupportedThingTypes().size(), is(3));
         assertTrue(discovery.getSupportedThingTypes().contains(TradfriBindingConstants.THING_TYPE_DIMMABLE_LIGHT));
         assertTrue(discovery.getSupportedThingTypes().contains(TradfriBindingConstants.THING_TYPE_COLOR_TEMP_LIGHT));
+        assertTrue(discovery.getSupportedThingTypes().contains(TradfriBindingConstants.THING_TYPE_COLOR_LIGHT));
     }
 
     @Test
@@ -101,4 +102,21 @@ public class TradfriDiscoveryServiceTest {
         assertThat(discoveryResult.getProperties().get(DeviceConfig.ID), is(65537));
         assertThat(discoveryResult.getRepresentationProperty(), is(DeviceConfig.ID));
     }
+
+    @Test
+    public void validDiscoveryResultColorLightCWS() {
+        String json = "{\"9001\":\"TRADFRI bulb E27 CWS opal 600lm\",\"9002\":1505151864,\"9020\":1505433527,\"9003\":65550,\"9019\":1,\"9054\":0,\"5750\":2,\"3\":{\"0\":\"IKEA of Sweden\",\"1\":\"TRADFRI bulb E27 CWS opal 600lm\",\"2\":\"\",\"3\":\"1.3.002\",\"6\":1},\"3311\":[{\"5850\":1,\"5708\":0,\"5851\":254,\"5707\":0,\"5709\":33137,\"5710\":27211,\"5711\":0,\"5706\":\"efd275\",\"9003\":0}]}";
+        JsonObject data = new JsonParser().parse(json).getAsJsonObject();
+
+        discovery.onUpdate("65550", data);
+
+        assertNotNull(discoveryResult);
+        assertThat(discoveryResult.getFlag(), is(DiscoveryResultFlag.NEW));
+        assertThat(discoveryResult.getThingUID(), is(new ThingUID("tradfri:0200:1:65550")));
+        assertThat(discoveryResult.getThingTypeUID(), is(TradfriBindingConstants.THING_TYPE_COLOR_LIGHT));
+        assertThat(discoveryResult.getBridgeUID(), is(new ThingUID("tradfri:gateway:1")));
+        assertThat(discoveryResult.getProperties().get(DeviceConfig.ID), is(65550));
+        assertThat(discoveryResult.getRepresentationProperty(), is(DeviceConfig.ID));
+    }
+
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColorTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColorTest.java
@@ -24,24 +24,32 @@ public class TradfriColorTest {
     public void testFromCieKnownGood1() {
         TradfriColor color = TradfriColor.fromCie(29577, 12294, 254);
         assertNotNull(color);
-        assertEquals(255, (int) color.rgbR);
-        assertEquals(21, (int) color.rgbG);
-        assertEquals(207, (int) color.rgbB);
+        assertEquals(254, (int) color.rgbR);
+        assertEquals(2, (int) color.rgbG);
+        assertEquals(158, (int) color.rgbB);
         assertEquals(29577, (int) color.xyX);
         assertEquals(12294, (int) color.xyY);
         assertEquals(254, (int) color.brightness);
+        assertNotNull(color.hsbType);
+        assertEquals(323, color.hsbType.getHue().intValue());
+        assertEquals(99, color.hsbType.getSaturation().intValue());
+        assertEquals(100, color.hsbType.getBrightness().intValue());
     }
 
     @Test
     public void testFromCieKnownGood2() {
         TradfriColor color = TradfriColor.fromCie(19983, 37417, 84);
         assertNotNull(color);
-        assertEquals(110, (int) color.rgbR);
-        assertEquals(174, (int) color.rgbG);
-        assertEquals(58, (int) color.rgbB);
+        assertEquals(30, (int) color.rgbR);
+        assertEquals(84, (int) color.rgbG);
+        assertEquals(7, (int) color.rgbB);
         assertEquals(19983, (int) color.xyX);
         assertEquals(37417, (int) color.xyY);
         assertEquals(84, (int) color.brightness);
+        assertNotNull(color.hsbType);
+        assertEquals(102, color.hsbType.getHue().intValue());
+        assertEquals(89, color.hsbType.getSaturation().intValue());
+        assertEquals(33, color.hsbType.getBrightness().intValue());
     }
 
     @Test
@@ -54,6 +62,10 @@ public class TradfriColorTest {
         assertEquals(45914, (int) color.xyX);
         assertEquals(19615, (int) color.xyY);
         assertEquals(254, (int) color.brightness);
+        assertNotNull(color.hsbType);
+        assertEquals(0, color.hsbType.getHue().intValue());
+        assertEquals(100, color.hsbType.getSaturation().intValue());
+        assertEquals(100, color.hsbType.getBrightness().intValue());
     }
 
     @Test
@@ -67,15 +79,23 @@ public class TradfriColorTest {
         assertEquals(11299, (int) color.xyX);
         assertEquals(48941, (int) color.xyY);
         assertEquals(254, (int) color.brightness);
+        assertNotNull(color.hsbType);
+        assertEquals(120, color.hsbType.getHue().intValue());
+        assertEquals(100, color.hsbType.getSaturation().intValue());
+        assertEquals(100, color.hsbType.getBrightness().intValue());
         // convert the result again based on the XY values
         TradfriColor reverse = TradfriColor.fromCie(color.xyX, color.xyY, color.brightness);
         assertNotNull(reverse);
         assertEquals(0, (int) reverse.rgbR);
-        assertEquals(255, (int) reverse.rgbG); // 255 instead of 254 - only approximated calculation
+        assertEquals(254, (int) reverse.rgbG);
         assertEquals(0, (int) reverse.rgbB);
         assertEquals(11299, (int) reverse.xyX);
         assertEquals(48941, (int) reverse.xyY);
         assertEquals(254, (int) reverse.brightness);
+        assertNotNull(reverse.hsbType);
+        assertEquals(120, reverse.hsbType.getHue().intValue());
+        assertEquals(100, reverse.hsbType.getSaturation().intValue());
+        assertEquals(100, reverse.hsbType.getBrightness().intValue());
     }
 
     @Test

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColorTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/src/test/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColorTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.junit.Test;
+
+/**
+ * Tests for {@link TradfriColor}.
+ *
+ * @author Holger Reichert - Initial contribution
+ */
+public class TradfriColorTest {
+
+    @Test
+    public void testFromCieKnownGood1() {
+        TradfriColor color = TradfriColor.fromCie(29577, 12294, 254);
+        assertNotNull(color);
+        assertEquals(255, (int) color.rgbR);
+        assertEquals(21, (int) color.rgbG);
+        assertEquals(207, (int) color.rgbB);
+        assertEquals(29577, (int) color.xyX);
+        assertEquals(12294, (int) color.xyY);
+        assertEquals(254, (int) color.brightness);
+    }
+
+    @Test
+    public void testFromCieKnownGood2() {
+        TradfriColor color = TradfriColor.fromCie(19983, 37417, 84);
+        assertNotNull(color);
+        assertEquals(110, (int) color.rgbR);
+        assertEquals(174, (int) color.rgbG);
+        assertEquals(58, (int) color.rgbB);
+        assertEquals(19983, (int) color.xyX);
+        assertEquals(37417, (int) color.xyY);
+        assertEquals(84, (int) color.brightness);
+    }
+
+    @Test
+    public void testFromHSBTypeKnownGood1() {
+        TradfriColor color = TradfriColor.fromHSBType(HSBType.RED);
+        assertNotNull(color);
+        assertEquals(254, (int) color.rgbR);
+        assertEquals(0, (int) color.rgbG);
+        assertEquals(0, (int) color.rgbB);
+        assertEquals(45914, (int) color.xyX);
+        assertEquals(19615, (int) color.xyY);
+        assertEquals(254, (int) color.brightness);
+    }
+
+    @Test
+    public void testConversionReverse() {
+        // convert from HSBType
+        TradfriColor color = TradfriColor.fromHSBType(HSBType.GREEN);
+        assertNotNull(color);
+        assertEquals(0, (int) color.rgbR);
+        assertEquals(254, (int) color.rgbG); // 254 instead of 255 - only approximated calculation
+        assertEquals(0, (int) color.rgbB);
+        assertEquals(11299, (int) color.xyX);
+        assertEquals(48941, (int) color.xyY);
+        assertEquals(254, (int) color.brightness);
+        // convert the result again based on the XY values
+        TradfriColor reverse = TradfriColor.fromCie(color.xyX, color.xyY, color.brightness);
+        assertNotNull(reverse);
+        assertEquals(0, (int) reverse.rgbR);
+        assertEquals(255, (int) reverse.rgbG); // 255 instead of 254 - only approximated calculation
+        assertEquals(0, (int) reverse.rgbB);
+        assertEquals(11299, (int) reverse.xyX);
+        assertEquals(48941, (int) reverse.xyY);
+        assertEquals(254, (int) reverse.brightness);
+    }
+
+    @Test
+    public void testFromColorTemperatureMinMiddleMax() {
+        // coldest color temperature -> preset 1
+        TradfriColor colorMin = TradfriColor.fromColorTemperature(PercentType.ZERO);
+        assertNotNull(colorMin);
+        assertEquals(24933, (int) colorMin.xyX);
+        assertEquals(24691, (int) colorMin.xyY);
+        // middle color temperature -> preset 2
+        TradfriColor colorMiddle = TradfriColor.fromColorTemperature(new PercentType(50));
+        assertNotNull(colorMiddle);
+        assertEquals(30138, (int) colorMiddle.xyX);
+        assertEquals(26909, (int) colorMiddle.xyY);
+        // warmest color temperature -> preset 3
+        TradfriColor colorMax = TradfriColor.fromColorTemperature(PercentType.HUNDRED);
+        assertNotNull(colorMax);
+        assertEquals(33137, (int) colorMax.xyX);
+        assertEquals(27211, (int) colorMax.xyY);
+    }
+
+    @Test
+    public void testFromColorTemperatureInbetween() {
+        // 30 percent must be between preset 1 and 2
+        TradfriColor color2 = TradfriColor.fromColorTemperature(new PercentType(30));
+        assertNotNull(color2);
+        assertEquals(28056, (int) color2.xyX);
+        assertEquals(26022, (int) color2.xyY);
+        // 70 percent must be between preset 2 and 3
+        TradfriColor color3 = TradfriColor.fromColorTemperature(new PercentType(70));
+        assertNotNull(color3);
+        assertEquals(31338, (int) color3.xyX);
+        assertEquals(27030, (int) color3.xyY);
+    }
+
+    @Test
+    public void testCalculateColorTemperature() {
+        // preset 1 -> coldest -> 0 percent
+        PercentType preset1 = TradfriColor.calculateColorTemperature(24933, 24691);
+        assertEquals(0, preset1.intValue());
+        // preset 2 -> middle -> 50 percent
+        PercentType preset2 = TradfriColor.calculateColorTemperature(30138, 26909);
+        assertEquals(50, preset2.intValue());
+        // preset 3 -> warmest -> 100 percent
+        PercentType preset3 = TradfriColor.calculateColorTemperature(33137, 27211);
+        assertEquals(100, preset3.intValue());
+        // preset 3 -> warmest -> 100 percent
+        PercentType colder = TradfriColor.calculateColorTemperature(22222, 23333);
+        assertEquals(0, colder.intValue());
+        // preset 3 -> warmest -> 100 percent
+        PercentType temp3 = TradfriColor.calculateColorTemperature(34000, 34000);
+        assertEquals(100, temp3.intValue());
+        // mixed case 1
+        PercentType mixed1 = TradfriColor.calculateColorTemperature(0, 1000000);
+        assertEquals(0, mixed1.intValue());
+        // mixed case 1
+        PercentType mixed2 = TradfriColor.calculateColorTemperature(1000000, 0);
+        assertEquals(100, mixed2.intValue());
+    }
+
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/i18n/tradfri_de.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/i18n/tradfri_de.properties
@@ -9,6 +9,8 @@ thing-type.tradfri.0100.label = Dimmbare Lampe (weiß)
 thing-type.tradfri.0100.description = Dimmbare Lampe mit fester Farbtemperatur.
 thing-type.tradfri.0220.label = Farbtemperatur Lampe (weiß)
 thing-type.tradfri.0220.description = Dimmbare Lampe mit einstellbarer Farbtemperatur.
+thing-type.tradfri.0200.label = Farbspektrum Lampe
+thing-type.tradfri.0200.description = Dimmbare Lampe mit einstellbarer Farbe und Farbtemperatur.
 
 # thing type configuration
 thing-type.config.tradfri.gateway.host.label = IP-Adresse
@@ -21,9 +23,13 @@ thing-type.config.tradfri.0100.id.label = ID der Lampe
 thing-type.config.tradfri.0100.id.description = ID zur Identifikation der Lampe.
 thing-type.config.tradfri.0220.id.label = ID der Lampe
 thing-type.config.tradfri.0220.id.description = ID zur Identifikation der Lampe.
+thing-type.config.tradfri.0200.id.label = ID der Lampe
+thing-type.config.tradfri.0200.id.description = ID zur Identifikation der Lampe.
 
 # channel types
 channel-type.tradfri.brightness.label = Helligkeit
 channel-type.tradfri.brightness.description = Ermöglicht die Steuerung der Helligkeit. Ermöglicht ebenfalls die Lampe ein- und auszuschalten.
 channel-type.tradfri.color_temperature.label = Farbtemperatur
 channel-type.tradfri.color_temperature.description = Ermöglicht die Steuerung der Farbtemperatur. Von Tageslichtweiß (0) bis Warmweiß (100).
+channel-type.tradfri.color.label = Farbe
+channel-type.tradfri.color.description = Ermöglicht die Steuerung der Farbe.

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/i18n/tradfri_de.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/i18n/tradfri_de.properties
@@ -9,8 +9,8 @@ thing-type.tradfri.0100.label = Dimmbare Lampe (weiﬂ)
 thing-type.tradfri.0100.description = Dimmbare Lampe mit fester Farbtemperatur.
 thing-type.tradfri.0220.label = Farbtemperatur Lampe (weiﬂ)
 thing-type.tradfri.0220.description = Dimmbare Lampe mit einstellbarer Farbtemperatur.
-thing-type.tradfri.0200.label = Farbspektrum Lampe
-thing-type.tradfri.0200.description = Dimmbare Lampe mit einstellbarer Farbe und Farbtemperatur.
+thing-type.tradfri.0210.label = Farbspektrum Lampe
+thing-type.tradfri.0210.description = Dimmbare Lampe mit einstellbarer Farbe und Farbtemperatur.
 
 # thing type configuration
 thing-type.config.tradfri.gateway.host.label = IP-Adresse
@@ -23,8 +23,8 @@ thing-type.config.tradfri.0100.id.label = ID der Lampe
 thing-type.config.tradfri.0100.id.description = ID zur Identifikation der Lampe.
 thing-type.config.tradfri.0220.id.label = ID der Lampe
 thing-type.config.tradfri.0220.id.description = ID zur Identifikation der Lampe.
-thing-type.config.tradfri.0200.id.label = ID der Lampe
-thing-type.config.tradfri.0200.id.description = ID zur Identifikation der Lampe.
+thing-type.config.tradfri.0210.id.label = ID der Lampe
+thing-type.config.tradfri.0210.id.description = ID zur Identifikation der Lampe.
 
 # channel types
 channel-type.tradfri.brightness.label = Helligkeit

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
@@ -71,7 +71,7 @@
         </config-description>
     </thing-type>
 
-    <thing-type id="0200">
+    <thing-type id="0210">
         <supported-bridge-type-refs>
             <bridge-type-ref id="gateway"/>
         </supported-bridge-type-refs>
@@ -80,7 +80,6 @@
         <description>A dimmable light that supports full colors and color temperature settings.</description>
 
         <channels>
-            <channel id="brightness" typeId="brightness"/>
             <channel id="color_temperature" typeId="color_temperature"/>
             <channel id="color" typeId="color"/>
         </channels>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
@@ -71,6 +71,28 @@
         </config-description>
     </thing-type>
 
+    <thing-type id="0200">
+        <supported-bridge-type-refs>
+            <bridge-type-ref id="gateway"/>
+        </supported-bridge-type-refs>
+
+        <label>Color Light</label>
+        <description>A dimmable light that supports full colors and color temperature settings.</description>
+
+        <channels>
+            <channel id="brightness" typeId="brightness"/>
+            <channel id="color_temperature" typeId="color_temperature"/>
+            <channel id="color" typeId="color"/>
+        </channels>
+
+        <config-description>
+            <parameter name="id" type="integer" required="true">
+                <label>ID</label>
+                <description>The identifier of the light on the gateway</description>
+            </parameter>
+        </config-description>
+    </thing-type>
+
     <!-- note that this isn't yet supported by the code as we do not receive any data from the gateway for it -->
     <thing-type id="0820" listed="false">
         <supported-bridge-type-refs>
@@ -105,6 +127,13 @@
         <item-type>Dimmer</item-type>
         <label>Color Temperature</label>
         <description>Control the color temperature of the light.</description>
+        <category>ColorLight</category>
+    </channel-type>
+
+    <channel-type id="color">
+        <item-type>Color</item-type>
+        <label>Color</label>
+        <description>Control the color of the light.</description>
         <category>ColorLight</category>
     </channel-type>
 

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
@@ -12,7 +12,7 @@ The thing type ids are defined according to the lighting devices defined for Zig
 |--------------------------|------------------|------------|
 | Dimmable Light           | 0x0100           | 0100       |
 | Colour Temperature Light | 0x0220           | 0220       |
-| Colour Light             | 0x0200           | 0200       |
+| Extended Colour Light    | 0x0210           | 0210       |
 
 The following matrix lists the capabilities (channels) for each of the supported lighting device types:
 
@@ -20,7 +20,7 @@ The following matrix lists the capabilities (channels) for each of the supported
 |-------------|:------:|:----------:|:-----:|:-----------------:|   
 |  0100       |    X   |     X      |       |                   |
 |  0220       |    X   |     X      |       |          X        |
-|  0200       |    X   |     X      |   X   |          X        |
+|  0210       |    X   |            |   X   |          X        |
 
 ## Thing Configuration
 
@@ -30,8 +30,12 @@ The devices require only a single (integer) parameter, which is their instance i
 
 ## Channels
 
-All devices support the `brightness` channel.
-The white spectrum bulbs additionally also support the `color_temperature` channel. Full color bulbs additionally also support the `color` channel.
+The dimmable bulbs support the `brightness` channel.
+The white spectrum bulbs additionally also support the `color_temperature` channel. 
+
+Full color bulbs support the `color_temperature` and `color` channels.
+Brightness can be changed with the `color` channel.
+
 Refer to the matrix above.
 
 | Channel Type ID   | Item Type | Description                                 |
@@ -48,7 +52,7 @@ demo.things:
 Bridge tradfri:gateway:mygateway [ host="192.168.0.177", code="EHPW5rIJKyXFgjH3" ] {
     0100 myDimmableBulb [ id=65537 ]    
     0220 myColorTempBulb [ id=65538 ]
-    0200 myColorBulb [ id=65539 ]
+    0210 myColorBulb [ id=65539 ]
 }
 ```
 
@@ -56,7 +60,7 @@ demo.items:
 
 ```
 Dimmer Light { channel="tradfri:0100:mygateway:myDimmableBulb:brightness" }
-Color ColorLight { channel="tradfri:0200:mygateway:myColorBulb:color" } 
+Color ColorLight { channel="tradfri:0210:mygateway:myColorBulb:color" } 
 ```
 
 demo.sitemap:

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
@@ -12,7 +12,7 @@ The thing type ids are defined according to the lighting devices defined for Zig
 |--------------------------|------------------|------------|
 | Dimmable Light           | 0x0100           | 0100       |
 | Colour Temperature Light | 0x0220           | 0220       |
-
+| Colour Light             | 0x0200           | 0200       |
 
 The following matrix lists the capabilities (channels) for each of the supported lighting device types:
 
@@ -20,6 +20,7 @@ The following matrix lists the capabilities (channels) for each of the supported
 |-------------|:------:|:----------:|:-----:|:-----------------:|   
 |  0100       |    X   |     X      |       |                   |
 |  0220       |    X   |     X      |       |          X        |
+|  0200       |    X   |     X      |   X   |          X        |
 
 ## Thing Configuration
 
@@ -29,12 +30,15 @@ The devices require only a single (integer) parameter, which is their instance i
 
 ## Channels
 
-All devices support the `brightness` channel, while the white spectrum bulbs additionally also support the `color_temperature` channel (refer to the matrix above).
+All devices support the `brightness` channel.
+The white spectrum bulbs additionally also support the `color_temperature` channel. Full color bulbs additionally also support the `color` channel.
+Refer to the matrix above.
 
 | Channel Type ID   | Item Type | Description                                 |
 |-------------------|-----------|---------------------------------------------|
 | brightness        | Dimmer    | The brightness of the bulb in percent       |
 | color_temperature | Dimmer    | color temperature from 0%=cold to 100%=warm |
+| color             | Color     | full color                                  |
 
 ## Full Example
 
@@ -43,14 +47,16 @@ demo.things:
 ```
 Bridge tradfri:gateway:mygateway [ host="192.168.0.177", code="EHPW5rIJKyXFgjH3" ] {
     0100 myDimmableBulb [ id=65537 ]    
-    0220 myColorTempBulb [ id=65538 ]    
+    0220 myColorTempBulb [ id=65538 ]
+    0200 myColorBulb [ id=65539 ]
 }
 ```
 
 demo.items:
 
 ```
-Dimmer Light { channel="tradfri:0100:mygateway:myDimmableBulb:brightness" } 
+Dimmer Light { channel="tradfri:0100:mygateway:myDimmableBulb:brightness" }
+Color ColorLight { channel="tradfri:0200:mygateway:myColorBulb:color" } 
 ```
 
 demo.sitemap:
@@ -60,6 +66,7 @@ sitemap demo label="Main Menu"
 {
     Frame {
         Slider item=Light label="Brightness [%.1f %%]"
+        Colorpicker item=ColorLight
     }
 }
 ```

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
@@ -29,10 +29,12 @@ public class TradfriBindingConstants {
 
     public final static ThingTypeUID THING_TYPE_DIMMABLE_LIGHT = new ThingTypeUID(BINDING_ID, "0100");
     public final static ThingTypeUID THING_TYPE_COLOR_TEMP_LIGHT = new ThingTypeUID(BINDING_ID, "0220");
+    public final static ThingTypeUID THING_TYPE_COLOR_LIGHT = new ThingTypeUID(BINDING_ID, "0200");
     public final static ThingTypeUID THING_TYPE_DIMMER = new ThingTypeUID(BINDING_ID, "0820");
 
-    public static final Set<ThingTypeUID> SUPPORTED_LIGHT_TYPES_UIDS = Collections.unmodifiableSet(
-            Stream.of(THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_COLOR_TEMP_LIGHT).collect(Collectors.toSet()));
+    public static final Set<ThingTypeUID> SUPPORTED_LIGHT_TYPES_UIDS = Collections
+            .unmodifiableSet(Stream.of(THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_COLOR_TEMP_LIGHT, THING_TYPE_COLOR_LIGHT)
+                    .collect(Collectors.toSet()));
 
     // Not yet used - included for future support
     public static final Set<ThingTypeUID> SUPPORTED_CONTROLLER_TYPES_UIDS = Collections.singleton(THING_TYPE_DIMMER);
@@ -40,6 +42,7 @@ public class TradfriBindingConstants {
     // List of all Channel IDs
     public static final String CHANNEL_BRIGHTNESS = "brightness";
     public static final String CHANNEL_COLOR_TEMPERATURE = "color_temperature";
+    public static final String CHANNEL_COLOR = "color";
 
     // IPSO Objects
     public static final String DEVICES = "15001";

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/TradfriBindingConstants.java
@@ -29,7 +29,7 @@ public class TradfriBindingConstants {
 
     public final static ThingTypeUID THING_TYPE_DIMMABLE_LIGHT = new ThingTypeUID(BINDING_ID, "0100");
     public final static ThingTypeUID THING_TYPE_COLOR_TEMP_LIGHT = new ThingTypeUID(BINDING_ID, "0220");
-    public final static ThingTypeUID THING_TYPE_COLOR_LIGHT = new ThingTypeUID(BINDING_ID, "0200");
+    public final static ThingTypeUID THING_TYPE_COLOR_LIGHT = new ThingTypeUID(BINDING_ID, "0210");
     public final static ThingTypeUID THING_TYPE_DIMMER = new ThingTypeUID(BINDING_ID, "0820");
 
     public static final Set<ThingTypeUID> SUPPORTED_LIGHT_TYPES_UIDS = Collections

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
@@ -126,7 +126,7 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
             }
 
             PercentType dimmer = state.getBrightness();
-            if (dimmer != null) {
+            if (dimmer != null && !lightHasColorSupport()) { // color lighs do not have brightness channel
                 updateState(CHANNEL_BRIGHTNESS, dimmer);
             }
 
@@ -422,7 +422,7 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
                 int brightness = dimmer.getAsInt();
                 // extract HSBType from converted xy/brightness
                 TradfriColor color = TradfriColor.fromCie(x, y, brightness);
-                return HSBType.fromRGB(color.rgbR, color.rgbG, color.rgbB);
+                return color.hsbType;
             }
             return null;
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriLightHandler.java
@@ -16,6 +16,8 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.smarthome.binding.tradfri.DeviceConfig;
 import org.eclipse.smarthome.binding.tradfri.internal.CoapCallback;
 import org.eclipse.smarthome.binding.tradfri.internal.TradfriCoapClient;
+import org.eclipse.smarthome.binding.tradfri.internal.TradfriColor;
+import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -41,6 +43,7 @@ import com.google.gson.JsonSyntaxException;
  * individual lights.
  *
  * @author Kai Kreuzer - Initial contribution
+ * @author Holger Reichert - Support for color bulbs
  */
 public class TradfriLightHandler extends BaseThingHandler implements CoapCallback {
 
@@ -115,6 +118,9 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
             if (!state.getOnOffState()) {
                 logger.debug("Setting state to OFF");
                 updateState(CHANNEL_BRIGHTNESS, PercentType.ZERO);
+                if (lightHasColorSupport()) {
+                    updateState(CHANNEL_COLOR, HSBType.BLACK);
+                }
                 // if we are turned off, we do not set any brightness value
                 return;
             }
@@ -128,27 +134,36 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
             if (colorTemp != null) {
                 updateState(CHANNEL_COLOR_TEMPERATURE, colorTemp);
             }
-            
+
+            HSBType color = null;
+            if (lightHasColorSupport()) {
+                color = state.getColor();
+                if (color != null) {
+                    updateState(CHANNEL_COLOR, color);
+                }
+            }
+
             String devicefirmware = state.getFirmwareVersion();
             if (devicefirmware != null) {
                 getThing().setProperty(Thing.PROPERTY_FIRMWARE_VERSION, devicefirmware);
             }
-            
+
             String modelId = state.getModelId();
             if (modelId != null) {
                 getThing().setProperty(Thing.PROPERTY_MODEL_ID, modelId);
             }
-            
+
             String vendor = state.getVendor();
             if (vendor != null) {
                 getThing().setProperty(Thing.PROPERTY_VENDOR, vendor);
             }
-            
-            logger.debug("Updating thing for lightId {} to state {dimmer: {}, colorTemp: {}, devicefirmware: {}, modelId: {}, vendor: {}}"
-                    , state.getLightId(), dimmer, colorTemp, devicefirmware, modelId, vendor);
+
+            logger.debug(
+                    "Updating thing for lightId {} to state {dimmer: {}, colorTemp: {}, color: {}, devicefirmware: {}, modelId: {}, vendor: {}}",
+                    state.getLightId(), dimmer, colorTemp, color, devicefirmware, modelId, vendor);
         }
     }
-    
+
     @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
         super.bridgeStatusChanged(bridgeStatusInfo);
@@ -183,6 +198,12 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
         set(data.getJsonString());
     }
 
+    private void setColor(HSBType hsb) {
+        LightData data = new LightData();
+        data.setColor(hsb).setTransitionTime(DEFAULT_DIMMER_TRANSITION_TIME);
+        set(data.getJsonString());
+    }
+
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
         if (command instanceof RefreshType) {
@@ -197,6 +218,9 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
                 break;
             case CHANNEL_COLOR_TEMPERATURE:
                 handleColorTemperatureCommand(command);
+                break;
+            case CHANNEL_COLOR:
+                handleColorCommand(command);
                 break;
             default:
                 logger.error("Unknown channel UID {}", channelUID);
@@ -243,16 +267,50 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
         }
     }
 
+    private void handleColorCommand(Command command) {
+        if (command instanceof HSBType) {
+            // tradfri can not handle color (xy) and brightness at once,
+            // so send color first and schedule the brightess update.
+            // 1500ms wait time because brightness setting would interrupt color fading
+            setColor((HSBType) command);
+            scheduler.schedule(() -> {
+                setBrightness(((HSBType) command).getBrightness());
+            }, 1500, TimeUnit.MILLISECONDS);
+        } else if (command instanceof OnOffType) {
+            setState(((OnOffType) command));
+        } else if (command instanceof PercentType) {
+            // PaperUI sends PercentType on color channel when changing Brightness
+            setBrightness((PercentType) command);
+        } else if (command instanceof IncreaseDecreaseType) {
+            // increase or decrease only the brightness, but keep color
+            if (state != null && state.getBrightness() != null) {
+                int current = state.getBrightness().intValue();
+                if (IncreaseDecreaseType.INCREASE.equals(command)) {
+                    setBrightness(new PercentType(Math.min(current + STEP, PercentType.HUNDRED.intValue())));
+                } else {
+                    setBrightness(new PercentType(Math.max(current - STEP, PercentType.ZERO.intValue())));
+                }
+            } else {
+                logger.debug("Cannot handle inc/dec for color as current brightness is not known.");
+            }
+        } else {
+            logger.debug("Can't handle command {} on channel {}", command, CHANNEL_COLOR);
+        }
+    }
+
+    /**
+     * Checks if this light supports full color.
+     *
+     * @return true if the light supports full color
+     */
+    private boolean lightHasColorSupport() {
+        return thing.getThingTypeUID().getId().equals(THING_TYPE_COLOR_LIGHT.getId());
+    }
+
     /**
      * This class is a Java wrapper for the raw JSON data about the light state.
      */
     private static class LightData {
-
-        // Tradfri uses the CIE color space (see https://en.wikipedia.org/wiki/CIE_1931_color_space),
-        // which uses x,y-coordinates.
-        // Its own app comes with 3 predefined color temperature settings (0,1,2), which have those values:
-        private final static double[] X = new double[] { 24933.0, 30138.0, 33137.0 };
-        private final static double[] Y = new double[] { 24691.0, 26909.0, 27211.0 };
 
         private final Logger logger = LoggerFactory.getLogger(LightData.class);
 
@@ -267,7 +325,7 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
             attributes = new JsonObject();
             array.add(attributes);
             root.add(LIGHT, array);
-            
+
             generalInfo = new JsonObject();
             root.add(DEVICE, generalInfo);
         }
@@ -325,44 +383,48 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
         }
 
         public LightData setColorTemperature(PercentType c) {
-            double percent = c.doubleValue();
-
-            long x, y;
-            if (percent < 50.0) {
-                // we calculate a value that is between preset 0 and 1
-                double p = percent / 50.0;
-                x = Math.round(X[0] + p * (X[1] - X[0]));
-                y = Math.round(Y[0] + p * (Y[1] - Y[0]));
-            } else {
-                // we calculate a value that is between preset 1 and 2
-                double p = (percent - 50) / 50.0;
-                x = Math.round(X[1] + p * (X[2] - X[1]));
-                y = Math.round(Y[1] + p * (Y[2] - Y[1]));
-            }
-            logger.debug("New color temperature: {},{} ({} %)", x, y, percent);
-
+            TradfriColor color = TradfriColor.fromColorTemperature(c);
+            int x = color.xyX;
+            int y = color.xyY;
+            logger.debug("New color temperature: {},{} ({} %)", x, y, c.intValue());
             attributes.add(COLOR_X, new JsonPrimitive(x));
             attributes.add(COLOR_Y, new JsonPrimitive(y));
             return this;
         }
 
         PercentType getColorTemperature() {
-            // we only need to check one of the coordinates and figure out where between the presets we are
             JsonElement colorX = attributes.get(COLOR_X);
-            if (colorX != null) {
-                double x = colorX.getAsInt();
-                double value = 0.0;
-                if (x > X[1]) {
-                    // is it between preset 1 and 2?
-                    value = (x - X[1]) / (X[2] - X[1]) / 2.0 + 0.5;
-                } else {
-                    // it is between preset 0 and 1
-                    value = (x - X[0]) / (X[1] - X[0]) / 2.0;
-                }
-                return new PercentType((int) Math.round(value * 100.0));
+            JsonElement colorY = attributes.get(COLOR_Y);
+            if (colorX != null && colorY != null) {
+                return TradfriColor.calculateColorTemperature(colorX.getAsInt(), colorY.getAsInt());
             } else {
                 return null;
             }
+        }
+
+        public LightData setColor(HSBType hsb) {
+            // construct new HSBType with full brightness and extract XY color values from it
+            HSBType hsbFullBright = new HSBType(hsb.getHue(), hsb.getSaturation(), PercentType.HUNDRED);
+            TradfriColor color = TradfriColor.fromHSBType(hsbFullBright);
+            attributes.add(COLOR_X, new JsonPrimitive(color.xyX));
+            attributes.add(COLOR_Y, new JsonPrimitive(color.xyY));
+            return this;
+        }
+
+        public HSBType getColor() {
+            // XY color coordinates plus brightness is needed for color calculation
+            JsonElement colorX = attributes.get(COLOR_X);
+            JsonElement colorY = attributes.get(COLOR_Y);
+            JsonElement dimmer = attributes.get(DIMMER);
+            if (colorX != null && colorY != null && dimmer != null) {
+                int x = colorX.getAsInt();
+                int y = colorY.getAsInt();
+                int brightness = dimmer.getAsInt();
+                // extract HSBType from converted xy/brightness
+                TradfriColor color = TradfriColor.fromCie(x, y, brightness);
+                return HSBType.fromRGB(color.rgbR, color.rgbG, color.rgbB);
+            }
+            return null;
         }
 
         LightData setOnOffState(boolean on) {
@@ -378,11 +440,11 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
                 return false;
             }
         }
-        
+
         Integer getLightId() {
             return root.get(INSTANCE_ID).getAsInt();
         }
-        
+
         String getFirmwareVersion() {
             if (generalInfo.get(DEVICE_FIRMWARE) != null) {
                 return generalInfo.get(DEVICE_FIRMWARE).getAsString();
@@ -390,7 +452,7 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
                 return null;
             }
         }
-        
+
         String getModelId() {
             if (generalInfo.get(DEVICE_MODEL) != null) {
                 return generalInfo.get(DEVICE_MODEL).getAsString();
@@ -398,7 +460,7 @@ public class TradfriLightHandler extends BaseThingHandler implements CoapCallbac
                 return null;
             }
         }
-        
+
         String getVendor() {
             if (generalInfo.get(DEVICE_VENDOR) != null) {
                 return generalInfo.get(DEVICE_VENDOR).getAsString();

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriColor.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.tradfri.internal;
+
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+
+/**
+ * The {@link TradfriColor} is used for conversion between color formats.
+ * Use the static methods {@link TradfriColor#fromCie(int, int, int)} and {@link TradfriColor#fromHSBType(HSBType)} for
+ * construction.
+ *
+ * @author Holger Reichert - Initial contribution
+ *
+ */
+public class TradfriColor {
+
+    // Tradfri uses the CIE color space (see https://en.wikipedia.org/wiki/CIE_1931_color_space),
+    // which uses x,y-coordinates.
+    // Its own app comes with 3 predefined color temperature settings (0,1,2), which have those values:
+    private final static double[] PRESET_X = new double[] { 24933.0, 30138.0, 33137.0 };
+    private final static double[] PRESET_Y = new double[] { 24691.0, 26909.0, 27211.0 };
+
+    /**
+     * RGB color values in the range 0 to 255.
+     * May be <code>null</code> if the calculation method does not support this color range.
+     */
+    public Integer rgbR, rgbG, rgbB;
+
+    /**
+     * CIE XY color values in the tradfri range 0 to 65535.
+     * May be <code>null</code> if the calculation method does not support this color range.
+     */
+    public Integer xyX, xyY;
+
+    /**
+     * Brightness level in the tradfri range 0 to 254.
+     * May be <code>null</code> if the calculation method does not support this color range.
+     */
+    public Integer brightness;
+
+    /**
+     * Private constructor based on all fields.
+     *
+     * @param rgbR RGB red value 0 to 255
+     * @param rgbG RGB green value 0 to 255
+     * @param rgbB RGB blue value 0 to 255
+     * @param xyX CIE x value 0 to 65535
+     * @param xyY CIE y value 0 to 65535
+     * @param brightness brightness level 0 to 254
+     */
+    private TradfriColor(Integer rgbR, Integer rgbG, Integer rgbB, Integer xyX, Integer xyY, Integer brightness) {
+        super();
+        this.rgbR = rgbR;
+        this.rgbG = rgbG;
+        this.rgbB = rgbB;
+        this.xyX = xyX;
+        this.xyY = xyY;
+        this.brightness = brightness;
+    }
+
+    /**
+     * Construct from CIE XY values in the tradfri range.
+     *
+     * @param xyX x value 0 to 65535
+     * @param xyY y value 0 to 65535
+     * @param xyBrightness brightness from 0 to 254
+     * @return {@link TradfriColor} object with converted color spaces
+     */
+    public static TradfriColor fromCie(int xyX, int xyY, int xyBrightness) {
+
+        // maximum brightness limited to 254
+        int brightness = xyBrightness;
+        if (brightness > 254) {
+            brightness = 254;
+        }
+
+        double x = unnormalize(xyX);
+        double y = unnormalize(xyY);
+
+        // calculate XYZ using xy and brightness
+        double z = 1.0 - x - y;
+        double Y = (brightness / 254.0);
+        double X = (Y / y) * x;
+        double Z = (Y / y) * z;
+
+        // Wide RGB D65 conversion
+        // math inspiration: http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+        double red = X * 1.656492 - Y * 0.354851 - Z * 0.255038;
+        double green = -X * 0.707196 + Y * 1.655397 + Z * 0.036152;
+        double blue = X * 0.051713 - Y * 0.121364 + Z * 1.011530;
+
+        // cap all values to 1.0 maximum
+        if (red > blue && red > green && red > 1.0) {
+            green = green / red;
+            blue = blue / red;
+            red = 1.0;
+        } else if (green > blue && green > red && green > 1.0) {
+            red = red / green;
+            blue = blue / green;
+            green = 1.0;
+        } else if (blue > red && blue > green && blue > 1.0) {
+            red = red / blue;
+            green = green / blue;
+            blue = 1.0;
+        }
+
+        // gamma correction
+        red = red <= 0.0031308 ? 12.92 * red : (1.0 + 0.055) * Math.pow(red, (1.0 / 2.4)) - 0.055;
+        green = green <= 0.0031308 ? 12.92 * green : (1.0 + 0.055) * Math.pow(green, (1.0 / 2.4)) - 0.055;
+        blue = blue <= 0.0031308 ? 12.92 * blue : (1.0 + 0.055) * Math.pow(blue, (1.0 / 2.4)) - 0.055;
+
+        // target range 0 to 255
+        int rgbR = (int) Math.round(red * 255.0);
+        int rgbG = (int) Math.round(green * 255.0);
+        int rgbB = (int) Math.round(blue * 255.0);
+
+        return new TradfriColor(rgbR, rgbG, rgbB, xyX, xyY, brightness);
+    }
+
+    /**
+     * Construct from {@link HSBType}.
+     *
+     * @param hsbType {@link HSBType}
+     * @return {@link TradfriColor} object with converted color spaces
+     */
+    public static TradfriColor fromHSBType(HSBType hsbType) {
+
+        // hsbType gives 0 to 100, we need 0.0 to 255.0
+        double red = hsbType.getRed().intValue() * 2.55;
+        double green = hsbType.getGreen().intValue() * 2.55;
+        double blue = hsbType.getBlue().intValue() * 2.55;
+
+        // saved for later use in constructor call
+        int rgbR = (int) red;
+        int rgbG = (int) green;
+        int rgbB = (int) blue;
+
+        // gamma correction
+        red = (red > 0.04045) ? Math.pow((red + 0.055) / (1.0 + 0.055), 2.4) : (red / 12.92);
+        green = (green > 0.04045) ? Math.pow((green + 0.055) / (1.0 + 0.055), 2.4) : (green / 12.92);
+        blue = (blue > 0.04045) ? Math.pow((blue + 0.055) / (1.0 + 0.055), 2.4) : (blue / 12.92);
+
+        // Wide RGB D65 conversion
+        // math inspiration: http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+        double X = red * 0.664511 + green * 0.154324 + blue * 0.162028;
+        double Y = red * 0.283881 + green * 0.668433 + blue * 0.047685;
+        double Z = red * 0.000088 + green * 0.072310 + blue * 0.986039;
+
+        // calculate the xy values from XYZ
+        double x = (X / (X + Y + Z));
+        double y = (Y / (X + Y + Z));
+
+        int xyX = normalize(x);
+        int xyY = normalize(y);
+        int brightness = (int) (hsbType.getBrightness().intValue() * 2.54);
+
+        return new TradfriColor(rgbR, rgbG, rgbB, xyX, xyY, brightness);
+    }
+
+    /**
+     * Construct from color temperature in percent.
+     * 0 (coldest) to 100 (warmest).
+     * Note: The resulting {@link TradfriColor} has only the {@link TradfriColor#xyX X} and {@link TradfriColor#xyY y}
+     * values set!
+     * 
+     * @param percentType the color temperature in percent
+     * @return {@link TradfriColor} object with x and y values
+     */
+    public static TradfriColor fromColorTemperature(PercentType percentType) {
+        double percent = percentType.doubleValue();
+
+        int x, y;
+        if (percent < 50.0) {
+            // we calculate a value that is between preset 0 and 1
+            double p = percent / 50.0;
+            x = (int) Math.round(PRESET_X[0] + p * (PRESET_X[1] - PRESET_X[0]));
+            y = (int) Math.round(PRESET_Y[0] + p * (PRESET_Y[1] - PRESET_Y[0]));
+        } else {
+            // we calculate a value that is between preset 1 and 2
+            double p = (percent - 50) / 50.0;
+            x = (int) Math.round(PRESET_X[1] + p * (PRESET_X[2] - PRESET_X[1]));
+            y = (int) Math.round(PRESET_Y[1] + p * (PRESET_Y[2] - PRESET_Y[1]));
+        }
+
+        return new TradfriColor(null, null, null, x, y, null);
+    }
+
+    /**
+     * Normalize value to the tradfri range.
+     *
+     * @param value double in the range 0.0 to 1.0
+     * @return normalized value in the range 0 to 65535
+     */
+    public static int normalize(double value) {
+        return (int) (value * 65535 + 0.5);
+    }
+
+    /**
+     * Reverse-normalize value from the tradfri range.
+     *
+     * @param value integer in the range 0 to 65535
+     * @return unnormalized value in the range 0.0 to 1.0
+     */
+    public static double unnormalize(int value) {
+        return (value / 65535.0);
+    }
+
+    /**
+     * Calculate the color temperature from given x and y values.
+     *
+     * @param xyX the CIE x value
+     * @param xyY the CIE y value
+     * @return {@link PercentType} with color temperature (0 = coolest, 100 = warmest)
+     */
+    public static PercentType calculateColorTemperature(int xyX, int xyY) {
+        double x = xyX;
+        double y = xyY;
+        double value = 0.0;
+        if ((x > PRESET_X[1] && y > PRESET_Y[1]) && (x <= PRESET_X[2] && y <= PRESET_Y[2])) {
+            // is it between preset 1 and 2?
+            value = (x - PRESET_X[1]) / (PRESET_X[2] - PRESET_X[1]) / 2.0 + 0.5;
+        } else if ((x >= PRESET_X[0] && y >= PRESET_Y[0]) && (x <= (PRESET_X[1] + 2.0) && y <= PRESET_Y[1])) {
+            // is it between preset 0 and 1?
+            // hint: in the above line we calculate 2.0 to PRESET_X[1] because
+            // some bulbs send slighty higher x values for this preset (maybe rounding errors?)
+            value = (x - PRESET_X[0]) / (PRESET_X[1] - PRESET_X[0]) / 2.0;
+        } else if (x < PRESET_X[0]) {
+            // cooler than coolest preset (full color bulbs)
+            value = 0.0;
+        } else if (x > PRESET_X[2]) {
+            // warmer than warmest preset (full color bulbs)
+            value = 1.0;
+        }
+        return new PercentType((int) Math.round(value * 100.0));
+    }
+
+}


### PR DESCRIPTION
Issue: #4251

Add support for the new TRADFRI full color lamps.
* New ThingType _0210_ / Extended Color Light with additional channel _color_
* Extended _TradfriLightHandler_
    * Handle color setting and retrieving
    * Changed color temperature calculation
* New class TradfriColor for colorspace conversions
* Extended _TradfriDiscoveryService_ for automatic discovery of color lights
* Tests for the above
* Documentation in README.md

I think it's ready for review.