### PR TITLE
the returned StateDescription combines values from GenericItemProvide…

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -408,6 +408,11 @@ abstract public class GenericItem implements ActiveItem {
                     result = stateDescription;
                 }
 
+                if (result != null && stateDescription != null) {
+                    result = new StateDescription(result.getMinimum(), result.getMaximum(), result.getStep(),
+                            result.getPattern(), stateDescription.isReadOnly(), result.getOptions());
+                }
+
                 // if the current StateDescription does provide options and we don't already have some, we pick them up
                 // here
                 if (stateDescription != null && !stateDescription.getOptions().isEmpty() && stateOptions.isEmpty()) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/internal/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/internal/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
@@ -11,8 +11,10 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.smarthome.core.library.items.NumberItem;
@@ -68,5 +70,29 @@ public class EnrichedItemDTOMapperWithTransformOSGiTest extends JavaOSGiTest {
         assertThat(sd.getOptions().get(0).getValue(), is("SOUND"));
         assertThat(sd.getOptions().get(0).getLabel(), is("My great sound."));
     }
+    
+    @Test
+    public void testStateDescriptionReadOnly() {
 
+        StateDescriptionProvider stateDescriptionProvider1 = mock(StateDescriptionProvider.class);
+        StateDescription stateDescriptionContainingPattern = new StateDescription(null, null, null, "somePattern",
+                false, null);
+        when(stateDescriptionProvider1.getStateDescription("Item2", null))
+                .thenReturn(stateDescriptionContainingPattern);
+
+        StateDescriptionProvider stateDescriptionProvider2 = mock(StateDescriptionProvider.class);
+        StateDescription stateDescriptionContainingReadOnlyValue = new StateDescription(null, null, null,
+                "defaultPattern", true, null);
+        when(stateDescriptionProvider2.getStateDescription("Item2", null))
+                .thenReturn(stateDescriptionContainingReadOnlyValue);
+
+        NumberItem item2 = new NumberItem("Item2");
+        item2.setStateDescriptionProviders(Arrays.asList(stateDescriptionProvider1, stateDescriptionProvider2));
+
+        EnrichedItemDTO enrichedDTO = EnrichedItemDTOMapper.map(item2, false, null, null);
+        StateDescription sd = enrichedDTO.stateDescription;
+
+        assertThat(sd.isReadOnly(), is(true));
+        assertThat(sd.getPattern(), is("somePattern"));
+    }
 }


### PR DESCRIPTION
Fix for issue [2267](https://github.com/eclipse/smarthome/issues/2267).

This fix relies on the fact that  **ChannelStateDescriptionProvider** has service ranking -1 and therefore when iterating through the stateDescriptionProviders in the **getStateDescription** method,  **ChannelStateDescriptionProvider** will come after **GenericItemProvider**.

If an item that is provided from the .items file and has a custom pattern, then the **GenericItemProvider** will provide a non null **StateDescription** and on the next iteration, the result will take the **isReadOnly** value from the **ChannelStateDescriptionProvider**.

