### PR TITLE
Leverage link configuration to select the profile

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/dto/ConfigDescriptionDTOMapper.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/dto/ConfigDescriptionDTOMapper.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.smarthome.config.core.dto;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -36,7 +37,12 @@ public class ConfigDescriptionDTOMapper {
         List<ConfigDescriptionParameterGroupDTO> parameterGroups = mapParameterGroups(
                 configDescription.getParameterGroups());
         List<ConfigDescriptionParameterDTO> parameters = mapParameters(configDescription.getParameters());
-        return new ConfigDescriptionDTO(configDescription.getUID().toString(), parameters, parameterGroups);
+        return new ConfigDescriptionDTO(toDecodedString(configDescription.getUID()), parameters, parameterGroups);
+    }
+
+    private static String toDecodedString(URI uri) {
+        // combine these partials because URI.toString() does not decode
+        return uri.getScheme() + ":" + uri.getSchemeSpecificPart();
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultMasterProfileTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultMasterProfileTest.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
 import static org.junit.Assert.assertEquals;
@@ -21,6 +28,11 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
+/**
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
 public class DefaultMasterProfileTest {
 
     private static final String TEST_ITEM = "testItem";

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultSlaveProfileTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultSlaveProfileTest.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
 import static org.junit.Assert.assertEquals;
@@ -21,6 +28,11 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
+/**
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
 public class DefaultSlaveProfileTest {
 
     private static final String TEST_ITEM = "testItem";

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.internal.link;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.smarthome.config.core.ConfigDescription;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
+import org.eclipse.smarthome.config.core.ConfigDescriptionProvider;
+import org.eclipse.smarthome.config.core.ParameterOption;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingRegistry;
+import org.eclipse.smarthome.core.thing.internal.profiles.DefaultProfileFactory;
+import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
+import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
+import org.eclipse.smarthome.core.thing.profiles.ProfileAdvisor;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+/**
+ * Provider for framework config parameters on {@link ItemChannelLink}s.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+@Component
+public class ItemChannelLinkConfigDescriptionProvider implements ConfigDescriptionProvider {
+
+    private static final String SCHEME = "link";
+
+    public static final String PARAM_PROFILE = "profile";
+
+    private final Set<ProfileAdvisor> profileAdvisors = new CopyOnWriteArraySet<>();
+    private final ProfileAdvisor defaultProfileFactory = new DefaultProfileFactory();
+
+    private ItemChannelLinkRegistry itemChannelLinkRegistry;
+    private ItemRegistry itemRegistry;
+    private ThingRegistry thingRegistry;
+
+    @Override
+    public Collection<ConfigDescription> getConfigDescriptions(Locale locale) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public ConfigDescription getConfigDescription(URI uri, Locale locale) {
+        if (SCHEME.equals(uri.getScheme())) {
+            ItemChannelLink link = itemChannelLinkRegistry.get(uri.getSchemeSpecificPart());
+            if (link == null) {
+                return null;
+            }
+            Item item = itemRegistry.get(link.getItemName());
+            if (item == null) {
+                return null;
+            }
+            Thing thing = thingRegistry.get(link.getLinkedUID().getThingUID());
+            if (thing == null) {
+                return null;
+            }
+            Channel channel = thing.getChannel(link.getLinkedUID().getId());
+            if (channel == null) {
+                return null;
+            }
+            ConfigDescriptionParameter paramProfile = ConfigDescriptionParameterBuilder.create(PARAM_PROFILE, Type.TEXT)
+                    .withLabel("Profile").withDescription("the profile to use").withRequired(false)
+                    .withLimitToOptions(true).withOptions(getOptions(link, item, channel, locale)).build();
+            return new ConfigDescription(uri, Collections.singletonList(paramProfile));
+        }
+        return null;
+    }
+
+    private List<ParameterOption> getOptions(ItemChannelLink link, Item item, Channel channel, Locale locale) {
+        return Stream
+                .concat(Stream.of(defaultProfileFactory.getApplicableProfileTypeUIDs(link, item, channel)),
+                        profileAdvisors.stream().map(f -> f.getApplicableProfileTypeUIDs(link, item, channel)))
+                .flatMap(c -> c.stream())
+                .map(profileTypeUID -> new ParameterOption(profileTypeUID.toString(), profileTypeUID.getLabel()))
+                .collect(Collectors.toList());
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    public void addProfileAdvisor(ProfileAdvisor profileAdvisor) {
+        profileAdvisors.add(profileAdvisor);
+    }
+
+    public void removeProfileAdvisor(ProfileAdvisor profileAdvisor) {
+        profileAdvisors.remove(profileAdvisor);
+    }
+
+    @Reference
+    public void setItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+    }
+
+    public void unsetItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
+        this.itemChannelLinkRegistry = null;
+    }
+
+    @Reference
+    public void setItemRegistry(ItemRegistry itemRegistry) {
+        this.itemRegistry = itemRegistry;
+    }
+
+    public void unsetItemRegistry(ItemRegistry itemRegistry) {
+        this.itemRegistry = null;
+    }
+
+    @Reference
+    public void setThingRegistry(ThingRegistry thingRegistry) {
+        this.thingRegistry = thingRegistry;
+    }
+
+    public void unsetThingRegistry(ThingRegistry thingRegistry) {
+        this.thingRegistry = thingRegistry;
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultMasterProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultMasterProfile.java
@@ -17,6 +17,7 @@ import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
 import org.eclipse.smarthome.core.thing.profiles.StateProfile;
 import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
 import org.eclipse.smarthome.core.types.Command;
@@ -36,6 +37,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultMasterProfile implements StateProfile {
 
     private final Logger logger = LoggerFactory.getLogger(DefaultMasterProfile.class);
+    public static final ProfileTypeUID UID = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "master", "Master");
 
     @Override
     public void onCommand(ItemChannelLink link, Thing thing, Command command) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultProfileFactory.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
+import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
+import org.eclipse.smarthome.core.thing.profiles.Profile;
+import org.eclipse.smarthome.core.thing.profiles.ProfileAdvisor;
+import org.eclipse.smarthome.core.thing.profiles.ProfileFactory;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * A factory and advisor for default profiles.
+ *
+ * This {@link ProfileAdvisor} and {@link ProfileFactory} implementation handles all default {@link Profile}s.
+ * It will be used as an advisor if the link is not configured and no other advisor returned a result (in that order).
+ * The same applies to the creation of profile instances: This factory will be used of no other factory supported the
+ * required profile type.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+@Component(service = DefaultProfileFactory.class)
+public class DefaultProfileFactory implements ProfileFactory, ProfileAdvisor {
+
+    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPES = Stream
+            .of(DefaultMasterProfile.UID, DefaultSlaveProfile.UID, RawButtonToggleProfile.UID)
+            .collect(Collectors.toSet());
+
+    @Override
+    public Profile createProfile(ProfileTypeUID profileTypeUID) {
+        if (DefaultMasterProfile.UID.equals(profileTypeUID)) {
+            return new DefaultMasterProfile();
+        } else if (DefaultSlaveProfile.UID.equals(profileTypeUID)) {
+            return new DefaultSlaveProfile();
+        } else if (RawButtonToggleProfile.UID.equals(profileTypeUID)) {
+            return new RawButtonToggleProfile();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public Collection<ProfileTypeUID> getSupportedProfileTypeUIDs() {
+        return SUPPORTED_PROFILE_TYPES;
+    }
+
+    @Override
+    public Collection<ProfileTypeUID> getApplicableProfileTypeUIDs(ItemChannelLink link, Item item, Channel channel) {
+        switch (channel.getKind()) {
+            case STATE:
+                return Stream.of(DefaultMasterProfile.UID, DefaultSlaveProfile.UID).collect(Collectors.toList());
+            case TRIGGER:
+                if (DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID().equals(channel.getChannelTypeUID())) {
+                    return Collections.singletonList(RawButtonToggleProfile.UID);
+                }
+                break;
+            default:
+                throw new NotImplementedException();
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public ProfileTypeUID getSuggestedProfileTypeUID(ItemChannelLink link, Item item, Channel channel) {
+        switch (channel.getKind()) {
+            case STATE:
+                return DefaultMasterProfile.UID;
+            case TRIGGER:
+                if (DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID().equals(channel.getChannelTypeUID())) {
+                    return RawButtonToggleProfile.UID;
+                }
+                break;
+            default:
+                throw new NotImplementedException();
+        }
+        return null;
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultSlaveProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/DefaultSlaveProfile.java
@@ -16,6 +16,7 @@ import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
 import org.eclipse.smarthome.core.thing.profiles.StateProfile;
 import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
 import org.eclipse.smarthome.core.types.Command;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 public class DefaultSlaveProfile implements StateProfile {
 
     private final Logger logger = LoggerFactory.getLogger(DefaultSlaveProfile.class);
+    public static final ProfileTypeUID UID = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "slave", "Slave");
 
     @Override
     public void onUpdate(ItemChannelLink link, Thing thing, State state) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonToggleProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonToggleProfile.java
@@ -13,6 +13,7 @@ import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
 import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
 
 /**
@@ -25,6 +26,9 @@ import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
  *
  */
 public class RawButtonToggleProfile implements TriggerProfile {
+
+    public static final ProfileTypeUID UID = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawbutton-toggle",
+            "Raw Button Toggle");
 
     @Override
     public void onTrigger(EventPublisher eventPublisher, ItemChannelLink link, String event, Item item) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileAdvisor.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileAdvisor.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.profiles;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
+
+/**
+ * Implementors can give advice which {@link Profile}s can/should be used for a given link.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+@NonNullByDefault
+public interface ProfileAdvisor {
+
+    /**
+     * Return all custom profiles which can be applied to the given link.
+     *
+     * Please note: The default profiles must not returned here.
+     *
+     * @param link the Link
+     * @param item the linked item (for convenience)
+     * @param channel the linked channel (for convenience)
+     * @return a collection of profile type IDs.
+     */
+    Collection<ProfileTypeUID> getApplicableProfileTypeUIDs(ItemChannelLink link, Item item, Channel channel);
+
+    /**
+     * Suggest a custom profile for the given link, if applicable at all.
+     *
+     * Please note:
+     * <ul>
+     * <li>This will override any default behavior
+     * <li>A "profile" configuration on the link will override this suggestion
+     * </ul>
+     *
+     * @param link the Link
+     * @param item the linked item (for convenience)
+     * @param channel the linked channel (for convenience)
+     * @return the profile identifier or {@code null} if this advisor
+     */
+    @Nullable
+    ProfileTypeUID getSuggestedProfileTypeUID(ItemChannelLink link, Item item, Channel channel);
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileFactory.java
@@ -7,29 +7,34 @@
  */
 package org.eclipse.smarthome.core.thing.profiles;
 
-import org.eclipse.jdt.annotation.NonNull;
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.core.items.Item;
-import org.eclipse.smarthome.core.thing.Channel;
-import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 
 /**
- * Implementors are capable of creating a {@link Profile} for one or several links.
+ * Implementors are capable of creating a {@link Profile} instances.
  *
  * @author Simon Kaufmann - initial contribution and API.
  *
  */
+@NonNullByDefault
 public interface ProfileFactory {
 
     /**
-     * Create a {@link Profile} instance for the given link
+     * Create a {@link Profile} instance for the given profile tye ID.
      *
-     * @param link the ItemChannelLink for which the profile should be created
-     * @param item the linked item (for convenience)
-     * @param channel the linked channel (for convenience)
-     * @return a profile instance or {@code null} if this factory does not handle the given link
+     * @param profileTypeUID the profile identifier
+     * @return a profile instance or {@code null} if this factory cannot handle the given link
      */
     @Nullable
-    Profile createProfile(@NonNull ItemChannelLink link, @NonNull Item item, @NonNull Channel channel);
+    Profile createProfile(ProfileTypeUID profileTypeUID);
+
+    /**
+     * Return the identifiers of all supported profile types
+     *
+     * @return a collection of all profile type identifier which this class is capable of creating
+     */
+    Collection<ProfileTypeUID> getSupportedProfileTypeUIDs();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeUID.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.profiles;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.UID;
+
+/**
+ * Identifier of a profile type.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+@NonNullByDefault
+public class ProfileTypeUID extends UID {
+
+    public static final String SYSTEM_SCOPE = "system";
+
+    @Nullable
+    private final String label;
+
+    public ProfileTypeUID(String profileType) {
+        super(profileType);
+        this.label = null;
+    }
+
+    public ProfileTypeUID(String scope, String id, String label) {
+        super(scope, id);
+        this.label = label;
+    }
+
+    @Override
+    protected int getMinimalNumberOfSegments() {
+        return 2;
+    }
+
+    public String getScope() {
+        return getSegment(0);
+    }
+
+    public String getId() {
+        return getSegment(1);
+    }
+
+    @Nullable
+    public String getLabel() {
+        return label;
+    }
+
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/config/ConfigDescriptionResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/config/ConfigDescriptionResource.java
@@ -8,7 +8,6 @@
 package org.eclipse.smarthome.io.rest.core.internal.config;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Locale;
 
@@ -21,6 +20,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
@@ -76,14 +76,10 @@ public class ConfigDescriptionResource implements RESTResource {
     public Response getByURI(@HeaderParam("Accept-Language") @ApiParam(value = "Accept-Language") String language,
             @PathParam("uri") @ApiParam(value = "uri") String uri) {
         Locale locale = LocaleUtil.getLocale(language);
-        try {
-            ConfigDescription configDescription = this.configDescriptionRegistry.getConfigDescription(new URI(uri),
-                    locale);
-            return configDescription != null ? Response.ok(ConfigDescriptionDTOMapper.map(configDescription)).build()
-                    : JSONResponse.createErrorResponse(Status.NOT_FOUND, "Configuration not found: " + uri);
-        } catch (URISyntaxException e) {
-            return JSONResponse.createErrorResponse(Status.BAD_REQUEST, "Exception getting confinguration description");
-        }
+        URI uriObject = UriBuilder.fromPath(uri).build();
+        ConfigDescription configDescription = this.configDescriptionRegistry.getConfigDescription(uriObject, locale);
+        return configDescription != null ? Response.ok(ConfigDescriptionDTOMapper.map(configDescription)).build()
+                : JSONResponse.createErrorResponse(Status.NOT_FOUND, "Configuration not found: " + uri);
     }
 
     protected void setConfigDescriptionRegistry(ConfigDescriptionRegistry configDescriptionRegistry) {


### PR DESCRIPTION
With this, the ItemChannelLink configuration can be used to select
which profile should be used:

```
Switch someItem {
      channel="a:b:c:channel1" [
          profile="master"
      ]
      channel="a:b:c:channel2" [
          profile="system:slave"
      ]
      channel="a:b:c:channel3" [
          profile="mybinding:foo"
      ]
}
```

The profile identifiers are namespaced, so bindings can bring their own.
There is a "system" namespace which also is the default if no namespace is
given (like in the "master" example above).

There is a config description available for the links under

```
    link:<itemName> -> <channelUID>
```

which also includes all applicable profiles in its options.

fixes #2226
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>