### PR TITLE
Thing REST config exception logging

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
@@ -419,8 +419,7 @@ public class ThingResource implements RESTResource {
                     ex.getValidationMessages());
             return Response.status(Status.BAD_REQUEST).entity(ex.getValidationMessages(locale)).build();
         } catch (Exception ex) {
-            logger.error("Exception during HTTP PUT request for update config at '{}' for thing '{}': {}",
-                    uriInfo.getPath(), thingUID, ex.getMessage());
+            logger.error("Exception during HTTP PUT request for update config at '{}'", uriInfo.getPath(), ex);
             return JSONResponse.createResponse(Status.INTERNAL_SERVER_ERROR, null, ex.getMessage());
         }
 


### PR DESCRIPTION
This probably isn't a good implementation, but I think we need to improve the exception logging in the REST resource(s). Currently, if there's an exception during a PUT, we end up with no information on how to find the issue.

Users are reporting for example -:
```
2017-Oct-06 20:08:00.760 [ERROR] [marthome.io.rest.core.internal.thing.ThingResource] - Exception during HTTP PUT request for update config at 'things/zwave:device:07cb40a2:node12/config' for thing 'zwave:device:07cb40a2:node12': null
```

I would like to log the actual exception so we have a way to debug (even if this PR isn't the best approach ;) ).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>