### PR TITLE
PaperUI: fix out of sync DimmerItem switch

### DIFF
--- a/bundles/test/org.eclipse.smarthome.magic/ESH-INF/thing/channel-types.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/ESH-INF/thing/channel-types.xml
@@ -18,6 +18,7 @@
 		<item-type>Dimmer</item-type>
 		<label>Dimmer</label>
 		<description>The dimmer channel allows to control the brightness.</description>
+		<category>DimmableLight</category>
 	</channel-type>
 
 	<channel-type id="color">

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -331,9 +331,9 @@ angular.module('PaperUI.controllers.control', []) //
     $scope.setOn = function(state) {
         $scope.sendCommand(state);
     }
-}).controller('DimmerItemController', function($scope, $timeout, itemService) {
+}).controller('DimmerItemController', function($scope, $timeout) {
     if ($scope.item.state === 'UNDEF' || $scope.item.state === 'NULL') {
-        $scope.item.state = '-'
+        $scope.item.state = '-';
     }
 
     // state.switchState overcomes the new $scope from ng-if directive
@@ -342,26 +342,26 @@ angular.module('PaperUI.controllers.control', []) //
     }
 
     $scope.setSwitch = function(state) {
-        sendCommand(state ? 'ON' : 'OFF')
+        sendCommand(state ? 'ON' : 'OFF');
     }
 
     $scope.setBrightness = function(brightness) {
-        $scope.state.switchState = brightness > 0
-        sendCommand(brightness)
+        $scope.state.switchState = brightness > 0;
+        sendCommand(brightness);
     }
 
     var commandTimeout = undefined;
 
     var sendCommand = function(command) {
         if (commandTimeout) {
-            $timeout.cancel(commandTimeout)
+            $timeout.cancel(commandTimeout);
         }
 
         // send updates every 300 ms only
         commandTimeout = $timeout(function() {
-            $scope.sendCommand(command)
-            commandTimeout = undefined
-        }, 300)
+            $scope.sendCommand(command);
+            commandTimeout = undefined;
+        }, 300);
     }
 
 }).controller('ColorItemController', function($scope, $timeout, $element, itemService) {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -333,44 +333,37 @@ angular.module('PaperUI.controllers.control', []) //
     }
 }).controller('DimmerItemController', function($scope, $timeout, itemService) {
     if ($scope.item.state === 'UNDEF' || $scope.item.state === 'NULL') {
-        $scope.item.state = '-';
+        $scope.item.state = '-'
     }
-    $scope.on = parseInt($scope.item.state) > 0 ? 'ON' : 'OFF';
 
-    $scope.setOn = function(on) {
-        $scope.on = on === 'ON' ? 'ON' : 'OFF';
-
-        $scope.sendCommand(on);
-
-        var brightness = parseInt($scope.item.state);
-        if (on === 'ON' && brightness === 0) {
-            $scope.item.state = 100;
-        }
-        if (on === 'OFF' && brightness > 0) {
-            $scope.item.state = 0;
-        }
+    // state.switchState overcomes the new $scope from ng-if directive
+    $scope.state = {
+        switchState : parseInt($scope.item.state) > 0
     }
-    $scope.pending = false;
+
+    $scope.setSwitch = function(state) {
+        sendCommand(state ? 'ON' : 'OFF')
+    }
+
     $scope.setBrightness = function(brightness) {
-        // send updates every 300 ms only
-        if (!$scope.pending) {
-            $timeout(function() {
-                var command = $scope.item.state === 0 ? '0' : $scope.item.state;
-                $scope.sendCommand(command);
-                $scope.pending = false;
-            }, 300);
-            $scope.pending = true;
-        }
+        $scope.state.switchState = brightness > 0
+        sendCommand(brightness)
     }
-    $scope.$watch('item.state', function() {
-        var brightness = parseInt($scope.item.state);
-        if (brightness > 0 && $scope.on === 'OFF') {
-            $scope.on = 'ON';
+
+    var commandTimeout = undefined;
+
+    var sendCommand = function(command) {
+        if (commandTimeout) {
+            $timeout.cancel(commandTimeout)
         }
-        if (brightness === 0 && $scope.on === 'ON') {
-            $scope.on = 'OFF';
-        }
-    });
+
+        // send updates every 300 ms only
+        commandTimeout = $timeout(function() {
+            $scope.sendCommand(command)
+            commandTimeout = undefined
+        }, 300)
+    }
+
 }).controller('ColorItemController', function($scope, $timeout, $element, itemService) {
 
     if ($scope.item.state === 'UNDEF' || $scope.item.state === 'NULL') {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.spec.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.spec.js
@@ -1,0 +1,65 @@
+describe('module PaperUI.controllers.control', function() {
+    beforeEach(function() {
+        module('PaperUI.controllers.control');
+    })
+
+    describe('DimmerItemController', function() {
+        var dimmerItemController;
+        var scope;
+        var timeout;
+
+        beforeEach(inject(function($rootScope, $injector, $controller) {
+            timeout = $injector.get('$timeout');
+
+            scope = $rootScope.$new();
+
+            // in real life item is available through the parent scope
+            scope.item = {
+                state : 0
+            }
+            // in real life sendCommand is defined on the parent scope
+            scope.sendCommand = jasmine.createSpy('sendCommand spy')
+
+            dimmerItemController = $controller('DimmerItemController', {
+                '$scope' : scope,
+                '$timeout' : timeout
+            });
+        }))
+
+        it('should be present', function() {
+            expect(dimmerItemController).toBeDefined();
+        })
+
+        it('should initialize $scope.state.switchState', function() {
+            expect(scope.state.switchState).toBe(false);
+        })
+
+        it('should trigger sendCommand(\'ON\') when switch toggels true', function() {
+            scope.setSwitch(true);
+            timeout.flush(); // immediately execute the delayed sendCommand timeout
+            expect(scope.sendCommand).toHaveBeenCalledWith('ON');
+        })
+
+        it('should trigger sendCommand(\'OFF\') when switch toggels false', function() {
+            scope.setSwitch(false);
+            timeout.flush(); // immediately execute the delayed sendCommand timeout
+            expect(scope.sendCommand).toHaveBeenCalledWith('OFF');
+        })
+
+        it('should trigger sendCommand(80) when brightness sets to 80', function() {
+            scope.setBrightness(80)
+            timeout.flush(); // immediately execute the delayed sendCommand timeout
+            expect(scope.sendCommand).toHaveBeenCalledWith(80);
+        })
+
+        it('should set switchState true for brightness > 0', function() {
+            scope.setBrightness(1);
+            expect(scope.state.switchState).toBe(true);
+        })
+
+        it('should set switchState false for brightness == 0', function() {
+            scope.setBrightness(0);
+            expect(scope.state.switchState).toBe(false);
+        })
+    })
+})

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/control.html
@@ -51,13 +51,13 @@
 											<h2>{{item.stateText}}</h2>
 										</div>
 									</div>
-									<md-slider ng-if="::(!isOptionList(item) && !item.readOnly)" ng-class="::{'left-padded' : showSwitch(item.category)}" class="md-default-theme" style="height: 40px;" flex min="0" max="100" ng-model="item.state" ng-change="setBrightness(item.state)" aria-label={{::item.label}}></md-slider>
+									<md-slider ng-if="::(!isOptionList(item) && !item.readOnly)" ng-class="::{'left-padded' : showSwitch(item.category)}" class="md-default-theme" style="height: 40px;" flex ng-min="0" ng-max="100" ng-model="item.state" ng-change="setBrightness(item.state)" aria-label={{::item.label}}></md-slider>
 									<div layout="row" layout-align="start center" class="dimmer-widget" ng-if="::(showSwitch(item.category) && !isOptionList(item) && !item.readOnly)">
 										<div flex="40">
 											<p class="no-icon-margin-left">Off/On</p>
 										</div>
 										<div flex="60" layout="row" layout-align="end center" class="dimmer-widget">
-											<md-switch class="md-default-theme" ng-model="on" ng-change="setOn(on)" ng-true-value="'ON'" ng-false-value="'OFF'" aria-label={{::item.label}}></md-switch>
+											<md-switch class="md-default-theme" ng-model="state.switchState" ng-change="setSwitch(state.switchState)" aria-label={{::item.label}}></md-switch>
 										</div>
 									</div>
 									<div layout="row" item-state-dropdown layout-align="end center" ng-if="::(isOptionList(item) && !item.readOnly)"></div>


### PR DESCRIPTION
Fix switch for DimmerItem:
- refactor and simplify DimmerItemController
- introduce containing object inside DimmerItemController $scope to overcome ng-if extra $scope

Fixes #4430, #3687

Signed-off-by: Henning Treu <henning.treu@telekom.de>