### PR TITLE
Renamed the discovery package to internal in the wemo binding.

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/discovery/test/WemoDiscoveryParticipantTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/discovery/test/WemoDiscoveryParticipantTest.groovy
@@ -11,7 +11,7 @@ import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 
 import org.eclipse.smarthome.binding.wemo.WemoBindingConstants
-import org.eclipse.smarthome.binding.wemo.discovery.WemoDiscoveryParticipant
+import org.eclipse.smarthome.binding.wemo.internal.discovery.WemoDiscoveryParticipant
 import org.eclipse.smarthome.binding.wemo.test.GenericWemoOSGiTest
 import org.eclipse.smarthome.config.discovery.DiscoveryResult
 import org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/discovery/test/WemoLinkDiscoveryServiceOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/discovery/test/WemoLinkDiscoveryServiceOSGiTest.groovy
@@ -9,14 +9,9 @@ package org.eclipse.smarthome.binding.wemo.discovery.test
 
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
-import groovy.xml.XmlUtil
-
-import javax.servlet.http.HttpServlet
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
 
 import org.eclipse.smarthome.binding.wemo.WemoBindingConstants
-import org.eclipse.smarthome.binding.wemo.discovery.WemoLinkDiscoveryService
+import org.eclipse.smarthome.binding.wemo.internal.discovery.WemoLinkDiscoveryService
 import org.eclipse.smarthome.binding.wemo.test.GenericWemoHttpServlet
 import org.eclipse.smarthome.binding.wemo.test.GenericWemoLightOSGiTest
 import org.eclipse.smarthome.config.discovery.DiscoveryResult
@@ -26,6 +21,8 @@ import org.eclipse.smarthome.core.thing.ThingUID
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+
+import groovy.xml.XmlUtil
 
 /**
  * Tests for {@link WemoLinkDiscoveryService}.

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/OSGI-INF/WemoDiscoveryParticipant.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/OSGI-INF/WemoDiscoveryParticipant.xml
@@ -9,7 +9,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.binding.wemo.discovery.WemoDiscoveryParticipant">
-   <implementation class="org.eclipse.smarthome.binding.wemo.discovery.WemoDiscoveryParticipant"/>
+   <implementation class="org.eclipse.smarthome.binding.wemo.internal.discovery.WemoDiscoveryParticipant"/>
    <service>
       <provide interface="org.eclipse.smarthome.config.discovery.UpnpDiscoveryParticipant"/>
    </service>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/OSGI-INF/WemoDiscoveryService.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/OSGI-INF/WemoDiscoveryService.xml
@@ -9,7 +9,7 @@
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.eclipse.smarthome.binding.wemo.discovery.WemoDiscoveryService">
-   <implementation class="org.eclipse.smarthome.binding.wemo.discovery.WemoDiscoveryService"/>
+   <implementation class="org.eclipse.smarthome.binding.wemo.internal.discovery.WemoDiscoveryService"/>
    <reference bind="setUpnpService" cardinality="1..1" interface="org.jupnp.UpnpService" name="UpnpService" policy="static" unbind="unsetUpnpService"/>
    <service>
       <provide interface="org.eclipse.smarthome.config.discovery.DiscoveryService"/>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/WemoHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/WemoHandlerFactory.java
@@ -15,12 +15,12 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.smarthome.binding.wemo.WemoBindingConstants;
-import org.eclipse.smarthome.binding.wemo.discovery.WemoLinkDiscoveryService;
 import org.eclipse.smarthome.binding.wemo.handler.WemoBridgeHandler;
 import org.eclipse.smarthome.binding.wemo.handler.WemoCoffeeHandler;
 import org.eclipse.smarthome.binding.wemo.handler.WemoHandler;
 import org.eclipse.smarthome.binding.wemo.handler.WemoLightHandler;
 import org.eclipse.smarthome.binding.wemo.handler.WemoMakerHandler;
+import org.eclipse.smarthome.binding.wemo.internal.discovery.WemoLinkDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/discovery/WemoDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/discovery/WemoDiscoveryParticipant.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.binding.wemo.discovery;
+package org.eclipse.smarthome.binding.wemo.internal.discovery;
 
 import static org.eclipse.smarthome.binding.wemo.WemoBindingConstants.*;
 

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/discovery/WemoDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/discovery/WemoDiscoveryService.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.binding.wemo.discovery;
+package org.eclipse.smarthome.binding.wemo.internal.discovery;
 
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.binding.wemo.discovery;
+package org.eclipse.smarthome.binding.wemo.internal.discovery;
 
 import static org.eclipse.smarthome.binding.wemo.WemoBindingConstants.*;
 


### PR DESCRIPTION
See openhab/static-code-analysis#100

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>