### PR TITLE
[ui/Charts] Explicitly close the image output-stream, using a try-with-resources

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/ChartServlet.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/ChartServlet.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import javax.imageio.ImageIO;
+import javax.imageio.stream.ImageOutputStream;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -274,10 +275,10 @@ public class ChartServlet extends HttpServlet {
 
         // Set the content type to that provided by the chart provider
         res.setContentType("image/" + provider.getChartType());
-        try {
+        try (ImageOutputStream imageOutputStream = ImageIO.createImageOutputStream(res.getOutputStream())) {
             BufferedImage chart = provider.createChart(serviceName, req.getParameter("theme"), timeBegin, timeEnd,
                     height, width, req.getParameter("items"), req.getParameter("groups"), dpi, legend);
-            ImageIO.write(chart, provider.getChartType().toString(), res.getOutputStream());
+            ImageIO.write(chart, provider.getChartType().toString(), imageOutputStream);
         } catch (ItemNotFoundException e) {
             logger.debug("{}", e.getMessage());
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Folloing the openHAB community topic:

https://community.openhab.org/t/java-io-ioexception-too-many-open-files/28204/10?u=martinvw

The current implementation is depending on: 

```
This class provide means to properly close hanging
image input/output streams on VM shutdown.
This might be useful for proper cleanup such as removal
of temporary files.
```
Source: https://github.com/frohoff/jdk8u-dev-jdk/blob/master/src/share/classes/com/sun/imageio/stream/StreamCloser.java#L34

The complete stack looks like
[ChartServlet.java:280](https://github.com/eclipse/smarthome/blob/master/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/ChartServlet.java#L280)
[ImageIO.java:1572](https://github.com/frohoff/jdk8u-dev-jdk/blob/master/src/share/classes/javax/imageio/ImageIO.java#L1572)
[ImageIO.java:419](https://github.com/frohoff/jdk8u-dev-jdk/blob/master/src/share/classes/javax/imageio/ImageIO.java#L419)
[OutputStreamImageOutputStreamSpi.java:68](https://github.com/frohoff/jdk8u-dev-jdk/blob/master/src/share/classes/com/sun/imageio/spi/OutputStreamImageOutputStreamSpi.java#L68)
[FileCacheImageOutputStream.java:95](https://github.com/frohoff/jdk8u-dev-jdk/blob/master/src/share/classes/javax/imageio/stream/FileCacheImageOutputStream.java#L95)

