### PR TITLE
[Tradfri] Increase default command delay

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriCoapClient.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public class TradfriCoapClient extends CoapClient {
 
     private static final int TIMEOUT = 2000;
-    private static final int DEFAULT_DELAY_MILLIS = 500;
+    private static final int DEFAULT_DELAY_MILLIS = 600;
     private final Logger logger;
     private final LinkedList<PayloadCallbackPair> commandsQueue;
     private final Runnable commandExecutor;


### PR DESCRIPTION
After some more tests with different devices
it turned out that 500 ms is not enough for some basic operations.
So - increasing the delay to 600 ms

Signed-off-by: Ivaylo Ivanov <ivivanov.bg@gmail.com>