### PR TITLE
Explain OSGi discovery service in binding documentation

### DIFF
--- a/docs/documentation/development/bindings/discovery-services.md
+++ b/docs/documentation/development/bindings/discovery-services.md
@@ -64,6 +64,7 @@ The following example shows the implementation of the above mentioned methods in
     protected void startBackgroundDiscovery() {
         logger.debug("Start WeMo device background discovery");
         if (wemoDiscoveryJob == null || wemoDiscoveryJob.isCancelled()) {
+            wemoDiscoveryJob = scheduler.scheduleWithFixedDelay(wemoDiscoveryRunnable, 0, refreshInterval, TimeUnit.SECONDS);
             wemoDiscoveryJob = scheduler.scheduleAtFixedRate(wemoDiscoveryRunnable, 0, refreshInterval, TimeUnit.SECONDS);
         }
     }

--- a/docs/documentation/development/bindings/discovery-services.md
+++ b/docs/documentation/development/bindings/discovery-services.md
@@ -41,6 +41,16 @@ The following example is taken from the `HueLightDiscoveryService`, it calls `th
 
 The discovery service needs to provide the list of supported thing types, that can be found by the discovery service. This list will be given to the constructor of `AbstractDiscoveryService` and can be requested by using `DiscoveryService#getSupportedThingTypes` method. 
 
+## Registering as an OSGi service
+
+The `Discovery` class of a binding which implements `AbstractDiscoveryService` should be annotated with
+
+```java
+@Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.<bindingID>")
+```
+
+where `<bindingID>` is the package name of the binding, i.e. `astro` for the Astro binding. Such a registered service will be picked up automatically by the framework.
+
 ## Discovery 
 
 ### Background Discovery 

--- a/docs/documentation/development/bindings/discovery-services.md
+++ b/docs/documentation/development/bindings/discovery-services.md
@@ -49,7 +49,7 @@ The `Discovery` class of a binding which implements `AbstractDiscoveryService` s
 @Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.<bindingID>")
 ```
 
-where `<bindingID>` is the package name of the binding, i.e. `astro` for the Astro binding. Such a registered service will be picked up automatically by the framework.
+where `<bindingID>` is the id of the binding, i.e. `astro` for the Astro binding. Such a registered service will be picked up automatically by the framework.
 
 ## Discovery 
 
@@ -65,7 +65,6 @@ The following example shows the implementation of the above mentioned methods in
         logger.debug("Start WeMo device background discovery");
         if (wemoDiscoveryJob == null || wemoDiscoveryJob.isCancelled()) {
             wemoDiscoveryJob = scheduler.scheduleWithFixedDelay(wemoDiscoveryRunnable, 0, refreshInterval, TimeUnit.SECONDS);
-            wemoDiscoveryJob = scheduler.scheduleAtFixedRate(wemoDiscoveryRunnable, 0, refreshInterval, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
Binding developers who are not familiar with OSGi do not know what
"register as an OSGi service" in our documentation means, see
https://github.com/openhab/openhab2-addons/pull/2659#discussion_r140767229

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>