### PR TITLE
Added a suppression for the org.eclipse.smarthome.core.thing bundle f…

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -19,4 +19,5 @@
     <!-- Some source files have different headers -->
     <suppress files=".+org.eclipse.smarthome.automation.+" checks="HeaderCheck"/>
     <suppress files=".+org.eclipse.smarthome.config.dispatch.test.+" checks="ServiceComponentManifestCheck"/>
+    <suppress files=".+org.eclipse.smarthome.core.thing.+" checks="PackageExportsNameCheck"/>
 </suppressions>


### PR DESCRIPTION
…or PackageExportsNameCheck.

See eclipse/smarthome#4342
See openhab/static-code-analysis#100

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>