### PR TITLE
[UI] Charts Enhancements: Themes, DPI, legend hiding

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -496,6 +496,7 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
             Chart chartWidget = (Chart) widget;
             bean.service = chartWidget.getService();
             bean.period = chartWidget.getPeriod();
+            bean.legend = chartWidget.getLegend();
             if (chartWidget.getRefresh() > 0) {
                 bean.refresh = chartWidget.getRefresh();
             }

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/WidgetDTO.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/WidgetDTO.java
@@ -45,6 +45,7 @@ public class WidgetDTO {
     public String encoding;
     public String service;
     public String period;
+    public Boolean legend;
 
     public EnrichedItemDTO item;
     public PageDTO linkedPage;

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
@@ -58,7 +58,7 @@ Video:
 
 Chart:
     'Chart' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
-    ('service=' service=(STRING))? & ('refresh=' refresh=INT)? & ('period=' period=ID) &
+    ('service=' service=(STRING))? & ('refresh=' refresh=INT)? & ('period=' period=ID) & ('legend=' legend=BOOLEAN_OBJECT)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)* ']'))?);
@@ -160,4 +160,6 @@ terminal ID:
 
 terminal FLOAT returns ecore::EBigDecimal:
     INT '.' INT;
-	
+
+BOOLEAN_OBJECT returns ecore::EBooleanObject:
+    'true' | 'false';

--- a/bundles/ui/org.eclipse.smarthome.ui/OSGI-INF/chartprovider.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui/OSGI-INF/chartprovider.xml
@@ -9,7 +9,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.eclipse.smarthome.ui.chart.defaultprovider">
-   <implementation class="org.eclipse.smarthome.ui.internal.chart.DefaultChartProvider"/>
+   <implementation class="org.eclipse.smarthome.ui.internal.chart.defaultchartprovider.DefaultChartProvider"/>
    <reference bind="setItemUIRegistry" cardinality="1..1" interface="org.eclipse.smarthome.ui.items.ItemUIRegistry" name="ItemUIRegistry" policy="dynamic" unbind="unsetItemUIRegistry"/>
    <reference bind="addPersistenceService" cardinality="0..n" interface="org.eclipse.smarthome.core.persistence.PersistenceService" name="PersistenceService" policy="dynamic" unbind="removePersistenceService"/>
    <service>

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/chart/ChartProvider.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/chart/ChartProvider.java
@@ -18,6 +18,7 @@ import org.eclipse.smarthome.core.items.ItemNotFoundException;
  * chart servlet and returns a chart image object (PNG).
  *
  * @author Chris Jackson
+ * @author Holger Reichert - Support for themes, DPI, legend hiding
  *
  */
 public interface ChartProvider {
@@ -52,6 +53,10 @@ public interface ChartProvider {
      *            The items to display on the chart
      * @param groups
      *            The groups to display on the chart
+     * @param dpi
+     *            The DPI (dots per inch) value, can be <code>null</code>
+     * @param legend
+     *            Show the legend? If <code>null</code>, the ChartProvider should make his own decision.
      *
      * @return BufferedImage object if the chart is rendered correctly,
      *         otherwise null.
@@ -60,7 +65,7 @@ public interface ChartProvider {
      * @throws IllegalArgumentException if an invalid argument is passed
      */
     BufferedImage createChart(String service, String theme, Date startTime, Date endTime, int height, int width,
-            String items, String groups) throws ItemNotFoundException;
+            String items, String groups, Integer dpi, Boolean legend) throws ItemNotFoundException;
 
     /**
      * Gets the type of data that will be written by the chart.

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartTheme.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartTheme.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.ui.internal.chart.defaultchartprovider;
+
+import java.awt.Color;
+import java.awt.Font;
+
+/**
+ * Chart styling theme for the {@link DefaultChartProvider}.
+ *
+ * @author Holger Reichert - Initial contribution
+ *
+ */
+public interface ChartTheme {
+
+    /**
+     * Theme name. Has to be unique across all themes.
+     *
+     * @return theme name
+     */
+    public String getThemeName();
+
+    /**
+     * Background color, plot area.
+     *
+     * @return background color, plot area
+     */
+    public Color getPlotBackgroundColor();
+
+    /**
+     * Color for the grid lines.
+     *
+     * @return color for the grid lines
+     */
+    public Color getPlotGridLinesColor();
+
+    /**
+     * Return the width of the grid lines.
+     *
+     * @param dpi DPI dots per inch to calculate the width
+     * @return width of the grid lines
+     */
+    public double getPlotGridLinesWidth(int dpi);
+
+    /**
+     * Return the dash spacing for the grid lines.
+     *
+     * @param dpi DPI dots per inch to calculate the width
+     * @return dash spacing for the grid lines
+     */
+    public double getPlotGridLinesDash(int dpi);
+
+    /**
+     * Background color, legend area.
+     *
+     * @return background color, legend area
+     */
+    public Color getLegendBackgroundColor();
+
+    /**
+     * Background color, whole chart
+     *
+     * @return background color, whole chart
+     */
+    public Color getChartBackgroundColor();
+
+    /**
+     * Font color, legend and general use.
+     *
+     * @return
+     */
+    public Color getChartFontColor();
+
+    /**
+     * Return a color for the given series number.
+     *
+     * @param series series number
+     * @return color for the given series numer
+     */
+    public Color getLineColor(int series);
+
+    /**
+     * Return the width of the series lines.
+     *
+     * @param dpi DPI dots per inch to calculate the width
+     * @return width of the series lines
+     */
+    public double getLineWidth(int dpi);
+
+    /**
+     * Color for the axis labels.
+     *
+     * @return
+     */
+    public Color getAxisTickLabelsColor();
+
+    /**
+     * Font for the axis labels.
+     * The font size gets calculated with the dpi parameter.
+     *
+     * @param dpi the DPI to calculate the font size
+     * @return {@link Font} for the axis labels.
+     */
+    public Font getAxisTickLabelsFont(int dpi);
+
+    /**
+     * Font for the legend text.
+     * The font size gets calculated with the dpi parameter.
+     *
+     * @param dpi the DPI to calculate the font size
+     * @return {@link Font} for the legend text
+     */
+    public Font getLegendFont(int dpi);
+
+    /**
+     * Padding of the chart.
+     *
+     * @return padding of the chart
+     */
+    public int getChartPadding();
+
+    /**
+     * Length of the line markers in the legend, in px.
+     *
+     * @return length of the line markers in the legend, in px
+     */
+    public int getLegendSeriesLineLength();
+
+}

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeBlack.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeBlack.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.ui.internal.chart.defaultchartprovider;
+
+import java.awt.Color;
+import java.awt.Font;
+
+/**
+ * Implementation of the black {@link ChartTheme chart theme}.
+ *
+ * @author Holger Reichert - Initial contribution
+ *
+ */
+public class ChartThemeBlack implements ChartTheme {
+
+    private static final String THEME_NAME = "black";
+
+    private Color[] LINECOLORS = new Color[] { //
+            new Color(244, 67, 54), // red
+            new Color(76, 175, 80), // green
+            new Color(63, 81, 181), // blue
+            new Color(156, 39, 176), // magenta/purple
+            new Color(255, 152, 0), // orange
+            new Color(0, 188, 212), // cyan
+            new Color(233, 30, 99), // pink
+            Color.WHITE, // white
+            new Color(255, 235, 59) // yellow
+    };
+
+    private static final String FONT_NAME = "SansSerif";
+
+    @Override
+    public String getThemeName() {
+        return THEME_NAME;
+    }
+
+    @Override
+    public Color getPlotBackgroundColor() {
+        return new Color(15, 15, 26);
+    }
+
+    @Override
+    public Color getPlotGridLinesColor() {
+        return Color.WHITE.darker();
+    }
+
+    @Override
+    public double getPlotGridLinesWidth(int dpi) {
+        return Math.max(1.0, dpi / 64.0);
+    }
+
+    @Override
+    public double getPlotGridLinesDash(int dpi) {
+        return Math.max(3.0f, dpi / 32.0);
+    }
+
+    @Override
+    public Color getLegendBackgroundColor() {
+        return new Color(30, 30, 50, 160);
+    }
+
+    @Override
+    public Color getChartBackgroundColor() {
+        return new Color(0, 0, 0);
+    }
+
+    @Override
+    public Color getChartFontColor() {
+        return new Color(255, 255, 255, 255);
+    }
+
+    @Override
+    public Color getLineColor(int series) {
+        return LINECOLORS[series % LINECOLORS.length];
+    }
+
+    @Override
+    public double getLineWidth(int dpi) {
+        return Math.max(1.0, dpi / 64.0);
+    }
+
+    @Override
+    public Color getAxisTickLabelsColor() {
+        return getChartFontColor();
+    }
+
+    @Override
+    public Font getAxisTickLabelsFont(int dpi) {
+        int fontsize = (int) Math.max(8, Math.round(dpi / 8.5));
+        return new Font(FONT_NAME, Font.PLAIN, fontsize);
+    }
+
+    @Override
+    public Font getLegendFont(int dpi) {
+        int fontsize = (int) Math.max(8, Math.round(dpi / 9.6));
+        return new Font(FONT_NAME, Font.PLAIN, fontsize);
+    }
+
+    @Override
+    public int getChartPadding() {
+        return 5;
+    }
+
+    @Override
+    public int getLegendSeriesLineLength() {
+        return 10;
+    }
+
+}

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeBright.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeBright.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.ui.internal.chart.defaultchartprovider;
+
+import java.awt.Color;
+import java.awt.Font;
+
+/**
+ * Implementation of the default bright {@link ChartTheme chart theme}.
+ *
+ * @author Holger Reichert - Initial contribution
+ *
+ */
+public class ChartThemeBright implements ChartTheme {
+
+    private static final String THEME_NAME = "bright";
+
+    private static final Color[] LINECOLORS = new Color[] { Color.RED, Color.GREEN, Color.BLUE, Color.MAGENTA,
+            Color.ORANGE, Color.CYAN, Color.PINK, Color.DARK_GRAY, Color.YELLOW };
+
+    private static final String FONT_NAME = "SansSerif";
+
+    @Override
+    public String getThemeName() {
+        return THEME_NAME;
+    }
+
+    @Override
+    public Color getPlotBackgroundColor() {
+        return new Color(254, 254, 254);
+    }
+
+    @Override
+    public Color getPlotGridLinesColor() {
+        return new Color(216, 216, 216);
+    }
+
+    @Override
+    public double getPlotGridLinesWidth(int dpi) {
+        return Math.max(1.0, dpi / 64.0);
+    }
+
+    @Override
+    public double getPlotGridLinesDash(int dpi) {
+        return Math.max(3.0f, dpi / 32.0);
+    }
+
+    @Override
+    public Color getLegendBackgroundColor() {
+        return new Color(224, 224, 224, 160);
+    }
+
+    @Override
+    public Color getChartBackgroundColor() {
+        return new Color(224, 224, 224, 224);
+    }
+
+    @Override
+    public Color getChartFontColor() {
+        return Color.BLACK;
+    }
+
+    @Override
+    public Color getLineColor(int series) {
+        return LINECOLORS[series % LINECOLORS.length];
+    }
+
+    @Override
+    public double getLineWidth(int dpi) {
+        return Math.max(1.0, dpi / 64.0);
+    }
+
+    @Override
+    public Color getAxisTickLabelsColor() {
+        return getChartFontColor();
+    }
+
+    @Override
+    public Font getAxisTickLabelsFont(int dpi) {
+        int fontsize = (int) Math.max(8, Math.round(dpi / 8.5));
+        return new Font(FONT_NAME, Font.PLAIN, fontsize);
+    }
+
+    @Override
+    public Font getLegendFont(int dpi) {
+        int fontsize = (int) Math.max(8, Math.round(dpi / 9.6));
+        return new Font(FONT_NAME, Font.PLAIN, fontsize);
+    }
+
+    @Override
+    public int getChartPadding() {
+        return 5;
+    }
+
+    @Override
+    public int getLegendSeriesLineLength() {
+        return 10;
+    }
+
+}

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeDark.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeDark.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.ui.internal.chart.defaultchartprovider;
+
+import java.awt.Color;
+import java.awt.Font;
+
+/**
+ * Implementation of the dark {@link ChartTheme chart theme}.
+ *
+ * @author Holger Reichert - Initial contribution
+ *
+ */
+public class ChartThemeDark implements ChartTheme {
+
+    private static final String THEME_NAME = "dark";
+
+    private Color[] LINECOLORS = new Color[] { //
+            new Color(244, 67, 54), // red
+            new Color(76, 175, 80), // green
+            new Color(63, 81, 181), // blue
+            new Color(156, 39, 176), // magenta/purple
+            new Color(255, 152, 0), // orange
+            new Color(0, 188, 212).darker(), // cyan
+            new Color(233, 30, 99).darker(), // pink
+            Color.WHITE, // white
+            new Color(255, 235, 59) // yellow
+    };
+
+    private static final String FONT_NAME = "SansSerif";
+
+    @Override
+    public String getThemeName() {
+        return THEME_NAME;
+    }
+
+    @Override
+    public Color getPlotBackgroundColor() {
+        return new Color(40, 40, 40);
+    }
+
+    @Override
+    public Color getPlotGridLinesColor() {
+        return Color.WHITE.darker();
+    }
+
+    @Override
+    public double getPlotGridLinesWidth(int dpi) {
+        return Math.max(1.0, dpi / 64.0);
+    }
+
+    @Override
+    public double getPlotGridLinesDash(int dpi) {
+        return Math.max(3.0f, dpi / 32.0);
+    }
+
+    @Override
+    public Color getLegendBackgroundColor() {
+        return new Color(30, 30, 30, 160);
+    }
+
+    @Override
+    public Color getChartBackgroundColor() {
+        return new Color(48, 48, 48);
+    }
+
+    @Override
+    public Color getChartFontColor() {
+        return new Color(255, 255, 255, 255);
+    }
+
+    @Override
+    public Color getLineColor(int series) {
+        return LINECOLORS[series % LINECOLORS.length];
+    }
+
+    @Override
+    public double getLineWidth(int dpi) {
+        return Math.max(1.0, dpi / 64.0);
+    }
+
+    @Override
+    public Color getAxisTickLabelsColor() {
+        return getChartFontColor();
+    }
+
+    @Override
+    public Font getAxisTickLabelsFont(int dpi) {
+        int fontsize = (int) Math.max(8, Math.round(dpi / 8.5));
+        return new Font(FONT_NAME, Font.PLAIN, fontsize);
+    }
+
+    @Override
+    public Font getLegendFont(int dpi) {
+        int fontsize = (int) Math.max(8, Math.round(dpi / 9.6));
+        return new Font(FONT_NAME, Font.PLAIN, fontsize);
+    }
+
+    @Override
+    public int getChartPadding() {
+        return 5;
+    }
+
+    @Override
+    public int getLegendSeriesLineLength() {
+        return 10;
+    }
+
+}

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ChartRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ChartRenderer.java
@@ -55,6 +55,13 @@ public class ChartRenderer extends AbstractWidgetRenderer {
             if (chart.getService() != null) {
                 chartUrl += "&service=" + chart.getService();
             }
+            if (chart.getLegend() != null) {
+                if (chart.getLegend()) {
+                    chartUrl += "&legend=true";
+                } else {
+                    chartUrl += "&legend=false";
+                }
+            }
             String url = chartUrl + "&t=" + (new Date()).getTime();
 
             String snippet = getSnippet("chart");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ChartRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/ChartRenderer.java
@@ -54,6 +54,13 @@ public class ChartRenderer extends AbstractWidgetRenderer {
             if (chart.getService() != null) {
                 url += "&service=" + chart.getService();
             }
+            if (chart.getLegend() != null) {
+                if (chart.getLegend()) {
+                    url += "&legend=true";
+                } else {
+                    url += "&legend=false";
+                }
+            }
 
             String snippet = getSnippet("image");
 


### PR DESCRIPTION
Add some enhancements to the ChartServlet, DefaultChartProvider, REST API, BasicUI/ClassicUI to support the following things:

* Chart themes for different looks
* `dpi` parameter for dynamic sizes based on DPI
* Automatic showing/hiding of the legend based on number of chart series
* `legend` parameter to hide/show the chart legend

**Please see issue #4288 for all details.**
The first comment has a up2date description.

:exclamation: This breaks the OH1 compatibility layer: `org.openhab.ui.chart.internal.ChartProviderDelegate`
If this gets merged, I create a PR in openhab/openhab-core

---
**Renderings**
Default theme "bright", default settings:
![chart_1](https://user-images.githubusercontent.com/21249127/30762704-644b431e-9fe3-11e7-9089-d2d8913c9f31.png)
Theme "dark", default settings:
![chart_2](https://user-images.githubusercontent.com/21249127/30762706-644ffc10-9fe3-11e7-9bd9-356d9803d37d.png)
Theme "black", default settings:
![chart_3](https://user-images.githubusercontent.com/21249127/30762705-644dc29c-9fe3-11e7-83eb-a6b2ab5f8402.png)