### PR TITLE
Null annotations: alter severity of IDE warnings

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
@@ -122,7 +122,7 @@ public abstract class AbstractManagedProvider<E extends Identifiable<K>, K, PE> 
         String key = getKeyAsString(element);
         if (storage.get(key) != null) {
             PE persistableElement = storage.put(key, toPersistableElement(element));
-            if (persistableElement != null) { // redundant but makes null reference check happy.
+            if (persistableElement != null) {
                 E oldElement = toElement(key, persistableElement);
                 notifyListenersAboutUpdatedElement(oldElement, element);
                 logger.debug("Updated element {} in {}.", key, this.getClass().getSimpleName());

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractManagedProvider.java
@@ -122,10 +122,12 @@ public abstract class AbstractManagedProvider<E extends Identifiable<K>, K, PE> 
         String key = getKeyAsString(element);
         if (storage.get(key) != null) {
             PE persistableElement = storage.put(key, toPersistableElement(element));
-            E oldElement = toElement(key, persistableElement);
-            notifyListenersAboutUpdatedElement(oldElement, element);
-            logger.debug("Updated element {} in {}.", key, this.getClass().getSimpleName());
-            return oldElement;
+            if (persistableElement != null) { // redundant but makes null reference check happy.
+                E oldElement = toElement(key, persistableElement);
+                notifyListenersAboutUpdatedElement(oldElement, element);
+                logger.debug("Updated element {} in {}.", key, this.getClass().getSimpleName());
+                return oldElement;
+            }
         } else {
             logger.warn("Could not update element with key {} in {}, because it does not exists.", key,
                     this.getClass().getSimpleName());

--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -107,12 +107,32 @@
           value="enabled"/>
       <setupTask
           xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.nonnullTypeVariableFromLegacyInvocation"
+          value="ignore"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.nullAnnotationInferenceConflict"
+          value="error"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.nullReference"
           value="error"/>
       <setupTask
           xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.nullSpecViolation"
+          value="error"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.nullUncheckedConversion"
+          value="ignore"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.parameterAssignment"
           value="warning"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariables"
+          value="ignore"/>
       <setupTask
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment"
@@ -120,6 +140,10 @@
       <setupTask
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.potentialNullReference"
+          value="warning"/>
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.redundantNullCheck"
           value="warning"/>
       <setupTask
           xsi:type="setup:PreferenceTask"


### PR DESCRIPTION
This addresses the proposal mentioned here https://github.com/eclipse/smarthome/issues/4321#issuecomment-332112083 to reduce the severity of some null annotation warnings. Also the "Null Reference" check was raised to `Error`.

Also: Make null reference check happy in `AbstractManagedProvider`.

Signed-off-by: Henning Treu <henning.treu@telekom.de>