### PR TITLE
Astro: Use float formatting instead of int for distances on channels

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.astro/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/ESH-INF/thing/channels.xml
@@ -420,14 +420,14 @@
 		<item-type>Number</item-type>
 		<label>Miles</label>
 		<description>The distance in miles</description>
-		<state readOnly="true" pattern="%d miles" />
+		<state readOnly="true" pattern="%.1f miles" />
 	</channel-type>
 
 	<channel-type id="kilometer">
 		<item-type>Number</item-type>
 		<label>Kilometer</label>
 		<description>The distance in kilometers</description>
-		<state readOnly="true" pattern="%d km" />
+		<state readOnly="true" pattern="%.1f km" />
 	</channel-type>
 
 	<channel-type id="distanceEvent">


### PR DESCRIPTION
Fixes #4394

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>