### PR TITLE
[BasicUI] Integrate ChartThemes in BasicUI themes

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/WebAppConfig.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/WebAppConfig.java
@@ -21,7 +21,10 @@ import java.util.Map;
 public class WebAppConfig {
     private final static String DEFAULT_SITEMAP = "default";
     private final static String DEFAULT_ICON_TYPE = "png";
-    private final static String DEFAULT_THEME = "default";
+
+    public final static String THEME_NAME_DEFAULT = "default";
+    public final static String THEME_NAME_DARK = "dark";
+    private final static String DEFAULT_THEME = THEME_NAME_DEFAULT;
 
     private String defaultSitemap = DEFAULT_SITEMAP;
     private String iconType = DEFAULT_ICON_TYPE;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ChartRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/ChartRenderer.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemNotFoundException;
 import org.eclipse.smarthome.model.sitemap.Chart;
 import org.eclipse.smarthome.model.sitemap.Widget;
+import org.eclipse.smarthome.ui.basic.internal.WebAppConfig;
 import org.eclipse.smarthome.ui.basic.render.RenderException;
 import org.eclipse.smarthome.ui.basic.render.WidgetRenderer;
 import org.slf4j.Logger;
@@ -55,6 +56,7 @@ public class ChartRenderer extends AbstractWidgetRenderer {
             if (chart.getService() != null) {
                 chartUrl += "&service=" + chart.getService();
             }
+            // if legend parameter is given, add correspondending GET parameter
             if (chart.getLegend() != null) {
                 if (chart.getLegend()) {
                     chartUrl += "&legend=true";
@@ -62,6 +64,20 @@ public class ChartRenderer extends AbstractWidgetRenderer {
                     chartUrl += "&legend=false";
                 }
             }
+            // add theme GET parameter
+            String chartTheme = null;
+            switch (config.getTheme()) {
+                case WebAppConfig.THEME_NAME_DEFAULT:
+                    chartTheme = "bright";
+                    break;
+                case WebAppConfig.THEME_NAME_DARK:
+                    chartTheme = "dark";
+                    break;
+            }
+            if (chartTheme != null) {
+                chartUrl += "&theme=" + chartTheme;
+            }
+            // add timestamp to circumvent browser cache
             String url = chartUrl + "&t=" + (new Date()).getTime();
 
             String snippet = getSnippet("chart");


### PR DESCRIPTION
This PR integrates chart themes to the BasicUI.

* https://github.com/eclipse/smarthome/pull/4137 introduced BasicUI themes
* https://github.com/eclipse/smarthome/pull/4291 introduced chart themes

Take a matching ChartTheme for the current BasicUI theme:
* If the `dark` theme is choosen in BasicUI, render a `dark` chart.
* If the `default` theme is choosen in BasicUI, render a `bright` chart.

As the `bright` chart theme has the same colors as the previous/current chart, there is no change if someone uses the `default` BasicUI theme.

BasicUI default:
![basicui_chart_default](https://user-images.githubusercontent.com/21249127/30829664-bff2bcb4-a241-11e7-9891-7871b1eae69b.png)

BasicUI dark:
![basicui_chart_dark](https://user-images.githubusercontent.com/21249127/30829672-c57cea4c-a241-11e7-9433-e15782480303.png)
