### PR TITLE
Support for quoted strings in rule triggers

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
@@ -96,7 +96,7 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
     @Activate
     public void activate() {
         injector = RulesStandaloneSetup.getInjector();
-        triggerManager = injector.getInstance(RuleTriggerManager.class);
+        triggerManager = new RuleTriggerManager(injector);
 
         if (!isEnabled()) {
             logger.info("Rule engine is disabled.");
@@ -440,5 +440,9 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
         } else if (event instanceof ThingStatusInfoChangedEvent) {
             receiveThingStatus((ThingStatusInfoChangedEvent) event);
         }
+    }
+
+    RuleTriggerManager getTriggerManager() {
+        return triggerManager;
     }
 }

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTriggerManager.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTriggerManager.java
@@ -61,7 +61,6 @@ import org.quartz.impl.matchers.GroupMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 
 /**
@@ -106,7 +105,6 @@ public class RuleTriggerManager {
     // the scheduler used for timer events
     private Scheduler scheduler;
 
-    @Inject
     public RuleTriggerManager(Injector injector) {
         try {
             scheduler = StdSchedulerFactory.getDefaultScheduler();
@@ -234,7 +232,7 @@ public class RuleTriggerManager {
                             EventEmittedTrigger et = (EventEmittedTrigger) t;
 
                             if (et.getChannel().equals(channel)
-                                    && (et.getTrigger() == null || et.getTrigger().equals(event))) {
+                                    && (et.getTrigger() == null || et.getTrigger().getValue().equals(event))) {
                                 // if the rule does not have a specific event , execute it on any event
                                 result.add(rule);
                             }
@@ -300,14 +298,14 @@ public class RuleTriggerManager {
                 if ((!isGroup) && (t instanceof UpdateEventTrigger)) {
                     final UpdateEventTrigger ut = (UpdateEventTrigger) t;
                     if (ut.getItem().equals(name)) {
-                        triggerStateString = ut.getState();
+                        triggerStateString = ut.getState().getValue();
                     } else {
                         continue;
                     }
                 } else if ((isGroup) && (t instanceof GroupMemberUpdateEventTrigger)) {
                     final GroupMemberUpdateEventTrigger gmut = (GroupMemberUpdateEventTrigger) t;
                     if (gmut.getGroup().equals(name)) {
-                        triggerStateString = gmut.getState();
+                        triggerStateString = gmut.getState().getValue();
                     } else {
                         continue;
                     }
@@ -335,16 +333,16 @@ public class RuleTriggerManager {
                 if ((!isGroup) && (t instanceof ChangedEventTrigger)) {
                     final ChangedEventTrigger ct = (ChangedEventTrigger) t;
                     if (ct.getItem().equals(name)) {
-                        triggerOldStateString = ct.getOldState();
-                        triggerNewStateString = ct.getNewState();
+                        triggerOldStateString = ct.getOldState().getValue();
+                        triggerNewStateString = ct.getNewState().getValue();
                     } else {
                         continue;
                     }
                 } else if ((isGroup) && (t instanceof GroupMemberChangedEventTrigger)) {
                     final GroupMemberChangedEventTrigger gmct = (GroupMemberChangedEventTrigger) t;
                     if (gmct.getGroup().equals(name)) {
-                        triggerOldStateString = gmct.getOldState();
-                        triggerNewStateString = gmct.getNewState();
+                        triggerOldStateString = gmct.getOldState().getValue();
+                        triggerNewStateString = gmct.getNewState().getValue();
                     } else {
                         continue;
                     }
@@ -377,14 +375,14 @@ public class RuleTriggerManager {
                 if ((!isGroup) && (t instanceof CommandEventTrigger)) {
                     final CommandEventTrigger ct = (CommandEventTrigger) t;
                     if (ct.getItem().equals(name)) {
-                        triggerCommandString = ct.getCommand();
+                        triggerCommandString = ct.getCommand().getValue();
                     } else {
                         continue;
                     }
                 } else if ((isGroup) && (t instanceof GroupMemberCommandEventTrigger)) {
                     final GroupMemberCommandEventTrigger gmct = (GroupMemberCommandEventTrigger) t;
                     if (gmct.getGroup().equals(name)) {
-                        triggerCommandString = gmct.getCommand();
+                        triggerCommandString = gmct.getCommand().getValue();
                     } else {
                         continue;
                     }

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/.classpath
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/.classpath
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
@@ -6,20 +6,26 @@ Bundle-SymbolicName: org.eclipse.smarthome.model.rule.tests;singleton:=t
  rue
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
+Fragment-Host: org.eclipse.smarthome.model.rule.runtime
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.library.items,
+ org.eclipse.smarthome.model.core,
  org.eclipse.smarthome.model.script.engine,
+ org.eclipse.smarthome.test.java,
+ org.hamcrest,
  org.hamcrest.core,
+ org.junit,
+ org.junit.runner;version="4.0.0",
  org.junit.runner.manipulation;version="4.0.0",
  org.junit.runner.notification;version="4.0.0",
- org.junit.runner;version="4.0.0",
- org.junit.runners.model;version="4.0.0",
- org.junit.runners;version="4.0.0"
+ org.junit.runners;version="4.0.0",
+ org.junit.runners.model;version="4.0.0"
 Require-Bundle: 
  com.google.guava,
  org.eclipse.core.runtime,
  org.eclipse.smarthome.model.rule,
  org.eclipse.xtend.lib,
- org.eclipse.xtext.xbase.lib
+ org.eclipse.xtext.xbase.lib,
+ org.hamcrest

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/build.properties
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/build.properties
@@ -1,5 +1,4 @@
-source.. = src/,\
-           xtend-gen/
+source.. = src
 output.. = target/classes/
 bin.includes = META-INF/,\
                .,\

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/org.eclipse.smarthome.model.rule.tests.launch
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/org.eclipse.smarthome.model.rule.tests.launch
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.JunitLaunchConfig">
+<booleanAttribute key="append.args" value="true"/>
+<stringAttribute key="application" value="org.eclipse.pde.junit.runtime.coretestapplication"/>
+<booleanAttribute key="askclear" value="false"/>
+<booleanAttribute key="automaticAdd" value="false"/>
+<booleanAttribute key="automaticValidate" value="true"/>
+<stringAttribute key="bootstrap" value=""/>
+<stringAttribute key="checked" value="[NONE]"/>
+<booleanAttribute key="clearConfig" value="true"/>
+<booleanAttribute key="clearws" value="true"/>
+<booleanAttribute key="clearwslog" value="false"/>
+<stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/pde-junit"/>
+<booleanAttribute key="default" value="false"/>
+<booleanAttribute key="default_auto_start" value="true"/>
+<booleanAttribute key="includeOptional" value="false"/>
+<stringAttribute key="location" value="${workspace_loc}/../junit-workspace"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/org.eclipse.smarthome.model.rule.tests"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="4"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=org.eclipse.smarthome.model.rule.tests"/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+<stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.smarthome.model.rule.tests"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea"/>
+<stringAttribute key="pde.version" value="3.3"/>
+<stringAttribute key="product" value="org.eclipse.equinox.p2.director.app.product"/>
+<booleanAttribute key="run_in_ui_thread" value="false"/>
+<stringAttribute key="selected_target_plugins" value="ch.qos.logback.classic@default:default,ch.qos.logback.core@default:default,ch.qos.logback.slf4j@default:false,com.google.gson*2.2.4.v201311231704@default:default,com.google.guava@default:default,com.google.inject@default:default,javax.inject@default:default,javax.measure.unit-api@default:default,javax.servlet-api@default:default,net.bytebuddy.byte-buddy-agent@default:default,net.bytebuddy.byte-buddy@default:default,org.antlr.runtime@default:default,org.apache.ant@default:default,org.apache.commons.collections@default:default,org.apache.commons.exec@default:default,org.apache.commons.io@default:default,org.apache.commons.lang@default:default,org.apache.commons.logging@default:default,org.apache.felix.scr@2:default,org.apache.log4j@default:default,org.codehaus.groovy@default:default,org.eclipse.core.contenttype@default:default,org.eclipse.core.jobs@default:default,org.eclipse.core.runtime@default:true,org.eclipse.emf.common@default:default,org.eclipse.emf.ecore.xmi@default:default,org.eclipse.emf.ecore@default:default,org.eclipse.equinox.app@default:default,org.eclipse.equinox.common@2:true,org.eclipse.equinox.ds@2:true,org.eclipse.equinox.event@2:default,org.eclipse.equinox.preferences@default:default,org.eclipse.equinox.registry@default:default,org.eclipse.equinox.supplement@default:default,org.eclipse.jetty.client@default:default,org.eclipse.jetty.http*9.3.15.v20161220@default:default,org.eclipse.jetty.io*9.3.15.v20161220@default:default,org.eclipse.jetty.util*9.3.15.v20161220@default:default,org.eclipse.osgi.services@default:default,org.eclipse.osgi.util@default:default,org.eclipse.osgi@-1:true,org.eclipse.xtend.lib.macro@default:default,org.eclipse.xtend.lib@default:default,org.eclipse.xtext.common.types@default:default,org.eclipse.xtext.ecore@default:default,org.eclipse.xtext.smap@default:default,org.eclipse.xtext.util@default:default,org.eclipse.xtext.xbase.lib@default:default,org.eclipse.xtext.xbase@default:default,org.eclipse.xtext@default:default,org.hamcrest.core@default:default,org.hamcrest.integration@default:default,org.hamcrest.library@default:default,org.hamcrest.text@default:default,org.hamcrest@default:default,org.junit@default:default,org.mockito.mockito-core@default:default,org.objectweb.asm@default:default,org.objenesis@default:default,org.slf4j.api@default:default,tec.uom.lib.uom-lib-common@default:default,tec.uom.se@default:default"/>
+<stringAttribute key="selected_workspace_plugins" value="org.eclipse.smarthome.config.core@default:default,org.eclipse.smarthome.config.xml@default:default,org.eclipse.smarthome.core.audio@default:default,org.eclipse.smarthome.core.autoupdate@default:default,org.eclipse.smarthome.core.persistence@default:default,org.eclipse.smarthome.core.scheduler@default:default,org.eclipse.smarthome.core.thing@default:default,org.eclipse.smarthome.core.transform@default:default,org.eclipse.smarthome.core.voice@default:default,org.eclipse.smarthome.core@default:default,org.eclipse.smarthome.io.console@default:default,org.eclipse.smarthome.io.net@default:default,org.eclipse.smarthome.model.core@default:default,org.eclipse.smarthome.model.item@default:default,org.eclipse.smarthome.model.persistence@default:default,org.eclipse.smarthome.model.rule.runtime@default:default,org.eclipse.smarthome.model.rule.tests@default:false,org.eclipse.smarthome.model.rule@default:default,org.eclipse.smarthome.model.script.runtime@default:default,org.eclipse.smarthome.model.script@default:default,org.eclipse.smarthome.test@default:default"/>
+<booleanAttribute key="show_selected_only" value="false"/>
+<booleanAttribute key="tracing" value="false"/>
+<booleanAttribute key="useCustomFeatures" value="false"/>
+<booleanAttribute key="useDefaultConfig" value="true"/>
+<booleanAttribute key="useDefaultConfigArea" value="false"/>
+<booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/pom.xml
@@ -27,12 +27,75 @@
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
           <environments combine.self="override"></environments>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.model.script.runtime</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
         </configuration>
       </plugin>
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-      </plugin>
+        <configuration>
+          <bundleStartLevel>
+            <bundle>
+              <id>org.eclipse.equinox.ds</id>
+              <level>1</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.equinox.event</id>
+              <level>2</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core.thing</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.model.core</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.model.rule</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.model.rule.runtime</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.model.script.runtime</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+          </bundleStartLevel>
+        </configuration>
+      </plugin>    
     </plugins>
   </build>
 

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.model.rule.runtime.internal.engine;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.util.Iterator;
+import java.util.function.Function;
+
+import org.eclipse.smarthome.model.core.ModelRepository;
+import org.eclipse.smarthome.model.rule.rules.ChangedEventTrigger;
+import org.eclipse.smarthome.model.rule.rules.CommandEventTrigger;
+import org.eclipse.smarthome.model.rule.rules.EventEmittedTrigger;
+import org.eclipse.smarthome.model.rule.rules.EventTrigger;
+import org.eclipse.smarthome.model.rule.rules.Rule;
+import org.eclipse.smarthome.model.rule.runtime.RuleEngine;
+import org.eclipse.smarthome.model.rule.runtime.internal.engine.RuleTriggerManager.TriggerTypes;
+import org.eclipse.smarthome.test.java.JavaOSGiTest;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Simon Kaufmann - initial contribution and API.
+ */
+public class RuleTest extends JavaOSGiTest {
+
+    private final static String TESTMODEL_NAME = "testModel.rules";
+    private ModelRepository modelRepository;
+
+    @Before
+    public void setup() {
+        modelRepository = getService(ModelRepository.class);
+        assertNotNull(modelRepository);
+    }
+
+    @Test
+    public void testChangedEventTrigger_withoutQuotes() throws Exception {
+        String model = "rule\"State Machine Rule 1\" " + //
+                "when " + //
+                "    Item test changed to world " + //
+                "then " + //
+                "    logInfo(\"test says\", \"Boo!\") " + //
+                "end ";
+
+        assertTriggerWith(model, TriggerTypes.CHANGE, ChangedEventTrigger.class,
+                trigger -> trigger.getNewState().getValue());
+    }
+
+    @Test
+    public void testChangedEventTrigger_withQuotes() throws Exception {
+        String model = "rule\"State Machine Rule 1\" " + //
+                "when " + //
+                "    Item test changed to \"world\" " + //
+                "then " + //
+                "    logInfo(\"test says\", \"Boo!\") " + //
+                "end ";
+
+        assertTriggerWith(model, TriggerTypes.CHANGE, ChangedEventTrigger.class,
+                trigger -> trigger.getNewState().getValue());
+    }
+
+    @Test
+    public void testCommandEventTrigger_withoutQuotes() throws Exception {
+        String model = "rule\"State Machine Rule 1\" " + //
+                "when " + //
+                "    Item test received command world " + //
+                "then " + //
+                "    logInfo(\"test says\", \"Boo!\") " + //
+                "end ";
+
+        assertTriggerWith(model, TriggerTypes.COMMAND, CommandEventTrigger.class,
+                trigger -> trigger.getCommand().getValue());
+    }
+
+    @Test
+    public void testCommandEventTrigger_withQuotes() throws Exception {
+        String model = "rule\"State Machine Rule 1\" " + //
+                "when " + //
+                "    Item test received command \"world\" " + //
+                "then " + //
+                "    logInfo(\"test says\", \"Boo!\") " + //
+                "end ";
+
+        assertTriggerWith(model, TriggerTypes.COMMAND, CommandEventTrigger.class,
+                trigger -> trigger.getCommand().getValue());
+    }
+
+    @Test
+    public void testEventEmittedTrigger_withoutQuotes() throws Exception {
+        String model = "rule\"State Machine Rule 1\" " + //
+                "when " + //
+                "    Channel test triggered world " + //
+                "then " + //
+                "    logInfo(\"test says\", \"Boo!\") " + //
+                "end ";
+
+        assertTriggerWith(model, TriggerTypes.TRIGGER, EventEmittedTrigger.class,
+                trigger -> trigger.getTrigger().getValue());
+    }
+
+    @Test
+    public void testEventEmittedTrigger_withQuotes() throws Exception {
+        String model = "rule\"State Machine Rule 1\" " + //
+                "when " + //
+                "    Channel test triggered \"world\" " + //
+                "then " + //
+                "    logInfo(\"test says\", \"Boo!\") " + //
+                "end ";
+
+        assertTriggerWith(model, TriggerTypes.TRIGGER, EventEmittedTrigger.class,
+                trigger -> trigger.getTrigger().getValue());
+    }
+
+    private <T> void assertTriggerWith(String model, TriggerTypes triggerType, Class<T> triggerClass,
+            Function<T, String> valueFunction) {
+        modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.getBytes()));
+
+        RuleTriggerManager triggerManager = ((RuleEngineImpl) getService(RuleEngine.class)).getTriggerManager();
+        waitForAssert(() -> {
+            Iterable<Rule> rules = triggerManager.getRules(triggerType);
+            Iterator<Rule> iterator = rules.iterator();
+            assertTrue(iterator.hasNext());
+        });
+        Rule rule = triggerManager.getRules(triggerType).iterator().next();
+        EventTrigger trigger = rule.getEventtrigger().get(0);
+        assertTrue(triggerClass.isInstance(trigger));
+        assertEquals("world", valueFunction.apply(triggerClass.cast(trigger)));
+    }
+
+}

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/xtend-gen/.gitignore
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/xtend-gen/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/Rules.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/Rules.xtext
@@ -102,15 +102,51 @@ ItemName :
 ;
 
 ValidState:
-	ID | Number | STRING
+    ValidStateId | ValidStateNumber | ValidStateString
+;
+
+ValidStateId:
+    value=ID
+;
+
+ValidStateNumber:
+    value=Number
+;
+
+ValidStateString:
+    value=STRING
 ;
 
 ValidCommand:
-	ID | Number | STRING
+    ValidCommandId | ValidCommandNumber | ValidCommandString
+;
+
+ValidCommandId:
+    value=ID
+;
+
+ValidCommandNumber:
+    value=Number
+;
+
+ValidCommandString:
+    value=STRING
 ;
 
 ValidTrigger:
-	ID | Number | STRING
+    ValidTriggerId | ValidTriggerNumber | ValidTriggerString
+;
+
+ValidTriggerId:
+    value=ID
+;
+
+ValidTriggerNumber:
+    value=Number
+;
+
+ValidTriggerString:
+    value=STRING
 ;
 
 ThingValidState:


### PR DESCRIPTION
According to #2826, the following works

```xtext
rule "Test Rule 1"
when
    Item test changed to world
then
    // This is IS working
end
```

while the following is NOT working:

```xtext
rule "Test Rule 2"
when
    Item test changed to "world"
then
    // This is NOT working
end
```

With this PR, I so far have only added a test-case for this. And indeed it fails and results as expected in 

```
testChangedEventTrigger_withoutQuotes(org.eclipse.smarthome.model.rule.runtime.internal.engine.RuleTest)  Time elapsed: 0.639 sec
testChangedEventTrigger_withQuotes(org.eclipse.smarthome.model.rule.runtime.internal.engine.RuleTest)  Time elapsed: 0.034 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<[world]> but was:<["world"]>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at org.eclipse.smarthome.model.rule.runtime.internal.engine.RuleTest.assertUpdateTriggerWithNewState(RuleTest.java:82)
	at org.eclipse.smarthome.model.rule.runtime.internal.engine.RuleTest.testChangedEventTrigger_withQuotes(RuleTest.java:66)
```

So the quotes somehow end up inside the string! 

It looks like this behavior gets better when defining the trigger in [Rules.xtext](https://github.com/eclipse/smarthome/blob/09d8095efe9933216874e488b379cd9a10aa85e2/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/Rules.xtext) instead as

```xtext
ChangedEventTrigger:
	'Item' item=ItemName 'changed' ('from' oldState=ValidState)? ('to' newState=ValidState)?
;		
ValidState:
	ID | Number | STRING
;
```

directly like this:

```xtext
ChangedEventTrigger:
	'Item' item=ItemName 'changed' ('from' oldState=(ID|Number|STRING)? ('to' newState=(ID|Number|STRING))?
;		
```

However, we then would lose the nice way of integrating the content proposal in [RulesProposalProvider.java](https://github.com/eclipse/smarthome/blob/3ae5d7b1b284f2bde6199bfe8dad950fd38cae39/bundles/model/org.eclipse.smarthome.model.rule.ui/src/org/eclipse/smarthome/model/rule/ui/contentassist/RulesProposalProvider.xtend). So there must be a better way to "trick" xtext into behaving well. Any suggestions? @chriskn or @cdietrich maybe?

relates to #2826
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>