### PR TITLE
Enhance rule interpretation errors

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/ExecuteRuleJob.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/ExecuteRuleJob.java
@@ -61,7 +61,7 @@ public class ExecuteRuleJob implements Job {
                     try {
                         script.execute(RuleContextHelper.getContext(rule, injector));
                     } catch (ScriptExecutionException e) {
-                        logger.error("Error during the execution of rule {}: {}", rule.getName(), e.getMessage());
+                        logger.error("Error during the execution of rule '{}': {}", rule.getName(), e.getMessage());
                     }
                 } else {
                     logger.debug("Scheduled rule '{}' does not exist", ruleName);

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
@@ -310,8 +310,8 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
                         triggerManager.removeRule(STARTUP, rule);
                     } catch (ScriptExecutionException e) {
                         if (!e.getMessage().contains("cannot be resolved to an item or type")) {
-                            logger.error("Error during the execution of startup rule '{}': {}",
-                                    new Object[] { rule.getName(), e.getCause().getMessage() });
+                            logger.error("Error during the execution of startup rule '{}': {}", rule.getName(),
+                                    e.getCause().getMessage());
                             triggerManager.removeRule(STARTUP, rule);
                         } else {
                             logger.debug(

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptError.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptError.java
@@ -7,6 +7,11 @@
  */
 package org.eclipse.smarthome.model.script.engine;
 
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.util.LineAndColumn;
+
 /**
  * A detailed error information for a script
  *
@@ -28,7 +33,7 @@ public final class ScriptError {
 
     /**
      * Creates new ScriptError.
-     * 
+     *
      * @param message Error Message
      * @param line Line number, or -1 if unknown
      * @param column Column number, or -1 if unknown
@@ -42,9 +47,27 @@ public final class ScriptError {
     }
 
     /**
+     * Creates new ScriptError.
+     *
+     * This constructor uses the given EObject instance to calculate the exact position.
+     *
+     * @param message Error Message
+     * @param atEObject the EObject instance to use for calculating the position
+     *
+     */
+    public ScriptError(final String message, final EObject atEObject) {
+        this.message = message;
+        INode node = NodeModelUtils.getNode(atEObject);
+        LineAndColumn lac = NodeModelUtils.getLineAndColumn(node, node.getOffset());
+        this.line = lac.getLine();
+        this.column = lac.getColumn();
+        this.length = node.getEndOffset() - node.getOffset();
+    }
+
+    /**
      * Returns a message containing the String passed to a constructor as well as line and column numbers if any of
      * these are known.
-     * 
+     *
      * @return The error message.
      */
     public String getMessage() {
@@ -66,7 +89,7 @@ public final class ScriptError {
 
     /**
      * Get the line number on which an error occurred.
-     * 
+     *
      * @return The line number. Returns -1 if a line number is unavailable.
      */
     public int getLineNumber() {
@@ -75,7 +98,7 @@ public final class ScriptError {
 
     /**
      * Get the column number on which an error occurred.
-     * 
+     *
      * @return The column number. Returns -1 if a column number is unavailable.
      */
     public int getColumnNumber() {
@@ -84,7 +107,7 @@ public final class ScriptError {
 
     /**
      * Get the number of columns affected by the error.
-     * 
+     *
      * @return The number of columns. Returns -1 if unavailable.
      */
     public int getLength() {

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptException.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptException.java
@@ -29,6 +29,12 @@ public abstract class ScriptException extends Exception {
         errors.add(new ScriptError(message, 0, 0, -1));
     }
 
+    protected ScriptException(ScriptError scriptError) {
+        super(scriptError.getMessage());
+        this.errors = new ArrayList<ScriptError>(1);
+        errors.add(scriptError);
+    }
+
     /**
      * @param message
      * @param cause
@@ -64,7 +70,7 @@ public abstract class ScriptException extends Exception {
 
     /**
      * Creates a ScriptException with one Error.
-     * 
+     *
      * @param errors
      */
     private ScriptException(final String scriptText, final ScriptError error) {
@@ -81,7 +87,7 @@ public abstract class ScriptException extends Exception {
 
     /**
      * All Errors that lead to this Exception.
-     * 
+     *
      * @return List of Error. Size >= 1, there is at last one ScriptError.
      */
     public List<ScriptError> getErrors() {
@@ -95,9 +101,9 @@ public abstract class ScriptException extends Exception {
     /**
      * Returns a concatenation of all errors in contained ScriptError instances.
      * Separated by newline, except for last error; no \n if only one error.
-     * 
+     *
      * @return The Message.
-     * 
+     *
      * @see ScriptError#getMessage()
      */
     @Override

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptExecutionException.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/engine/ScriptExecutionException.java
@@ -21,6 +21,10 @@ public class ScriptExecutionException extends ScriptException {
         super(message, null, line, column, length);
     }
 
+    public ScriptExecutionException(final ScriptError scriptError) {
+        super(scriptError);
+    }
+
     public ScriptExecutionException(final String message, final Throwable cause, final int line, final int column,
             final int length) {
         super(cause, message, null, line, column, length);

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/interpreter/ScriptInterpreter.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/interpreter/ScriptInterpreter.xtend
@@ -78,14 +78,14 @@ public class ScriptInterpreter extends XbaseInterpreter {
             if (featureCall instanceof XMemberFeatureCall) {
                 throw new ScriptExecutionException(new ScriptError(
                     "'" + featureCall.getConcreteSyntaxFeatureName() + "' is not a member of '" +
-                        receiverObj?.getClass()?.getName() + "'.", featureCall));
+                        receiverObj?.getClass()?.getName() + "'", featureCall));
             } else if (featureCall instanceof XFeatureCall) {
                 throw new ScriptExecutionException(new ScriptError(
                     "The name '" + featureCall.getConcreteSyntaxFeatureName() +
-                        "' cannot be resolved to an item or type.", featureCall));
+                        "' cannot be resolved to an item or type", featureCall));
             } else {
                 throw new ScriptExecutionException(new ScriptError(
-                    "Unknown variable or command '" + featureCall.getConcreteSyntaxFeatureName() + "'.", featureCall));
+                    "Unknown variable or command '" + featureCall.getConcreteSyntaxFeatureName() + "'", featureCall));
             }
         }
         super.invokeFeature(feature, featureCall, receiverObj, context, indicator)

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/interpreter/ScriptInterpreter.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/interpreter/ScriptInterpreter.xtend
@@ -25,6 +25,8 @@ import org.eclipse.xtext.xbase.interpreter.IEvaluationContext
 import org.eclipse.xtext.xbase.interpreter.impl.XbaseInterpreter
 import org.eclipse.xtext.xbase.jvmmodel.IJvmModelAssociations
 import org.eclipse.smarthome.model.script.engine.ScriptExecutionException
+import org.eclipse.xtext.xbase.XMemberFeatureCall
+import org.eclipse.xtext.xbase.XFeatureCall
 
 /**
  * The script interpreter handles ESH specific script components, which are not known
@@ -68,8 +70,15 @@ public class ScriptInterpreter extends XbaseInterpreter {
 	override protected invokeFeature(JvmIdentifiableElement feature, XAbstractFeatureCall featureCall,
 		Object receiverObj, IEvaluationContext context, CancelIndicator indicator) {
 		if (feature != null && feature.eIsProxy) {
-			throw new RuntimeException(
-				"The name '" + featureCall.toString() + "' cannot be resolved to an item or type.");
+		    if (featureCall instanceof XMemberFeatureCall) {
+                throw new ScriptExecutionException(
+                    "'" + featureCall.getConcreteSyntaxFeatureName() + "' is not a member of '" + receiverObj?.getClass()?.getName() + "'.");
+		    } else if (featureCall instanceof XFeatureCall) {
+                throw new ScriptExecutionException(
+                    "The name '" + featureCall.getConcreteSyntaxFeatureName() + "' cannot be resolved to an item or type.");
+		    } else {
+                throw new ScriptExecutionException("Unknown variable or command '" + featureCall.getConcreteSyntaxFeatureName() + "'.");
+		    }
 		}
         super.invokeFeature(feature, featureCall, receiverObj, context, indicator)
 	}


### PR DESCRIPTION
see #4317.

This improves the logged error messages as following:

#### Class cast exception:

```
Rule 'myRuleTest': java.lang.Number
```

becomes

```
Could not cast NULL to java.lang.Number; line 6, column 35, length 26
```

#### Unknown member:

```
The name '<XCastedExpressionImpl>.blaaa' cannot be resolved to an item or type.
```

becomes 

```
'blaaa' is not a member of 'org.eclipse.smarthome.core.types.UnDefType'; line 6, column 34, length 24
```