### PR TITLE
prevent NPE if no network interface is present

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -66,6 +66,11 @@ public class NetUtil implements NetworkAddressService {
 
     @Override
     public String getPrimaryIpv4HostAddress() {
+        if (primaryAddress == null) {
+            // we do not seem to have any network interfaces
+            return null;
+        }
+
         String primaryIP;
 
         String[] addrString = primaryAddress.split("/");


### PR DESCRIPTION
If running on an offline host without network interfaces, we currently see exceptions like
```
java.lang.NullPointerException: null
	at org.eclipse.smarthome.core.net.NetUtil.getPrimaryIpv4HostAddress(NetUtil.java:71) ~[?:?]
	at org.openhab.ui.dashboard.internal.DashboardService.activate(DashboardService.java:76) ~[?:?]
```

This fix should prevent this (and the Javadoc also already specifically notes that null is returned if not interface is present).

Signed-off-by: Kai Kreuzer <kai@openhab.org>