### PR TITLE
JsonPath transformation service comply with the contract

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
@@ -8,4 +8,6 @@ Bundle-Version: 0.9.0.qualifier
 Fragment-Host: org.eclipse.smarthome.transform.jsonpath
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
+ org.hamcrest,
  org.junit;version="4.0.0"
+Require-Bundle: org.hamcrest

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
@@ -7,8 +7,9 @@
  */
 package org.eclipse.smarthome.transform.jsonpath.internal;
 
+import static org.junit.Assert.assertEquals;
+
 import org.eclipse.smarthome.core.transform.TransformationException;
-import org.eclipse.smarthome.transform.jsonpath.internal.JSonPathTransformationService;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,47 +28,45 @@ public class JSonPathTransformationServiceTest {
 
     @Test
     public void testTransformByJSon() throws TransformationException {
-    	
-    	String json = "{'store':{'book':[{'category':'reference','author':'Nigel Rees','title': 'Sayings of the Century', 'price': 8.95  } ],  'bicycle': { 'color': 'red',  'price': 19.95} }}"; 
+
+        String json = "{'store':{'book':[{'category':'reference','author':'Nigel Rees','title': 'Sayings of the Century', 'price': 8.95  } ],  'bicycle': { 'color': 'red',  'price': 19.95} }}";
         // method under test
-        String transformedResponse = processor.transform("$.store.book[0].author",json);
+        String transformedResponse = processor.transform("$.store.book[0].author", json);
 
         // Asserts
         Assert.assertEquals("Nigel Rees", transformedResponse);
     }
-    
-    private static final String jsonArray = "["
-            + "{ \"id\":1, \"name\":\"bob\" },"
-            + "{ \"id\":2, \"name\":\"alice\" }"
-            + "]";
+
+    private static final String jsonArray = "[" + //
+            "{ \"id\":1, \"name\":\"bob\" }," + //
+            "{ \"id\":2, \"name\":\"alice\" }" + //
+            "]";
 
     @Test
     public void testValidPath1() throws TransformationException {
         String transformedResponse = processor.transform("$[0].name", jsonArray);
-        assert(transformedResponse == "bob");
+        assertEquals("bob", transformedResponse);
     }
 
     @Test
     public void testValidPath2() throws TransformationException {
         String transformedResponse = processor.transform("$[1].id", jsonArray);
-        assert(transformedResponse == "2");
+        assertEquals("2", transformedResponse);
     }
-    
+
     @Test(expected = TransformationException.class)
     public void testInvalidPathThrowsException() throws TransformationException {
         processor.transform("$$", jsonArray);
     }
-    
-    @Test
+
+    @Test(expected = TransformationException.class)
     public void testPathMismatchReturnNull() throws TransformationException {
-        String transformedResponse = processor.transform("$[5].id", jsonArray);
-        assert(transformedResponse == null);
+        processor.transform("$[5].id", jsonArray);
     }
-    
-    @Test
+
+    @Test(expected = TransformationException.class)
     public void testInvalidJsonReturnNull() throws TransformationException {
-        String transformedResponse = processor.transform("$", jsonArray.substring(1));
-        assert(transformedResponse == null);
+        processor.transform("$", "{id:");
     }
 
 }

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -12,6 +12,7 @@ import org.eclipse.smarthome.core.transform.TransformationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.jayway.jsonpath.InvalidJsonException;
 import com.jayway.jsonpath.InvalidPathException;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.PathNotFoundException;
@@ -48,10 +49,10 @@ public class JSonPathTransformationService implements TransformationService {
         try {
             Object transformationResult = JsonPath.read(source, jsonPathExpression);
             logger.debug("transformation resulted in '{}'", transformationResult);
-            return (transformationResult != null) ? transformationResult.toString() : null;
+            return (transformationResult != null) ? transformationResult.toString() : source;
         } catch (PathNotFoundException e) {
-            return null;
-        } catch (InvalidPathException e) {
+            throw new TransformationException("Invalid path '" + jsonPathExpression + "' in '" + source + "'");
+        } catch (InvalidPathException | InvalidJsonException e) {
             throw new TransformationException("An error occurred while transforming JSON expression.", e);
         }
 


### PR DESCRIPTION
...as it was returning null in case the path pointed to an element which did not exist.
Now it throws a TransformationException. 

I'm not 100% sure though if this _really_ is _always_ the right way of fixing it. A missing element in JSON is somewhat similar to "intentionally null", i.e. `UndefType.UNDEF` might also be a consideration. Any deeper insights anybody?

fixes #4376
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>