### PR TITLE
Sonos: fix thing type matching for ZP80 and ZP100

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/discovery/ZonePlayerDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/discovery/ZonePlayerDiscoveryParticipant.java
@@ -76,9 +76,9 @@ public class ZonePlayerDiscoveryParticipant implements UpnpDiscoveryParticipant 
 
                     String modelName = getModelName(device);
                     if (modelName.equals("ZP80")) {
-                        modelName = "PLAY3";
+                        modelName = "CONNECT";
                     } else if (modelName.equals("ZP100")) {
-                        modelName = "PLAY5";
+                        modelName = "CONNECTAMP";
                     }
                     ThingTypeUID thingUID = new ThingTypeUID(SonosBindingConstants.BINDING_ID, modelName);
 


### PR DESCRIPTION
ZP80 -> CONNECT
ZP100 -> CONNECT:AMP

Signed-off-by: Laurent Garnier <lg.hc@free.fr>