### PR TITLE
[core] Adjustments to ExpiringCacheMap

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheMapTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheMapTest.java
@@ -13,188 +13,197 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.junit.Before;
 
 /**
  * Test class for the {@link ExpiringCacheMap} class.
  *
  * @author Christoph Weitkamp - Initial contribution.
+ * @author Martin van Wingerden - Added tests for putIfAbsentAndGet
  */
 public class ExpiringCacheMapTest {
+    private static final long CACHE_EXPIRY = TimeUnit.SECONDS.toMillis(2);
 
-    private final Logger logger = LoggerFactory.getLogger(ExpiringCacheMapTest.class);
+    private static final String RESPONSE_1 = "ACTION 1";
+    private static final String RESPONSE_2 = "ACTION 2";
 
-    public static final long CACHE_EXPIRY = 2 * 1000; // 2s
+    private static final Supplier<String> CACHE_ACTION = () -> RandomStringUtils.random(8);
+    private static final Supplier<String> PREDICTABLE_CACHE_ACTION_1 = () -> RESPONSE_1;
+    private static final Supplier<String> PREDICTABLE_CACHE_ACTION_2 = () -> RESPONSE_2;
 
-    public static final Supplier<String> CACHE_ACTION = () -> RandomStringUtils.random(8);
+    private static final String FIRST_TEST_KEY = "FIRST_TEST_KEY";
+    private static final String SECOND_TEST_KEY = "SECOND_TEST_KEY";
 
-    public static final String FIRST_TEST_KEY = "FIRST_TEST_KEY";
-    public static final String SECOND_TEST_KEY = "SECOND_TEST_KEY";
-
+    private ExpiringCacheMap<String, String> subject;
+    
+    @Before
+    public void setUp() {
+        subject = new ExpiringCacheMap<>(CACHE_EXPIRY);
+    }
+    
+    
     @Test(expected = IllegalArgumentException.class)
-    public void testAddIllegalArgumentException1() throws IllegalArgumentException {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
-
-        final Supplier<String> action = null;
-        cache.put(FIRST_TEST_KEY, action);
+    public void testPutIllegalArgumentException1() throws IllegalArgumentException {
+        subject.put(FIRST_TEST_KEY, (Supplier<String>) null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testAddIllegalArgumentException2() throws IllegalArgumentException {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
-
-        final ExpiringCache<String> item = null;
-        cache.put(FIRST_TEST_KEY, item);
+    public void testPutIllegalArgumentException2() throws IllegalArgumentException {
+        subject.put(FIRST_TEST_KEY, (ExpiringCache<String>) null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testAddIllegalArgumentException3() throws IllegalArgumentException {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
+    public void testPutIllegalArgumentException3() throws IllegalArgumentException {
+        subject.put(null, CACHE_ACTION);
+    }
+    
+    @Test
+    public void testPut() {
+        subject.put(FIRST_TEST_KEY, PREDICTABLE_CACHE_ACTION_1);
 
-        cache.put(null, CACHE_ACTION);
+        assertEquals(RESPONSE_1, subject.get(FIRST_TEST_KEY));
+
+        subject.put(FIRST_TEST_KEY, PREDICTABLE_CACHE_ACTION_2);
+
+        assertEquals(RESPONSE_2, subject.get(FIRST_TEST_KEY));
+    }
+
+    @Test
+    public void testPutIfAbsentAndGet() {
+        String response = subject.putIfAbsentAndGet(FIRST_TEST_KEY, PREDICTABLE_CACHE_ACTION_1);
+
+        assertEquals(RESPONSE_1, response);
+        assertEquals(RESPONSE_1, subject.get(FIRST_TEST_KEY));
+
+        response = subject.putIfAbsentAndGet(FIRST_TEST_KEY, PREDICTABLE_CACHE_ACTION_2);
+
+        assertEquals(RESPONSE_1, response);
     }
 
     @Test
     public void testContainsKey() {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
+        subject.put(FIRST_TEST_KEY, CACHE_ACTION);
 
-        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
-
-        assertTrue(cache.containsKey(FIRST_TEST_KEY));
+        assertTrue(subject.containsKey(FIRST_TEST_KEY));
     }
 
     @Test
     public void testKeys() {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
-
-        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+        subject.put(FIRST_TEST_KEY, CACHE_ACTION);
 
         // get all keys
-        final Set<String> expected_keys = new LinkedHashSet<>();
-        expected_keys.add(FIRST_TEST_KEY);
+        final Set<String> expectedKeys = new LinkedHashSet<>();
+        expectedKeys.add(FIRST_TEST_KEY);
 
-        final Set<String> keys = cache.keys();
-        assertEquals(expected_keys, keys);
+        final Set<String> keys = subject.keys();
+        assertEquals(expectedKeys, keys);
     }
 
     @Test
     public void testValues() {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
-
-        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+        subject.put(FIRST_TEST_KEY, CACHE_ACTION);
 
         // use the same key twice
-        String value1 = cache.get(FIRST_TEST_KEY);
+        String value1 = subject.get(FIRST_TEST_KEY);
         assertNotNull(value1);
-        String value2 = cache.get(FIRST_TEST_KEY);
+        String value2 = subject.get(FIRST_TEST_KEY);
         assertNotNull(value2);
         assertEquals(value1, value2);
 
-        cache.put(SECOND_TEST_KEY, CACHE_ACTION);
+        subject.put(SECOND_TEST_KEY, CACHE_ACTION);
 
         // use a different key
-        String value3 = cache.get(SECOND_TEST_KEY);
+        String value3 = subject.get(SECOND_TEST_KEY);
         assertNotNull(value3);
         assertNotEquals(value1, value3);
 
         // get all values
-        final Collection<String> expected_values = new LinkedList<>();
-        expected_values.add(value3);
-        expected_values.add(value1);
+        final Collection<String> expectedValues = new LinkedList<>();
+        expectedValues.add(value3);
+        expectedValues.add(value1);
 
-        final Collection<String> values = cache.values();
-        assertEquals(expected_values, values);
+        final Collection<String> values = subject.values();
+        assertEquals(expectedValues, values);
 
         // use another different key
-        String value4 = cache.get("KEY_NOT_FOUND");
+        String value4 = subject.get("KEY_NOT_FOUND");
         assertNull(value4);
     }
 
     @Test
     public void testExpired() throws InterruptedException {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
+        subject.put(FIRST_TEST_KEY, CACHE_ACTION);
 
-        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
-
-        String value1 = cache.get(FIRST_TEST_KEY);
+        String value1 = subject.get(FIRST_TEST_KEY);
 
         // wait until cache expires
         Thread.sleep(CACHE_EXPIRY + 100);
 
-        String value2 = cache.get(FIRST_TEST_KEY);
+        String value2 = subject.get(FIRST_TEST_KEY);
         assertNotEquals(value1, value2);
     }
 
     @Test
     public void testInvalidate() {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
+        subject.put(FIRST_TEST_KEY, CACHE_ACTION);
 
-        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
-
-        String value1 = cache.get(FIRST_TEST_KEY);
+        String value1 = subject.get(FIRST_TEST_KEY);
 
         // invalidate item
-        cache.invalidate(FIRST_TEST_KEY);
+        subject.invalidate(FIRST_TEST_KEY);
 
-        String value2 = cache.get(FIRST_TEST_KEY);
+        String value2 = subject.get(FIRST_TEST_KEY);
         assertNotEquals(value1, value2);
 
         // invalidate all
-        cache.invalidateAll();
+        subject.invalidateAll();
 
-        String value3 = cache.get(FIRST_TEST_KEY);
+        String value3 = subject.get(FIRST_TEST_KEY);
         assertNotEquals(value2, value3);
     }
 
     @Test
     public void testRefresh() {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
+        subject.put(FIRST_TEST_KEY, CACHE_ACTION);
 
-        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
-
-        String value1 = cache.get(FIRST_TEST_KEY);
+        String value1 = subject.get(FIRST_TEST_KEY);
 
         // refresh item
-        String value2 = cache.refresh(FIRST_TEST_KEY);
+        String value2 = subject.refresh(FIRST_TEST_KEY);
         assertNotEquals(value1, value2);
 
         // refresh all
-        final Collection<String> expected_values = new LinkedList<>();
-        expected_values.add(value2);
+        final Collection<String> expectedValues = new LinkedList<>();
+        expectedValues.add(value2);
 
-        final Collection<String> values = cache.refreshAll();
-        assertNotEquals(expected_values, values);
+        final Collection<String> values = subject.refreshAll();
+        assertNotEquals(expectedValues, values);
     }
 
     @Test
     public void testRemove() {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
-
-        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+        subject.put(FIRST_TEST_KEY, CACHE_ACTION);
 
         // remove item
-        cache.remove(FIRST_TEST_KEY);
+        subject.remove(FIRST_TEST_KEY);
 
-        String value1 = cache.get(FIRST_TEST_KEY);
+        String value1 = subject.get(FIRST_TEST_KEY);
         assertNull(value1);
-
     }
 
     @Test
     public void testClear() {
-        final ExpiringCacheMap<String, String> cache = new ExpiringCacheMap<>(CACHE_EXPIRY);
-
-        cache.put(FIRST_TEST_KEY, CACHE_ACTION);
+        subject.put(FIRST_TEST_KEY, CACHE_ACTION);
 
         // clear cache
-        cache.clear();
+        subject.clear();
 
-        String value1 = cache.get(FIRST_TEST_KEY);
+        String value1 = subject.get(FIRST_TEST_KEY);
         assertNull(value1);
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheMapTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheMapTest.java
@@ -70,7 +70,9 @@ public class ExpiringCacheMapTest {
 
         subject.put(FIRST_TEST_KEY, PREDICTABLE_CACHE_ACTION_2);
 
-        assertEquals(RESPONSE_2, subject.get(FIRST_TEST_KEY));
+        String response = subject.get(FIRST_TEST_KEY);
+        assertNotEquals(RESPONSE_1, response);
+        assertEquals(RESPONSE_2, response);
     }
 
     @Test
@@ -83,6 +85,7 @@ public class ExpiringCacheMapTest {
         response = subject.putIfAbsentAndGet(FIRST_TEST_KEY, PREDICTABLE_CACHE_ACTION_2);
 
         assertEquals(RESPONSE_1, response);
+        assertNotEquals(RESPONSE_2, response);
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCache.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCache.java
@@ -51,10 +51,11 @@ public class ExpiringCache<V> {
      */
     @Nullable
     public synchronized V getValue() {
-        if (value.get() == null || isExpired()) {
+        V cachedValue = value.get();
+        if (cachedValue == null || isExpired()) {
             return refreshValue();
         }
-        return value.get();
+        return cachedValue;
     }
 
     /**
@@ -72,9 +73,10 @@ public class ExpiringCache<V> {
      */
     @Nullable
     public synchronized V refreshValue() {
-        value = new SoftReference<>(action.get());
+        V freshValue = action.get();
+        value = new SoftReference<>(freshValue);
         expiresAt = System.nanoTime() + expiry;
-        return value.get();
+        return freshValue;
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheMap.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheMap.java
@@ -83,7 +83,26 @@ public class ExpiringCacheMap<K, V> {
     }
 
     /**
-     * Creates an {@link ExpiringCache} and adds it to the cache.
+     * If the specified key is not already associated with a value, associate it with the given expiringCache.
+     *
+     * @param key the key with which the specified value is to be associated
+     * @param item the item to be associated with the specified key
+     */
+    public void putIfAbsent(K key, ExpiringCache<V> item) {
+        if (key == null) {
+            throw new IllegalArgumentException("Item cannot be added as key is null.");
+        }
+        if (item == null) {
+            throw new IllegalArgumentException("Item cannot be added as item is null.");
+        }
+
+        items.putIfAbsent(key, item);
+    }
+
+    /**
+     * If the specified key is not already associated, associate it with the given action.
+     *
+     * Note that this method has the overhead of actually calling/performing the action
      *
      * @param key the key with which the specified value is to be associated
      * @param action the action for the item to be associated with the specified key to retrieve/calculate the value
@@ -94,21 +113,16 @@ public class ExpiringCacheMap<K, V> {
     }
 
     /**
-     * If the specified key is not already associated with a value, associate it with the given value.
+     * If the specified key is not already associated with a value, associate it with the given expiringCache.
+     *
+     * Note that this method has the overhead of actually calling/performing the action
      *
      * @param key the key with which the specified value is to be associated
      * @param item the item to be associated with the specified key
      * @return the (cached) value for the specified key
      */
     public V putIfAbsentAndGet(K key, ExpiringCache<V> item) {
-        if (key == null) {
-            throw new IllegalArgumentException("Item cannot be added as key is null.");
-        }
-        if (item == null) {
-            throw new IllegalArgumentException("Item cannot be added as item is null.");
-        }
-
-        items.putIfAbsent(key, item);
+        putIfAbsent(key, item);
 
         return this.get(key);
     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheMap.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheMap.java
@@ -83,7 +83,7 @@ public class ExpiringCacheMap<K, V> {
     }
 
     /**
-     * If the specified key is not already associated with a value, associate it with the given expiringCache.
+     * If the specified key is not already associated with a value, associate it with the given {@link ExpiringCache}.
      *
      * @param key the key with which the specified value is to be associated
      * @param item the item to be associated with the specified key
@@ -113,7 +113,7 @@ public class ExpiringCacheMap<K, V> {
     }
 
     /**
-     * If the specified key is not already associated with a value, associate it with the given expiringCache.
+     * If the specified key is not already associated with a value, associate it with the given {@link ExpiringCache}.
      *
      * Note that this method has the overhead of actually calling/performing the action
      *

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheMap.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCacheMap.java
@@ -7,6 +7,7 @@
  */
 package org.eclipse.smarthome.core.cache;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -23,6 +24,7 @@ import org.slf4j.LoggerFactory;
  * specified duration has passed since the item was created, or the most recent replacement of the value.
  *
  * @author Christoph Weitkamp - Initial contribution and API.
+ * @author Martin van Wingerden - Added constructor accepting Duration and putIfAbsentAndGet
  *
  * @param <K> the type of the key
  * @param <V> the type of the value
@@ -33,6 +35,15 @@ public class ExpiringCacheMap<K, V> {
 
     private final long expiry;
     private final ConcurrentMap<K, ExpiringCache<V>> items;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param expiry the duration for how long the value stays valid
+     */
+    public ExpiringCacheMap(Duration expiry) {
+        this(expiry.toMillis());
+    }
 
     /**
      * Creates a new instance.
@@ -69,6 +80,37 @@ public class ExpiringCacheMap<K, V> {
         }
 
         items.put(key, item);
+    }
+
+    /**
+     * Creates an {@link ExpiringCache} and adds it to the cache.
+     *
+     * @param key the key with which the specified value is to be associated
+     * @param action the action for the item to be associated with the specified key to retrieve/calculate the value
+     * @return the (cached) value for the specified key
+     */
+    public V putIfAbsentAndGet(K key, Supplier<V> action) {
+        return putIfAbsentAndGet(key, new ExpiringCache<>(expiry, action));
+    }
+
+    /**
+     * If the specified key is not already associated with a value, associate it with the given value.
+     *
+     * @param key the key with which the specified value is to be associated
+     * @param item the item to be associated with the specified key
+     * @return the (cached) value for the specified key
+     */
+    public V putIfAbsentAndGet(K key, ExpiringCache<V> item) {
+        if (key == null) {
+            throw new IllegalArgumentException("Item cannot be added as key is null.");
+        }
+        if (item == null) {
+            throw new IllegalArgumentException("Item cannot be added as item is null.");
+        }
+
+        items.putIfAbsent(key, item);
+
+        return this.get(key);
     }
 
     /**


### PR DESCRIPTION
I wanted the `ExpiringCacheMap` to be more like a Java 8 `Map`, ideally it would have implemented the `Map` interface but our `get` and `put` are not symmetrical, for very good reasons. 

Given that checking whether an entry exists and adding it, if it doesn't is very common I added it, I also changed the constructor to accept a duration to make more readable code possible.

Example:

```java
ExpiringCacheMap<String, RawData> cache = new ExpiringCacheMap<>(Duration.ofMinutes(15));

...

RawType image = cache.putIfAbsentAndGet(url, () -> {
    logger.debug("Try to download the content of URL {}", url);
    return HttpUtil.downloadImage(url);
});

``` 

@cweitkamp wdyt?


PS: I did not name if `putIfAbsent` because it behaves differently
PS2: could we already use proper java 8 here?