### PR TITLE
Discovery result localization: consider last locale settings

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -23,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.smarthome.config.discovery.internal.DiscoveryResultImpl;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.i18n.I18nUtil;
+import org.eclipse.smarthome.core.i18n.LocaleProvider;
 import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -67,7 +67,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
     private ScheduledFuture<?> scheduledStop;
 
     protected TranslationProvider i18nProvider;
-    protected Locale locale;
+    protected LocaleProvider localeProvider;
 
     /**
      * Creates a new instance of this class with the specified parameters.
@@ -258,7 +258,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
      *            Holds the information needed to identify the discovered device.
      */
     protected void thingDiscovered(DiscoveryResult discoveryResult) {
-        if (this.i18nProvider != null && this.locale != null) {
+        if (this.i18nProvider != null && this.localeProvider != null) {
             Bundle bundle = FrameworkUtil.getBundle(this.getClass());
 
             String defaultLabel = discoveryResult.getLabel();
@@ -266,7 +266,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
             String key = I18nUtil.isConstant(defaultLabel) ? I18nUtil.stripConstant(defaultLabel)
                     : inferKey(discoveryResult, "label");
 
-            String label = this.i18nProvider.getText(bundle, key, defaultLabel, this.locale);
+            String label = this.i18nProvider.getText(bundle, key, defaultLabel, this.localeProvider.getLocale());
 
             discoveryResult = new DiscoveryResultImpl(discoveryResult.getThingTypeUID(), discoveryResult.getThingUID(),
                     discoveryResult.getBridgeUID(), discoveryResult.getProperties(),

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/discovery/AstroDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/discovery/AstroDiscoveryService.java
@@ -128,11 +128,11 @@ public class AstroDiscoveryService extends AbstractDiscoveryService {
 
     @Reference
     protected void setLocaleProvider(final LocaleProvider localeProvider) {
-        this.locale = localeProvider.getLocale();
+        this.localeProvider = localeProvider;
     }
 
     protected void unsetLocaleProvider(final LocaleProvider localeProvider) {
-        this.locale = null;
+        this.localeProvider = null;
     }
 
     @Reference

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/discovery/NtpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/discovery/NtpDiscovery.java
@@ -78,11 +78,11 @@ public class NtpDiscovery extends AbstractDiscoveryService {
 
     @Reference
     protected void setLocaleProvider(final LocaleProvider localeProvider) {
-        this.locale = localeProvider.getLocale();
+        this.localeProvider = localeProvider;
     }
 
     protected void unsetLocaleProvider(final LocaleProvider localeProvider) {
-        this.locale = null;
+        this.localeProvider = null;
     }
 
     @Reference

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/discovery/WeatherUndergroundDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/discovery/WeatherUndergroundDiscoveryService.java
@@ -127,11 +127,11 @@ public class WeatherUndergroundDiscoveryService extends AbstractDiscoveryService
 
     @Reference
     protected void setLocaleProvider(final LocaleProvider localeProvider) {
-        this.locale = localeProvider.getLocale();
+        this.localeProvider = localeProvider;
     }
 
     protected void unsetLocaleProvider(final LocaleProvider localeProvider) {
-        this.locale = null;
+        this.localeProvider = null;
     }
 
     @Reference


### PR DESCRIPTION
The localization of a discovery result was considering the initial locale settings and not the last one updated. This problem was discovered after I read a review comment from @sjka on another of my PR. This PR fixes this problem. Of course I tested the behaviour is now as expected.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>