### PR TITLE
[LIFX] Update products

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Products.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Products.java
@@ -24,19 +24,24 @@ public enum Products {
     W800LV(1, 10, "White 800 (Low Voltage)", false, false, false),
     W800HV(1, 11, "White 800 (High Voltage)", false, false, false),
     W900LV(1, 18, "White 900 BR30 (Low Voltage)", false, false, false),
-    C900(1, 20, "Color 900 BR30", true, false, false),
+    C1000BR30(1, 20, "Color 1000 BR30", true, false, false),
     C1000(1, 22, "Color 1000", true, false, false),
     LA19_1(1, 27, "LIFX A19", true, false, false),
     LBR30_1(1, 28, "LIFX BR30", true, false, false),
-    LPA19(1, 29, "LIFX+ A19", true, true, false),
-    LPBR30(1, 30, "LIFX+ BR30", true, true, false),
-    LZ(1, 31, "LIFX Z", true, false, true),
+    LPA19_1(1, 29, "LIFX+ A19", true, true, false),
+    LPBR30_1(1, 30, "LIFX+ BR30", true, true, false),
+    LZ_1(1, 31, "LIFX Z", true, false, true),
+    LZ_2(1, 32, "LIFX Z 2", true, false, true),
     LDL_1(1, 36, "LIFX Downlight", true, false, false),
     LDL_2(1, 37, "LIFX Downlight", true, false, false),
     LA19_2(1, 43, "LIFX A19", true, false, false),
     LBR30_2(1, 44, "LIFX BR30", true, false, false),
     LPA19_2(1, 45, "LIFX+ A19", true, true, false),
-    LPBR30_2(1, 46, "LIFX+ BR30", true, true, false);
+    LPBR30_2(1, 46, "LIFX+ BR30", true, true, false),
+    LM(1, 49, "LIFX Mini", true, false, false),
+    LMW(1, 50, "LIFX Mini White", false, false, false),
+    LMWDD(1, 51, "LIFX Mini Day and Dusk", false, false, false),
+    LGU10(1, 52, "LIFX GU10", true, false, false);
 
     private final long vendorID;
     private final long productID;


### PR DESCRIPTION
Adds product IDs and capabilities of the following new LIFX products:
* LIFX Z 2
* LIFX Mini
* LIFX Mini White
* LIFX Mini Day and Dusk
* LIFX GU10

Corrects the name of the 'Color 900 BR30' to 'Color 1000 BR30'.

Based on: https://github.com/LIFX/products