### PR TITLE
RFC: Rework manifest

### DIFF
--- a/bundles/auth/org.eclipse.smarthome.auth.jaas/META-INF/MANIFEST.MF
+++ b/bundles/auth/org.eclipse.smarthome.auth.jaas/META-INF/MANIFEST.MF
@@ -1,14 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome JAAS Auth
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.auth.jaas
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Bundle-SymbolicName: org.eclipse.smarthome.auth.jaas
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.auth,
  org.osgi.service.cm,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/automation/org.eclipse.smarthome.automation.api/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/META-INF/MANIFEST.MF
@@ -1,10 +1,20 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation API
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.api
-Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.automation,
+ org.eclipse.smarthome.automation.dto,
+ org.eclipse.smarthome.automation.events,
+ org.eclipse.smarthome.automation.handler,
+ org.eclipse.smarthome.automation.parser,
+ org.eclipse.smarthome.automation.template,
+ org.eclipse.smarthome.automation.type
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.dto,
  org.eclipse.smarthome.automation.events,
@@ -17,12 +27,3 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.events,
  org.osgi.framework,
  org.slf4j
-Export-Package: 
- org.eclipse.smarthome.automation,
- org.eclipse.smarthome.automation.dto,
- org.eclipse.smarthome.automation.events,
- org.eclipse.smarthome.automation.handler,
- org.eclipse.smarthome.automation.parser,
- org.eclipse.smarthome.automation.template,
- org.eclipse.smarthome.automation.type
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/automation/org.eclipse.smarthome.automation.commands/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.commands/META-INF/MANIFEST.MF
@@ -1,9 +1,12 @@
+Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Automation commands
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.commands
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Name: Eclipse SmartHome Automation commands
-Import-Package: org.apache.commons.lang,
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.parser,
@@ -17,5 +20,4 @@ Import-Package: org.apache.commons.lang,
  org.osgi.service.component,
  org.osgi.util.tracker,
  org.slf4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml

--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Automation Core
-Bundle-SymbolicName: org.eclipse.smarthome.automation.core.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.automation.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.junit;bundle-version="4.8.1"
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.core.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.automation.core
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.test.storage
+Require-Bundle: org.junit;bundle-version="4.8.1"

--- a/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
@@ -2,8 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Core
 Bundle-SymbolicName: org.eclipse.smarthome.automation.core
-Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.automation.core.util
 Import-Package: 
  com.google.gson,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -23,4 +24,3 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.automation.core.util

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Event Test
-Bundle-SymbolicName: org.eclipse.smarthome.automation.event.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.event.test;singlet
+ on:=true
+Bundle-Vendor: Eclipse/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ com.google.common.collect,
  groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
@@ -21,10 +23,10 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.autoupdate,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.items,
- org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.core.items.events,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
@@ -32,9 +34,10 @@ Import-Package: com.google.common.collect,
  org.osgi.service.event,
  org.osgi.util.tracker,
  org.slf4j;version="1.7.2"
-Require-Bundle: org.junit;bundle-version="4.0.0",
+Require-Bundle: 
  org.eclipse.smarthome.automation.api,
  org.eclipse.smarthome.automation.core,
  org.eclipse.smarthome.automation.module.core,
  org.eclipse.smarthome.automation.parser.gson,
- org.eclipse.smarthome.automation.providers
+ org.eclipse.smarthome.automation.providers,
+ org.junit;bundle-version="4.0.0"

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Integration Test
-Bundle-SymbolicName: org.eclipse.smarthome.automation.integration.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.integration.test;s
+ ingleton:=true
+Bundle-Vendor: Eclipse/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ com.google.common.collect,
  groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
@@ -36,11 +38,12 @@ Import-Package: com.google.common.collect,
  org.osgi.service.packageadmin,
  org.osgi.util.tracker,
  org.slf4j;version="1.7.2"
-Require-Bundle: org.junit;bundle-version="4.0.0",
+Require-Bundle: 
  org.eclipse.smarthome.automation.api,
  org.eclipse.smarthome.automation.core,
  org.eclipse.smarthome.automation.module.core,
  org.eclipse.smarthome.automation.parser.gson,
  org.eclipse.smarthome.automation.providers,
  org.eclipse.smarthome.automation.sample.extension.json,
- org.eclipse.smarthome.io.console
+ org.eclipse.smarthome.io.console,
+ org.junit;bundle-version="4.0.0"

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Test
-Bundle-SymbolicName: org.eclipse.smarthome.automation.module.core.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.module.core.test;s
+ ingleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.events,
  org.eclipse.smarthome.automation.type,
@@ -21,9 +23,10 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.test.storage,
  org.osgi.framework,
  org.slf4j
-Require-Bundle: org.junit;bundle-version="4.0.0",
+Require-Bundle: 
  org.eclipse.smarthome.automation.api,
  org.eclipse.smarthome.automation.core,
  org.eclipse.smarthome.automation.module.core,
  org.eclipse.smarthome.automation.parser.gson,
- org.eclipse.smarthome.automation.providers
+ org.eclipse.smarthome.automation.providers,
+ org.junit;bundle-version="4.0.0"

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
@@ -1,10 +1,16 @@
 Manifest-Version: 1.0
+Automation-ResourceType: json
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Core
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.core
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Export-Package: 
+ org.eclipse.smarthome.automation.module.core.factory,
+ org.eclipse.smarthome.automation.module.core.handler
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.handler,
  org.eclipse.smarthome.automation.module.core.factory,
@@ -20,8 +26,4 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.service.component,
  org.osgi.util.tracker,
  org.slf4j;version="1.7.2"
-Automation-ResourceType: json
-Export-Package: org.eclipse.smarthome.automation.module.core.factory,
- org.eclipse.smarthome.automation.module.core.handler
-Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml

--- a/bundles/automation/org.eclipse.smarthome.automation.module.media/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.media/META-INF/MANIFEST.MF
@@ -1,10 +1,16 @@
 Manifest-Version: 1.0
+Automation-ResourceType: json
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Media Modules
-Bundle-SymbolicName: org.eclipse.smarthome.automation.module.media
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.module.media
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.automation.module.media.handler
+Import-Package: 
+ com.google.common.collect,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
@@ -18,9 +24,4 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.voice,
  org.osgi.framework,
  org.slf4j
-Automation-ResourceType: json
-Export-Package: org.eclipse.smarthome.automation.module.media.handler
-Bundle-ClassPath: .
-Bundle-Vendor: Eclipse.org/SmartHome
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
@@ -1,11 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Script Globals
-Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.defaultscope
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.apache.commons.io,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.defa
+ ultscope
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
@@ -20,4 +23,3 @@ Import-Package: org.apache.commons.io,
  org.joda.time;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/META-INF/MANIFEST.MF
@@ -1,17 +1,29 @@
 Manifest-Version: 1.0
+Automation-ResourceType: json
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Script RuleSupport
-Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.rulesupport
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.rule
+ support
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.automation.module.script.rulesupport.shared,
+ org.eclipse.smarthome.automation.module.script.rulesupport.shared.facto
+ ries,
+ org.eclipse.smarthome.automation.module.script.rulesupport.shared.simpl
+ e
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.handler,
  org.eclipse.smarthome.automation.module.script,
  org.eclipse.smarthome.automation.module.script.rulesupport.shared,
- org.eclipse.smarthome.automation.module.script.rulesupport.shared.factories,
- org.eclipse.smarthome.automation.module.script.rulesupport.shared.simple,
+ org.eclipse.smarthome.automation.module.script.rulesupport.shared.facto
+ ries,
+ org.eclipse.smarthome.automation.module.script.rulesupport.shared.simpl
+ e,
  org.eclipse.smarthome.automation.parser,
  org.eclipse.smarthome.automation.template,
  org.eclipse.smarthome.automation.type,
@@ -31,9 +43,4 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.service.component,
  org.osgi.util.tracker,
  org.slf4j
-Export-Package: org.eclipse.smarthome.automation.module.script.rulesupport.shared,
- org.eclipse.smarthome.automation.module.script.rulesupport.shared.factories,
- org.eclipse.smarthome.automation.module.script.rulesupport.shared.simple
-Automation-ResourceType: json
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome JSR233 Automation Module Tests
-Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.automation.module.script
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.automation.module.script
+Import-Package: 
+ com.google.common.collect,
  groovy.lang,
  org.apache.commons.io,
  org.apache.commons.lang,
@@ -37,7 +38,8 @@ Import-Package: com.google.common.collect,
  org.osgi.service.event,
  org.osgi.util.tracker,
  org.slf4j
-Require-Bundle: org.eclipse.smarthome.automation.core,
+Require-Bundle: 
+ org.eclipse.smarthome.automation.core,
  org.eclipse.smarthome.automation.module.core,
  org.eclipse.smarthome.automation.module.script.defaultscope,
  org.eclipse.smarthome.automation.parser.gson,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
@@ -1,10 +1,16 @@
 Manifest-Version: 1.0
+Automation-ResourceType: json
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Script
-Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.base,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+DynamicImport-Package: *
+Export-Package: org.eclipse.smarthome.automation.module.script
+Import-Package: 
+ com.google.common.base,
  javax.script,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
@@ -22,9 +28,4 @@ Import-Package: com.google.common.base,
  org.osgi.framework,
  org.osgi.util.tracker,
  org.slf4j
-Automation-ResourceType: json
 Service-Component: OSGI-INF/*.xml
-Bundle-Vendor: Eclipse.org/SmartHome
-Export-Package: org.eclipse.smarthome.automation.module.script
-Bundle-ActivationPolicy: lazy
-DynamicImport-Package: *

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Timer Test
-Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer.test;
+ singleton:=true
+Bundle-Vendor: Eclipse/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ com.google.common.collect,
  groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
@@ -34,10 +36,11 @@ Import-Package: com.google.common.collect,
  org.osgi.service.event,
  org.osgi.util.tracker,
  org.slf4j;version="1.7.2"
-Require-Bundle: org.junit;bundle-version="4.0.0",
+Require-Bundle: 
  org.eclipse.smarthome.automation.api,
  org.eclipse.smarthome.automation.core,
  org.eclipse.smarthome.automation.module.core,
- org.eclipse.smarthome.automation.providers,
  org.eclipse.smarthome.automation.module.timer,
- org.eclipse.smarthome.automation.parser.gson
+ org.eclipse.smarthome.automation.parser.gson,
+ org.eclipse.smarthome.automation.providers,
+ org.junit;bundle-version="4.0.0"

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
@@ -1,11 +1,19 @@
 Manifest-Version: 1.0
+Automation-ResourceType: json
+Bundle-Activator: org.eclipse.smarthome.automation.module.timer.internal
+ .Activator
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Timer
-Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer
-Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.automation.module.timer.internal.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.automation.module.timer.factory,
+ org.eclipse.smarthome.automation.module.timer.handler
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.handler,
@@ -15,8 +23,3 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.core.scheduler,
  org.osgi.framework,
  org.slf4j;version="1.7.2"
-Automation-ResourceType: json
-Export-Package: org.eclipse.smarthome.automation.module.timer.factory,
- org.eclipse.smarthome.automation.module.timer.handler
-Bundle-ClassPath: .
-Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation GSON Parser
-Bundle-SymbolicName: org.eclipse.smarthome.automation.parser.gson
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.gson,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.parser.gson
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ com.google.gson,
  com.google.gson.stream,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.provider.file/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.provider.file/META-INF/MANIFEST.MF
@@ -1,9 +1,12 @@
+Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Automation File Provider
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.provider.file
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Name: Eclipse SmartHome Automation File Provider
-Import-Package: org.apache.commons.lang,
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.parser,
@@ -17,4 +20,3 @@ Import-Package: org.apache.commons.lang,
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/META-INF/MANIFEST.MF
@@ -1,9 +1,12 @@
+Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Automation Providers
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.providers
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Name: Eclipse SmartHome Automation Providers
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.parser,
  org.eclipse.smarthome.automation.template,
@@ -17,4 +20,3 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation REST API
-Bundle-SymbolicName: org.eclipse.smarthome.automation.rest
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: io.swagger.annotations;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.rest
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ io.swagger.annotations;resolution:=optional,
  javax.ws.rs,
  javax.ws.rs.core,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/META-INF/MANIFEST.MF
@@ -1,11 +1,16 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.automation.sample.extension.java
+ .Activator
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse SmartHome Automation Sample Extension Java - Welcome Home Application
-Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.java
-Bundle-Activator: org.eclipse.smarthome.automation.sample.extension.java.Activator
-Bundle-Version: 0.9.0.qualifier
+Bundle-Name: Eclipse SmartHome Automation Sample Extension Java - Welcom
+ e Home Application
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.j
+ ava
 Bundle-Vendor: Eclipse.org/SmartHome
-Import-Package: org.apache.commons.lang,
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.handler,
@@ -17,4 +22,3 @@ Import-Package: org.apache.commons.lang,
  org.eclipse.smarthome.io.console.extensions,
  org.osgi.framework,
  org.slf4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
@@ -1,10 +1,15 @@
+Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.automation.internal.sample.json.
+ handler.Activator
 Bundle-ManifestVersion: 2
-Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.json
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Name: Automation Sample JSON
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.j
+ son
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.handler,
  org.eclipse.smarthome.automation.parser,
@@ -13,8 +18,7 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.io.console,
  org.eclipse.smarthome.io.console.extensions,
- org.slf4j,
  org.osgi.framework,
  org.osgi.service.event,
- org.osgi.util.tracker;version="1.4.0"
-Bundle-Activator: org.eclipse.smarthome.automation.internal.sample.json.handler.Activator
+ org.osgi.util.tracker;version="1.4.0",
+ org.slf4j

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
+Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Automation Java Demo
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.java.demo
 Bundle-Vendor: Bosch Software Innovations GmbH
 Bundle-Version: 0.9.0.qualifier
-Bundle-Name: Eclipse SmartHome Automation Java Demo
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.config.core,
- org.osgi.service.component,
- org.eclipse.smarthome.core.common.registry
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+ org.eclipse.smarthome.core.common.registry,
+ org.osgi.service.component
 Service-Component: OSGI-INF/*.xml

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
+Automation-ResourceType: json
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Json Demo
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.json.demo
-Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Bosch Software Innovations GmbH
-Automation-ResourceType: json
-Bundle-ClassPath: .
+Bundle-Version: 0.9.0.qualifier
 Import-Package: org.eclipse.jdt.annotation;resolution:=optional
 Service-Component: OSGI-INF/*.xml

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/META-INF/MANIFEST.MF
@@ -1,10 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Type Demo
-Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.moduletype.demo
-Bundle-Version: 0.9.0.qualifier
+Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.moduletype.
+ demo
 Bundle-Vendor: Bosch Software Innovations GmbH
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.handler,
  org.eclipse.smarthome.config.core,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/META-INF/MANIFEST.MF
@@ -1,14 +1,16 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.automation.sample.rest.api.Activ
+ ator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Sample REST API
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.rest.api
-Bundle-Activator: org.eclipse.smarthome.automation.sample.rest.api.Activator
-Bundle-Version: 0.9.0.qualifier
 Bundle-Vendor: Eclipse.org/SmartHome
-Import-Package: javax.servlet,
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ javax.servlet,
  javax.servlet.http,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework,
  org.osgi.service.http,
  org.osgi.util.tracker
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Configuration Core Tests
-Bundle-SymbolicName: org.eclipse.smarthome.config.core.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.config.core.test;singleton:=t
+ rue
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.config.core
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,

--- a/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
@@ -1,11 +1,20 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.config.core.internal.Activator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config Core
-Bundle-SymbolicName: org.eclipse.smarthome.config.core
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.base,
+Bundle-SymbolicName: org.eclipse.smarthome.config.core
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.core.dto,
+ org.eclipse.smarthome.config.core.i18n,
+ org.eclipse.smarthome.config.core.status,
+ org.eclipse.smarthome.config.core.status.events,
+ org.eclipse.smarthome.config.core.validation
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  com.google.gson,
  org.apache.commons.lang.reflect,
@@ -26,11 +35,4 @@ Import-Package: com.google.common.base,
  org.osgi.service.component,
  org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
-Export-Package: org.eclipse.smarthome.config.core,
- org.eclipse.smarthome.config.core.dto,
- org.eclipse.smarthome.config.core.i18n,
- org.eclipse.smarthome.config.core.status,
- org.eclipse.smarthome.config.core.status.events,
- org.eclipse.smarthome.config.core.validation
 Service-Component: OSGI-INF/*.xml
-Bundle-Activator: org.eclipse.smarthome.config.core.internal.Activator

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Configuration Discovery Tests
-Bundle-SymbolicName: org.eclipse.smarthome.config.discovery.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.config.discovery.test;singlet
+ on:=true
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.config.discovery
-Import-Package: com.google.gson,
+Import-Package: 
+ com.google.gson,
  groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
@@ -15,9 +17,9 @@ Import-Package: com.google.gson,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.storage,
- org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.thing.binding.builder,
+ org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.java,

--- a/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
@@ -1,11 +1,17 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Configuration Discovery
-Bundle-SymbolicName: org.eclipse.smarthome.config.discovery
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.base,
+Bundle-SymbolicName: org.eclipse.smarthome.config.discovery
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.config.discovery.dto,
+ org.eclipse.smarthome.config.discovery.inbox,
+ org.eclipse.smarthome.config.discovery.inbox.events
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
@@ -24,18 +30,14 @@ Import-Package: com.google.common.base,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.io.console,
  org.eclipse.smarthome.io.console.extensions,
- org.jupnp;resolution:=optional,
  org.jupnp.controlpoint;resolution:=optional,
  org.jupnp.model.message.header;resolution:=optional,
  org.jupnp.model.meta;resolution:=optional,
  org.jupnp.registry;resolution:=optional,
+ org.jupnp;resolution:=optional,
  org.osgi.framework,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.config.discovery,
- org.eclipse.smarthome.config.discovery.dto,
- org.eclipse.smarthome.config.discovery.inbox,
- org.eclipse.smarthome.config.discovery.inbox.events

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config Dispatcher Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.dispatch.test
 Bundle-Version: 0.9.0.qualifier
-Bundle-ClassPath: .
 Fragment-Host: org.eclipse.smarthome.config.dispatch
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.test.java,
  org.hamcrest;core=split,
  org.junit,

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config Dispatcher
-Bundle-SymbolicName: org.eclipse.smarthome.config.dispatch
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.apache.commons.io;version="2.2.0",
+Bundle-SymbolicName: org.eclipse.smarthome.config.dispatch
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.apache.commons.io;version="2.2.0",
  org.apache.commons.lang;version="2.6.0",
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config XML Tests
-Bundle-SymbolicName: org.eclipse.smarthome.config.xml.test;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.config.xml.test;singleton:=tr
+ ue
+Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.config.xml
-Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.apache.commons.io,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
-Bundle-SymbolicName: ConfigDescriptionsFragmentTest.fragment;singleton:=true
-Bundle-Version: 0.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
+Bundle-SymbolicName: ConfigDescriptionsFragmentTest.fragment;singleton:=
+ true
+Bundle-Version: 0.0.1.qualifier
 Fragment-Host: ConfigDescriptionsFragmentTest.host
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ConfigDescriptionsFragmentTest.host;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
@@ -1,10 +1,12 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
-Bundle-SymbolicName: LoadingConfigDescriptionsTest.bundle;singleton:=true
-Bundle-Version: 0.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: LoadingConfigDescriptionsTest.bundle;singleton:=tru
+ e
+Bundle-Version: 0.0.1.qualifier
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.7.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
@@ -1,11 +1,28 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: lib/xstream-1.4.7.jar,.
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config XML
-Bundle-SymbolicName: org.eclipse.smarthome.config.xml
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.thoughtworks.xstream,
+Bundle-SymbolicName: org.eclipse.smarthome.config.xml
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ com.thoughtworks.xstream,
+ com.thoughtworks.xstream.annotations,
+ com.thoughtworks.xstream.converters,
+ com.thoughtworks.xstream.converters.basic,
+ com.thoughtworks.xstream.converters.reflection,
+ com.thoughtworks.xstream.core,
+ com.thoughtworks.xstream.core.util,
+ com.thoughtworks.xstream.io,
+ com.thoughtworks.xstream.io.naming,
+ com.thoughtworks.xstream.io.xml,
+ com.thoughtworks.xstream.mapper,
+ org.eclipse.smarthome.config.xml,
+ org.eclipse.smarthome.config.xml.osgi,
+ org.eclipse.smarthome.config.xml.util
+Import-Package: 
+ com.thoughtworks.xstream,
  com.thoughtworks.xstream.annotations,
  com.thoughtworks.xstream.converters,
  com.thoughtworks.xstream.converters.basic,
@@ -37,20 +54,4 @@ Import-Package: com.thoughtworks.xstream,
  org.osgi.service.component.annotations;resolution:=optional,
  org.osgi.util.tracker,
  org.slf4j
-Export-Package: com.thoughtworks.xstream,
- com.thoughtworks.xstream.annotations,
- com.thoughtworks.xstream.converters,
- com.thoughtworks.xstream.converters.basic,
- com.thoughtworks.xstream.converters.reflection,
- com.thoughtworks.xstream.core,
- com.thoughtworks.xstream.core.util,
- com.thoughtworks.xstream.io,
- com.thoughtworks.xstream.io.naming,
- com.thoughtworks.xstream.io.xml,
- com.thoughtworks.xstream.mapper,
- org.eclipse.smarthome.config.xml,
- org.eclipse.smarthome.config.xml.osgi,
- org.eclipse.smarthome.config.xml.util
-Bundle-ClassPath: lib/xstream-1.4.7.jar,
- .
 Service-Component: OSGI-INF/*.xml

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Smarthome Audio Test
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.audio.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.audio
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,

--- a/bundles/core/org.eclipse.smarthome.core.audio/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.audio/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Audio
-Bundle-SymbolicName: org.eclipse.smarthome.core.audio
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: javax.servlet,
+Bundle-SymbolicName: org.eclipse.smarthome.core.audio
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.core.audio,
+ org.eclipse.smarthome.core.audio.utils
+Import-Package: 
+ javax.servlet,
  javax.servlet.http,
  org.apache.commons.io,
  org.apache.commons.lang,
@@ -27,7 +32,4 @@ Import-Package: javax.servlet,
  org.osgi.framework,
  org.osgi.service.http,
  org.slf4j
-Export-Package: org.eclipse.smarthome.core.audio,
- org.eclipse.smarthome.core.audio.utils
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
-Private-Package: org.eclipse.smarthome.core.autoupdate.internal
-Ignore-Package: org.eclipse.smarthome.core.autoupdate.internal
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome AutoUpdate Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.autoupdate
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Export-Package: org.eclipse.smarthome.core.autoupdate
+Ignore-Package: org.eclipse.smarthome.core.autoupdate.internal
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.autoupdate,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.items,
@@ -14,10 +19,5 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.types,
  org.osgi.framework,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.core.autoupdate
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Private-Package: org.eclipse.smarthome.core.autoupdate.internal
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-Export-Package: org.eclipse.smarthome.core.autoupdate
-Bundle-ActivationPolicy: lazy
-

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Binding XML Tests
-Bundle-SymbolicName: org.eclipse.smarthome.core.binding.xml.test;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.binding.xml.test;singlet
+ on:=true
+Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.binding.xml
-Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.apache.commons.io,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTest.bundle/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: BundleInfoTest.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTestNoAuthor.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTestNoAuthor.bundle/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: BundleInfoTestNoAuthor.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.7.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Binding XML
-Bundle-SymbolicName: org.eclipse.smarthome.core.binding.xml
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.thoughtworks.xstream,
+Bundle-SymbolicName: org.eclipse.smarthome.core.binding.xml
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ com.thoughtworks.xstream,
  com.thoughtworks.xstream.converters,
  com.thoughtworks.xstream.io,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sample Extension Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.extension.sample
+Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Import-Package: org.apache.commons.lang,
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.extension
-Bundle-Vendor: Eclipse.org/SmartHome
 Service-Component: OSGI-INF/*.xml
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome ID Tests
-Bundle-SymbolicName: org.eclipse.smarthome.core.id.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.id.test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.id
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,

--- a/bundles/core/org.eclipse.smarthome.core.id/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id/META-INF/MANIFEST.MF
@@ -1,16 +1,17 @@
 Manifest-Version: 1.0
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core ID
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.id
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Bundle-SymbolicName: org.eclipse.smarthome.core.id
 Export-Package: org.eclipse.smarthome.core.id
-Import-Package: io.swagger.annotations;resolution:=optional,
+Import-Package: 
+ io.swagger.annotations;resolution:=optional,
  javax.annotation.security;resolution:=optional,
- javax.ws.rs;resolution:=optional,
  javax.ws.rs.core;resolution:=optional,
+ javax.ws.rs;resolution:=optional,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/core/org.eclipse.smarthome.core.persistence/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/META-INF/MANIFEST.MF
@@ -1,12 +1,20 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Persistence
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.persistence
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Bundle-SymbolicName: org.eclipse.smarthome.core.persistence
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Export-Package: 
+ org.eclipse.smarthome.core.persistence,
+ org.eclipse.smarthome.core.persistence.config,
+ org.eclipse.smarthome.core.persistence.dto,
+ org.eclipse.smarthome.core.persistence.strategy
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.items,
@@ -17,10 +25,4 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.scheduler,
  org.eclipse.smarthome.core.types,
  org.slf4j
-Export-Package: org.eclipse.smarthome.core.persistence,
- org.eclipse.smarthome.core.persistence.config,
- org.eclipse.smarthome.core.persistence.dto,
- org.eclipse.smarthome.core.persistence.strategy
-Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/core/org.eclipse.smarthome.core.scheduler/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.scheduler/META-INF/MANIFEST.MF
@@ -1,18 +1,52 @@
 Manifest-Version: 1.0
-Private-Package: org.eclipse.smarthome.core.scheduler.internal
-Ignore-Package: org.eclipse.smarthome.core.scheduler.internal
+Bundle-Activator: org.eclipse.smarthome.core.scheduler.internal.Schedule
+ rActivator
+Bundle-ClassPath: .,lib/quartz-2.2.1.jar,lib/quartz-jobs-2.2.1.jar
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Scheduler Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.scheduler
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Bundle-SymbolicName: org.eclipse.smarthome.core.scheduler
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .,
- lib/quartz-2.2.1.jar,
- lib/quartz-jobs-2.2.1.jar
-Import-Package: org.osgi.framework,
+Export-Package: 
+ org.quartz,
+ org.quartz.commonj,
+ org.quartz.core,
+ org.quartz.core.jmx,
+ org.quartz.ee.jmx.jboss,
+ org.quartz.ee.jta,
+ org.quartz.ee.servlet,
+ org.quartz.helpers,
+ org.quartz.impl,
+ org.quartz.impl.calendar,
+ org.quartz.impl.jdbcjobstore,
+ org.quartz.impl.jdbcjobstore.oracle,
+ org.quartz.impl.jdbcjobstore.oracle.weblogic,
+ org.quartz.impl.matchers,
+ org.quartz.impl.triggers,
+ org.quartz.jobs,
+ org.quartz.jobs.ee.ejb,
+ org.quartz.jobs.ee.jms,
+ org.quartz.jobs.ee.jmx,
+ org.quartz.jobs.ee.mail,
+ org.quartz.listeners,
+ org.quartz.management,
+ org.quartz.plugins,
+ org.quartz.plugins.history,
+ org.quartz.plugins.management,
+ org.quartz.plugins.xml,
+ org.quartz.simpl,
+ org.quartz.spi,
+ org.quartz.utils,
+ org.quartz.utils.counter,
+ org.quartz.utils.counter.sampled,
+ org.quartz.utils.weblogic,
+ org.quartz.xml
+Ignore-Package: org.eclipse.smarthome.core.scheduler.internal
+Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
+ org.osgi.framework,
  org.quartz,
  org.quartz.commonj,
  org.quartz.core,
@@ -47,37 +81,4 @@ Import-Package: org.osgi.framework,
  org.quartz.utils.weblogic,
  org.quartz.xml,
  org.slf4j
-Bundle-Activator: org.eclipse.smarthome.core.scheduler.internal.SchedulerActivator
-Export-Package: org.quartz,
- org.quartz.commonj,
- org.quartz.core,
- org.quartz.core.jmx,
- org.quartz.ee.jmx.jboss,
- org.quartz.ee.jta,
- org.quartz.ee.servlet,
- org.quartz.helpers,
- org.quartz.impl,
- org.quartz.impl.calendar,
- org.quartz.impl.jdbcjobstore,
- org.quartz.impl.jdbcjobstore.oracle,
- org.quartz.impl.jdbcjobstore.oracle.weblogic,
- org.quartz.impl.matchers,
- org.quartz.impl.triggers,
- org.quartz.jobs,
- org.quartz.jobs.ee.ejb,
- org.quartz.jobs.ee.jms,
- org.quartz.jobs.ee.jmx,
- org.quartz.jobs.ee.mail,
- org.quartz.listeners,
- org.quartz.management,
- org.quartz.plugins,
- org.quartz.plugins.history,
- org.quartz.plugins.management,
- org.quartz.plugins.xml,
- org.quartz.simpl,
- org.quartz.spi,
- org.quartz.utils,
- org.quartz.utils.counter,
- org.quartz.utils.counter.sampled,
- org.quartz.utils.weblogic,
- org.quartz.xml
+Private-Package: org.eclipse.smarthome.core.scheduler.internal

--- a/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Eclipse SmartHome Core
-Bundle-SymbolicName: org.eclipse.smarthome.core.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: groovy.lang,
+Bundle-SymbolicName: org.eclipse.smarthome.core.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.core
+Import-Package: 
+ groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,
@@ -22,4 +23,7 @@ Import-Package: groovy.lang,
  org.junit.runners,
  org.mockito,
  org.osgi.service.cm
-Require-Bundle: org.junit,org.mockito,org.hamcrest
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Tests
-Bundle-SymbolicName: org.eclipse.smarthome.core.thing.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.thing.test;singleton:=tr
+ ue
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.thing
-Import-Package: com.google.gson,
+Import-Package: 
+ com.google.gson,
  groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
@@ -26,8 +28,8 @@ Import-Package: com.google.gson,
  org.eclipse.smarthome.test.java,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
- org.junit;version="4.0.0",
  org.junit.rules,
+ org.junit;version="4.0.0",
  org.mockito,
  org.mockito.invocation,
  org.mockito.stubbing,

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Thing XML Tests
-Bundle-SymbolicName: org.eclipse.smarthome.core.thing.xml.test;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.thing.xml.test;singleton
+ :=true
+Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.thing.xml
-Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.apache.commons.io,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesI18nTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesI18nTest.bundle/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ChannelTypesI18nTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesTest.bundle/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ChannelTypesTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ConfigDescriptionsTest.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: SystemChannels.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsInChannelGroups.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsInChannelGroups.bundle/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
-Bundle-SymbolicName: SystemChannelsInChannelGroups.bundle;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: SystemChannelsInChannelGroups.bundle;singleton:=tru
+ e
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: SystemChannelsNoThingTypes.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: SystemChannelsUser.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ThingTypesTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ThingTypesTest.bundle/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ThingTypesTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Synthetic Test Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Thing XML
-Bundle-SymbolicName: org.eclipse.smarthome.core.thing.xml
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.thoughtworks.xstream,
+Bundle-SymbolicName: org.eclipse.smarthome.core.thing.xml
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ com.thoughtworks.xstream,
  com.thoughtworks.xstream.converters,
  com.thoughtworks.xstream.io,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -1,12 +1,29 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.core.thing.internal.Activator
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Thing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.thing
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Bundle-SymbolicName: org.eclipse.smarthome.core.thing
-Import-Package: com.google.common.base,
+Export-Package: 
+ org.eclipse.smarthome.core.thing,
+ org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.thing.binding.builder,
+ org.eclipse.smarthome.core.thing.binding.firmware,
+ org.eclipse.smarthome.core.thing.dto,
+ org.eclipse.smarthome.core.thing.events,
+ org.eclipse.smarthome.core.thing.firmware,
+ org.eclipse.smarthome.core.thing.firmware.dto,
+ org.eclipse.smarthome.core.thing.i18n,
+ org.eclipse.smarthome.core.thing.link,
+ org.eclipse.smarthome.core.thing.link.dto,
+ org.eclipse.smarthome.core.thing.link.events,
+ org.eclipse.smarthome.core.thing.type,
+ org.eclipse.smarthome.core.thing.util
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  org.apache.commons.collections.iterators,
  org.apache.commons.io,
@@ -51,19 +68,4 @@ Import-Package: com.google.common.base,
  org.osgi.service.event,
  org.osgi.util.tracker,
  org.slf4j
-Export-Package: org.eclipse.smarthome.core.thing,
- org.eclipse.smarthome.core.thing.binding,
- org.eclipse.smarthome.core.thing.binding.builder,
- org.eclipse.smarthome.core.thing.binding.firmware,
- org.eclipse.smarthome.core.thing.dto,
- org.eclipse.smarthome.core.thing.events,
- org.eclipse.smarthome.core.thing.firmware,
- org.eclipse.smarthome.core.thing.firmware.dto,
- org.eclipse.smarthome.core.thing.i18n,
- org.eclipse.smarthome.core.thing.link,
- org.eclipse.smarthome.core.thing.link.dto,
- org.eclipse.smarthome.core.thing.link.events,
- org.eclipse.smarthome.core.thing.type,
- org.eclipse.smarthome.core.thing.util
 Service-Component: OSGI-INF/*.xml
-Bundle-Activator: org.eclipse.smarthome.core.thing.internal.Activator

--- a/bundles/core/org.eclipse.smarthome.core.transform/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.transform/META-INF/MANIFEST.MF
@@ -1,13 +1,20 @@
 Manifest-Version: 1.0
-Private-Package: org.eclipse.smarthome.binding.http.internal
-Ignore-Package: org.eclipse.smarthome.binding.http.internal
+Bundle-Activator: org.eclipse.smarthome.core.transform.internal.Transfor
+ mationActivator
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.transform
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.core.transform.internal.TransformationActivator
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.apache.commons.io,
+Export-Package: 
+ org.eclipse.smarthome.core.transform,
+ org.eclipse.smarthome.core.transform.actions
+Ignore-Package: org.eclipse.smarthome.binding.http.internal
+Import-Package: 
+ org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.i18n,
@@ -16,8 +23,4 @@ Import-Package: org.apache.commons.io,
  org.osgi.framework,
  org.osgi.util.tracker,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.core.transform
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Export-Package: org.eclipse.smarthome.core.transform,
- org.eclipse.smarthome.core.transform.actions
+Private-Package: org.eclipse.smarthome.binding.http.internal

--- a/bundles/core/org.eclipse.smarthome.core.voice.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.voice.test/META-INF/MANIFEST.MF
@@ -1,21 +1,22 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Voice Tests
-Bundle-SymbolicName: org.eclipse.smarthome.core.voice.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.core.voice
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.core.voice.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.core.voice
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.voice,
  org.eclipse.smarthome.test.java,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
- org.junit;version="4.0.0",
  org.junit.rules,
  org.junit.runner,
  org.junit.runners,
+ org.junit;version="4.0.0",
  org.osgi.service.cm
-Bundle-ClassPath: .

--- a/bundles/core/org.eclipse.smarthome.core.voice/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.voice/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core Voice
-Bundle-SymbolicName: org.eclipse.smarthome.core.voice
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.commons.collections.map,
+Bundle-SymbolicName: org.eclipse.smarthome.core.voice
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.core.voice,
+ org.eclipse.smarthome.core.voice.text
+Import-Package: 
+ org.apache.commons.collections.map,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -25,7 +30,4 @@ Import-Package: org.apache.commons.collections.map,
  org.eclipse.smarthome.io.console.extensions,
  org.osgi.framework,
  org.slf4j
-Export-Package: org.eclipse.smarthome.core.voice,
- org.eclipse.smarthome.core.voice.text
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -1,17 +1,28 @@
 Manifest-Version: 1.0
-Export-Package: org.eclipse.smarthome.core.auth,
+Bundle-Activator: org.eclipse.smarthome.core.internal.CoreActivator
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Core
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.core.auth,
  org.eclipse.smarthome.core.binding,
  org.eclipse.smarthome.core.binding.dto,
  org.eclipse.smarthome.core.cache,
  org.eclipse.smarthome.core.common,
  org.eclipse.smarthome.core.common.osgi,
  org.eclipse.smarthome.core.common.registry,
- org.eclipse.smarthome.core.events;uses:="org.eclipse.smarthome.core.items,org.osgi.service.event,org.eclipse.smarthome.core.types",
+ org.eclipse.smarthome.core.events;uses:="org.eclipse.smarthome.core.ite
+ ms,org.osgi.service.event,org.eclipse.smarthome.core.types",
  org.eclipse.smarthome.core.extension,
  org.eclipse.smarthome.core.i18n,
- org.eclipse.smarthome.core.items;uses:="org.eclipse.smarthome.core.types,org.eclipse.smarthome.core.events",
  org.eclipse.smarthome.core.items.dto,
  org.eclipse.smarthome.core.items.events,
+ org.eclipse.smarthome.core.items;uses:="org.eclipse.smarthome.core.type
+ s,org.eclipse.smarthome.core.events",
  org.eclipse.smarthome.core.library,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.core.library.types,
@@ -20,20 +31,11 @@ Export-Package: org.eclipse.smarthome.core.auth,
  org.eclipse.smarthome.core.service,
  org.eclipse.smarthome.core.storage,
  org.eclipse.smarthome.core.types
-Service-Component: OSGI-INF/*.xml
-Private-Package: org.eclipse.smarthome.core.internal,org.eclipse.smarthome.core.internal.e
- vents,org.eclipse.smarthome.core.internal.items,org.eclipse.smarthome.core.internal.loggi
- ng
-Ignore-Package: org.eclipse.smarthome.core.internal.items,org.eclipse.smarthome.core.inter
- nal,org.eclipse.smarthome.core.internal.events,org.eclipse.smarthome.core.internal.loggin
- g
-Bundle-Name: Eclipse SmartHome Core
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: com.google.common.base,
+Ignore-Package: org.eclipse.smarthome.core.internal.items,org.eclipse.sm
+ arthome.core.internal,org.eclipse.smarthome.core.internal.events,org.ec
+ lipse.smarthome.core.internal.logging
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  com.google.gson,
  org.apache.commons.io,
@@ -67,5 +69,7 @@ Import-Package: com.google.common.base,
  org.osgi.service.packageadmin,
  org.osgi.util.tracker,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.core
-Bundle-Activator: org.eclipse.smarthome.core.internal.CoreActivator
+Private-Package: org.eclipse.smarthome.core.internal,org.eclipse.smartho
+ me.core.internal.events,org.eclipse.smarthome.core.internal.items,org.e
+ clipse.smarthome.core.internal.logging
+Service-Component: OSGI-INF/*.xml

--- a/bundles/designer/org.eclipse.smarthome.designer.core/META-INF/MANIFEST.MF
+++ b/bundles/designer/org.eclipse.smarthome.designer.core/META-INF/MANIFEST.MF
@@ -1,22 +1,25 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.designer.core.CoreActivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Designer Core
-Bundle-SymbolicName: org.eclipse.smarthome.designer.core;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.designer.core.CoreActivator
-Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.core.resources,
- org.eclipse.jdt.core,
- org.eclipse.xtend.lib,
- com.google.guava,
- org.eclipse.xtext.xbase.lib
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.designer.core,org.eclipse.smarth
- ome.designer.core.config
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.designer.core;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.designer.core,
+ org.eclipse.smarthome.designer.core.config
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.model.script.engine.action,
  org.osgi.service.cm,
  org.slf4j
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ com.google.guava,
+ org.eclipse.core.resources,
+ org.eclipse.core.runtime,
+ org.eclipse.jdt.core,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/designer/org.eclipse.smarthome.designer.ui/META-INF/MANIFEST.MF
+++ b/bundles/designer/org.eclipse.smarthome.designer.ui/META-INF/MANIFEST.MF
@@ -1,19 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.designer.ui.UIActivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Designer UI
-Bundle-SymbolicName: org.eclipse.smarthome.designer.ui;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.designer.ui.UIActivator
-Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
- org.eclipse.smarthome.designer.core,
- org.eclipse.ui.ide,
- org.eclipse.core.resources,
- org.eclipse.ui.navigator,
- org.eclipse.ui.navigator.resources
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.apache.commons.lang,
+Bundle-SymbolicName: org.eclipse.smarthome.designer.ui;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.designer.ui
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.common.registry,
@@ -22,5 +18,11 @@ Import-Package: org.apache.commons.lang,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.designer.ui,
  org.slf4j
-Export-Package: org.eclipse.smarthome.designer.ui
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ org.eclipse.core.resources,
+ org.eclipse.core.runtime,
+ org.eclipse.smarthome.designer.core,
+ org.eclipse.ui,
+ org.eclipse.ui.ide,
+ org.eclipse.ui.navigator,
+ org.eclipse.ui.navigator.resources

--- a/bundles/io/org.eclipse.smarthome.io.console.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.eclipse/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse SmartHome Console for OSGi framework Eclipse Equinox
+Bundle-Name: Eclipse SmartHome Console for OSGi framework Eclipse Equino
+ x
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.eclipse
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.commons.lang,
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.osgi.framework.console,
  org.eclipse.smarthome.io.console,

--- a/bundles/io/org.eclipse.smarthome.io.console.karaf/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.karaf/META-INF/MANIFEST.MF
@@ -1,13 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Console for OSGi runtime Karaf
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.karaf
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.karaf.shell.api.action;version="4.0.0",
+Import-Package: 
  org.apache.karaf.shell.api.action.lifecycle;version="4.0.0",
+ org.apache.karaf.shell.api.action;version="4.0.0",
  org.apache.karaf.shell.api.console;version="4.0.0",
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.io.console,

--- a/bundles/io/org.eclipse.smarthome.io.console.rfc147/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.rfc147/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Console for OSGi Console RFC 147
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.rfc147
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.io.console,
  org.eclipse.smarthome.io.console.extensions,
  org.osgi.framework,

--- a/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
@@ -1,10 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Console
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.io.console
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.apache.commons.lang,
+Export-Package: 
+ org.eclipse.smarthome.io.console,
+ org.eclipse.smarthome.io.console.extensions
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.events,
@@ -16,10 +23,5 @@ Import-Package: org.apache.commons.lang,
  org.osgi.framework,
  org.osgi.util.tracker,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.io.console
 Originally-Created-By: Apache Maven Bundle Plugin
 Service-Component: OSGI-INF/*.xml
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.io.console,
- org.eclipse.smarthome.io.console.extensions
-Bundle-ActivationPolicy: lazy

--- a/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
@@ -1,14 +1,16 @@
 Manifest-Version: 1.0
-Service-Component: OSGI-INF/*.xml
-Private-Package: org.eclipse.smarthome.core.monitor.internal
-Ignore-Package: org.eclipse.smarthome.core.monitor.internal
+Bundle-Activator: org.eclipse.smarthome.io.monitor.internal.MonitorActiv
+ ator
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Monitor
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.io.monitor
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.io.monitor.internal.MonitorActivator
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: com.google.common.collect,
+Ignore-Package: org.eclipse.smarthome.core.monitor.internal
+Import-Package: 
+ com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.items,
@@ -18,6 +20,5 @@ Import-Package: com.google.common.collect,
  org.osgi.framework,
  org.osgi.service.event,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.io.monitor
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-
+Private-Package: org.eclipse.smarthome.core.monitor.internal
+Service-Component: OSGI-INF/*.xml

--- a/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Network I/O bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.net.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.io.net
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
- org.junit;version="4.0.0",
- org.hamcrest.core
+Bundle-SymbolicName: org.eclipse.smarthome.io.net.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.io.net
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
+ org.hamcrest.core,
+ org.junit;version="4.0.0"

--- a/bundles/io/org.eclipse.smarthome.io.net/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net/META-INF/MANIFEST.MF
@@ -1,11 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Net I/O Bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.net
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.apache.commons.exec,
+Bundle-SymbolicName: org.eclipse.smarthome.io.net
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.io.net.exec,
+ org.eclipse.smarthome.io.net.http
+Import-Package: 
+ org.apache.commons.exec,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.jetty.client,
@@ -20,6 +25,3 @@ Import-Package: org.apache.commons.exec,
  org.eclipse.smarthome.io.net.exec,
  org.eclipse.smarthome.io.net.http,
  org.slf4j
-Bundle-ClassPath: .
-Export-Package: org.eclipse.smarthome.io.net.exec,
- org.eclipse.smarthome.io.net.http

--- a/bundles/io/org.eclipse.smarthome.io.rest.auth.basic/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.auth.basic/META-INF/MANIFEST.MF
@@ -1,11 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Basic Auth Support for REST Interface
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.auth.basic
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.eclipsesource.jaxrs.provider.security,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.auth.basic
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ com.eclipsesource.jaxrs.provider.security,
  javax.ws.rs.container,
  javax.ws.rs.core,
  org.apache.commons.codec.binary,
@@ -13,7 +16,4 @@ Import-Package: com.eclipsesource.jaxrs.provider.security,
  org.eclipse.smarthome.core.auth,
  org.eclipse.smarthome.io.rest.auth,
  org.slf4j
-Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy
-

--- a/bundles/io/org.eclipse.smarthome.io.rest.auth/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.auth/META-INF/MANIFEST.MF
@@ -1,15 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse SmartHome Authentication Support for the REST Interface
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.auth
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Name: Eclipse SmartHome Authentication Support for the REST Inter
+ face
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.ws.rs.container,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.auth
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.io.rest.auth
+Import-Package: 
+ com.eclipsesource.jaxrs.provider.security,
+ javax.ws.rs.container,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.auth,
- com.eclipsesource.jaxrs.provider.security,
  org.slf4j
-Bundle-ClassPath: .
-Export-Package: org.eclipse.smarthome.io.rest.auth
-

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IO REST Core Tests
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.core.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.core.test;singleton:=
+ true
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.rest.core
-Import-Package: com.jayway.jsonpath,
+Import-Package: 
+ com.jayway.jsonpath,
  groovy.lang,
  javax.ws.rs.core;version="1.1.1",
  org.apache.commons.io,
@@ -39,4 +41,7 @@ Import-Package: com.jayway.jsonpath,
  org.junit;version="4.0.0",
  org.mockito,
  org.slf4j
-Require-Bundle: org.junit,org.mockito,org.hamcrest
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -1,11 +1,19 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.io.rest.core.internal.RESTCoreAc
+ tivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Core REST API
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.core
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.base,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.core
+Bundle-Vendor: Eclipse.org
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.io.rest.core.config,
+ org.eclipse.smarthome.io.rest.core.item,
+ org.eclipse.smarthome.io.rest.core.service,
+ org.eclipse.smarthome.io.rest.core.thing
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  com.google.gson,
  io.swagger.annotations;resolution:=optional,
@@ -55,9 +63,4 @@ Import-Package: com.google.common.base,
  org.osgi.service.cm,
  org.osgi.service.component,
  org.slf4j
-Export-Package: org.eclipse.smarthome.io.rest.core.config,
- org.eclipse.smarthome.io.rest.core.service,
- org.eclipse.smarthome.io.rest.core.item,
- org.eclipse.smarthome.io.rest.core.thing
 Service-Component: OSGI-INF/*.xml
-Bundle-Activator: org.eclipse.smarthome.io.rest.core.internal.RESTCoreActivator

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UI Logging Handler
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.log;singleton:=true
 Bundle-Vendor: Eclipse.org
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: io.swagger.annotations;resolution:=optional,
+Import-Package: 
+ io.swagger.annotations;resolution:=optional,
  javax.ws.rs,
  javax.ws.rs.core,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.rest.mdns/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.mdns/META-INF/MANIFEST.MF
@@ -1,15 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome REST mDNS Announcer
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.mdns
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.mdns
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.net,
  org.eclipse.smarthome.io.rest,
  org.eclipse.smarthome.io.transport.mdns,
  org.osgi.framework,
  org.slf4j
-Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml

--- a/bundles/io/org.eclipse.smarthome.io.rest.optimize/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.optimize/META-INF/MANIFEST.MF
@@ -1,12 +1,15 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.io.rest.optimize.internal.Activa
+ tor
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome REST Interface JAX-RS optimization Bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.optimize;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.eclipsesource.jaxrs.publisher,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.optimize;singleton:=t
+ rue
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ com.eclipsesource.jaxrs.publisher,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework,
  org.slf4j
-Bundle-Activator: org.eclipse.smarthome.io.rest.optimize.internal.Activator
-Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap REST API
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sitemap
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sitemap
+Bundle-Vendor: Eclipse.org
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.io.rest.sitemap
+Import-Package: 
+ com.google.common.collect,
  io.swagger.annotations;resolution:=optional,
  javax.annotation.security;resolution:=optional,
  javax.servlet,
@@ -13,9 +15,9 @@ Import-Package: com.google.common.collect,
  javax.ws.rs,
  javax.ws.rs.core,
  org.apache.commons.lang,
- org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.emf.common.util,
  org.eclipse.emf.ecore,
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.auth,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.items.dto,
@@ -29,4 +31,3 @@ Import-Package: com.google.common.collect,
  org.glassfish.jersey.server,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.io.rest.sitemap

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
@@ -1,24 +1,26 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IO SSE Tests
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sse.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sse.test;singleton:=t
+ rue
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.rest.sse
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,
  org.codehaus.groovy.runtime.typehandling,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.core.library.items,
+ org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.storage,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.types,
- org.eclipse.smarthome.core.library.types,
- org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.test,
  org.hamcrest;core=split,
  org.junit;version="4.0.0"

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
@@ -1,17 +1,22 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.io.rest.sse.internal.SseActivato
+ r
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome SSE REST API
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sse
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Activator: org.eclipse.smarthome.io.rest.sse.internal.SseActivator
-Import-Package: com.google.common.collect,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sse
+Bundle-Vendor: Eclipse.org
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.io.rest.sse,
+ org.eclipse.smarthome.io.rest.sse.beans
+Import-Package: 
+ com.google.common.collect,
  io.swagger.annotations;resolution:=optional,
  javax.annotation.security;resolution:=optional,
  javax.inject,
- javax.servlet;version="[2.4.0,4.0.0)",
  javax.servlet.http;version="[2.4.0,4.0.0)",
+ javax.servlet;version="[2.4.0,4.0.0)",
  javax.ws.rs,
  javax.ws.rs.core,
  javax.ws.rs.ext,
@@ -43,5 +48,3 @@ Import-Package: com.google.common.collect,
  org.osgi.service.event,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.io.rest.sse,
- org.eclipse.smarthome.io.rest.sse.beans

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IO REST Tests
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.rest
-Import-Package: com.google.gson.annotations,
+Import-Package: 
+ com.google.gson.annotations,
  groovy.lang,
  org.apache.commons.io,
  org.codehaus.groovy.reflection,
@@ -24,4 +25,7 @@ Import-Package: com.google.gson.annotations,
  org.hamcrest;core=split,
  org.junit;version="4.0.0",
  org.mockito
-Require-Bundle: org.junit,org.mockito,org.hamcrest
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/bundles/io/org.eclipse.smarthome.io.rest.voice/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.voice/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Voice REST API
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest.voice
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: io.swagger.annotations;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest.voice
+Bundle-Vendor: Eclipse.org
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ io.swagger.annotations;resolution:=optional,
  javax.annotation.security;resolution:=optional,
  javax.ws.rs,
  javax.ws.rs.core,
@@ -16,4 +18,3 @@ Import-Package: io.swagger.annotations;resolution:=optional,
  org.eclipse.smarthome.io.rest,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
@@ -1,11 +1,15 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.io.rest.internal.RESTActivator
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome REST Interface Bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.rest
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.base,
+Bundle-SymbolicName: org.eclipse.smarthome.io.rest
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.io.rest
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  com.google.gson,
  com.google.gson.stream,
@@ -33,8 +37,4 @@ Import-Package: com.google.common.base,
  org.osgi.service.http,
  org.osgi.util.tracker,
  org.slf4j
-Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.io.rest
-Bundle-Activator: org.eclipse.smarthome.io.rest.internal.RESTActivator
-

--- a/bundles/io/org.eclipse.smarthome.io.transport.dbus/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.dbus/META-INF/MANIFEST.MF
@@ -1,21 +1,19 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .,lib/unix-0.5.jar,lib/libdbus-java-2.7.jar
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome DBus Transport Bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.transport.dbus
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.freedesktop,
- org.freedesktop.dbus,
- org.freedesktop.dbus.exceptions,
+Bundle-SymbolicName: org.eclipse.smarthome.io.transport.dbus
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
  cx.ath.matthew.debug,
+ cx.ath.matthew.unix,
  cx.ath.matthew.utils,
- cx.ath.matthew.unix
+ org.freedesktop,
+ org.freedesktop.dbus,
+ org.freedesktop.dbus.exceptions
 Import-Package: 
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.slf4j
-Bundle-ClassPath: .,
- lib/unix-0.5.jar,
- lib/libdbus-java-2.7.jar
-

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
@@ -1,12 +1,18 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.io.transport.mdns.internal.MDNSA
+ ctivator
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Bonjour/MDS Service Discovery Bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mdns
-Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.io.transport.mdns.internal.MDNSActivator
-Service-Component: OSGI-INF/*.xml
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.jmdns,
+Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mdns
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.io.transport.mdns,
+ org.eclipse.smarthome.io.transport.mdns.discovery
+Import-Package: 
+ javax.jmdns,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.core.thing,
@@ -14,7 +20,4 @@ Import-Package: javax.jmdns,
  org.eclipse.smarthome.io.transport.mdns.discovery,
  org.osgi.framework,
  org.slf4j
-Export-Package: org.eclipse.smarthome.io.transport.mdns,
- org.eclipse.smarthome.io.transport.mdns.discovery
-Bundle-ClassPath: .
-Bundle-Vendor: Eclipse.org/SmartHome
+Service-Component: OSGI-INF/*.xml

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Mqtt transport I/O bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mqtt.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.io.transport.mqtt
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mqtt.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.io.transport.mqtt
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.io.transport.mqtt,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.java,
@@ -15,4 +16,7 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.junit.runner,
  org.junit.runners,
  org.mockito
-Require-Bundle: org.junit,org.mockito,org.hamcrest
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
@@ -1,14 +1,19 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome MQTT Transport Bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mqtt;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.io.transport.mqtt,
+Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mqtt;singleton:=
+ true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.io.transport.mqtt,
  org.eclipse.smarthome.io.transport.mqtt.reconnect,
  org.eclipse.smarthome.io.transport.mqtt.sslcontext
-Import-Package: javax.naming,
+Import-Package: 
+ javax.naming,
  javax.net,
  javax.net.ssl,
  org.apache.commons.lang,
@@ -19,10 +24,8 @@ Import-Package: javax.naming,
  org.eclipse.paho.client.mqttv3.util,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.io.transport.mqtt,
+ org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.component.annotations;resolution:=optional,
- org.osgi.service.cm,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-Bundle-ActivationPolicy: lazy

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IO UPnP Tests
-Bundle-SymbolicName: org.eclipse.smarthome.io.transport.upnp.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.io.transport.upnp.test;single
+ ton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.transport.upnp
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/META-INF/MANIFEST.MF
@@ -1,10 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UPnP Transport Bundle
-Bundle-SymbolicName: org.eclipse.smarthome.io.transport.upnp
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.io.transport.upnp
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.io.transport.upnp
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.io.transport.upnp,
  org.jupnp,
  org.jupnp.controlpoint,
@@ -18,6 +21,4 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.jupnp.registry,
  org.osgi.framework;version="1.3.0",
  org.slf4j
-Export-Package: org.eclipse.smarthome.io.transport.upnp
 Service-Component: OSGI-INF/*.xml
-Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/model/org.eclipse.smarthome.model.codegen/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.codegen/META-INF/MANIFEST.MF
@@ -1,22 +1,22 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Codegen Project
-Bundle-SymbolicName: org.eclipse.smarthome.model.codegen
-Bundle-Version: 1.0.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.eclipse.emf.mwe2.launch;bundle-version="2.2.0",
- org.apache.log4j;bundle-version="1.2.15",
+Bundle-SymbolicName: org.eclipse.smarthome.model.codegen
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 1.0.0.qualifier
+Import-Package: org.eclipse.jdt.annotation;resolution:=optional
+Require-Bundle: 
  org.apache.commons.logging;bundle-version="1.0.4",
+ org.apache.log4j;bundle-version="1.2.15",
  org.eclipse.emf.codegen;bundle-version="2.6.0",
+ org.eclipse.emf.mwe2.launch;bundle-version="2.2.0",
  org.eclipse.smarthome.model.item,
+ org.eclipse.smarthome.model.persistence,
  org.eclipse.smarthome.model.rule,
  org.eclipse.smarthome.model.script,
  org.eclipse.smarthome.model.sitemap,
  org.eclipse.smarthome.model.thing,
  org.eclipse.xtext.generator,
- org.eclipse.smarthome.model.persistence,
  org.objectweb.asm;bundle-version="3.3.1";resolution:=optional
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional
-Bundle-ClassPath: .
-

--- a/bundles/model/org.eclipse.smarthome.model.core.test/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/META-INF/MANIFEST.MF
@@ -1,14 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Model Core Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.core.test
 Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.model.core
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.junit,
- org.mockito,
- org.hamcrest
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.service,
  org.eclipse.smarthome.test,
@@ -19,3 +17,7 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.mockito,
  org.osgi.framework,
  org.slf4j
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
@@ -1,12 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.model.core.internal.ModelCoreAct
+ ivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Model Core
-Bundle-SymbolicName: org.eclipse.smarthome.model.core;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.model.core.internal.ModelCoreActivator
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: com.google.common.base,
+Bundle-SymbolicName: org.eclipse.smarthome.model.core;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.model.core
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  com.google.inject,
  org.apache.commons.collections,
@@ -29,5 +33,3 @@ Import-Package: com.google.common.base,
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.model.core
-Bundle-ActivationPolicy: lazy

--- a/bundles/model/org.eclipse.smarthome.model.item.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.ide/META-INF/MANIFEST.MF
@@ -1,15 +1,17 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Model IDE
-Bundle-SymbolicName: org.eclipse.smarthome.model.item.ide
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.item.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.smarthome.model.item,
- org.eclipse.xtext.ide,
- org.antlr.runtime,
- org.eclipse.xtext.xbase.lib
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional
-Export-Package: org.eclipse.smarthome.model.ide,
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.model.ide,
  org.eclipse.smarthome.model.ide.contentassist.antlr,
  org.eclipse.smarthome.model.ide.contentassist.antlr.internal
+Import-Package: org.eclipse.jdt.annotation;resolution:=optional
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.smarthome.model.item,
+ org.eclipse.xtext.ide,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Model Runtime
-Bundle-SymbolicName: org.eclipse.smarthome.model.item.runtime;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.item.runtime;singleton:
+ =true
 Bundle-Vendor: Eclipse.org/SmartHome
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.model.core,
  org.osgi.framework,
  org.slf4j

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/META-INF/MANIFEST.MF
@@ -1,14 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Model Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.item.tests; singleton:=
+ true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.item.tests; singleton:=true
-Require-Bundle: org.eclipse.core.runtime,
- org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.xbase.lib
-Import-Package: groovy.lang,
+Fragment-Host: org.eclipse.smarthome.model.item
+Import-Package: 
+ groovy.lang,
  org.apache.log4j,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
@@ -20,13 +20,16 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.core.thing.util,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.java,
- org.hamcrest;core=split,
  org.hamcrest.core,
- org.junit;version="4.0.0",
- org.junit.runner;version="4.0.0",
+ org.hamcrest;core=split,
  org.junit.runner.manipulation;version="4.0.0",
  org.junit.runner.notification;version="4.0.0",
+ org.junit.runner;version="4.0.0",
+ org.junit.runners.model;version="4.0.0",
  org.junit.runners;version="4.0.0",
- org.junit.runners.model;version="4.0.0"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Fragment-Host: org.eclipse.smarthome.model.item
+ org.junit;version="4.0.0"
+Require-Bundle: 
+ org.eclipse.core.runtime,
+ org.eclipse.xtext.testing,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase.testing

--- a/bundles/model/org.eclipse.smarthome.model.item.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.ui/META-INF/MANIFEST.MF
@@ -1,24 +1,19 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.model.ui.internal.ItemsActivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Editor UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.item.ui;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.item.ui;singleton:=true
-Require-Bundle: org.eclipse.smarthome.model.item;visibility:=reexport,
- org.eclipse.xtext.ui,
- org.eclipse.ui.editors,
- org.eclipse.ui.ide,
- org.eclipse.xtext.ui.shared,
- org.eclipse.ui,
- org.eclipse.xtext.builder,
- org.antlr.runtime,
- org.eclipse.xtext.common.types.ui,
- org.eclipse.xtext.ui.codetemplates.ui,
- org.eclipse.compare,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional,
- org.eclipse.smarthome.model.item.ide
-Import-Package: com.google.common.collect,
+Export-Package: 
+ org.eclipse.smarthome.model.item.ui.internal,
+ org.eclipse.smarthome.model.item.ui.internal,
+ org.eclipse.smarthome.model.ui.contentassist,
+ org.eclipse.smarthome.model.ui.quickfix
+Import-Package: 
+ com.google.common.collect,
  org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,
@@ -26,10 +21,18 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.model.core,
  org.eclipse.xtext.xbase.lib,
  org.osgi.service.event
-Export-Package: org.eclipse.smarthome.model.ui.contentassist,
- org.eclipse.smarthome.model.ui.quickfix,
- org.eclipse.smarthome.model.item.ui.internal,
- org.eclipse.smarthome.model.item.ui.internal
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-Activator: org.eclipse.smarthome.model.ui.internal.ItemsActivator
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.compare,
+ org.eclipse.smarthome.model.item.ide,
+ org.eclipse.smarthome.model.item;visibility:=reexport,
+ org.eclipse.ui,
+ org.eclipse.ui.editors,
+ org.eclipse.ui.ide,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.builder,
+ org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
@@ -1,26 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Item Model
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.item;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.item;singleton:=true
-Require-Bundle: org.eclipse.xtext,
- org.eclipse.xtext.generator;resolution:=optional,
- org.apache.commons.logging;resolution:=optional,
- org.eclipse.emf.codegen.ecore;resolution:=optional,
- org.eclipse.emf.mwe.utils;resolution:=optional,
- org.eclipse.emf.mwe2.launch;resolution:=optional,
- com.ibm.icu;resolution:=optional,
- org.eclipse.xtext.util,
- org.eclipse.emf.ecore;visibility:=reexport,
- org.eclipse.emf.common,
- org.antlr.runtime,
- org.eclipse.xtext.common.types,
- org.eclipse.smarthome.model.lazygen;resolution:=optional,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.model,
+Export-Package: 
+ org.eclipse.smarthome.model,
  org.eclipse.smarthome.model.formatting,
  org.eclipse.smarthome.model.generator,
  org.eclipse.smarthome.model.item,
@@ -33,7 +19,8 @@ Export-Package: org.eclipse.smarthome.model,
  org.eclipse.smarthome.model.serializer,
  org.eclipse.smarthome.model.services,
  org.eclipse.smarthome.model.validation
-Import-Package: org.apache.commons.lang,
+Import-Package: 
+ org.apache.commons.lang,
  org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.autoupdate,
@@ -47,4 +34,20 @@ Import-Package: org.apache.commons.lang,
  org.eclipse.xtext.xbase.lib,
  org.osgi.framework,
  org.slf4j
+Require-Bundle: 
+ com.ibm.icu;resolution:=optional,
+ org.antlr.runtime,
+ org.apache.commons.logging;resolution:=optional,
+ org.eclipse.emf.codegen.ecore;resolution:=optional,
+ org.eclipse.emf.common,
+ org.eclipse.emf.ecore;visibility:=reexport,
+ org.eclipse.emf.mwe.utils;resolution:=optional,
+ org.eclipse.emf.mwe2.launch;resolution:=optional,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext,
+ org.eclipse.xtext.common.types,
+ org.eclipse.xtext.generator;resolution:=optional,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase.lib
 Service-Component: OSGI-INF/*.xml

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
@@ -1,15 +1,17 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Model Lazy Generation
-Bundle-SymbolicName: org.eclipse.smarthome.model.lazygen
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.lazygen
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.xtext,
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.apache.log4j,
+ org.eclipse.jdt.annotation;resolution:=optional
+Require-Bundle: 
  org.apache.commons.logging,
  org.eclipse.emf.codegen,
  org.eclipse.emf.codegen.ecore,
- org.eclipse.xtext.generator,
- org.eclipse.xtext.ecore
-Import-Package: org.apache.log4j,
- org.eclipse.jdt.annotation;resolution:=optional
+ org.eclipse.xtext,
+ org.eclipse.xtext.ecore,
+ org.eclipse.xtext.generator

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ide/META-INF/MANIFEST.MF
@@ -1,15 +1,17 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Persistence Model IDE
-Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.ide
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.smarthome.model.persistence,
- org.eclipse.xtext.ide,
- org.antlr.runtime,
- org.eclipse.xtext.xbase.lib
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.model.persistence.ide.contentassist.antlr,
+ org.eclipse.smarthome.model.persistence.ide.contentassist.antlr.interna
+ l
 Import-Package: org.eclipse.jdt.annotation;resolution:=optional
-Export-Package: org.eclipse.smarthome.model.persistence.ide.contentassist.antlr.internal,
- org.eclipse.smarthome.model.persistence.ide.contentassist.antlr
-
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.smarthome.model.persistence,
+ org.eclipse.xtext.ide,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Persistence Runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.runtime;sin
+ gleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.runtime;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.model.core,
  org.osgi.framework,
  org.slf4j

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
@@ -1,11 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Persistence Model Tests
-Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.tests
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.tests
+Bundle-Vendor: Eclipse.org
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.model.persistence.extensions,
+ org.eclipse.smarthome.model.persistence.tests
+Fragment-Host: org.eclipse.smarthome.model.persistence
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.persistence,
@@ -15,7 +21,3 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.joda.time,
  org.joda.time.base,
  org.junit;version="4.0.0"
-Export-Package: org.eclipse.smarthome.model.persistence.extensions,org
- .eclipse.smarthome.model.persistence.tests
-Bundle-ClassPath: .
-Fragment-Host: org.eclipse.smarthome.model.persistence

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ui/META-INF/MANIFEST.MF
@@ -1,33 +1,38 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.model.persistence.ui.internal.Pe
+ rsistenceActivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Persistence Model UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.ui;singleto
+ n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.ui;singleton:=true
-Require-Bundle: org.eclipse.smarthome.model.persistence;visibility:=reexport,
- org.eclipse.smarthome.model.persistence.ide,
- org.eclipse.xtext.ui,
- org.eclipse.ui.editors;bundle-version="3.5.0",
- org.eclipse.ui.ide;bundle-version="3.5.0",
- org.eclipse.xtext.ui.shared,
- org.eclipse.ui,
- org.eclipse.xtext.builder,
- org.antlr.runtime,
- org.eclipse.xtext.common.types.ui,
- org.eclipse.xtext.ui.codetemplates.ui,
- org.eclipse.compare,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: com.google.common.collect,
+Export-Package: 
+ org.eclipse.smarthome.model.persistence.ui.contentassist,
+ org.eclipse.smarthome.model.persistence.ui.internal,
+ org.eclipse.smarthome.model.persistence.ui.quickfix
+Import-Package: 
+ com.google.common.collect,
  org.apache.commons.logging,
  org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.designer.ui,
  org.eclipse.xtext.xbase.lib
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.model.persistence.ui.contentassist,
- org.eclipse.smarthome.model.persistence.ui.internal,
- org.eclipse.smarthome.model.persistence.ui.quickfix
-Bundle-Activator: org.eclipse.smarthome.model.persistence.ui.internal.PersistenceActivator
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.compare,
+ org.eclipse.smarthome.model.persistence.ide,
+ org.eclipse.smarthome.model.persistence;visibility:=reexport,
+ org.eclipse.ui,
+ org.eclipse.ui.editors;bundle-version="3.5.0",
+ org.eclipse.ui.ide;bundle-version="3.5.0",
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.builder,
+ org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
@@ -1,45 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: lib/joda-time-2.9.2.jar,.
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Persistence Model
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.persistence;singleton:=
+ true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.persistence;singleton:=true
-Require-Bundle: org.eclipse.xtext;bundle-version="2.1.0";visibility:=reexport,
- org.eclipse.xtext.xbase;bundle-version="2.1.0";resolution:=optional;visibility:=reexport,
- org.eclipse.xtext.generator;resolution:=optional,
- org.eclipse.emf.codegen.ecore;resolution:=optional,
- org.eclipse.emf.mwe.utils;resolution:=optional,
- org.eclipse.emf.mwe2.launch;resolution:=optional,
- org.eclipse.smarthome.model.item,
- org.eclipse.xtext.util,
- org.eclipse.emf.ecore,
- org.eclipse.emf.common,
- org.antlr.runtime,
- org.eclipse.xtext.common.types,
- org.eclipse.smarthome.model.lazygen;resolution:=optional,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: com.google.common.base,
- com.google.common.collect,
- org.apache.commons.logging,
- org.apache.log4j,
- org.eclipse.jdt.annotation;resolution:=optional,
- org.eclipse.smarthome.core.common.registry,
- org.eclipse.smarthome.core.events,
- org.eclipse.smarthome.core.items,
- org.eclipse.smarthome.core.library.types,
- org.eclipse.smarthome.core.persistence,
- org.eclipse.smarthome.core.persistence.config,
- org.eclipse.smarthome.core.persistence.strategy,
- org.eclipse.smarthome.core.types,
- org.eclipse.smarthome.model.core,
- org.eclipse.xtext.xbase.lib,
- org.osgi.framework,
- org.osgi.service.cm,
- org.osgi.service.event,
- org.slf4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.model.persistence,
+Export-Package: 
+ org.eclipse.smarthome.model.persistence,
  org.eclipse.smarthome.model.persistence.extensions,
  org.eclipse.smarthome.model.persistence.formatting,
  org.eclipse.smarthome.model.persistence.generator,
@@ -59,5 +28,41 @@ Export-Package: org.eclipse.smarthome.model.persistence,
  org.joda.time.field,
  org.joda.time.format,
  org.joda.time.tz
+Import-Package: 
+ com.google.common.base,
+ com.google.common.collect,
+ org.apache.commons.logging,
+ org.apache.log4j,
+ org.eclipse.jdt.annotation;resolution:=optional,
+ org.eclipse.smarthome.core.common.registry,
+ org.eclipse.smarthome.core.events,
+ org.eclipse.smarthome.core.items,
+ org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.persistence,
+ org.eclipse.smarthome.core.persistence.config,
+ org.eclipse.smarthome.core.persistence.strategy,
+ org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.model.core,
+ org.eclipse.xtext.xbase.lib,
+ org.osgi.framework,
+ org.osgi.service.cm,
+ org.osgi.service.event,
+ org.slf4j
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.emf.codegen.ecore;resolution:=optional,
+ org.eclipse.emf.common,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.mwe.utils;resolution:=optional,
+ org.eclipse.emf.mwe2.launch;resolution:=optional,
+ org.eclipse.smarthome.model.item,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.common.types,
+ org.eclipse.xtext.generator;resolution:=optional,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase;bundle-version="2.1.0";resolution:=optional;vis
+ ibility:=reexport,
+ org.eclipse.xtext;bundle-version="2.1.0";visibility:=reexport
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: lib/joda-time-2.9.2.jar,.

--- a/bundles/model/org.eclipse.smarthome.model.rule.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ide/META-INF/MANIFEST.MF
@@ -1,17 +1,18 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Model IDE
-Bundle-SymbolicName: org.eclipse.smarthome.model.rule.ide
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.rule.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.smarthome.model.rule,
- org.eclipse.xtext.ide,
- org.antlr.runtime,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtext.xbase.ide,
- org.eclipse.smarthome.model.script
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.model.rule.ide.contentassist.antlr,
+ org.eclipse.smarthome.model.rule.ide.contentassist.antlr.internal
 Import-Package: org.eclipse.jdt.annotation;resolution:=optional
-Export-Package: org.eclipse.smarthome.model.rule.ide.contentassist.antlr.internal,
- org.eclipse.smarthome.model.rule.ide.contentassist.antlr
-
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.smarthome.model.rule,
+ org.eclipse.smarthome.model.script,
+ org.eclipse.xtext.ide,
+ org.eclipse.xtext.xbase.ide,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
@@ -1,12 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.rule.runtime;singleton:
+ =true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.rule.runtime;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Service-Component: OSGI-INF/*.xml
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Export-Package: org.eclipse.smarthome.model.rule.runtime
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.common,
  org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.events,
@@ -31,5 +34,4 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.quartz.utils,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.rule
-Export-Package: org.eclipse.smarthome.model.rule.runtime
-Bundle-ActivationPolicy: lazy
+Service-Component: OSGI-INF/*.xml

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
@@ -1,22 +1,25 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Model Tests
-Bundle-SymbolicName: org.eclipse.smarthome.model.rule.tests;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.rule.tests;singleton:=t
+ rue
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.smarthome.model.rule,
- org.eclipse.core.runtime,
- org.eclipse.xtend.lib,
- com.google.guava,
- org.eclipse.xtext.xbase.lib
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.model.script.engine,
  org.hamcrest.core,
- org.junit.runner;version="4.0.0",
  org.junit.runner.manipulation;version="4.0.0",
  org.junit.runner.notification;version="4.0.0",
- org.junit.runners;version="4.0.0",
- org.junit.runners.model;version="4.0.0"
+ org.junit.runner;version="4.0.0",
+ org.junit.runners.model;version="4.0.0",
+ org.junit.runners;version="4.0.0"
+Require-Bundle: 
+ com.google.guava,
+ org.eclipse.core.runtime,
+ org.eclipse.smarthome.model.rule,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.rule.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ui/META-INF/MANIFEST.MF
@@ -1,29 +1,19 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.model.rule.ui.internal.RuleModel
+ UIActivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Model UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.rule.ui;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.rule.ui;singleton:=true
-Require-Bundle: org.eclipse.smarthome.model.rule;visibility:=reexport,
- org.eclipse.smarthome.model.rule.ide,
- org.eclipse.xtext.ui,
- org.eclipse.ui.editors,
- org.eclipse.ui.ide,
- org.eclipse.xtext.ui.shared,
- org.eclipse.ui,
- org.eclipse.xtext.builder,
- org.antlr.runtime,
- org.eclipse.xtext.common.types.ui,
- org.eclipse.compare,
- org.eclipse.xtext.ui.codetemplates.ui,
- org.eclipse.xtext.xbase.ui,
- org.eclipse.smarthome.model.item.ui,
- org.eclipse.smarthome.model.script.ui,
- org.eclipse.smarthome.core,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.jdt.debug.ui,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: com.google.common.base,
+Export-Package: 
+ org.eclipse.smarthome.model.rule.ui.contentassist,
+ org.eclipse.smarthome.model.rule.ui.internal,
+ org.eclipse.smarthome.model.rule.ui.quickfix
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  org.apache.commons.lang,
  org.apache.log4j;version="1.2.17",
@@ -38,9 +28,23 @@ Import-Package: com.google.common.base,
  org.joda.time.base,
  org.osgi.service.cm,
  org.slf4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.model.rule.ui.contentassist,
- org.eclipse.smarthome.model.rule.ui.internal,
- org.eclipse.smarthome.model.rule.ui.quickfix
-Bundle-Activator: org.eclipse.smarthome.model.rule.ui.internal.RuleModelUIActivator
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.compare,
+ org.eclipse.jdt.debug.ui,
+ org.eclipse.smarthome.core,
+ org.eclipse.smarthome.model.item.ui,
+ org.eclipse.smarthome.model.rule.ide,
+ org.eclipse.smarthome.model.rule;visibility:=reexport,
+ org.eclipse.smarthome.model.script.ui,
+ org.eclipse.ui,
+ org.eclipse.ui.editors,
+ org.eclipse.ui.ide,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.builder,
+ org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase.ui

--- a/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
@@ -1,25 +1,26 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Rule Model
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.rule;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.rule;singleton:=true
-Require-Bundle: org.eclipse.xtext;visibility:=reexport,
- org.eclipse.xtext.generator;resolution:=optional,
- org.eclipse.xtext.util,
- org.eclipse.emf.ecore,
- org.eclipse.emf.common,
- org.antlr.runtime,
- org.eclipse.emf.mwe2.launch;resolution:=optional,
- org.eclipse.xtext.common.types,
- org.eclipse.xtext.xbase,
- org.eclipse.smarthome.model.item,
- org.eclipse.smarthome.model.script,
- org.eclipse.xtext.xbase.lib,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
- org.eclipse.smarthome.model.lazygen;resolution:=optional,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: com.google.common.collect,
+Export-Package: 
+ org.eclipse.smarthome.model.rule,
+ org.eclipse.smarthome.model.rule.formatting,
+ org.eclipse.smarthome.model.rule.jvmmodel,
+ org.eclipse.smarthome.model.rule.parser.antlr,
+ org.eclipse.smarthome.model.rule.parser.antlr.internal,
+ org.eclipse.smarthome.model.rule.rules,
+ org.eclipse.smarthome.model.rule.rules.impl,
+ org.eclipse.smarthome.model.rule.rules.util,
+ org.eclipse.smarthome.model.rule.scoping,
+ org.eclipse.smarthome.model.rule.serializer,
+ org.eclipse.smarthome.model.rule.services,
+ org.eclipse.smarthome.model.rule.validation
+Import-Package: 
+ com.google.common.collect,
  org.apache.commons.lang,
  org.apache.commons.logging,
  org.apache.log4j,
@@ -52,18 +53,20 @@ Import-Package: com.google.common.collect,
  org.quartz.spi,
  org.quartz.utils,
  org.slf4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.emf.common,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.mwe2.launch;resolution:=optional,
+ org.eclipse.smarthome.model.item,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional,
+ org.eclipse.smarthome.model.script,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.common.types,
+ org.eclipse.xtext.generator;resolution:=optional,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext;visibility:=reexport,
+ org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.model.rule,
- org.eclipse.smarthome.model.rule.services,
- org.eclipse.smarthome.model.rule.rules,
- org.eclipse.smarthome.model.rule.rules.impl,
- org.eclipse.smarthome.model.rule.rules.util,
- org.eclipse.smarthome.model.rule.parser.antlr,
- org.eclipse.smarthome.model.rule.parser.antlr.internal,
- org.eclipse.smarthome.model.rule.validation,
- org.eclipse.smarthome.model.rule.formatting,
- org.eclipse.smarthome.model.rule.jvmmodel,
- org.eclipse.smarthome.model.rule.serializer,
- org.eclipse.smarthome.model.rule.scoping
-Bundle-ActivationPolicy: lazy

--- a/bundles/model/org.eclipse.smarthome.model.script.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.ide/META-INF/MANIFEST.MF
@@ -1,16 +1,17 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script Model IDE
-Bundle-SymbolicName: org.eclipse.smarthome.model.script.ide
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.script.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.smarthome.model.script,
- org.eclipse.xtext.ide,
- org.antlr.runtime,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtext.xbase.ide
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional
-Export-Package: org.eclipse.smarthome.model.script.ide.contentassist.antlr,
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.model.script.ide.contentassist.antlr,
  org.eclipse.smarthome.model.script.ide.contentassist.antlr.internal
-
+Import-Package: org.eclipse.jdt.annotation;resolution:=optional
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.smarthome.model.script,
+ org.eclipse.xtext.ide,
+ org.eclipse.xtext.xbase.ide,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
@@ -1,15 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script Runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.script.runtime;singleto
+ n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.script.runtime;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Service-Component: OSGI-INF/*.xml
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.model.core,
  org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.script
-Bundle-ActivationPolicy: lazy
+Service-Component: OSGI-INF/*.xml

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/META-INF/MANIFEST.MF
@@ -1,15 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script Tests
-Bundle-SymbolicName: org.eclipse.smarthome.model.script.tests;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.script.tests;singleton:
+ =true
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.xtend.lib,
- com.google.guava,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.core.runtime
-Import-Package: groovy.lang,
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,
@@ -25,13 +24,17 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.model.script.engine.action,
  org.eclipse.smarthome.test,
  org.eclipse.xtext.xbase,
- org.hamcrest;core=split,
  org.hamcrest.core,
- org.junit;version="4.0.0",
- org.junit.runner;version="4.0.0",
+ org.hamcrest;core=split,
  org.junit.runner.manipulation;version="4.0.0",
  org.junit.runner.notification;version="4.0.0",
- org.junit.runners;version="4.0.0",
+ org.junit.runner;version="4.0.0",
  org.junit.runners.model;version="4.0.0",
+ org.junit.runners;version="4.0.0",
+ org.junit;version="4.0.0",
  org.slf4j
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ com.google.guava,
+ org.eclipse.core.runtime,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.script.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.ui/META-INF/MANIFEST.MF
@@ -1,26 +1,20 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.model.script.ui.internal.ScriptU
+ IActivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.script.ui;singleton:=tr
+ ue
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.script.ui;singleton:=true
-Require-Bundle: org.eclipse.smarthome.model.script;visibility:=reexport,
- org.eclipse.smarthome.model.script.ide,
- org.eclipse.xtext.ui,
- org.eclipse.ui.editors;bundle-version="3.5.0",
- org.eclipse.ui.ide;bundle-version="3.5.0",
- org.eclipse.xtext.ui.shared,
- org.eclipse.ui,
- org.eclipse.xtext.builder,
- org.antlr.runtime,
- org.eclipse.xtext.common.types.ui,
- org.eclipse.xtext.xbase.ui,
- org.eclipse.xtext.ui.codetemplates.ui,
- org.eclipse.compare,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.jdt.debug.ui,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: com.google.common.base,
+Export-Package: 
+ org.eclipse.smarthome.model.script.ui.contentassist,
+ org.eclipse.smarthome.model.script.ui.internal,
+ org.eclipse.smarthome.model.script.ui.quickfix
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  org.apache.commons.lang,
  org.apache.commons.logging,
@@ -38,9 +32,20 @@ Import-Package: com.google.common.base,
  org.joda.time.base,
  org.osgi.service.cm,
  org.slf4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.model.script.ui.contentassist,
- org.eclipse.smarthome.model.script.ui.internal,
- org.eclipse.smarthome.model.script.ui.quickfix
-Bundle-Activator: org.eclipse.smarthome.model.script.ui.internal.ScriptUIActivator
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.compare,
+ org.eclipse.jdt.debug.ui,
+ org.eclipse.smarthome.model.script.ide,
+ org.eclipse.smarthome.model.script;visibility:=reexport,
+ org.eclipse.ui,
+ org.eclipse.ui.editors;bundle-version="3.5.0",
+ org.eclipse.ui.ide;bundle-version="3.5.0",
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.builder,
+ org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase.ui

--- a/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
@@ -1,24 +1,33 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Script
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.script;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.script;singleton:=true
-Require-Bundle: org.eclipse.xtext;visibility:=reexport,
- org.eclipse.xtext.xbase;visibility:=reexport,
- org.eclipse.xtext.util,
- org.eclipse.emf.ecore,
- org.eclipse.emf.common,
- org.antlr.runtime,
- org.eclipse.xtext.common.types,
- org.eclipse.smarthome.model.item,
- org.eclipse.emf.mwe2.launch;resolution:=optional,
- org.eclipse.xtext.generator;resolution:=optional,
- org.eclipse.xtext.xbase.lib,
- org.objectweb.asm;resolution:=optional,
- org.eclipse.smarthome.model.lazygen;resolution:=optional,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: com.google.common.base,
+Export-Package: 
+ org.eclipse.smarthome.model.script,
+ org.eclipse.smarthome.model.script.actions,
+ org.eclipse.smarthome.model.script.engine,
+ org.eclipse.smarthome.model.script.engine.action,
+ org.eclipse.smarthome.model.script.extension,
+ org.eclipse.smarthome.model.script.formatting,
+ org.eclipse.smarthome.model.script.interpreter,
+ org.eclipse.smarthome.model.script.jvmmodel,
+ org.eclipse.smarthome.model.script.lib,
+ org.eclipse.smarthome.model.script.parser.antlr,
+ org.eclipse.smarthome.model.script.parser.antlr.internal,
+ org.eclipse.smarthome.model.script.scoping,
+ org.eclipse.smarthome.model.script.script,
+ org.eclipse.smarthome.model.script.script.impl,
+ org.eclipse.smarthome.model.script.script.util,
+ org.eclipse.smarthome.model.script.serializer,
+ org.eclipse.smarthome.model.script.services,
+ org.eclipse.smarthome.model.script.validation
+Import-Package: 
+ com.google.common.base,
  com.google.common.collect,
  org.apache.commons.io,
  org.apache.commons.lang,
@@ -57,25 +66,19 @@ Import-Package: com.google.common.base,
  org.quartz.impl.matchers,
  org.quartz.utils,
  org.slf4j
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.emf.common,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.mwe2.launch;resolution:=optional,
+ org.eclipse.smarthome.model.item,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.common.types,
+ org.eclipse.xtext.generator;resolution:=optional,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase;visibility:=reexport,
+ org.eclipse.xtext;visibility:=reexport,
+ org.objectweb.asm;resolution:=optional
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.model.script,
- org.eclipse.smarthome.model.script.actions,
- org.eclipse.smarthome.model.script.engine,
- org.eclipse.smarthome.model.script.engine.action,
- org.eclipse.smarthome.model.script.extension,
- org.eclipse.smarthome.model.script.formatting,
- org.eclipse.smarthome.model.script.interpreter,
- org.eclipse.smarthome.model.script.jvmmodel,
- org.eclipse.smarthome.model.script.lib,
- org.eclipse.smarthome.model.script.parser.antlr,
- org.eclipse.smarthome.model.script.parser.antlr.internal,
- org.eclipse.smarthome.model.script.scoping,
- org.eclipse.smarthome.model.script.script,
- org.eclipse.smarthome.model.script.script.impl,
- org.eclipse.smarthome.model.script.script.util,
- org.eclipse.smarthome.model.script.serializer,
- org.eclipse.smarthome.model.script.services,
- org.eclipse.smarthome.model.script.validation
-Bundle-ClassPath: .
-Bundle-ActivationPolicy: lazy

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ide/META-INF/MANIFEST.MF
@@ -1,15 +1,16 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap Model IDE
-Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.ide
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.smarthome.model.sitemap,
- org.eclipse.xtext.ide,
- org.antlr.runtime,
- org.eclipse.xtext.xbase.lib
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.model.ide.contentassist.antlr,
+ org.eclipse.smarthome.model.ide.contentassist.antlr.internal
 Import-Package: org.eclipse.jdt.annotation;resolution:=optional
-Export-Package: org.eclipse.smarthome.model.ide.contentassist.antlr.internal,
- org.eclipse.smarthome.model.ide.contentassist.antlr
-
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.smarthome.model.sitemap,
+ org.eclipse.xtext.ide,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
@@ -1,11 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap Runtime
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.runtime;singlet
+ on:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.runtime;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.model.core,
  org.osgi.framework,
  org.slf4j

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ui/META-INF/MANIFEST.MF
@@ -1,32 +1,37 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.model.ui.internal.SitemapActivat
+ or
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap Editor UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.ui;singleton:=t
+ rue
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.ui;singleton:=true
-Require-Bundle: org.eclipse.smarthome.model.sitemap;visibility:=reexport,
- org.eclipse.smarthome.model.sitemap.ide,
- org.eclipse.xtext.ui,
- org.eclipse.ui.editors,
- org.eclipse.ui.ide,
- org.eclipse.xtext.ui.shared,
- org.eclipse.ui,
- org.antlr.runtime,
- org.eclipse.xtext.builder,
- org.eclipse.xtext.ui.codetemplates.ui,
- org.eclipse.compare,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: com.google.common.collect,
+Export-Package: 
+ org.eclipse.smarthome.model.sitemap.ui.internal,
+ org.eclipse.smarthome.model.ui.contentassist,
+ org.eclipse.smarthome.model.ui.quickfix
+Import-Package: 
+ com.google.common.collect,
  org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.designer.core.config,
  org.eclipse.smarthome.designer.ui,
  org.eclipse.xtext.xbase.lib
-Export-Package: org.eclipse.smarthome.model.sitemap.ui.internal,
- org.eclipse.smarthome.model.ui.contentassist,
- org.eclipse.smarthome.model.ui.quickfix
-Bundle-Activator: org.eclipse.smarthome.model.ui.internal.SitemapActivator
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.compare,
+ org.eclipse.smarthome.model.sitemap.ide,
+ org.eclipse.smarthome.model.sitemap;visibility:=reexport,
+ org.eclipse.ui,
+ org.eclipse.ui.editors,
+ org.eclipse.ui.ide,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.builder,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
@@ -1,30 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Sitemap Model
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap;singleton:=true
-Require-Bundle: org.eclipse.xtext,
- org.eclipse.xtext.generator;resolution:=optional,
- org.eclipse.xtext.util,
- org.apache.commons.logging;resolution:=optional,
- org.eclipse.emf.mwe2.launch;resolution:=optional,
- org.eclipse.emf.ecore,
- org.eclipse.emf.common,
- org.antlr.runtime,
- org.eclipse.smarthome.model.lazygen;resolution:=optional,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: org.apache.commons.lang,
- org.apache.log4j,
- org.eclipse.jdt.annotation;resolution:=optional,
- org.eclipse.smarthome.core.items.dto,
- org.eclipse.smarthome.model.core,
- org.eclipse.xtext.xbase.lib,
- org.osgi.framework,
- org.osgi.service.cm,
- org.slf4j
-Export-Package: org.eclipse.smarthome.model,
+Export-Package: 
+ org.eclipse.smarthome.model,
  org.eclipse.smarthome.model.formatting,
  org.eclipse.smarthome.model.generator,
  org.eclipse.smarthome.model.parser.antlr,
@@ -36,5 +18,26 @@ Export-Package: org.eclipse.smarthome.model,
  org.eclipse.smarthome.model.sitemap.impl,
  org.eclipse.smarthome.model.sitemap.util,
  org.eclipse.smarthome.model.validation
+Import-Package: 
+ org.apache.commons.lang,
+ org.apache.log4j,
+ org.eclipse.jdt.annotation;resolution:=optional,
+ org.eclipse.smarthome.core.items.dto,
+ org.eclipse.smarthome.model.core,
+ org.eclipse.xtext.xbase.lib,
+ org.osgi.framework,
+ org.osgi.service.cm,
+ org.slf4j
+Require-Bundle: 
+ org.antlr.runtime,
+ org.apache.commons.logging;resolution:=optional,
+ org.eclipse.emf.common,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.mwe2.launch;resolution:=optional,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext,
+ org.eclipse.xtext.generator;resolution:=optional,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase.lib
 Service-Component: OSGI-INF/*.xml
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/bundles/model/org.eclipse.smarthome.model.thing.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ide/META-INF/MANIFEST.MF
@@ -1,15 +1,16 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Model IDE
-Bundle-SymbolicName: org.eclipse.smarthome.model.thing.ide
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.thing.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Require-Bundle: org.eclipse.smarthome.model.thing,
- org.eclipse.xtext.ide,
- org.antlr.runtime,
- org.eclipse.xtext.xbase.lib
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.model.thing.ide.contentassist.antlr,
+ org.eclipse.smarthome.model.thing.ide.contentassist.antlr.internal
 Import-Package: org.eclipse.jdt.annotation;resolution:=optional
-Export-Package: org.eclipse.smarthome.model.thing.ide.contentassist.antlr.internal,
- org.eclipse.smarthome.model.thing.ide.contentassist.antlr
-
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.smarthome.model.thing,
+ org.eclipse.xtext.ide,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
@@ -1,14 +1,15 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Model Runtime
-Bundle-SymbolicName: org.eclipse.smarthome.model.thing.runtime;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.model.thing.runtime;singleton
+ :=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.model.core,
  org.osgi.framework,
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.thing
 Service-Component: OSGI-INF/*.xml
-

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/META-INF/MANIFEST.MF
@@ -1,12 +1,15 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Model Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.thing.tests; singleton:
+ =true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.thing.tests; singleton:=true
-Require-Bundle: org.eclipse.core.runtime,
- org.hamcrest
-Import-Package: groovy.lang,
+Export-Package: org.eclipse.smarthome.model.thing
+Fragment-Host: org.eclipse.smarthome.model.thing
+Import-Package: 
+ groovy.lang,
  org.apache.log4j,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
@@ -19,19 +22,18 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.java,
- org.hamcrest;core=split,
  org.hamcrest.core,
- org.junit;version="4.0.0",
- org.junit.runner;version="4.0.0",
+ org.hamcrest;core=split,
  org.junit.runner.manipulation;version="4.0.0",
  org.junit.runner.notification;version="4.0.0",
- org.junit.runners;version="4.0.0",
+ org.junit.runner;version="4.0.0",
  org.junit.runners.model;version="4.0.0",
+ org.junit.runners;version="4.0.0",
+ org.junit;version="4.0.0",
  org.mockito,
  org.mockito.verification,
  org.osgi.service.component;version="1.2.2"
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Fragment-Host: org.eclipse.smarthome.model.thing
-Export-Package: org.eclipse.smarthome.model.thing
+Require-Bundle: 
+ org.eclipse.core.runtime,
+ org.hamcrest
 Service-Component: OSGI-INF/*.xml
- 

--- a/bundles/model/org.eclipse.smarthome.model.thing.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ui/META-INF/MANIFEST.MF
@@ -1,29 +1,34 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: org.eclipse.smarthome.model.thing.ui.internal.ThingAct
+ ivator
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Editor UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.thing.ui; singleton:=tr
+ ue
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.thing.ui; singleton:=true
-Require-Bundle: org.eclipse.smarthome.model.thing;visibility:=reexport,
- org.eclipse.smarthome.model.thing.ide,
- org.eclipse.xtext.ui,
- org.eclipse.ui.editors;bundle-version="3.5.0",
- org.eclipse.ui.ide;bundle-version="3.5.0",
- org.eclipse.xtext.ui.shared,
- org.eclipse.ui,
- org.eclipse.xtext.builder,
- org.antlr.runtime,
- org.eclipse.xtext.common.types.ui,
- org.eclipse.xtext.ui.codetemplates.ui,
- org.eclipse.compare,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: org.apache.log4j,
+Export-Package: 
+ org.eclipse.smarthome.model.thing.ui.contentassist,
+ org.eclipse.smarthome.model.thing.ui.internal,
+ org.eclipse.smarthome.model.thing.ui.quickfix
+Import-Package: 
+ org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.xtext.xbase.lib
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.model.thing.ui.quickfix,
- org.eclipse.smarthome.model.thing.ui.contentassist,
- org.eclipse.smarthome.model.thing.ui.internal
-Bundle-Activator: org.eclipse.smarthome.model.thing.ui.internal.ThingActivator
-Bundle-ActivationPolicy: lazy
+Require-Bundle: 
+ org.antlr.runtime,
+ org.eclipse.compare,
+ org.eclipse.smarthome.model.thing.ide,
+ org.eclipse.smarthome.model.thing;visibility:=reexport,
+ org.eclipse.ui,
+ org.eclipse.ui.editors;bundle-version="3.5.0",
+ org.eclipse.ui.ide;bundle-version="3.5.0",
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.builder,
+ org.eclipse.xtext.common.types.ui,
+ org.eclipse.xtext.ui,
+ org.eclipse.xtext.ui.codetemplates.ui,
+ org.eclipse.xtext.ui.shared,
+ org.eclipse.xtext.xbase.lib

--- a/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
@@ -1,26 +1,25 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Thing Model
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.model.thing; singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-SymbolicName: org.eclipse.smarthome.model.thing; singleton:=true
-Require-Bundle: org.eclipse.xtext;visibility:=reexport,
- org.eclipse.xtext.xbase;resolution:=optional;visibility:=reexport,
- org.eclipse.xtext.generator;resolution:=optional,
- org.apache.commons.logging;bundle-version="1.0.4";resolution:=optional,
- org.eclipse.emf.codegen.ecore;resolution:=optional,
- org.eclipse.emf.mwe.utils;resolution:=optional,
- org.eclipse.emf.mwe2.launch;resolution:=optional,
- org.eclipse.xtext.util,
- org.eclipse.emf.ecore,
- org.eclipse.emf.common,
- org.antlr.runtime,
- org.eclipse.xtext.common.types,
- org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional,
- org.eclipse.smarthome.model.lazygen;resolution:=optional,
- org.eclipse.xtext.xbase.lib,
- org.eclipse.xtend.lib;resolution:=optional
-Import-Package: org.apache.log4j,
+Export-Package: 
+ org.eclipse.smarthome.model.thing,
+ org.eclipse.smarthome.model.thing.formatting,
+ org.eclipse.smarthome.model.thing.generator,
+ org.eclipse.smarthome.model.thing.parser.antlr,
+ org.eclipse.smarthome.model.thing.parser.antlr.internal,
+ org.eclipse.smarthome.model.thing.scoping,
+ org.eclipse.smarthome.model.thing.serializer,
+ org.eclipse.smarthome.model.thing.services,
+ org.eclipse.smarthome.model.thing.thing,
+ org.eclipse.smarthome.model.thing.thing.impl,
+ org.eclipse.smarthome.model.thing.thing.util,
+ org.eclipse.smarthome.model.thing.validation
+Import-Package: 
+ org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.common.registry,
@@ -39,18 +38,21 @@ Import-Package: org.apache.log4j,
  org.osgi.framework,
  org.osgi.service.component,
  org.slf4j
+Require-Bundle: 
+ org.antlr.runtime,
+ org.apache.commons.logging;bundle-version="1.0.4";resolution:=optional,
+ org.eclipse.emf.codegen.ecore;resolution:=optional,
+ org.eclipse.emf.common,
+ org.eclipse.emf.ecore,
+ org.eclipse.emf.mwe.utils;resolution:=optional,
+ org.eclipse.emf.mwe2.launch;resolution:=optional,
+ org.eclipse.smarthome.model.lazygen;resolution:=optional,
+ org.eclipse.xtend.lib;resolution:=optional,
+ org.eclipse.xtext.common.types,
+ org.eclipse.xtext.generator;resolution:=optional,
+ org.eclipse.xtext.util,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase;resolution:=optional;visibility:=reexport,
+ org.eclipse.xtext;visibility:=reexport,
+ org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
 Service-Component: OSGI-INF/*.xml
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.model.thing,
- org.eclipse.smarthome.model.thing.services,
- org.eclipse.smarthome.model.thing.thing,
- org.eclipse.smarthome.model.thing.thing.impl,
- org.eclipse.smarthome.model.thing.thing.util,
- org.eclipse.smarthome.model.thing.serializer,
- org.eclipse.smarthome.model.thing.parser.antlr,
- org.eclipse.smarthome.model.thing.parser.antlr.internal,
- org.eclipse.smarthome.model.thing.validation,
- org.eclipse.smarthome.model.thing.scoping,
- org.eclipse.smarthome.model.thing.generator,
- org.eclipse.smarthome.model.thing.formatting
-

--- a/bundles/storage/org.eclipse.smarthome.storage.json.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.json.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Eclipse SmartHome Json Storage
-Bundle-SymbolicName: org.eclipse.smarthome.storage.json.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.storage.json
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: groovy.lang,
+Bundle-SymbolicName: org.eclipse.smarthome.storage.json.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.storage.json
+Import-Package: 
+ groovy.lang,
  org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,
@@ -14,5 +15,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.java,
  org.hamcrest;core=split,
- org.junit;version="4.0.0",
- org.junit.matchers;version="4.0.0"
+ org.junit.matchers;version="4.0.0",
+ org.junit;version="4.0.0"

--- a/bundles/storage/org.eclipse.smarthome.storage.json/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/META-INF/MANIFEST.MF
@@ -1,10 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Json Storage Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.storage.json;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: com.google.gson,
+Import-Package: 
+ com.google.gson,
  com.google.gson.annotations,
  com.google.gson.reflect,
  com.google.gson.stream,
@@ -16,7 +20,4 @@ Import-Package: com.google.gson,
  org.osgi.service.component,
  org.osgi.service.event,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.storage.json;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Eclipse SmartHome MapDB Storage
-Bundle-SymbolicName: org.eclipse.smarthome.storage.mapdb.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.storage.mapdb
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: groovy.lang,
+Bundle-SymbolicName: org.eclipse.smarthome.storage.mapdb.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.storage.mapdb
+Import-Package: 
+ groovy.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
  org.codehaus.groovy.runtime.callsite,
@@ -16,5 +17,5 @@ Import-Package: groovy.lang,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.test,
  org.hamcrest;core=split,
- org.junit;version="4.0.0",
- org.junit.matchers;version="4.0.0"
+ org.junit.matchers;version="4.0.0",
+ org.junit;version="4.0.0"

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
@@ -1,10 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome MapDB Storage Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.storage.mapdb;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: com.google.gson,
+Import-Package: 
+ com.google.gson,
  com.google.gson.annotations,
  com.google.gson.internal,
  com.google.gson.internal.bind,
@@ -18,7 +22,4 @@ Import-Package: com.google.gson,
  org.osgi.service.cm,
  org.osgi.service.event,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.storage.mapdb;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
 Service-Component: OSGI-INF/*.xml

--- a/bundles/test/org.eclipse.smarthome.magic.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Magic Bundle Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.magic.test
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: org.eclipse.smarthome.magic.binding
 Fragment-Host: org.eclipse.smarthome.magic
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.thing.util,
  org.eclipse.smarthome.magic.binding,
@@ -19,5 +21,7 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework,
  org.osgi.service.device,
  org.slf4j
-Require-Bundle: org.junit,org.mockito,org.hamcrest
-Export-Package: org.eclipse.smarthome.magic.binding
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
@@ -1,11 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Magic Bundle
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.magic;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
+Export-Package: 
+ org.eclipse.smarthome.magic.binding,
+ org.eclipse.smarthome.magic.binding.handler
 Import-Package: 
  com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -19,7 +23,4 @@ Import-Package:
  org.eclipse.smarthome.magic.binding,
  org.eclipse.smarthome.magic.binding.handler,
  org.slf4j
-Export-Package: org.eclipse.smarthome.magic.binding,
- org.eclipse.smarthome.magic.binding.handler
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
@@ -1,15 +1,17 @@
 Manifest-Version: 1.0
-Export-Package: org.eclipse.smarthome.test;uses:="groovy.lang,org.osgi.framework",
- org.eclipse.smarthome.test.java,
- org.eclipse.smarthome.test.storage
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.test
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Bundle-SymbolicName: org.eclipse.smarthome.test
-Import-Package: com.google.common.collect,
+Export-Package: 
+ org.eclipse.smarthome.test.java,
+ org.eclipse.smarthome.test.storage,
+ org.eclipse.smarthome.test;uses:="groovy.lang,org.osgi.framework"
+Import-Package: 
+ com.google.common.collect,
  groovy.lang,
  org.apache.commons.io,
  org.codehaus.groovy.reflection,
@@ -26,8 +28,8 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.test.java,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
- org.junit;version="4.0.0",
  org.junit.matchers;version="4.0.0",
+ org.junit;version="4.0.0",
  org.osgi.framework,
  org.osgi.service.cm;resolution:=optional,
  org.slf4j

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UI Icons Tests
-Bundle-SymbolicName: org.eclipse.smarthome.ui.icon.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.ui.icon
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: groovy.lang,
+Bundle-SymbolicName: org.eclipse.smarthome.ui.icon.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.ui.icon
+Import-Package: 
+ groovy.lang,
  javax.servlet,
  javax.servlet.http,
  org.codehaus.groovy.reflection,

--- a/bundles/ui/org.eclipse.smarthome.ui.icon/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon/META-INF/MANIFEST.MF
@@ -1,14 +1,16 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UI Icons
-Bundle-SymbolicName: org.eclipse.smarthome.ui.icon
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: javax.servlet,
+Bundle-SymbolicName: org.eclipse.smarthome.ui.icon
+Bundle-Vendor: Eclipse.org
+Bundle-Version: 0.9.0.qualifier
+Export-Package: org.eclipse.smarthome.ui.icon
+Import-Package: 
+ javax.servlet,
  javax.servlet.http,
- javax.ws.rs;resolution:=optional,
  javax.ws.rs.core;resolution:=optional,
+ javax.ws.rs;resolution:=optional,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -20,4 +22,3 @@ Import-Package: javax.servlet,
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.ui.icon

--- a/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
@@ -1,16 +1,19 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UI Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.ui.test
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
 Fragment-Host: org.eclipse.smarthome.ui
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Bundle-SymbolicName: org.eclipse.smarthome.ui.test
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.hamcrest;core=split,
  org.mockito,
  org.objenesis
-Require-Bundle: org.junit,
- org.mockito,org.hamcrest
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/bundles/ui/org.eclipse.smarthome.ui/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui/META-INF/MANIFEST.MF
@@ -1,13 +1,19 @@
 Manifest-Version: 1.0
-Private-Package: org.eclipse.smarthome.ui.internal
-Ignore-Package: org.eclipse.smarthome.ui.internal
+Bundle-Activator: org.eclipse.smarthome.ui.internal.UIActivator
+Bundle-ClassPath: .,lib/xchart-2.6.1.jar
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.ui
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.ui.internal.UIActivator
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: javax.imageio,
+Export-Package: 
+ org.eclipse.smarthome.ui.chart,
+ org.eclipse.smarthome.ui.items
+Ignore-Package: org.eclipse.smarthome.ui.internal
+Import-Package: 
+ javax.imageio,
  javax.servlet,
  javax.servlet.http,
  org.apache.commons.io,
@@ -40,10 +46,5 @@ Import-Package: javax.imageio,
  org.osgi.service.cm,
  org.osgi.service.http,
  org.slf4j
-Bundle-ClassPath: .,
- lib/xchart-2.6.1.jar
-Bundle-SymbolicName: org.eclipse.smarthome.ui
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Export-Package: org.eclipse.smarthome.ui.chart,
- org.eclipse.smarthome.ui.items
+Private-Package: org.eclipse.smarthome.ui.internal
 Service-Component: OSGI-INF/*.xml

--- a/extensions/binding/org.eclipse.smarthome.binding.astro.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name:  Astro Binding Tests
-Bundle-SymbolicName: org.eclipse.smarthome.binding.astro.test;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.astro.test;singleton:
+ =true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: org.eclipse.smarthome.binding.astro
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.apache.commons.lang,
  org.codehaus.groovy.reflection,
  org.codehaus.groovy.runtime,
@@ -28,7 +30,7 @@ Import-Package: groovy.lang,
  org.junit.runners,
  org.mockito,
  org.osgi.framework
-Require-Bundle: org.junit,
- org.mockito,
- org.hamcrest
-
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/META-INF/MANIFEST.MF
@@ -1,11 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-Copyright: Eclipse Public License v1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Astro Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.astro;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Copyright: Eclipse Public License v1.0
-Import-Package: org.apache.commons.lang,
+Export-Package: 
+ org.eclipse.smarthome.binding.astro,
+ org.eclipse.smarthome.binding.astro.handler
+Import-Package: 
+ org.apache.commons.lang,
  org.apache.commons.lang.builder,
  org.apache.commons.lang.reflect,
  org.apache.commons.lang.time,
@@ -24,8 +30,4 @@ Import-Package: org.apache.commons.lang,
  org.osgi.framework,
  org.osgi.service.component,
  org.slf4j
-Export-Package: org.eclipse.smarthome.binding.astro,
- org.eclipse.smarthome.binding.astro.handler
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: DigitalSTROM Binding
-Bundle-SymbolicName: org.eclipse.smarthome.binding.digitalstrom;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.digitalstrom;singleto
+ n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.common.collect,
+Export-Package: 
+ org.eclipse.smarthome.binding.digitalstrom,
+ org.eclipse.smarthome.binding.digitalstrom.handler
+Import-Package: 
+ com.google.common.collect,
  com.google.gson,
  javax.jmdns,
  javax.net.ssl,
@@ -31,5 +36,3 @@ Import-Package: com.google.common.collect,
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.digitalstrom,
- org.eclipse.smarthome.binding.digitalstrom.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/META-INF/MANIFEST.MF
@@ -1,12 +1,18 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Name: Dmx Binding Tests
-Bundle-SymbolicName: org.eclipse.smarthome.binding.dmx.test;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.dmx.test;singleton:=t
+ rue
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: 
+ org.eclipse.smarthome.binding.dmx.test;x-internal:=true,
+ org.eclipse.smarthome.binding.dmx;uses:="org.eclipse.smarthome.test"
 Fragment-Host: org.eclipse.smarthome.binding.dmx
-Import-Package: com.google.gson,
+Import-Package: 
+ com.google.gson,
  com.google.gson.reflect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.dmx,
@@ -24,8 +30,8 @@ Import-Package: com.google.gson,
  org.osgi.service.component.annotations;resolution:=optional,
  org.osgi.service.device,
  org.slf4j
-Require-Bundle: org.junit,org.mockito,org.hamcrest
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.dmx;uses:="org.eclipse.smarthome.test",
- org.eclipse.smarthome.binding.dmx.test;x-internal:=true
-Bundle-ActivationPolicy: lazy

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
@@ -1,11 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: DMX Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.dmx;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
+Export-Package: 
+ org.eclipse.smarthome.binding.dmx,
+ org.eclipse.smarthome.binding.dmx.handler
 Import-Package: 
  com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -23,6 +27,3 @@ Import-Package:
  org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.dmx,
- org.eclipse.smarthome.binding.dmx.handler
-Bundle-ActivationPolicy: lazy

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Smarthome FSInternetRadio Binding Test
-Bundle-SymbolicName: org.eclipse.smarthome.binding.fsinternetradio.test
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.fsinternetradio.test
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.binding.fsinternetradio
-Import-Package: javax.servlet,
+Import-Package: 
+ javax.servlet,
  javax.servlet.http,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
@@ -1,11 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: FSInternetRadio Binding
-Bundle-SymbolicName: org.eclipse.smarthome.binding.fsinternetradio;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.fsinternetradio;singl
+ eton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
+Export-Package: 
+ org.eclipse.smarthome.binding.fsinternetradio,
+ org.eclipse.smarthome.binding.fsinternetradio.handler
 Import-Package: 
  org.apache.commons.io,
  org.apache.commons.lang,
@@ -26,5 +30,3 @@ Import-Package:
  org.jupnp.model.meta,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.fsinternetradio,
- org.eclipse.smarthome.binding.fsinternetradio.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome hue Binding Tests
-Bundle-SymbolicName: org.eclipse.smarthome.binding.hue.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.hue.test;singleton:=t
+ rue
 Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.binding.hue
-Import-Package: com.google.gson,
+Import-Package: 
+ com.google.gson,
  com.google.gson.reflect,
  groovy.json,
  groovy.lang,

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
@@ -1,12 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome hue Binding
-Bundle-SymbolicName: org.eclipse.smarthome.binding.hue;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.gson,
+Bundle-SymbolicName: org.eclipse.smarthome.binding.hue;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Export-Package: 
+ org.eclipse.smarthome.binding.hue,
+ org.eclipse.smarthome.binding.hue.handler
+Import-Package: 
+ com.google.gson,
  com.google.gson.annotations,
  com.google.gson.reflect,
  com.google.gson.stream,
@@ -27,5 +31,3 @@ Import-Package: com.google.gson,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.hue,
- org.eclipse.smarthome.binding.hue.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome LIFX Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.lifx;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.commons.lang,
+Export-Package: 
+ org.eclipse.smarthome.binding.lifx,
+ org.eclipse.smarthome.binding.lifx.handler
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.lifx,
  org.eclipse.smarthome.binding.lifx.handler,
@@ -25,6 +30,3 @@ Import-Package: org.apache.commons.lang,
  org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.lifx,
- org.eclipse.smarthome.binding.lifx.handler
-Bundle-ActivationPolicy: lazy

--- a/extensions/binding/org.eclipse.smarthome.binding.lirc/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.lirc/META-INF/MANIFEST.MF
@@ -1,12 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome LIRC Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.lirc;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.commons.io,
+Export-Package: 
+ org.eclipse.smarthome.binding.lirc,
+ org.eclipse.smarthome.binding.lirc.handler
+Import-Package: 
+ org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.lirc,
  org.eclipse.smarthome.binding.lirc.handler,
@@ -21,5 +25,3 @@ Import-Package: org.apache.commons.io,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.lirc,
- org.eclipse.smarthome.binding.lirc.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome NTP Binding Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.ntp.test
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: org.eclipse.smarthome.binding.ntp
-Import-Package: groovy.lang,
+Import-Package: 
+ groovy.lang,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.codehaus.groovy.reflection,

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
@@ -1,11 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: ntp Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.ntp;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
+Export-Package: 
+ org.eclipse.smarthome.binding.ntp,
+ org.eclipse.smarthome.binding.ntp.handler
 Import-Package: 
  org.apache.commons.net,
  org.apache.commons.net.ntp,
@@ -22,5 +25,3 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.ntp,
- org.eclipse.smarthome.binding.ntp.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Sonos Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.sonos
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.commons.io,
+Export-Package: 
+ org.eclipse.smarthome.binding.sonos,
+ org.eclipse.smarthome.binding.sonos.handler
+Import-Package: 
+ org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.sonos,
@@ -35,6 +40,3 @@ Import-Package: org.apache.commons.io,
  org.xml.sax,
  org.xml.sax.helpers
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.sonos,
- org.eclipse.smarthome.binding.sonos.handler
-Bundle-ActivationPolicy: lazy

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
@@ -1,12 +1,16 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name:  Tradfri Binding Tests
-Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri.test;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri.test;singleto
+ n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: org.eclipse.smarthome.binding.tradfri;uses:="org.eclipse
+ .smarthome.test"
 Fragment-Host: org.eclipse.smarthome.binding.tradfri
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.tradfri,
  org.eclipse.smarthome.binding.tradfri.handler,
  org.eclipse.smarthome.core.common.registry,
@@ -20,6 +24,7 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework,
  org.osgi.service.device,
  org.slf4j
-Require-Bundle: org.junit,org.mockito,org.hamcrest
-Export-Package: org.eclipse.smarthome.binding.tradfri;uses:="org.eclipse.smarthome.test"
-
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
@@ -1,12 +1,18 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Tradfri Binding
-Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri;singleton:=tr
+ ue
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.gson,
+Export-Package: 
+ org.eclipse.smarthome.binding.tradfri,
+ org.eclipse.smarthome.binding.tradfri.handler
+Import-Package: 
+ com.google.gson,
  javax.jmdns,
  org.eclipse.californium.core,
  org.eclipse.californium.core.coap,
@@ -31,6 +37,3 @@ Import-Package: com.google.gson,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.tradfri,
- org.eclipse.smarthome.binding.tradfri.handler
-Bundle-ActivationPolicy: lazy

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: WeatherUnderground Binding
-Bundle-SymbolicName: org.eclipse.smarthome.binding.weatherunderground;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.weatherunderground;si
+ ngleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.google.gson,
+Export-Package: 
+ org.eclipse.smarthome.binding.weatherunderground,
+ org.eclipse.smarthome.binding.weatherunderground.handler
+Import-Package: 
+ com.google.gson,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.weatherunderground,
@@ -24,5 +29,3 @@ Import-Package: com.google.gson,
  org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.weatherunderground,
- org.eclipse.smarthome.binding.weatherunderground.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Wemo Binding Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.wemo.test
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Fragment-Host: org.eclipse.smarthome.binding.wemo
-Import-Package: groovy.json,
+Import-Package: 
+ groovy.json,
  groovy.lang,
  groovy.util,
  groovy.xml,
@@ -28,9 +29,9 @@ Import-Package: groovy.json,
  org.eclipse.smarthome.test,
  org.eclipse.smarthome.test.storage,
  org.hamcrest;core=split,
- org.junit;version="4.0.0",
  org.junit.runner,
  org.junit.runners,
+ org.junit;version="4.0.0",
  org.jupnp,
  org.jupnp.mock,
  org.osgi.service.cm,

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
@@ -1,12 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Wemo Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.wemo;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.commons.io,
+Export-Package: 
+ org.eclipse.smarthome.binding.wemo,
+ org.eclipse.smarthome.binding.wemo.handler
+Import-Package: 
+ org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.wemo,
@@ -29,5 +33,3 @@ Import-Package: org.apache.commons.io,
  org.w3c.dom,
  org.xml.sax
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.wemo,
- org.eclipse.smarthome.binding.wemo.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
@@ -1,12 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: YahooWeather Binding
-Bundle-SymbolicName: org.eclipse.smarthome.binding.yahooweather;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.binding.yahooweather;singleto
+ n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.commons.lang,
+Export-Package: 
+ org.eclipse.smarthome.binding.yahooweather,
+ org.eclipse.smarthome.binding.yahooweather.handler
+Import-Package: 
+ org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.yahooweather,
  org.eclipse.smarthome.binding.yahooweather.handler,
@@ -20,5 +25,3 @@ Import-Package: org.apache.commons.lang,
  org.eclipse.smarthome.io.net.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.binding.yahooweather,org.eclipse
- .smarthome.binding.yahooweather.handler

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/META-INF/MANIFEST.MF
@@ -1,12 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse SmartHome IoT Marketplace Extension Automation Support
-Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace.automation;singleton:=true
+Bundle-Name: Eclipse SmartHome IoT Marketplace Extension Automation Supp
+ ort
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace.
+ automation;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.apache.commons.io,
+Import-Package: 
+ org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation.parser,
  org.eclipse.smarthome.automation.template,
@@ -17,5 +21,4 @@ Import-Package: org.apache.commons.io,
  org.eclipse.smarthome.extensionservice.marketplace,
  org.osgi.framework,
  org.slf4j
-Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/META-INF/MANIFEST.MF
@@ -1,14 +1,19 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IoT Marketplace Extension Service Test
-Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace.test;singleton:=true
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.extensionservice.marketplace
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace.
+ test;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.extensionservice.marketplace
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.extensionservice.marketplace,
  org.hamcrest;core=split,
  org.mockito
-Require-Bundle: org.junit,org.mockito,org.hamcrest
-Bundle-ClassPath: .
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/META-INF/MANIFEST.MF
@@ -1,12 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome IoT Marketplace Extension Service
-Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace;singleton:=true
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace;
+ singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: com.thoughtworks.xstream,
+Export-Package: org.eclipse.smarthome.extensionservice.marketplace
+Import-Package: 
+ com.thoughtworks.xstream,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -20,6 +24,4 @@ Import-Package: com.thoughtworks.xstream,
  org.eclipse.smarthome.extensionservice.marketplace,
  org.osgi.framework,
  org.slf4j
-Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.extensionservice.marketplace

--- a/extensions/io/org.eclipse.smarthome.io.javasound/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.javasound/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome JavaSound I/O
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.javasound
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: javax.sound.sampled,
+Import-Package: 
+ javax.sound.sampled,
  org.apache.commons.collections,
  org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -14,5 +16,4 @@ Import-Package: javax.sound.sampled,
  org.eclipse.smarthome.core.library.types,
  org.osgi.framework,
  org.slf4j
-Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Web Audio Support
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.webaudio
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: javax.sound.sampled,
+Import-Package: 
+ javax.sound.sampled,
  org.apache.commons.collections,
  org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
@@ -15,5 +17,4 @@ Import-Package: javax.sound.sampled,
  org.eclipse.smarthome.core.library.types,
  org.osgi.framework,
  org.slf4j
-Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/META-INF/MANIFEST.MF
@@ -1,15 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Exec Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.transform.exec
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.transform,
  org.eclipse.smarthome.io.net.exec,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.transform.exec
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
@@ -1,17 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome JavaScript Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.transform.javascript
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: javax.script,
+Import-Package: 
+ javax.script,
  org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.transform,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.transform.javascript
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the JSonPath Transformation Service
-Bundle-SymbolicName: org.eclipse.smarthome.transform.jsonpath.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.transform.jsonpath
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.transform.jsonpath.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.transform.jsonpath
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.junit;version="4.0.0"

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
@@ -1,10 +1,14 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome JSonPath Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.transform.jsonpath
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: com.jayway.jsonpath,
+Import-Package: 
+ com.jayway.jsonpath,
  net.minidev.json,
  net.minidev.json.annotate,
  net.minidev.json.parser,
@@ -13,7 +17,4 @@ Import-Package: com.jayway.jsonpath,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.transform,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.transform.jsonpath
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
@@ -1,12 +1,13 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Map Transformation Service
-Bundle-SymbolicName: org.eclipse.smarthome.transform.map.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.transform.map
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.apache.commons.io,
+Bundle-SymbolicName: org.eclipse.smarthome.transform.map.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.transform.map
+Import-Package: 
+ org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
- org.junit,
- org.hamcrest.core
+ org.hamcrest.core,
+ org.junit

--- a/extensions/transform/org.eclipse.smarthome.transform.map/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/META-INF/MANIFEST.MF
@@ -1,16 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Map Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.transform.map
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.i18n,
  org.eclipse.smarthome.core.transform,
  org.osgi.framework,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.transform.map
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the RegEx Transformation Service
-Bundle-SymbolicName: org.eclipse.smarthome.transform.regex.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.transform.regex
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.transform.regex.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.transform.regex
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.junit;version="4.0.0"

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
@@ -1,15 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome RegEx Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.transform.regex
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.transform,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.transform.regex
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Scale Transformation Service
-Bundle-SymbolicName: org.eclipse.smarthome.transform.scale.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.transform.scale
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
- org.junit,
- org.hamcrest.core
+Bundle-SymbolicName: org.eclipse.smarthome.transform.scale.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.transform.scale
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
+ org.hamcrest.core,
+ org.junit

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
@@ -1,16 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Scale Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.transform.scale
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.i18n,
  org.eclipse.smarthome.core.transform,
  org.osgi.framework,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.transform.scale
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the XPath Transformation Service
-Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.transform.xpath
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.transform.xpath
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.junit;version="4.0.0"

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
@@ -1,18 +1,18 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome XPath Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: javax.xml.parsers,
+Import-Package: 
+ javax.xml.parsers,
  javax.xml.xpath,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.transform,
  org.slf4j,
  org.w3c.dom,
  org.xml.sax
-Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
@@ -1,10 +1,11 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Tests for the Xslt Transformation Service
-Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.transform.xslt
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.transform.xslt
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.junit;version="4.0.0"

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
@@ -1,17 +1,17 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Xslt Transformation Service
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: javax.xml.transform,
+Import-Package: 
+ javax.xml.transform,
  javax.xml.transform.stream,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.transform,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: .
-

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/META-INF/MANIFEST.MF
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/META-INF/MANIFEST.MF
@@ -1,11 +1,12 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Classic IconSet
-Bundle-SymbolicName: org.eclipse.smarthome.ui.iconset.classic
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.ui.iconset.classic
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.i18n,
  org.eclipse.smarthome.ui.icon,
  org.osgi.framework,

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/META-INF/MANIFEST.MF
@@ -1,11 +1,17 @@
 Manifest-Version: 1.0
+Bundle-Activator: org.eclipse.smarthome.ui.basic.internal.WebAppActivato
+ r
+Bundle-ClassPath: patch/,.
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Basic UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.ui.basic
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.ui.basic.internal.WebAppActivator
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: com.google.gson,
+Export-Package: org.eclipse.smarthome.ui.basic.render
+Import-Package: 
+ com.google.gson,
  javax.servlet,
  org.apache.commons.io,
  org.apache.commons.lang,
@@ -29,8 +35,4 @@ Import-Package: com.google.gson,
  org.osgi.service.component,
  org.osgi.service.http,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.ui.basic
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.ui.basic.render
-Bundle-ClassPath: patch/,.

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/META-INF/MANIFEST.MF
@@ -1,13 +1,18 @@
 Manifest-Version: 1.0
-Private-Package: org.eclipse.smarthome.ui.webapp.internal
-Ignore-Package: org.eclipse.smarthome.ui.webapp.internal
+Bundle-Activator: org.eclipse.smarthome.ui.classic.internal.WebAppActiva
+ tor
+Bundle-ClassPath: patch/,.
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome WebApp UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.ui.classic
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-Activator: org.eclipse.smarthome.ui.classic.internal.WebAppActivator
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: javax.servlet,
+Export-Package: org.eclipse.smarthome.ui.classic.render
+Ignore-Package: org.eclipse.smarthome.ui.webapp.internal
+Import-Package: 
+ javax.servlet,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.emf.common.util,
@@ -26,8 +31,5 @@ Import-Package: javax.servlet,
  org.osgi.service.component,
  org.osgi.service.http,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.ui.classic
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Private-Package: org.eclipse.smarthome.ui.webapp.internal
 Service-Component: OSGI-INF/*.xml
-Export-Package: org.eclipse.smarthome.ui.classic.render
-Bundle-ClassPath: patch/,.

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/META-INF/MANIFEST.MF
@@ -1,14 +1,15 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: patch/,.
+Bundle-License: http://www.eclipse.org/legal/epl-v10.html
+Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Paper UI
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.ui.paper;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-ManifestVersion: 2
-Bundle-License: http://www.eclipse.org/legal/epl-v10.html
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.service.component,
  org.osgi.service.http,
  org.slf4j
-Bundle-SymbolicName: org.eclipse.smarthome.ui.paper;singleton:=true
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Service-Component: OSGI-INF/*.xml
-Bundle-ClassPath: patch/,.

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
@@ -1,15 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Mac TTS Tests
-Bundle-SymbolicName: org.eclipse.smarthome.voice.mactts.test
-Bundle-Version: 0.9.0.qualifier
-Bundle-Vendor: Eclipse.org/SmartHome
-Fragment-Host: org.eclipse.smarthome.voice.mactts
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Bundle-SymbolicName: org.eclipse.smarthome.voice.mactts.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Fragment-Host: org.eclipse.smarthome.voice.mactts
+Import-Package: 
+ org.apache.commons.io,
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.audio,
  org.eclipse.smarthome.core.voice,
  org.hamcrest.core,
- org.junit;version="4.0.0",
- org.apache.commons.io
-Bundle-ClassPath: .
+ org.junit;version="4.0.0"

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
@@ -1,15 +1,16 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: MacOS Text-to-Speech
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.voice.mactts;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
- org.eclipse.smarthome.core.voice,
- org.eclipse.smarthome.core.audio,
+Import-Package: 
  org.apache.commons.io,
+ org.eclipse.jdt.annotation;resolution:=optional,
+ org.eclipse.smarthome.core.audio,
+ org.eclipse.smarthome.core.voice,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Bundle-ActivationPolicy: lazy

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -1,12 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ${bindingIdCamelCase} Binding Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ${artifactId};singleton:=true
 Bundle-Vendor: ${vendorName}
 Bundle-Version: ${version.replaceAll("-SNAPSHOT", ".qualifier")}
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Export-Package: ${package};uses:="org.eclipse.smarthome.test"
 Fragment-Host: ${package}
-Import-Package: ${package},
+Import-Package: 
+ ${package},
  ${package}.handler,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.common.registry,
@@ -23,6 +25,7 @@ Import-Package: ${package},
  org.osgi.framework,
  org.osgi.service.device,
  org.slf4j
-Require-Bundle: org.junit,org.mockito,org.hamcrest
-Export-Package: ${package};uses:="org.eclipse.smarthome.test"
-
+Require-Bundle: 
+ org.hamcrest,
+ org.junit,
+ org.mockito

--- a/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -1,14 +1,19 @@
 Manifest-Version: 1.0
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
 Bundle-Name: ${bindingIdCamelCase} Binding
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ${artifactId};singleton:=true
 Bundle-Vendor: ${vendorName}
 Bundle-Version: ${version.replaceAll("-SNAPSHOT", ".qualifier")}
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Bundle-ClassPath: .
-Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
+Export-Package: 
+ ${package},
+ ${package}.handler
+Import-Package: 
  ${package},
  ${package}.handler,
+ org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.thing,
@@ -19,6 +24,3 @@ Import-Package: org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.service.component.annotations;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
-Export-Package: ${package},
- ${package}.handler
-Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Yesterday I removed my old openHAB IDE setup and started a fresh checkout using the openHAB setup and choose every repo.
After the IDE has been started and all repos has been cloned I realized some error messages that are related to the optional nullness annotation support that is not present on all bundles:
* The project was not built since its build path is incomplete. Cannot find the class file for org.eclipse.jdt.annotation.NonNullByDefault.
* The type org.eclipse.jdt.annotation.NonNullByDefault cannot be resolved. It is indirectly referenced from required .class files	...

For the ESH bundles I added the JTD annotation import manually: https://github.com/eclipse/smarthome/pull/4280

Now I have written a small tool (it is not finished yet) that read every manifest, adds the optional import if it is missing and apply some other cleanups:
* sort Import-Package, Export-Package and Require-Bundle section alphabetical
* remove duplicates from the above sections
* use "niceness" to add line breaks for some lists (e.g. the sections above and some others)

As a side effect the attributes (except the manifest version) seems to be ordered alphabetical, too.

The tool has been written just for personal interest to know how to automate such a task and to support the openHAB repositories to add that import to all that manifests.
I don't know if we should apply this for the ESH manifests, too. Perhaps some of them looks better, but I leave it up to you.