### PR TITLE
[UI] Charts: New white theme and small improvements

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartTheme.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartTheme.java
@@ -120,15 +120,17 @@ public interface ChartTheme {
     /**
      * Padding of the chart.
      *
+     * @param dpi the DPI to calculate the padding
      * @return padding of the chart
      */
-    public int getChartPadding();
+    public int getChartPadding(int dpi);
 
     /**
      * Length of the line markers in the legend, in px.
      *
+     * @param dpi the DPI to calculate the line length
      * @return length of the line markers in the legend, in px
      */
-    public int getLegendSeriesLineLength();
+    public int getLegendSeriesLineLength(int dpi);
 
 }

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeBlack.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeBlack.java
@@ -102,13 +102,13 @@ public class ChartThemeBlack implements ChartTheme {
     }
 
     @Override
-    public int getChartPadding() {
-        return 5;
+    public int getChartPadding(int dpi) {
+        return (int) Math.max(5, Math.round(dpi / 19.0));
     }
 
     @Override
-    public int getLegendSeriesLineLength() {
-        return 10;
+    public int getLegendSeriesLineLength(int dpi) {
+        return (int) Math.max(10, Math.round(dpi / 12.0));
     }
 
 }

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeDark.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeDark.java
@@ -102,13 +102,13 @@ public class ChartThemeDark implements ChartTheme {
     }
 
     @Override
-    public int getChartPadding() {
-        return 5;
+    public int getChartPadding(int dpi) {
+        return (int) Math.max(5, Math.round(dpi / 19.0));
     }
 
     @Override
-    public int getLegendSeriesLineLength() {
-        return 10;
+    public int getLegendSeriesLineLength(int dpi) {
+        return (int) Math.max(10, Math.round(dpi / 12.0));
     }
 
 }

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeWhite.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/ChartThemeWhite.java
@@ -11,17 +11,26 @@ import java.awt.Color;
 import java.awt.Font;
 
 /**
- * Implementation of the default bright {@link ChartTheme chart theme}.
+ * Implementation of the white {@link ChartTheme chart theme}.
  *
  * @author Holger Reichert - Initial contribution
  *
  */
-public class ChartThemeBright implements ChartTheme {
+public class ChartThemeWhite implements ChartTheme {
 
-    private static final String THEME_NAME = "bright";
+    private static final String THEME_NAME = "white";
 
-    private static final Color[] LINECOLORS = new Color[] { Color.RED, Color.GREEN, Color.BLUE, Color.MAGENTA,
-            Color.ORANGE, Color.CYAN, Color.PINK, Color.DARK_GRAY, Color.YELLOW };
+    private Color[] LINECOLORS = new Color[] { //
+            new Color(244, 67, 54), // red
+            new Color(76, 175, 80), // green
+            new Color(63, 81, 181), // blue
+            new Color(156, 39, 176), // magenta/purple
+            new Color(255, 152, 0), // orange
+            new Color(0, 188, 212), // cyan
+            new Color(233, 30, 99), // pink
+            new Color(50, 50, 50), // dark grey
+            new Color(205, 220, 57) // yellow/lime
+    };
 
     private static final String FONT_NAME = "SansSerif";
 
@@ -32,7 +41,7 @@ public class ChartThemeBright implements ChartTheme {
 
     @Override
     public Color getPlotBackgroundColor() {
-        return new Color(254, 254, 254);
+        return Color.WHITE;
     }
 
     @Override
@@ -52,12 +61,12 @@ public class ChartThemeBright implements ChartTheme {
 
     @Override
     public Color getLegendBackgroundColor() {
-        return new Color(224, 224, 224, 160);
+        return new Color(255, 255, 255, 160);
     }
 
     @Override
     public Color getChartBackgroundColor() {
-        return new Color(224, 224, 224, 224);
+        return Color.WHITE;
     }
 
     @Override

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/defaultchartprovider/DefaultChartProvider.java
@@ -64,8 +64,8 @@ public class DefaultChartProvider implements ChartProvider {
 
     private int legendPosition = 0;
 
-    private static final ChartTheme[] CHART_THEMES_AVAILABLE = { new ChartThemeBright(), new ChartThemeDark(),
-            new ChartThemeBlack() };
+    private static final ChartTheme[] CHART_THEMES_AVAILABLE = { new ChartThemeWhite(), new ChartThemeBright(),
+            new ChartThemeDark(), new ChartThemeBlack() };
     public static final String CHART_THEME_DEFAULT_NAME = "bright";
     private Map<String, ChartTheme> chartThemes = null;
 
@@ -157,11 +157,12 @@ public class DefaultChartProvider implements ChartProvider {
         chart.getStyleManager().setAxisTickLabelsColor(chartTheme.getAxisTickLabelsColor());
         chart.getStyleManager().setXAxisMin(startTime.getTime());
         chart.getStyleManager().setXAxisMax(endTime.getTime());
-        chart.getStyleManager().setYAxisTickMarkSpacingHint(height / 10);
+        int yAxisSpacing = Math.max(height / 10, chartTheme.getAxisTickLabelsFont(dpi).getSize());
+        chart.getStyleManager().setYAxisTickMarkSpacingHint(yAxisSpacing);
         // chart
         chart.getStyleManager().setChartBackgroundColor(chartTheme.getChartBackgroundColor());
         chart.getStyleManager().setChartFontColor(chartTheme.getChartFontColor());
-        chart.getStyleManager().setChartPadding(chartTheme.getChartPadding());
+        chart.getStyleManager().setChartPadding(chartTheme.getChartPadding(dpi));
         chart.getStyleManager().setPlotBackgroundColor(chartTheme.getPlotBackgroundColor());
         float plotGridLinesDash = (float) chartTheme.getPlotGridLinesDash(dpi);
         float[] plotGridLinesDashArray = { plotGridLinesDash, plotGridLinesDash };
@@ -171,7 +172,7 @@ public class DefaultChartProvider implements ChartProvider {
         // legend
         chart.getStyleManager().setLegendBackgroundColor(chartTheme.getLegendBackgroundColor());
         chart.getStyleManager().setLegendFont(chartTheme.getLegendFont(dpi));
-        chart.getStyleManager().setLegendSeriesLineLength(chartTheme.getLegendSeriesLineLength());
+        chart.getStyleManager().setLegendSeriesLineLength(chartTheme.getLegendSeriesLineLength(dpi));
 
         // If a persistence service is specified, find the provider
         persistenceService = null;
@@ -378,7 +379,8 @@ public class DefaultChartProvider implements ChartProvider {
         }
 
         Series series = chart.addSeries(label, xData, yData);
-        series.setLineStyle(new BasicStroke((float) chartTheme.getLineWidth(dpi)));
+        float lineWidth = (float) chartTheme.getLineWidth(dpi);
+        series.setLineStyle(new BasicStroke(lineWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER));
         series.setMarker(SeriesMarker.NONE);
         series.setLineColor(color);
 


### PR DESCRIPTION
Add new `white` chart theme and some small improvements.

# New chart theme `white`
Currently there are 3 chart themes: bright, dark, black
This PR completes the list with a new `white` theme, so that the following themes are available:
* white :left_right_arrow: black
* bright :left_right_arrow: dark

Rendering with `theme=white`:
![chart_white](https://user-images.githubusercontent.com/21249127/31101377-b16bea12-a7cd-11e7-8c6b-5b4b093e5ada.png)

# Better DPI based calculations
With high resolutions and high DPI values, the padding and the legend line widths were not calculated correctly. This resulted in chopped off and/or overlapping axis labels. The calculation is now based on the DPI value.

# Revised chart stroking options
With high DPI values, the chart strokes looked a bit ugly. Fixed with better parameters for the `BasicStroke`

Before:
![chart_stroke_1](https://user-images.githubusercontent.com/21249127/31101707-2528b434-a7cf-11e7-9157-798409bc446d.png)

After:
![chart_stroke_2](https://user-images.githubusercontent.com/21249127/31101713-2988d932-a7cf-11e7-96b3-cf5c36362a40.png)
