### PR TITLE
PaperUI: Always show add channel button for extensible things

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.things.view.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/configuration.things.view.html
@@ -31,7 +31,7 @@
 		</div>
 		<div ng-include="'partials/configuration.firmware.html'"></div>
 		<br />
-		<h2 class="inline" ng-show="thing.channels.length > 0">Channels
+		<h2 class="inline" ng-show="thing.channels.length > 0 || isExtensible()">Channels
 		<button ng-if="isExtensible()" class="extensible-thing md-fab md-custom-plus md-button md-ink-ripple" type="button" ng-click="addChannel($event)" aria-label="Add">
 		    <span class="ng-scope">+</span>
 		    <div class="md-ripple-container"></div>


### PR DESCRIPTION
This fixes an issue where the "+" button was not shown when no channels where present on the specific thing.

Signed-off-by: Henning Treu <henning.treu@telekom.de>