### PR TITLE
Renamed the discovery package to internal in the astro binding.

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/discovery/AstroDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/discovery/AstroDiscoveryService.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.binding.astro.discovery;
+package org.eclipse.smarthome.binding.astro.internal.discovery;
 
 import static org.eclipse.smarthome.binding.astro.AstroBindingConstants.*;
 


### PR DESCRIPTION
See openhab/static-code-analysis#100

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>