### PR TITLE
The HueLightHandlerOSGiTest uses this class, which results in an erro…

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HttpClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HttpClient.java
@@ -21,7 +21,7 @@ import org.apache.commons.io.IOUtils;
  * @author Q42, standalone Jue library (https://github.com/Q42/Jue)
  * @author Denis Dudnik - moved Jue library source code inside the smarthome Hue binding
  */
-class HttpClient {
+public class HttpClient {
     private int timeout = 1000;
 
     public void setTimeout(int timeout) {


### PR DESCRIPTION
…r marker in the IDE as it is package private.

As we are using OSGi and not exporting this package, it is imho fully ok to declare the class as public instead.

Signed-off-by: Kai Kreuzer <kai@openhab.org>