### PR TITLE
Renamed the discovery package to internal in the ntp binding.

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/discovery/NtpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/discovery/NtpDiscovery.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.binding.ntp.discovery;
+package org.eclipse.smarthome.binding.ntp.internal.discovery;
 
 import static org.eclipse.smarthome.binding.ntp.NtpBindingConstants.*;
 


### PR DESCRIPTION
See openhab/static-code-analysis#100

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>