### PR TITLE
Fix order dependent processing of config files

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_no_conflict_services/global.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_no_conflict_services/global.pid.service.file.cfg
@@ -1,2 +1,2 @@
 pid:no.conflict.global.and.local.pid
-global.property=global.value
+exclusive.property=global.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_no_conflict_services/local.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_no_conflict_services/local.pid.service.file.cfg
@@ -1,1 +1,1 @@
-no.conflict.global.and.local.pid:local.property=local.value
+no.conflict.global.and.local.pid:inline.property=local.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_global_services/b.overriden.global.pid.service.file.cfg
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/configurations/global_and_local_pid_different_files_conf/global_and_local_pid_overridden_global_services/b.overriden.global.pid.service.file.cfg
@@ -1,2 +1,1 @@
-pid:overridden.global.pid
-global.and.local.property=global.value
+overridden.global.pid:global.and.local.property=global.value

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/src/test/java/org/eclipse/smarthome/config/dispatch/test/ConfigDispatcherOSGiTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/src/test/java/org/eclipse/smarthome/config/dispatch/test/ConfigDispatcherOSGiTest.java
@@ -621,7 +621,7 @@ public class ConfigDispatcherOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void theSameLocalAndGlobalPIDsInDifferentFilesAreConsideredOnePID() {
+    public void whenExclusivePIDisDefinedInlineFromDifferentFile_skipTheLine() {
         String configDirectory = configBaseDirectory + SEP + "global_and_local_pid_different_files_conf";
         String servicesDirectory = "global_and_local_pid_no_conflict_services";
         String defaultConfigFilePath = configDirectory + SEP + "global.and.local.pid.default.file.cfg";
@@ -629,8 +629,8 @@ public class ConfigDispatcherOSGiTest extends JavaOSGiTest {
         initialize(configDirectory, servicesDirectory, defaultConfigFilePath);
 
         // Assert that the configuration is updated with all the properties for a pid from all the processed files.
-        verifyValueOfConfigurationProperty("no.conflict.global.and.local.pid", "global.property", "global.value");
-        verifyValueOfConfigurationProperty("no.conflict.global.and.local.pid", "local.property", "local.value");
+        verifyValueOfConfigurationProperty("no.conflict.global.and.local.pid", "exclusive.property", "global.value");
+        verifyNotExistingConfigurationProperty("no.conflict.global.and.local.pid", "inline.property");
     }
 
     @Test


### PR DESCRIPTION
Fixes #4424.

Implemented as described in https://github.com/eclipse/smarthome/issues/4424#issuecomment-342455604.

Signed-off-by: Henning Treu <henning.treu@telekom.de>