### PR TITLE
Configurable ItemChannelLinks

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLink.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLink.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.smarthome.core.thing.link;
 
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 
@@ -15,10 +16,12 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
  *
  * @author Dennis Nobel - Initial contribution, Added getIDFor method
  * @author Jochen Hiller - Bugfix 455434: added default constructor, object is now mutable
+ * @author Simon Kaufmann - added configuration
  */
 public class ItemChannelLink extends AbstractLink {
 
-    private ChannelUID channelUID;
+    private final ChannelUID channelUID;
+    private final Configuration configuration;
 
     /**
      * Default constructor in package scope only. Will allow to instantiate this
@@ -27,16 +30,26 @@ public class ItemChannelLink extends AbstractLink {
     ItemChannelLink() {
         super();
         this.channelUID = null;
+        this.configuration = new Configuration();
     }
 
     public ItemChannelLink(String itemName, ChannelUID channelUID) {
+        this(itemName, channelUID, new Configuration());
+    }
+
+    public ItemChannelLink(String itemName, ChannelUID channelUID, Configuration configuration) {
         super(itemName);
         this.channelUID = channelUID;
+        this.configuration = configuration;
     }
 
     @Override
     public ChannelUID getLinkedUID() {
         return this.channelUID;
+    }
+
+    public Configuration getConfiguration() {
+        return configuration;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
@@ -63,14 +63,6 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
         return channelUIDs;
     }
 
-    /**
-     * Channels can not be updated, so this methods throws an {@link UnsupportedOperationException}.
-     */
-    @Override
-    public ItemChannelLink update(ItemChannelLink element) {
-        throw new UnsupportedOperationException("Channels can not be updated.");
-    }
-
     @Override
     public Set<String> getLinkedItemNames(UID uid) {
         final Set<String> linkedItems = new LinkedHashSet<>();

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/dto/ItemChannelLinkDTO.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/dto/ItemChannelLinkDTO.java
@@ -7,6 +7,8 @@
  */
 package org.eclipse.smarthome.core.thing.link.dto;
 
+import java.util.Map;
+
 /**
  * This is a data transfer object that is used to serialize links.
  *
@@ -15,6 +17,7 @@ package org.eclipse.smarthome.core.thing.link.dto;
 public class ItemChannelLinkDTO extends AbstractLinkDTO {
 
     public String channelUID;
+    public Map<String, Object> configuration;
 
     /**
      * Default constructor for deserialization e.g. by Gson.
@@ -22,9 +25,10 @@ public class ItemChannelLinkDTO extends AbstractLinkDTO {
     protected ItemChannelLinkDTO() {
     }
 
-    public ItemChannelLinkDTO(String itemName, String channelUID) {
+    public ItemChannelLinkDTO(String itemName, String channelUID, Map<String, Object> configuration) {
         super(itemName);
         this.channelUID = channelUID;
+        this.configuration = configuration;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/events/LinkEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/events/LinkEventFactory.java
@@ -106,7 +106,8 @@ public class LinkEventFactory extends AbstractEventFactory {
     }
 
     private static ItemChannelLinkDTO map(ItemChannelLink itemChannelLink) {
-        return new ItemChannelLinkDTO(itemChannelLink.getItemName(), itemChannelLink.getLinkedUID().toString());
+        return new ItemChannelLinkDTO(itemChannelLink.getItemName(), itemChannelLink.getLinkedUID().toString(),
+                itemChannelLink.getConfiguration().getProperties());
     }
 
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -22,13 +22,13 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.auth.Role;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.link.AbstractLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.link.ThingLinkManager;
-import org.eclipse.smarthome.core.thing.link.dto.AbstractLinkDTO;
 import org.eclipse.smarthome.core.thing.link.dto.ItemChannelLinkDTO;
 import org.eclipse.smarthome.io.rest.JSONResponse;
 import org.eclipse.smarthome.io.rest.RESTResource;
@@ -68,7 +68,7 @@ public class ItemChannelLinkResource implements RESTResource {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "OK", response = ItemChannelLinkDTO.class, responseContainer = "Collection") })
     public Response getAll() {
-        Stream<AbstractLinkDTO> linkStream = itemChannelLinkRegistry.getAll().stream().map(this::toBeans);
+        Stream<ItemChannelLinkDTO> linkStream = itemChannelLinkRegistry.getAll().stream().map(this::toBeans);
         return Response.ok(new Stream2JSONInputStream(linkStream)).build();
     }
 
@@ -85,10 +85,27 @@ public class ItemChannelLinkResource implements RESTResource {
     @Path("/{itemName}/{channelUID}")
     @ApiOperation(value = "Links item to a channel.")
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK"),
-            @ApiResponse(code = 400, message = "Item already linked to the channel.") })
+            @ApiResponse(code = 400, message = "Content does not match the path") })
     public Response link(@PathParam("itemName") @ApiParam(value = "itemName") String itemName,
-            @PathParam("channelUID") @ApiParam(value = "channelUID") String channelUid) {
-        itemChannelLinkRegistry.add(new ItemChannelLink(itemName, new ChannelUID(channelUid)));
+            @PathParam("channelUID") @ApiParam(value = "channelUID") String channelUid,
+            @ApiParam(value = "link data", required = false) ItemChannelLinkDTO bean) {
+        ItemChannelLink link;
+        if (bean == null) {
+            link = new ItemChannelLink(itemName, new ChannelUID(channelUid), new Configuration());
+        } else {
+            if (bean.channelUID != null && !bean.channelUID.equals(channelUid)) {
+                return Response.status(Status.BAD_REQUEST).build();
+            }
+            if (bean.itemName != null && !bean.itemName.equals(itemName)) {
+                return Response.status(Status.BAD_REQUEST).build();
+            }
+            link = new ItemChannelLink(itemName, new ChannelUID(channelUid), new Configuration(bean.configuration));
+        }
+        if (itemChannelLinkRegistry.get(link.getUID()) == null) {
+            itemChannelLinkRegistry.add(link);
+        } else {
+            itemChannelLinkRegistry.update(link);
+        }
         return Response.ok().build();
     }
 
@@ -132,8 +149,9 @@ public class ItemChannelLinkResource implements RESTResource {
         this.itemChannelLinkRegistry = null;
     }
 
-    private AbstractLinkDTO toBeans(ItemChannelLink link) {
-        return new ItemChannelLinkDTO(link.getItemName(), link.getLinkedUID().toString());
+    private ItemChannelLinkDTO toBeans(ItemChannelLink link) {
+        return new ItemChannelLinkDTO(link.getItemName(), link.getLinkedUID().toString(),
+                link.getConfiguration().getProperties());
     }
 
     @Override

--- a/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.core;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.9.0.qualifier
-Export-Package: org.eclipse.smarthome.model.core
+Export-Package: org.eclipse.smarthome.model.core,
+ org.eclipse.smarthome.model.core.valueconverter
 Import-Package: 
  com.google.common.base,
  com.google.common.collect,
@@ -27,8 +28,11 @@ Import-Package:
  org.eclipse.smarthome.core.service,
  org.eclipse.smarthome.model.core,
  org.eclipse.xtext.common.types.impl,
+ org.eclipse.xtext.conversion,
+ org.eclipse.xtext.nodemodel,
  org.eclipse.xtext.resource,
  org.eclipse.xtext.resource.impl,
+ org.eclipse.xtext.util,
  org.osgi.framework,
  org.osgi.service.component,
  org.slf4j

--- a/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/valueconverter/ValueTypeToStringConverter.java
+++ b/bundles/model/org.eclipse.smarthome.model.core/src/main/java/org/eclipse/smarthome/model/core/valueconverter/ValueTypeToStringConverter.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.model.thing.valueconverter;
+package org.eclipse.smarthome.model.core.valueconverter;
 
 import java.math.BigDecimal;
 

--- a/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
@@ -23,6 +23,7 @@ Import-Package:
  org.apache.commons.lang,
  org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional,
+ org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.autoupdate,
  org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.items,
@@ -31,6 +32,7 @@ Import-Package:
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.model.core,
+ org.eclipse.smarthome.model.core.valueconverter,
  org.eclipse.xtext.xbase.lib,
  org.osgi.framework,
  org.slf4j

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/Items.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/Items.xtext
@@ -39,7 +39,26 @@ ModelItemType :
 ;
 
 ModelBinding:
-	type=ID '=' configuration=STRING
+	type=ID '=' configuration=STRING   
+	('['
+        properties+=ModelProperty? (',' properties+=ModelProperty)*
+    ']')?
+;
+
+ModelProperty:
+    key=ID '=' value=ValueType
+;
+
+ValueType returns ecore::EJavaObject:
+    STRING | NUMBER | BOOLEAN
+;
+
+BOOLEAN returns ecore::EBoolean: 
+    'true' | 'false'
+;
+
+NUMBER returns ecore::EBigDecimal:
+    ID ('.' ID )?
 ;
 
 terminal ID  		: '^'?('a'..'z'|'A'..'Z'|'_'|'0'..'9') ('a'..'z'|'A'..'Z'|'_'|'-'|'0'..'9')*;

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/ItemsRuntimeModule.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/ItemsRuntimeModule.xtend
@@ -11,14 +11,21 @@ package
  */
 org.eclipse.smarthome.model
 
-import org.eclipse.xtext.linking.lazy.LazyURIEncoder
 import com.google.inject.Binder
 import com.google.inject.name.Names
+import org.eclipse.smarthome.model.internal.valueconverter.ItemValueConverters
+import org.eclipse.xtext.conversion.IValueConverterService
+import org.eclipse.xtext.linking.lazy.LazyURIEncoder
 
 /** 
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
  */
-class ItemsRuntimeModule extends org.eclipse.smarthome.model.AbstractItemsRuntimeModule {
+class ItemsRuntimeModule extends AbstractItemsRuntimeModule {
+    
+    override Class<? extends IValueConverterService> bindIValueConverterService() {
+        return ItemValueConverters
+    }
+    
     override void configureUseIndexFragmentsForLazyLinking(Binder binder) {
         binder.bind(Boolean.TYPE).annotatedWith(Names.named(LazyURIEncoder.USE_INDEXED_FRAGMENTS_BINDING)).toInstance(
             Boolean.FALSE)

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/internal/valueconverter/ItemValueConverters.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/internal/valueconverter/ItemValueConverters.java
@@ -5,7 +5,7 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  */
-package org.eclipse.smarthome.model.thing.valueconverter;
+package org.eclipse.smarthome.model.internal.valueconverter;
 
 import org.eclipse.smarthome.model.core.valueconverter.ValueTypeToStringConverter;
 import org.eclipse.xtext.common.services.DefaultTerminalConverters;
@@ -14,22 +14,20 @@ import org.eclipse.xtext.conversion.ValueConverter;
 
 import com.google.inject.Inject;
 
-public class ThingValueConverters extends DefaultTerminalConverters {
+/**
+ * Registers {@link IValueConverter}s for the items language.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+public class ItemValueConverters extends DefaultTerminalConverters {
 
     @Inject
     private ValueTypeToStringConverter valueTypeToStringConverter;
 
-    @Inject
-    private UIDtoStringConverter uidToStringConverter;
-
     @ValueConverter(rule = "ValueType")
     public IValueConverter<Object> ValueType() {
         return valueTypeToStringConverter;
-    }
-
-    @ValueConverter(rule = "UID")
-    public IValueConverter<String> UID() {
-        return uidToStringConverter;
     }
 
 }

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
@@ -16,6 +16,7 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.autoupdate.AutoUpdateBindingConfigProvider;
 
 /**
@@ -23,7 +24,7 @@ import org.eclipse.smarthome.core.autoupdate.AutoUpdateBindingConfigProvider;
  * This class can parse information from the generic binding format and provides AutoUpdate binding information from it.
  * If no binding configuration is provided <code>autoupdate</code> is evaluated to true. This means every received
  * <code>Command</code> will update its corresponding <code>State</code> by default.
- * 
+ *
  * <p>
  * This class registers as a {@link AutoUpdateBindingConfigProvider} service as well.
  *
@@ -60,8 +61,8 @@ public class AutoUpdateGenericBindingConfigProvider implements AutoUpdateBinding
     }
 
     @Override
-    public void processBindingConfiguration(String context, String itemType, String itemName, String bindingConfig)
-            throws BindingConfigParseException {
+    public void processBindingConfiguration(String context, String itemType, String itemName, String bindingConfig,
+            Configuration configuration) throws BindingConfigParseException {
         Set<String> itemNames = contextMap.get(context);
         if (itemNames == null) {
             itemNames = new HashSet<String>();

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/BindingConfigReader.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/BindingConfigReader.java
@@ -7,12 +7,13 @@
  */
 package org.eclipse.smarthome.model.item;
 
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.model.item.internal.GenericItemProvider;
 
 /**
  * This interface must be implemented by services, which can parse the generic
  * binding configuration string used in the {@link GenericItemProvider}.
- * 
+ *
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
@@ -20,18 +21,18 @@ public interface BindingConfigReader {
 
     /**
      * This defines the type of binding this reader will process, e.g. "knx".
-     * 
+     *
      * @return the type of the binding
      */
     public String getBindingType();
 
     /**
      * Validates if the type of <code>item</code> is valid for this binding.
-     * 
+     *
      * @param itemType the type of the item to validate
      * @param bindingConfig the config string which could be used to refine the
      *            validation
-     * 
+     *
      * @throws BindingConfigParseException if the item type is
      *             invalid for this binding
      */
@@ -40,29 +41,30 @@ public interface BindingConfigReader {
     /**
      * This method is called by the {@link GenericItemProvider} whenever it comes
      * across a binding configuration string for an item.
-     * 
+     *
      * @param context a string of the context from where this item comes from. Usually the file name of the config file
      * @param itemType the item type for which the binding config is defined
      * @param itemName the item name for which the binding config is defined
      * @param bindingConfig the configuration string that must be processed
-     * 
+     *
      * @throws BindingConfigParseException if the configuration string is not valid
      */
-    public void processBindingConfiguration(String context, String itemType, String itemName, String bindingConfig)
-            throws BindingConfigParseException;
+    public void processBindingConfiguration(String context, String itemType, String itemName, String bindingConfig,
+            Configuration configuration) throws BindingConfigParseException;
 
     /**
      * Informs the reader that configurations will be processed for a given context. This is usually called if a config
      * file is reloaded, so that the old values are removed, before the new ones are processed.
-     * 
+     *
      * @param context the context of the configurations that will be processed
      */
     public void startConfigurationUpdate(String context);
 
     /**
-     * Informs the reader that configuration update is completed for a given context. This is usually called after a config
+     * Informs the reader that configuration update is completed for a given context. This is usually called after a
+     * config
      * file is reloaded, so that the reader can clean up afterwards.
-     * 
+     *
      * @param context the context of the configurations that were processed
      */
     public void stopConfigurationUpdate(String context);

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.common.registry.AbstractProvider;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupFunction;
@@ -57,15 +58,15 @@ public class GenericItemProvider extends AbstractProvider<Item>
     private final Logger logger = LoggerFactory.getLogger(GenericItemProvider.class);
 
     /** to keep track of all binding config readers */
-    private Map<String, BindingConfigReader> bindingConfigReaders = new HashMap<String, BindingConfigReader>();
+    private final Map<String, BindingConfigReader> bindingConfigReaders = new HashMap<String, BindingConfigReader>();
 
     private ModelRepository modelRepository = null;
 
-    private Map<String, Collection<Item>> itemsMap = new ConcurrentHashMap<>();
+    private final Map<String, Collection<Item>> itemsMap = new ConcurrentHashMap<>();
 
-    private Collection<ItemFactory> itemFactorys = new ArrayList<ItemFactory>();
+    private final Collection<ItemFactory> itemFactorys = new ArrayList<ItemFactory>();
 
-    private Map<String, StateDescription> stateDescriptions = new ConcurrentHashMap<>();
+    private final Map<String, StateDescription> stateDescriptions = new ConcurrentHashMap<>();
 
     private Integer rank;
 
@@ -309,6 +310,9 @@ public class GenericItemProvider extends AbstractProvider<Item>
             String bindingType = binding.getType();
             String config = binding.getConfiguration();
 
+            Configuration configuration = new Configuration();
+            binding.getProperties().forEach(p -> configuration.put(p.getKey(), p.getValue()));
+
             BindingConfigReader localReader = reader;
             if (reader == null) {
                 logger.trace("Given binding config reader is null > query cache to find appropriate reader!");
@@ -328,7 +332,8 @@ public class GenericItemProvider extends AbstractProvider<Item>
             if (localReader != null) {
                 try {
                     localReader.validateItemType(item.getType(), config);
-                    localReader.processBindingConfiguration(modelName, item.getType(), item.getName(), config);
+                    localReader.processBindingConfiguration(modelName, item.getType(), item.getName(), config,
+                            configuration);
                 } catch (BindingConfigParseException e) {
                     logger.error("Binding configuration of type '{}' of item '{}' could not be parsed correctly.",
                             bindingType, item.getName(), e);

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericItemChannelLinkProviderJavaTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericItemChannelLinkProviderJavaTest.java
@@ -8,14 +8,16 @@
 package org.eclipse.smarthome.model.thing.tests;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.ByteArrayInputStream;
+import java.math.BigDecimal;
 import java.util.Collection;
 
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.thing.ChannelUID;
@@ -132,7 +134,7 @@ public class GenericItemChannelLinkProviderJavaTest extends JavaOSGiTest {
         provider.addProviderChangeListener(listener);
 
         provider.startConfigurationUpdate(ITEMS_TESTMODEL_NAME);
-        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, "Number", ITEM, CHANNEL);
+        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, "Number", ITEM, CHANNEL, new Configuration());
         provider.stopConfigurationUpdate(ITEMS_TESTMODEL_NAME);
         assertThat(provider.getAll().size(), is(1));
         assertThat(provider.getAll().iterator().next().toString(), is(LINK));
@@ -140,7 +142,7 @@ public class GenericItemChannelLinkProviderJavaTest extends JavaOSGiTest {
 
         reset(listener);
         provider.startConfigurationUpdate(ITEMS_TESTMODEL_NAME);
-        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, "Number", ITEM, CHANNEL);
+        provider.processBindingConfiguration(ITEMS_TESTMODEL_NAME, "Number", ITEM, CHANNEL, new Configuration());
         provider.stopConfigurationUpdate(ITEMS_TESTMODEL_NAME);
         assertThat(provider.getAll().size(), is(1));
         assertThat(provider.getAll().iterator().next().toString(), is(LINK));
@@ -152,6 +154,37 @@ public class GenericItemChannelLinkProviderJavaTest extends JavaOSGiTest {
         provider.stopConfigurationUpdate(ITEMS_TESTMODEL_NAME);
         assertThat(provider.getAll().size(), is(0));
         verify(listener, only()).removed(same(provider), eq(new ItemChannelLink(ITEM, new ChannelUID(CHANNEL))));
+    }
+
+    @Test
+    public void testLinkConfiguration() {
+        Collection<Thing> things = thingRegistry.getAll();
+        assertThat(things.size(), is(0));
+
+        String thingsModel = "Bridge hue:bridge:huebridge [ ipAddress = \"192.168.3.84\", userName = \"19fc3fa6fc870a4280a55f21315631f\" ] {"
+                + "LCT001 bulb3 [ lightId = \"3\" ]" //
+                + "LCT001 bulb4 [ lightId = \"3\" ]" //
+                + "}";
+        modelRepository.addOrRefreshModel(THINGS_TESTMODEL_NAME, new ByteArrayInputStream(thingsModel.getBytes()));
+
+        String itemsModel = "Color Light3Color \"Light3 Color\" { channel=\"hue:LCT001:huebridge:bulb3:color\" [ foo=\"bar\", answer=42, always=true ] }"
+                + "Group:Switch:MAX TestSwitches";
+        modelRepository.addOrRefreshModel(ITEMS_TESTMODEL_NAME, new ByteArrayInputStream(itemsModel.getBytes()));
+
+        waitForAssert(() -> {
+            assertThat(thingRegistry.getAll().size(), is(3));
+            assertThat(itemRegistry.getItems().size(), is(2));
+            assertThat(itemChannelLinkRegistry.getAll().size(), is(1));
+        });
+
+        ItemChannelLink link = itemChannelLinkRegistry.get("Light3Color -> hue:LCT001:huebridge:bulb3:color");
+        assertNotNull(link);
+        assertEquals("Light3Color", link.getItemName());
+        assertEquals("hue:LCT001:huebridge:bulb3:color", link.getLinkedUID().toString());
+        assertEquals("bar", link.getConfiguration().get("foo"));
+        assertEquals(new BigDecimal(42), link.getConfiguration().get("answer"));
+        assertEquals(true, link.getConfiguration().get("always"));
+
     }
 
 }

--- a/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
@@ -33,6 +33,7 @@ Import-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.thing.util,
  org.eclipse.smarthome.model.core,
+ org.eclipse.smarthome.model.core.valueconverter,
  org.eclipse.smarthome.model.item,
  org.eclipse.xtext.xbase.lib,
  org.osgi.framework,

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericItemChannelLinkProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericItemChannelLinkProvider.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.common.registry.AbstractProvider;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
@@ -56,19 +57,19 @@ public class GenericItemChannelLinkProvider extends AbstractProvider<ItemChannel
     }
 
     @Override
-    public void processBindingConfiguration(String context, String itemType, String itemName, String bindingConfig)
-            throws BindingConfigParseException {
+    public void processBindingConfiguration(String context, String itemType, String itemName, String bindingConfig,
+            Configuration configuration) throws BindingConfigParseException {
         String[] uids = bindingConfig.split(",");
         if (uids.length == 0) {
             throw new BindingConfigParseException(
                     "At least one Channel UID should be provided: <bindingID>.<thingTypeId>.<thingId>.<channelId>");
         }
         for (String uid : uids) {
-            createItemChannelLink(context, itemName, uid.trim());
+            createItemChannelLink(context, itemName, uid.trim(), configuration);
         }
     }
 
-    private void createItemChannelLink(String context, String itemName, String channelUID)
+    private void createItemChannelLink(String context, String itemName, String channelUID, Configuration configuration)
             throws BindingConfigParseException {
         ChannelUID channelUIDObject = null;
         try {
@@ -76,7 +77,7 @@ public class GenericItemChannelLinkProvider extends AbstractProvider<ItemChannel
         } catch (IllegalArgumentException e) {
             throw new BindingConfigParseException(e.getMessage());
         }
-        ItemChannelLink itemChannelLink = new ItemChannelLink(itemName, channelUIDObject);
+        ItemChannelLink itemChannelLink = new ItemChannelLink(itemName, channelUIDObject, configuration);
 
         Set<String> itemNames = contextMap.get(context);
         if (itemNames == null) {


### PR DESCRIPTION
This allows adding some configuration properties onto links, e.g. though

```xtext
  Switch someItem {
      channel="a:b:c:channel" [
          foo="bar",
          answer=42,
          always=true
      ]
  }
```

or the REST API.

As a consequence, ItemChannelLinks now also can be updated through the REST API.

❗️ This is API breaking, it adds a `Configuration` argument to `BindingConfigReader.processBindingConfiguration(...)`. I wouldn't expect many implementations out there - apart from the OH1 compatibility layer. Let me know any concerns, than I will think of something different - but I didn't want to clutter the API without a need.

fixes #583
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>