### PR TITLE
[Tradfri] Added FLOALT panels

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/binding/binding.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/binding/binding.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<binding:binding id="tradfri"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
-        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+<binding:binding id="tradfri" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
 
-    <name>Trådfri Binding</name>
-    <description>This binding supports IKEA Trådfri lighting devices through the IKEA gateway.</description>
+	<name>TRÅDFRI Binding</name>
+	<description>This binding supports IKEA TRÅDFRI lighting devices through the IKEA gateway.</description>
 
 </binding:binding>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/config/config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/config/config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:tradfri:device">
+		<parameter-group name="device">
+			<label>Device</label>
+			<description>Device specific settings.</description>
+		</parameter-group>
+		<parameter name="id" type="integer" required="true" groupName="device">
+			<label>ID</label>
+			<description>The identifier of the device on the gateway.</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/config/config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/config/config.xml
@@ -4,11 +4,7 @@
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
 	<config-description uri="thing-type:tradfri:device">
-		<parameter-group name="device">
-			<label>Device</label>
-			<description>Device specific settings.</description>
-		</parameter-group>
-		<parameter name="id" type="integer" required="true" groupName="device">
+		<parameter name="id" type="integer" required="true">
 			<label>ID</label>
 			<description>The identifier of the device on the gateway.</description>
 		</parameter>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/i18n/tradfri_de.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/i18n/tradfri_de.properties
@@ -22,10 +22,6 @@ thing-type.tradfri.0210.description = Dimmbare Lampe mit einstellbarer Farbe und
 thing-type.tradfri.0220.label = Farbtemperatur Lampe (weiß)
 thing-type.tradfri.0220.description = Dimmbare Lampe mit einstellbarer Farbtemperatur.
 
-# thing types config groups
-thing-type.config.tradfri.device.group.device.label = Gerät
-thing-type.config.tradfri.device.group.device.description = Einstellungen für das Gerät.
-
 # thing types config
 thing-type.config.tradfri.device.id.label = ID der Lampe
 thing-type.config.tradfri.device.id.description = ID zur Identifikation der Lampe.

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/i18n/tradfri_de.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/i18n/tradfri_de.properties
@@ -2,29 +2,33 @@
 binding.tradfri.name = TRÅDFRI Binding
 binding.tradfri.description = Dieses Binding integriert das IKEA TRÅDFRI System. Durch dieses können die TRÅDFRI Lampen und Leuchten gesteuert werden. 
 
-# thing types
+# bridge types
 thing-type.tradfri.gateway.label = TRÅDFRI Gateway
 thing-type.tradfri.gateway.description = IKEA TRÅDFRI Gateway/zentrale Steuereinheit.
-thing-type.tradfri.0100.label = Dimmbare Lampe (weiß)
-thing-type.tradfri.0100.description = Dimmbare Lampe mit fester Farbtemperatur.
-thing-type.tradfri.0220.label = Farbtemperatur Lampe (weiß)
-thing-type.tradfri.0220.description = Dimmbare Lampe mit einstellbarer Farbtemperatur.
-thing-type.tradfri.0210.label = Farbspektrum Lampe
-thing-type.tradfri.0210.description = Dimmbare Lampe mit einstellbarer Farbe und Farbtemperatur.
 
-# thing type configuration
+# bridge type configuration
 thing-type.config.tradfri.gateway.host.label = IP-Adresse
 thing-type.config.tradfri.gateway.host.description = Lokale IP-Adresse oder Hostname des TRÅDFRI Gateway.
 thing-type.config.tradfri.gateway.port.label = Port
 thing-type.config.tradfri.gateway.port.description = Port des TRÅDFRI Gateway.
 thing-type.config.tradfri.gateway.code.label = Security Code
 thing-type.config.tradfri.gateway.code.description = Security Code zur Authentifizierung am TRÅDFRI Gateway. Befindet sich unterhalb des TRÅDFRI Gateway.
-thing-type.config.tradfri.0100.id.label = ID der Lampe
-thing-type.config.tradfri.0100.id.description = ID zur Identifikation der Lampe.
-thing-type.config.tradfri.0220.id.label = ID der Lampe
-thing-type.config.tradfri.0220.id.description = ID zur Identifikation der Lampe.
-thing-type.config.tradfri.0210.id.label = ID der Lampe
-thing-type.config.tradfri.0210.id.description = ID zur Identifikation der Lampe.
+
+# thing types
+thing-type.tradfri.0100.label = Dimmbare Lampe (weiß)
+thing-type.tradfri.0100.description = Dimmbare Lampe mit fester Farbtemperatur.
+thing-type.tradfri.0210.label = Farbspektrum Lampe
+thing-type.tradfri.0210.description = Dimmbare Lampe mit einstellbarer Farbe und Farbtemperatur.
+thing-type.tradfri.0220.label = Farbtemperatur Lampe (weiß)
+thing-type.tradfri.0220.description = Dimmbare Lampe mit einstellbarer Farbtemperatur.
+
+# thing types config groups
+thing-type.config.tradfri.device.group.device.label = Gerät
+thing-type.config.tradfri.device.group.device.description = Einstellungen für das Gerät.
+
+# thing types config
+thing-type.config.tradfri.device.id.label = ID der Lampe
+thing-type.config.tradfri.device.id.description = ID zur Identifikation der Lampe.
 
 # channel types
 channel-type.tradfri.brightness.label = Helligkeit

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
@@ -82,8 +82,7 @@
 		<config-description-ref uri="thing-type:tradfri:device" />
 	</thing-type>
 
-	<!-- note that this isn't yet supported by the code as we do not receive any data 
-		from the gateway for it -->
+	<!-- note that this isn't yet supported by the code as we do not receive any data from the gateway for it -->
 	<thing-type id="0820" listed="false">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="gateway" />

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
@@ -1,127 +1,127 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <thing:thing-descriptions bindingId="tradfri"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <bridge-type id="gateway">
-        <label>TRÅDFRI Gateway</label>
-        <description>IKEA TRÅDFRI IP Gateway</description>
+	<bridge-type id="gateway">
+		<label>TRÅDFRI Gateway</label>
+		<description>IKEA TRÅDFRI IP Gateway</description>
 
-        <config-description>
-            <parameter name="host" type="text" required="true">
-                <context>network-address</context>
-                <label>Host</label>
-                <description>Hostname or IP address of the IKEA Trådfri gateway</description>
-            </parameter>
-            <parameter name="port" type="integer" required="false">
-                <label>Port</label>
-                <description>Port for accessing the gateway</description>
-                <advanced>true</advanced>
-                <default>5684</default>
-            </parameter>
-            <parameter name="code" type="text" required="true">
-                <context>password</context>
-                <label>Security Code</label>
-                <description>Security code printed on the label underneath the gateway.</description>
-            </parameter>
-        </config-description>
-    </bridge-type>
+		<config-description>
+			<parameter name="host" type="text" required="true">
+				<context>network-address</context>
+				<label>Host</label>
+				<description>Hostname or IP address of the IKEA TRÅDFRI gateway</description>
+			</parameter>
+			<parameter name="port" type="integer" required="false">
+				<label>Port</label>
+				<description>Port for accessing the gateway</description>
+				<advanced>true</advanced>
+				<default>5684</default>
+			</parameter>
+			<parameter name="code" type="text" required="true">
+				<context>password</context>
+				<label>Security Code</label>
+				<description>Security code printed on the label underneath the gateway.</description>
+			</parameter>
+		</config-description>
+	</bridge-type>
 
-    <!-- thing types for devices -->
-    <!-- their IDs refer to the Zigbee Lightlink device ids (see chapter 2.2 in https://www.nxp.com/documents/user_manual/JN-UG-3091.pdf) -->
-    <thing-type id="0100">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="gateway"/>
-        </supported-bridge-type-refs>
+	<!-- thing types for devices -->
+	<!-- their IDs refer to the Zigbee Lightlink device ids (see chapter 2.2 in https://www.nxp.com/documents/user_manual/JN-UG-3091.pdf) -->
+	<thing-type id="0100">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
 
-        <label>Dimmable Light</label>
-        <description>A light that has continuous brightness control.</description>
+		<label>Dimmable Light</label>
+		<description>A light that has continuous brightness control.</description>
 
-        <channels>
-            <channel id="brightness" typeId="brightness"/>
-        </channels>
+		<channels>
+			<channel id="brightness" typeId="brightness" />
+		</channels>
 
-        <representation-property>id</representation-property>
+		<representation-property>id</representation-property>
 
-        <config-description-ref uri="thing-type:tradfri:device" />
-    </thing-type>
+		<config-description-ref uri="thing-type:tradfri:device" />
+	</thing-type>
 
-    <thing-type id="0220">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="gateway"/>
-        </supported-bridge-type-refs>
+	<thing-type id="0220">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
 
-        <label>Color Temperature Light</label>
-        <description>A dimmable light that supports different color temperature settings.</description>
+		<label>Color Temperature Light</label>
+		<description>A dimmable light that supports different color temperature settings.</description>
 
-        <channels>
-            <channel id="brightness" typeId="brightness"/>
-            <channel id="color_temperature" typeId="color_temperature"/>
-        </channels>
+		<channels>
+			<channel id="brightness" typeId="brightness" />
+			<channel id="color_temperature" typeId="color_temperature" />
+		</channels>
 
-        <representation-property>id</representation-property>
+		<representation-property>id</representation-property>
 
-        <config-description-ref uri="thing-type:tradfri:device" />
-    </thing-type>
+		<config-description-ref uri="thing-type:tradfri:device" />
+	</thing-type>
 
-    <thing-type id="0210">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="gateway"/>
-        </supported-bridge-type-refs>
+	<thing-type id="0210">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
 
-        <label>Color Light</label>
-        <description>A dimmable light that supports full colors and color temperature settings.</description>
+		<label>Color Light</label>
+		<description>A dimmable light that supports full colors and color temperature settings.</description>
 
-        <channels>
-            <channel id="color_temperature" typeId="color_temperature"/>
-            <channel id="color" typeId="color"/>
-        </channels>
+		<channels>
+			<channel id="color_temperature" typeId="color_temperature" />
+			<channel id="color" typeId="color" />
+		</channels>
 
-        <representation-property>id</representation-property>
+		<representation-property>id</representation-property>
 
-        <config-description-ref uri="thing-type:tradfri:device" />
-    </thing-type>
+		<config-description-ref uri="thing-type:tradfri:device" />
+	</thing-type>
 
-    <!-- note that this isn't yet supported by the code as we do not receive any data from the gateway for it -->
-    <thing-type id="0820" listed="false">
-        <supported-bridge-type-refs>
-            <bridge-type-ref id="gateway"/>
-        </supported-bridge-type-refs>
+	<!-- note that this isn't yet supported by the code as we do not receive any data 
+		from the gateway for it -->
+	<thing-type id="0820" listed="false">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
 
-        <label>Non-Color Control Unit</label>
+		<label>Non-Color Control Unit</label>
 
-        <channels>
-            <channel id="brightness" typeId="brightness"/>
-        </channels>
+		<channels>
+			<channel id="brightness" typeId="brightness" />
+		</channels>
 
-        <representation-property>id</representation-property>
+		<representation-property>id</representation-property>
 
-        <config-description-ref uri="thing-type:tradfri:device" />
-    </thing-type>
+		<config-description-ref uri="thing-type:tradfri:device" />
+	</thing-type>
 
-    <channel-type id="brightness">
-        <item-type>Dimmer</item-type>
-        <label>Brightness</label>
-        <description>Control the brightness and switch the light on and off.</description>
-        <category>DimmableLight</category>
-        <tags>
-            <tag>Lighting</tag>
-        </tags>
-    </channel-type>
+	<channel-type id="brightness">
+		<item-type>Dimmer</item-type>
+		<label>Brightness</label>
+		<description>Control the brightness and switch the light on and off.</description>
+		<category>DimmableLight</category>
+		<tags>
+			<tag>Lighting</tag>
+		</tags>
+	</channel-type>
 
-    <channel-type id="color_temperature">
-        <item-type>Dimmer</item-type>
-        <label>Color Temperature</label>
-        <description>Control the color temperature of the light.</description>
-        <category>ColorLight</category>
-    </channel-type>
+	<channel-type id="color_temperature">
+		<item-type>Dimmer</item-type>
+		<label>Color Temperature</label>
+		<description>Control the color temperature of the light.</description>
+		<category>ColorLight</category>
+	</channel-type>
 
-    <channel-type id="color">
-        <item-type>Color</item-type>
-        <label>Color</label>
-        <description>Control the color of the light.</description>
-        <category>ColorLight</category>
-    </channel-type>
+	<channel-type id="color">
+		<item-type>Color</item-type>
+		<label>Color</label>
+		<description>Control the color of the light.</description>
+		<category>ColorLight</category>
+	</channel-type>
 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/ESH-INF/thing/thing-types.xml
@@ -42,12 +42,9 @@
             <channel id="brightness" typeId="brightness"/>
         </channels>
 
-        <config-description>
-            <parameter name="id" type="integer" required="true">
-                <label>ID</label>
-                <description>The identifier of the light on the gateway</description>
-            </parameter>
-        </config-description>
+        <representation-property>id</representation-property>
+
+        <config-description-ref uri="thing-type:tradfri:device" />
     </thing-type>
 
     <thing-type id="0220">
@@ -63,12 +60,9 @@
             <channel id="color_temperature" typeId="color_temperature"/>
         </channels>
 
-        <config-description>
-            <parameter name="id" type="integer" required="true">
-                <label>ID</label>
-                <description>The identifier of the light on the gateway</description>
-            </parameter>
-        </config-description>
+        <representation-property>id</representation-property>
+
+        <config-description-ref uri="thing-type:tradfri:device" />
     </thing-type>
 
     <thing-type id="0210">
@@ -84,12 +78,9 @@
             <channel id="color" typeId="color"/>
         </channels>
 
-        <config-description>
-            <parameter name="id" type="integer" required="true">
-                <label>ID</label>
-                <description>The identifier of the light on the gateway</description>
-            </parameter>
-        </config-description>
+        <representation-property>id</representation-property>
+
+        <config-description-ref uri="thing-type:tradfri:device" />
     </thing-type>
 
     <!-- note that this isn't yet supported by the code as we do not receive any data from the gateway for it -->
@@ -104,12 +95,9 @@
             <channel id="brightness" typeId="brightness"/>
         </channels>
 
-        <config-description>
-            <parameter name="id" type="integer" required="true">
-                <label>ID</label>
-                <description>The identifier of the controller on the gateway</description>
-            </parameter>
-        </config-description>
+        <representation-property>id</representation-property>
+
+        <config-description-ref uri="thing-type:tradfri:device" />
     </thing-type>
 
     <channel-type id="brightness">

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Tradfri Binding
+Bundle-Name: TRÅDFRI Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri;singleton:=tr
  ue

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/README.md
@@ -1,6 +1,6 @@
-# Trådfri Binding
+# TRÅDFRI Binding
 
-This binding integrates the IKEA Trådfri gateway and devices connected to it (such as dimmable LED bulbs).
+This binding integrates the IKEA TRÅDFRI gateway and devices connected to it (such as dimmable LED bulbs).
 
 ## Supported Things
 

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/pom.xml
@@ -13,7 +13,7 @@
 	<artifactId>org.eclipse.smarthome.binding.tradfri</artifactId>
 	<version>0.9.0-SNAPSHOT</version>
 
-	<name>Tradfri Binding</name>
+	<name>TRÅDFRI Binding</name>
 	<packaging>eclipse-plugin</packaging>
 
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryParticipant.java
@@ -76,7 +76,7 @@ public class TradfriDiscoveryParticipant implements MDNSDiscoveryParticipant {
                 if (fwVersion != null) {
                     properties.put(Thing.PROPERTY_FIRMWARE_VERSION, fwVersion);
                 }
-                return DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel("Trådfri Gateway")
+                return DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel("TRÅDFRI Gateway")
                         .withRepresentationProperty(GatewayConfig.HOST).build();
             }
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants;
 import org.eclipse.smarthome.binding.tradfri.handler.TradfriGatewayHandler;
 import org.eclipse.smarthome.binding.tradfri.internal.DeviceUpdateListener;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
@@ -40,13 +39,13 @@ public class TradfriDiscoveryService extends AbstractDiscoveryService implements
     private final TradfriGatewayHandler handler;
 
     private static final String[] COLOR_TEMP_MODELS = new String[] { "TRADFRI bulb E27 WS opal 980lm",
-            "TRADFRI bulb GU10 WS 400lm", "TRADFRI bulb E14 WS opal 400lm", "FLOALT panel WS 30x30",
-            "FLOALT panel WS 60x60", "FLOALT panel WS 30x90" };
+            "TRADFRI bulb E27 WS clear 950lm", "TRADFRI bulb GU10 WS 400lm", "TRADFRI bulb E14 WS opal 400lm",
+            "FLOALT panel WS 30x30", "FLOALT panel WS 60x60", "FLOALT panel WS 30x90" };
 
     private static final String COLOR_MODELS_IDENTIFIER = "CWS";
 
     public TradfriDiscoveryService(TradfriGatewayHandler bridgeHandler) {
-        super(TradfriBindingConstants.SUPPORTED_LIGHT_TYPES_UIDS, 10, true);
+        super(SUPPORTED_LIGHT_TYPES_UIDS, 10, true);
         this.handler = bridgeHandler;
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -39,10 +39,11 @@ public class TradfriDiscoveryService extends AbstractDiscoveryService implements
 
     private final TradfriGatewayHandler handler;
 
-    private final String[] COLOR_TEMP_MODELS = new String[] { "TRADFRI bulb E27 WS opal 980lm",
-            "TRADFRI bulb GU10 WS 400lm", "TRADFRI bulb E14 WS opal 400lm" };
+    private static final String[] COLOR_TEMP_MODELS = new String[] { "TRADFRI bulb E27 WS opal 980lm",
+            "TRADFRI bulb GU10 WS 400lm", "TRADFRI bulb E14 WS opal 400lm", "FLOALT panel WS 30x30",
+            "FLOALT panel WS 60x60", "FLOALT panel WS 30x90" };
 
-    private final String COLOR_MODELS_IDENTIFIER = "CWS";
+    private static final String COLOR_MODELS_IDENTIFIER = "CWS";
 
     public TradfriDiscoveryService(TradfriGatewayHandler bridgeHandler) {
         super(TradfriBindingConstants.SUPPORTED_LIGHT_TYPES_UIDS, 10, true);


### PR DESCRIPTION
- Added "FLOALT" panels and "TRADFRI bulb E27 WS clear 950lm" to `COLOR_TEMP_MODELS`
- Added representation-property to thing types
- Refactored xml files and applied formatter on xml files
- Changed spelling of TRÅDFRI throughout the whole binding

After you added a FLOALT panel to your environment it is correclty discovered as 0220 thing type. Once it becomes not reachable it is additionally discovered as 0100 thing type. This fix should prevent this behavior.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>