### PR TITLE
Basic/Classic UI: support for HTTP Live Stream

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.basic/snippets/video.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/snippets/video.html
@@ -4,6 +4,6 @@
 		data-control-type="video"
 		data-widget-id="%widget_id%"
 	>
-	   <video autoplay controls src="%url%"></video>
+	   <video autoplay controls src="%url%" %media_type%></video>
 	</div>
 </div>

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/VideoRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/VideoRenderer.java
@@ -9,6 +9,8 @@ package org.eclipse.smarthome.ui.basic.internal.render;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.model.sitemap.Video;
 import org.eclipse.smarthome.model.sitemap.Widget;
 import org.eclipse.smarthome.ui.basic.render.RenderException;
@@ -36,14 +38,22 @@ public class VideoRenderer extends AbstractWidgetRenderer {
         String widgetId = itemUIRegistry.getWidgetId(w);
         String sitemap = w.eResource().getURI().path();
 
-        if (videoWidget.getEncoding() != null && videoWidget.getEncoding().contains("mjpeg")) {
+        if (videoWidget.getEncoding() != null && videoWidget.getEncoding().toLowerCase().contains("mjpeg")) {
             // we handle mjpeg streams as an html image as browser can usually handle this
             snippet = getSnippet("image");
         } else {
             snippet = getSnippet("video");
         }
         String url = "../proxy?sitemap=" + sitemap + "&widgetId=" + widgetId;
+        String mediaType = "";
+        if (videoWidget.getEncoding() != null && videoWidget.getEncoding().toLowerCase().contains("hls")) {
+            // For HTTP Live Stream we don't proxy the URL and we set the appropriate media type
+            State state = itemUIRegistry.getState(w);
+            url = (state instanceof StringType) ? state.toString() : videoWidget.getUrl();
+            mediaType = "type=\"application/vnd.apple.mpegurl\"";
+        }
         snippet = StringUtils.replace(snippet, "%url%", url);
+        snippet = StringUtils.replace(snippet, "%media_type%", mediaType);
         snippet = preprocessSnippet(snippet, videoWidget);
 
         sb.append(snippet);

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/snippets/video.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/snippets/video.html
@@ -1,1 +1,1 @@
-<p><center><video style="padding:10px;width:90%" autoplay controls src="%url%"/></center></p>
+<p><center><video style="padding:10px;width:90%" autoplay controls src="%url%"  %media_type%/></center></p>

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/VideoRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/VideoRenderer.java
@@ -9,6 +9,8 @@ package org.eclipse.smarthome.ui.classic.internal.render;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.model.sitemap.Video;
 import org.eclipse.smarthome.model.sitemap.Widget;
 import org.eclipse.smarthome.ui.classic.render.RenderException;
@@ -36,7 +38,7 @@ public class VideoRenderer extends AbstractWidgetRenderer {
         String widgetId = itemUIRegistry.getWidgetId(w);
         String sitemap = w.eResource().getURI().path();
 
-        if (videoWidget.getEncoding() != null && videoWidget.getEncoding().contains("mjpeg")) {
+        if (videoWidget.getEncoding() != null && videoWidget.getEncoding().toLowerCase().contains("mjpeg")) {
             // we handle mjpeg streams as an html image as browser can usually handle this
             snippet = getSnippet("image");
             snippet = StringUtils.replace(snippet, "%setrefresh%", "");
@@ -45,7 +47,15 @@ public class VideoRenderer extends AbstractWidgetRenderer {
             snippet = getSnippet("video");
         }
         String url = "../proxy?sitemap=" + sitemap + "&widgetId=" + widgetId;
+        String mediaType = "";
+        if (videoWidget.getEncoding() != null && videoWidget.getEncoding().toLowerCase().contains("hls")) {
+            // For HTTP Live Stream we don't proxy the URL and we set the appropriate media type
+            State state = itemUIRegistry.getState(w);
+            url = (state instanceof StringType) ? state.toString() : videoWidget.getUrl();
+            mediaType = "type=\"application/vnd.apple.mpegurl\"";
+        }
         snippet = StringUtils.replace(snippet, "%url%", url);
+        snippet = StringUtils.replace(snippet, "%media_type%", mediaType);
         sb.append(snippet);
         return null;
     }


### PR DESCRIPTION
Add support for HLS in compatible WEB browsers
Use encoding="HLS" in the video sitemap element.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>