### PR TITLE
[i18n] Fixed translation of channel definitions (label and description)

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/java/org/eclipse/smarthome/core/thing/xml/test/SystemWideChannelTypesTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/java/org/eclipse/smarthome/core/thing/xml/test/SystemWideChannelTypesTest.java
@@ -103,31 +103,27 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
         // install test bundle
         Bundle sysBundle = SyntheticBundleInstaller.install(bundleContext, SYSTEM_CHANNELS_BUNDLE_NAME);
         assertThat(sysBundle, is(notNullValue()));
-        List<ThingType> thingTypes = thingTypeProvider.getThingTypes(null).stream()
-                .filter(it -> it.getUID().getId().equals("wireless-router")).collect(Collectors.toList());
 
-        assertThat(thingTypes.size(), is(1));
+        ThingType wirelessRouterType = thingTypeProvider.getThingTypes(null).stream()
+                .filter(it -> it.getUID().getAsString().equals("SystemChannels:wireless-router")).findFirst().get();
+        assertThat(wirelessRouterType, is(notNullValue()));
 
-        Collection<ChannelDefinition> channelDefs = thingTypes.get(0).getChannelDefinitions();
-
+        Collection<ChannelDefinition> channelDefs = wirelessRouterType.getChannelDefinitions();
         assertThat(channelDefs.size(), is(3));
 
-        List<ChannelDefinition> myChannel = channelDefs.stream().filter(
+        ChannelDefinition myChannel = channelDefs.stream().filter(
                 it -> it.getId().equals("test") && it.getChannelTypeUID().getAsString().equals("system:my-channel"))
-                .collect(Collectors.toList());
+                .findFirst().get();
+        assertThat(myChannel, is(notNullValue()));
 
-        List<ChannelDefinition> sigStr = channelDefs.stream()
-                .filter(it -> it.getId().equals("sigstr")
-                        && it.getChannelTypeUID().getAsString().equals("system:signal-strength"))
-                .collect(Collectors.toList());
+        ChannelDefinition sigStr = channelDefs.stream().filter(it -> it.getId().equals("sigstr")
+                && it.getChannelTypeUID().getAsString().equals("system:signal-strength")).findFirst().get();
+        assertThat(sigStr, is(notNullValue()));
 
-        List<ChannelDefinition> lowBat = channelDefs.stream().filter(
+        ChannelDefinition lowBat = channelDefs.stream().filter(
                 it -> it.getId().equals("lowbat") && it.getChannelTypeUID().getAsString().equals("system:low-battery"))
-                .collect(Collectors.toList());
-
-        assertThat(myChannel.size(), is(1));
-        assertThat(sigStr.size(), is(1));
-        assertThat(lowBat.size(), is(1));
+                .findFirst().get();
+        assertThat(lowBat, is(notNullValue()));
     }
 
     @Test
@@ -150,7 +146,6 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
         assertThat(sysBundle.getState(), is(Bundle.UNINSTALLED));
 
         assertThat(getChannelTypes().size(), is(initialNumberOfChannelTypes));
-
     }
 
     @Test
@@ -164,45 +159,45 @@ public class SystemWideChannelTypesTest extends JavaOSGiTest {
         Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
         assertThat(thingTypes.size(), is(initialNumberOfThingTypes + 1));
 
-        List<ThingType> thingsFiltered = thingTypes.stream()
-                .filter(it -> it.getUID().getAsString().equals("SystemChannels:wireless-router"))
-                .collect(Collectors.toList());
+        ThingType wirelessRouterType = thingTypes.stream()
+                .filter(it -> it.getUID().getAsString().equals("SystemChannels:wireless-router")).findFirst().get();
+        assertThat(wirelessRouterType, is(notNullValue()));
 
-        assertThat(thingsFiltered.size(), is(1));
-        List<ChannelDefinition> channelDefs = thingsFiltered.get(0).getChannelDefinitions();
+        List<ChannelDefinition> channelDefs = wirelessRouterType.getChannelDefinitions();
+        assertThat(channelDefs.size(), is(3));
 
-        List<ChannelDefinition> myChannel = channelDefs.stream().filter(
+        ChannelDefinition myChannel = channelDefs.stream().filter(
                 it -> it.getId().equals("test") && it.getChannelTypeUID().getAsString().equals("system:my-channel"))
-                .collect(Collectors.toList());
+                .findFirst().get();
+        assertThat(myChannel, is(notNullValue()));
 
-        List<ChannelDefinition> sigStr = channelDefs.stream()
-                .filter(it -> it.getId().equals("sigstr")
-                        && it.getChannelTypeUID().getAsString().equals("system:signal-strength"))
-                .collect(Collectors.toList());
+        ChannelDefinition sigStr = channelDefs.stream().filter(it -> it.getId().equals("sigstr")
+                && it.getChannelTypeUID().getAsString().equals("system:signal-strength")).findFirst().get();
+        assertThat(sigStr, is(notNullValue()));
 
-        List<ChannelDefinition> lowBat = channelDefs.stream().filter(
+        ChannelDefinition lowBat = channelDefs.stream().filter(
                 it -> it.getId().equals("lowbat") && it.getChannelTypeUID().getAsString().equals("system:low-battery"))
-                .collect(Collectors.toList());
+                .findFirst().get();
+        assertThat(lowBat, is(notNullValue()));
 
-        assertThat(myChannel.size(), is(1));
-        assertThat(sigStr.size(), is(1));
-        assertThat(lowBat.size(), is(1));
-
-        assertThat(TypeResolver.resolve(myChannel.get(0).getChannelTypeUID(), Locale.GERMAN).getLabel(),
+        assertThat(TypeResolver.resolve(myChannel.getChannelTypeUID(), Locale.GERMAN).getLabel(),
                 is("Mein String My Channel"));
-        assertThat(TypeResolver.resolve(myChannel.get(0).getChannelTypeUID(), Locale.GERMAN).getDescription(),
+        assertThat(TypeResolver.resolve(myChannel.getChannelTypeUID(), Locale.GERMAN).getDescription(),
                 is("Wetterinformation mit My Channel Type Beschreibung"));
 
-        assertThat(TypeResolver.resolve(sigStr.get(0).getChannelTypeUID(), Locale.GERMAN).getLabel(),
-                is(not("Mein String Signal Strength")));
-        assertThat(TypeResolver.resolve(sigStr.get(0).getChannelTypeUID(), Locale.GERMAN).getDescription(),
-                is(not("Wetterinformation mit Signal Strength Channel Type Beschreibung")));
+        assertThat(myChannel.getLabel(), is("Mein String My Channel"));
+        assertThat(myChannel.getDescription(), is("Wetterinformation mit My Channel Type Beschreibung"));
 
-        assertThat(TypeResolver.resolve(sigStr.get(0).getChannelTypeUID(), Locale.GERMAN).getLabel(),
-                is("Signalstärke"));
+        assertThat(TypeResolver.resolve(sigStr.getChannelTypeUID(), Locale.GERMAN).getLabel(), is("Signalstärke"));
 
-        assertThat(TypeResolver.resolve(lowBat.get(0).getChannelTypeUID(), Locale.GERMAN).getLabel(),
+        assertThat(sigStr.getLabel(), is("Meine spezial Signalstärke"));
+        assertThat(sigStr.getDescription(), is("Meine spezial Beschreibung für Signalstärke"));
+
+        assertThat(TypeResolver.resolve(lowBat.getChannelTypeUID(), Locale.GERMAN).getLabel(),
                 is("Niedriger Batteriestatus"));
+
+        assertThat(lowBat.getLabel(), is("Niedriger Batteriestatus"));
+        assertThat(lowBat.getDescription(), is(nullValue()));
     }
 
     private List<ChannelType> getChannelTypes() {

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypeI18nTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/java/org/eclipse/smarthome/core/thing/xml/test/ThingTypeI18nTest.java
@@ -14,6 +14,8 @@ import java.util.Collection;
 import java.util.Locale;
 
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ThingType;
@@ -56,6 +58,7 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
         ThingType weatherType = thingTypes.stream().filter(it -> it.toString().equals("yahooweather:weather"))
                 .findFirst().get();
         assertThat(weatherType, is(notNullValue()));
+
         assertThat(weatherType.getLabel(), is("Wetterinformation"));
         assertThat(weatherType.getDescription(), is("Stellt verschiedene Wetterdaten vom yahoo Wetterdienst bereit"));
     }
@@ -73,12 +76,46 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
 
         ThingType weatherGroupType = thingTypes.stream()
                 .filter(it -> it.toString().equals("yahooweather:weather-with-group")).findFirst().get();
-
         assertThat(weatherGroupType, is(notNullValue()));
+
         ChannelGroupType channelGroupType = TypeResolver
                 .resolve(weatherGroupType.getChannelGroupDefinitions().get(0).getTypeUID(), Locale.GERMAN);
+        assertThat(channelGroupType, is(notNullValue()));
+
         assertThat(channelGroupType.getLabel(), is("Wetterinformation mit Gruppe"));
-        assertThat(channelGroupType.getDescription(), is("Wetterinformation mit Gruppe Beschreibung"));
+        assertThat(channelGroupType.getDescription(), is("Wetterinformation mit Gruppe Beschreibung."));
+    }
+
+    @Test
+    public void channelGroupsShouldBeLocalized() throws Exception {
+        int initialNumberOfThingTypes = thingTypeProvider.getThingTypes(null).size();
+
+        // install test bundle
+        Bundle bundle = SyntheticBundleInstaller.install(bundleContext, TEST_BUNDLE_NAME);
+        assertThat(bundle, is(notNullValue()));
+
+        Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
+        assertThat(thingTypes.size(), is(initialNumberOfThingTypes + 2));
+
+        ThingType weatherGroupType = thingTypes.stream()
+                .filter(it -> it.toString().equals("yahooweather:weather-with-group")).findFirst().get();
+        assertThat(weatherGroupType, is(notNullValue()));
+        assertThat(weatherGroupType.getChannelGroupDefinitions().size(), is(2));
+
+        ChannelGroupDefinition forecastTodayChannelGroupDefinition = weatherGroupType.getChannelGroupDefinitions()
+                .stream().filter(it -> it.getId().equals("forecastToday")).findFirst().get();
+        assertThat(forecastTodayChannelGroupDefinition, is(notNullValue()));
+
+        assertThat(forecastTodayChannelGroupDefinition.getLabel(), is("Wettervorhersage heute"));
+        assertThat(forecastTodayChannelGroupDefinition.getDescription(), is("Wettervorhersage für den heutigen Tag."));
+
+        ChannelGroupDefinition forecastTomorrowChannelGroupDefinition = weatherGroupType.getChannelGroupDefinitions()
+                .stream().filter(it -> it.getId().equals("forecastTomorrow")).findFirst().get();
+        assertThat(forecastTomorrowChannelGroupDefinition, is(notNullValue()));
+
+        assertThat(forecastTomorrowChannelGroupDefinition.getLabel(), is("Wettervorhersage morgen"));
+        assertThat(forecastTomorrowChannelGroupDefinition.getDescription(),
+                is("Wettervorhersage für den morgigen Tag."));
     }
 
     @Test
@@ -94,13 +131,51 @@ public class ThingTypeI18nTest extends JavaOSGiTest {
 
         ThingType weatherType = thingTypes.stream().filter(it -> it.toString().equals("yahooweather:weather"))
                 .findFirst().get();
+        assertThat(weatherType, is(notNullValue()));
+        assertThat(weatherType.getChannelDefinitions().size(), is(2));
+
         ChannelType temperatureChannelType = TypeResolver.resolve(weatherType.getChannelDefinitions().stream()
                 .filter(it -> it.getId().equals("temperature")).findFirst().get().getChannelTypeUID(), Locale.GERMAN);
+        assertThat(temperatureChannelType, is(notNullValue()));
 
         assertThat(temperatureChannelType.getLabel(), is("Temperatur"));
-        assertThat(temperatureChannelType.getDescription(), is("Temperaturwert"));
+        assertThat(temperatureChannelType.getDescription(),
+                is("Aktuelle Temperatur in Grad Celsius (Metrisch) oder Fahrenheit (Imperial)."));
         assertThat(temperatureChannelType.getState().getPattern(), is("%d Grad Celsius"));
         assertThat(temperatureChannelType.getState().getOptions().get(0).getLabel(), is("Mein String"));
+    }
+
+    @Test
+    public void channelsShouldBeLocalized() throws Exception {
+        int initialNumberOfThingTypes = thingTypeProvider.getThingTypes(null).size();
+
+        // install test bundle
+        Bundle bundle = SyntheticBundleInstaller.install(bundleContext, TEST_BUNDLE_NAME);
+        assertThat(bundle, is(notNullValue()));
+
+        Collection<ThingType> thingTypes = thingTypeProvider.getThingTypes(Locale.GERMAN);
+        assertThat(thingTypes.size(), is(initialNumberOfThingTypes + 2));
+
+        ThingType weatherType = thingTypes.stream().filter(it -> it.toString().equals("yahooweather:weather"))
+                .findFirst().get();
+        assertThat(weatherType, is(notNullValue()));
+        assertThat(weatherType.getChannelDefinitions().size(), is(2));
+
+        ChannelDefinition temperatureChannelDefinition = weatherType.getChannelDefinitions().stream()
+                .filter(it -> it.getId().equals("temperature")).findFirst().get();
+        assertThat(temperatureChannelDefinition, is(notNullValue()));
+
+        assertThat(temperatureChannelDefinition.getLabel(), is("Temperatur"));
+        assertThat(temperatureChannelDefinition.getDescription(),
+                is("Aktuelle Temperatur in Grad Celsius (Metrisch) oder Fahrenheit (Imperial)."));
+
+        ChannelDefinition minTemperatureChannelDefinition = weatherType.getChannelDefinitions().stream()
+                .filter(it -> it.getId().equals("minTemperature")).findFirst().get();
+        assertThat(minTemperatureChannelDefinition, is(notNullValue()));
+
+        assertThat(minTemperatureChannelDefinition.getLabel(), is("Min. Temperatur"));
+        assertThat(minTemperatureChannelDefinition.getDescription(),
+                is("Minimale Temperatur in Grad Celsius (Metrisch) oder Fahrenheit (Imperial)."));
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/i18n/SystemChannels_de.properties
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/i18n/SystemChannels_de.properties
@@ -1,5 +1,5 @@
 channel-type.system.my-channel.label = Mein String My Channel
 channel-type.system.my-channel.description = Wetterinformation mit My Channel Type Beschreibung
 
-channel-type.system.signal-strength.label = Mein String Signal Strength
-channel-type.system.signal-strength.description = Wetterinformation mit Signal Strength Channel Type Beschreibung
+thing-type.SystemChannels.wireless-router.channel.sigstr.label = Meine spezial Signalstärke
+thing-type.SystemChannels.wireless-router.channel.sigstr.description = Meine spezial Beschreibung für Signalstärke

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/ESH-INF/thing/thing-types.xml
@@ -1,23 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="SystemChannels"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+<thing:thing-descriptions bindingId="SystemChannels" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <!-- YahooWeather Binding -->
-    <thing-type id="wireless-router">
-        <label>Simple wireless router</label>
-        <description>Simple wireless router</description>
+	<!-- YahooWeather Binding -->
+	<thing-type id="wireless-router">
+		<label>Simple wireless router</label>
+		<description>Simple wireless router</description>
 
 		<channels>
-			<channel id="sigstr" typeId="system.signal-strength" />
+			<channel id="sigstr" typeId="system.signal-strength">
+				<label>My special Signal Strength</label>
+				<description>My special description for Signal Strength</description>
+			</channel>
 			<channel id="test" typeId="system.my-channel" />
 			<channel id="lowbat" typeId="system.low-battery" />
 		</channels>
 
-    </thing-type> 
-    
-    <!-- System Channel Type -->
+	</thing-type>
+
+	<!-- System Channel Type -->
 	<channel-type id="my-channel" system="true">
 		<item-type>Number</item-type>
 		<label>My Channel</label>
@@ -28,9 +30,8 @@
 			</tag>
 		</tags>
 		<config-description>
-			<parameter name="range" type="integer" readOnly="true" min="0"
-				max="4" step="1" />
+			<parameter name="range" type="integer" readOnly="true" min="0" max="4" step="1" />
 		</config-description>
 	</channel-type>
-    
+
 </thing:thing-descriptions>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/ESH-INF/i18n/yahooweather_de.properties
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/ESH-INF/i18n/yahooweather_de.properties
@@ -1,8 +1,14 @@
 thing-type.yahooweather.weather.label = Wetterinformation
-channel-group-type.yahooweather.group.label = Wetterinformation mit Gruppe
-channel-group-type.yahooweather.group.description = Wetterinformation mit Gruppe Beschreibung
+channel-group-type.yahooweather.forecast.label = Wetterinformation mit Gruppe
+channel-group-type.yahooweather.forecast.description = Wetterinformation mit Gruppe Beschreibung.
+thing-type.yahooweather.weather-with-group.group.forecastToday.label = Wettervorhersage heute
+thing-type.yahooweather.weather-with-group.group.forecastToday.description = Wettervorhersage für den heutigen Tag.
+thing-type.yahooweather.weather-with-group.group.forecastTomorrow.label = Wettervorhersage morgen
+thing-type.yahooweather.weather-with-group.group.forecastTomorrow.description = Wettervorhersage für den morgigen Tag.
 channel-type.yahooweather.temperature.label = Temperatur
-channel-type.yahooweather.temperature.description = Temperaturwert
+channel-type.yahooweather.temperature.description = Aktuelle Temperatur in Grad Celsius (Metrisch) oder Fahrenheit (Imperial).
 channel-type.yahooweather.temperature.state.pattern = %d Grad Celsius
 channel-type.yahooweather.temperature.state.option.VALUE = Mein String
+thing-type.yahooweather.weather.channel.minTemperature.label = Min. Temperatur
+thing-type.yahooweather.weather.channel.minTemperature.description = Minimale Temperatur in Grad Celsius (Metrisch) oder Fahrenheit (Imperial).
 CUSTOM_KEY= Stellt verschiedene Wetterdaten vom yahoo Wetterdienst bereit

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/ESH-INF/thing/thing-types.xml
@@ -1,47 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="yahooweather"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-        xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+<thing:thing-descriptions bindingId="yahooweather" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-    <!-- YahooWeather Binding -->
-    <thing-type id="weather">
-        <label>Weather Information *</label>
-        <description>@text/CUSTOM_KEY</description>
+	<!-- YahooWeather Binding -->
+	<thing-type id="weather">
+		<label>Weather Information *</label>
+		<description>@text/CUSTOM_KEY</description>
 
 		<channels>
 			<channel id="temperature" typeId="temperature" />
+			<channel id="minTemperature" typeId="temperature">
+			     <label>Min. Temperature</label>
+			     <description>Minimum temperature in degrees celsius (metric) or fahrenheit (us).</description>
+			</channel>
 		</channels>
 
-    </thing-type>
-    
-    <!-- YahooWeather Binding with group -->
-    <thing-type id="weather-with-group">
-        <label>Weather Information with Group</label>
+	</thing-type>
 
-        <channel-groups>
-            <channel-group id="group" typeId="group" />
-        </channel-groups>
+	<!-- YahooWeather Binding with group -->
+	<thing-type id="weather-with-group">
+		<label>Weather Information with Group</label>
 
-    </thing-type>
+		<channel-groups>
+			<channel-group id="forecastToday" typeId="forecast">
+				<label>Today</label>
+				<description>This is the weather forecast for today.</description>
+			</channel-group>
+			<channel-group id="forecastTomorrow" typeId="forecast">
+				<label>Weather Forecast Tomorrow</label>
+				<description>This is the weather forecast for tomorrow.</description>
+			</channel-group>
+		</channel-groups>
 
-    <channel-type id="temperature">
-        <item-type>Number</item-type>
-        <label>Temperature</label>
-        <description>Current temperature in degrees celsius (metric) or fahrenheit (us)</description>
-        <state pattern="%d degree Celsius">
-            <options>
-                <option value="VALUE">My label</option>
-            </options>
-        </state>
-    </channel-type>
-    
-    <!-- Channel Group -->
-    <channel-group-type id="group">
-        <label>Weather information group</label>
-        <description>Weather information group description.</description>
-        <channels>
-        </channels>
-    </channel-group-type>
-    
+	</thing-type>
+
+	<channel-type id="temperature">
+		<item-type>Number</item-type>
+		<label>Temperature</label>
+		<description>Current temperature in degrees celsius (metric) or fahrenheit (us).</description>
+		<state pattern="%d degree Celsius">
+			<options>
+				<option value="VALUE">My label</option>
+			</options>
+		</state>
+	</channel-type>
+
+	<!-- Channel Group -->
+	<channel-group-type id="forecast">
+		<label>Weather information group</label>
+		<description>Weather information group description.</description>
+		<channels>
+		</channels>
+	</channel-group-type>
+
 </thing:thing-descriptions>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nLocalizationService.java
@@ -58,10 +58,10 @@ public class ThingTypeI18nLocalizationService {
                 thingType.getChannelDefinitions().size());
 
         for (final ChannelDefinition channelDefinition : thingType.getChannelDefinitions()) {
-            String channelLabel = this.thingTypeI18nUtil.getChannelLabel(bundle, channelDefinition.getChannelTypeUID(),
+            String channelLabel = this.thingTypeI18nUtil.getChannelLabel(bundle, thingType.getUID(), channelDefinition,
                     channelDefinition.getLabel(), locale);
-            String channelDescription = this.thingTypeI18nUtil.getChannelDescription(bundle,
-                    channelDefinition.getChannelTypeUID(), channelDefinition.getDescription(), locale);
+            String channelDescription = this.thingTypeI18nUtil.getChannelDescription(bundle, thingType.getUID(),
+                    channelDefinition, channelDefinition.getDescription(), locale);
             if (channelLabel == null || channelDescription == null) {
                 ChannelType channelType = TypeResolver.resolve(channelDefinition.getChannelTypeUID(), locale);
                 if (channelType != null) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ThingTypeI18nUtil.java
@@ -135,8 +135,8 @@ public class ThingTypeI18nUtil {
     }
 
     private String inferThingTypeKey(ThingTypeUID thingTypeUID, ChannelDefinition channel, String lastSegment) {
-        return "thing-type." + thingTypeUID.getBindingId() + "." + thingTypeUID.getId() + "." + channel.getId() + "."
-                + lastSegment;
+        return "thing-type." + thingTypeUID.getBindingId() + "." + thingTypeUID.getId() + ".channel." + channel.getId()
+                + "." + lastSegment;
     }
 
 }

--- a/docs/documentation/features/internationalization.md
+++ b/docs/documentation/features/internationalization.md
@@ -86,6 +86,10 @@ XML file (thing-types.xml):
         <channels>
             <channel id="precipitation" typeId="precipitation" />
             <channel id="temperature" typeId="temperature" />
+            <channel id="minTemperature" typeId="temperature">
+                <label>Min. Temperature</label>
+                <description>Minimum temperature in degrees celsius (metric) or fahrenheit (imperial).</description>
+            </channel>
         </channels>
         <config-description>
             <parameter name="location" type="text">
@@ -148,6 +152,9 @@ channel-type.yahooweather.temperature.label = Temperatur
 channel-type.yahooweather.temperature.description = Aktuelle Temperatur in Grad Celsius (Metrisch) oder Grad Fahrenheit (US).
 channel-type.yahooweather.temperature.state.pattern = %d Wert
 
+thing-type.yahooweather.weather.channel.minTemperature.label = Min. Temperatur
+thing-type.yahooweather.weather.channel.minTemperature.description = Minimale Temperatur in Grad Celsius (Metrisch) oder Grad Fahrenheit (US).
+
 channel-type.config.yahooweather.temperature.unit.label = Temperatur Einheit
 channel-type.config.yahooweather.temperature.unit.description = Auswahl der gewünschten Temperatur Einheit.
 channel-type.config.yahooweather.temperature.unit.option.C = Grad Celsius
@@ -155,7 +162,7 @@ channel-type.config.yahooweather.temperature.unit.option.F = Grad Fahrenheit
 ```
 
 So the key for referencing a label of a defined thing type is `thing-type.<binding-id>.<thing-type-id>.label`.
-A label of a channel can be referenced with `channel-type.<binding-id>.<channel-type-id>.label`.
+A label of a channel type can be referenced with `channel-type.<binding-id>.<channel-type-id>.label` and a label of a channel definition with `thing-type.<binding-id>.<thing-type-id>.channel.<channel-id>.label`.
 And finally the config description parameter key is `thing-type.config.<binding-id>.<thing-type-id>.<parameter-name>.label` or `channel-type.config.<binding-id>.<channel-type-id>.<parameter-name>.label`.
 
 The following snippet shows an excerpt of the thing type definition XML file of the Weather Underground Binding and its language file that localizes labels and descriptions for the French language.


### PR DESCRIPTION
- Added test case for translating channel definitions and channel group definitions
- Fixed translation of channel definitions (suggested by @ppieczul )
- Added 'channel' identifier in translation component
- Updated documentation

See https://github.com/openhab/openhab2-addons/pull/2768#issuecomment-335045841

An additional step I want to test if it's working for channel definitions with default system channel-types, too. That didn't work before. See https://github.com/eclipse/smarthome/issues/3623#issuecomment-308498668

Also-by: Pawel Pieczul <pieczul@gmail.com>
Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>