### PR TITLE
log a warning if a rule cannot convert an argument to a type

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/actions/BusEvent.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/actions/BusEvent.java
@@ -7,8 +7,10 @@
  */
 package org.eclipse.smarthome.model.script.actions;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.GroupItem;
@@ -77,12 +79,23 @@ public class BusEvent {
             try {
                 Item item = registry.getItem(itemName);
                 Command command = TypeParser.parseCommand(item.getAcceptedCommandTypes(), commandString);
-                publisher.post(ItemEventFactory.createCommandEvent(itemName, command));
+                if (command != null) {
+                    publisher.post(ItemEventFactory.createCommandEvent(itemName, command));
+                } else {
+                    LoggerFactory.getLogger(BusEvent.class).warn(
+                            "Cannot convert '{}' to a command type which item '{}' accepts: {}.", commandString,
+                            itemName, getAcceptedCommandNames(item));
+                }
+
             } catch (ItemNotFoundException e) {
                 LoggerFactory.getLogger(BusEvent.class).warn("Item '{}' does not exist.", itemName);
             }
         }
         return null;
+    }
+
+    private static <T extends State> List<String> getAcceptedCommandNames(Item item) {
+        return item.getAcceptedCommandTypes().stream().map(t -> t.getSimpleName()).collect(Collectors.toList());
     }
 
     /**
@@ -140,12 +153,22 @@ public class BusEvent {
             try {
                 Item item = registry.getItem(itemName);
                 State state = TypeParser.parseState(item.getAcceptedDataTypes(), stateString);
-                publisher.post(ItemEventFactory.createStateEvent(itemName, state));
+                if (state != null) {
+                    publisher.post(ItemEventFactory.createStateEvent(itemName, state));
+                } else {
+                    LoggerFactory.getLogger(BusEvent.class).warn(
+                            "Cannot convert '{}' to a state type which item '{}' accepts: {}.", stateString, itemName,
+                            getAcceptedDataTypeNames(item));
+                }
             } catch (ItemNotFoundException e) {
                 LoggerFactory.getLogger(BusEvent.class).warn("Item '{}' does not exist.", itemName);
             }
         }
         return null;
+    }
+
+    private static <T extends State> List<String> getAcceptedDataTypeNames(Item item) {
+        return item.getAcceptedDataTypes().stream().map(t -> t.getSimpleName()).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
...so that sendCommand or postUpdate don't fail with a weird NPE anymore
if e.g. a non-parsable string is attempted to be sent to a number item.

See https://github.com/eclipse/smarthome/issues/4317#issuecomment-331917181
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>