### PR TITLE
[PaperUI] fix UNDEF/NULL display

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
@@ -97,9 +97,7 @@ angular.module('PaperUI.controllers', [ 'PaperUI.constants' ]).controller('BodyC
                 }
                 if (item.type === "Number" || item.groupType === "Number") {
                     var parsedValue = Number(state);
-                    if (isNaN(parsedValue)) {
-                        state = null;
-                    } else {
+                    if (!isNaN(parsedValue)) {
                         state = parsedValue;
                     }
                 }


### PR DESCRIPTION
there used to be a `-` displayed only, but apparently this got broken as a side-effect of #1888 and became `-NaN`. This is my attempt to bring back our lovely `-`.

fixes #4407
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>