### PR TITLE
PaperUI: No force-update repositories when control page activates

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -11,9 +11,9 @@ angular.module('PaperUI.controllers.control', []) //
             channelTypeRepository.getAll(function() {
                 thingTypeRepository.getAll(function() {
                     renderTabs();
-                }, true)
-            }, true)
-        }, true);
+                })
+            })
+        });
     }
 
     function renderTabs() {


### PR DESCRIPTION
Fixes #4255.

Signed-off-by: Henning Treu <henning.treu@telekom.de>