### PR TITLE
Sliders handle NumberItems gracefully

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -102,7 +102,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     protected ItemRegistry itemRegistry;
 
-    private Map<Widget, Widget> defaultWidgets = Collections.synchronizedMap(new WeakHashMap<Widget, Widget>());
+    private final Map<Widget, Widget> defaultWidgets = Collections.synchronizedMap(new WeakHashMap<Widget, Widget>());
 
     public ItemUIRegistryImpl() {
     }
@@ -521,9 +521,15 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     private State convertState(Widget w, Item i) {
         State returnState = null;
 
-        // RollerShutter are represented as Switch in a Sitemap but need a PercentType state
-        if (w instanceof Slider || (w instanceof Switch && i instanceof RollershutterItem)) {
+        if (w instanceof Switch && i instanceof RollershutterItem) {
+            // RollerShutter are represented as Switch in a Sitemap but need a PercentType state
             returnState = i.getStateAs(PercentType.class);
+        } else if (w instanceof Slider) {
+            if (i.getAcceptedDataTypes().contains(PercentType.class)) {
+                returnState = i.getStateAs(PercentType.class);
+            } else {
+                returnState = i.getStateAs(DecimalType.class);
+            }
         } else if (w instanceof Switch) {
             Switch sw = (Switch) w;
             if (sw.getMappings().size() == 0) {


### PR DESCRIPTION
The forceful conversion of any state to a PercentType has shown
to be desastrious when having Sliders represent Number items.
Although they are primarily intended to be used with Dimmer items
only, this is the only place which prevents them being used for
Number items, causing an Exception which was pretty confusing for
users.

When looking at https://github.com/eclipse/smarthome/issues/1700#issuecomment-289928566 I understand that they actually are not meant to be used with Number items. So this PR is just _one_ way of fixing it (by actually making it work). The other possible solution would be to throw a more meaningful exception, telling the user what he did wrong. It cannot however stay as it was because it makes the whole sitemap unusable and leaving the user in the dark. @kaikreuzer / @resetnow / @lolodomo: your call!

fixes #4397
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>