### PR TITLE
WIP: External null annotations via jar from maven central

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/.classpath
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/.classpath
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="annotationpath" value="/targetplatform/eea/jdk.zip"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins">
+		<attributes>
+			<attribute name="annotationpath" value="/targetplatform/eea/jdk.zip"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/.classpath
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/.classpath
@@ -1,15 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
-		<attributes>
-			<attribute name="annotationpath" value="/targetplatform/eea/jdk.zip"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins">
-		<attributes>
-			<attribute name="annotationpath" value="/targetplatform/eea/jdk.zip"/>
-		</attributes>
-	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/.classpath
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/.classpath
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="annotationpath" value="/targetplatform/eeas.jar"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins">
+		<attributes>
+			<attribute name="annotationpath" value="/targetplatform/eeas.jar"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="src" path="src/main/java"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -74,25 +74,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>wagon-maven-plugin</artifactId>
-        <version>1.0</version>
-        <executions>
-          <execution>
-            <id>download-eea-zip</id>
-            <phase>initialize</phase>
-            <goals>
-              <goal>download-single</goal>
-            </goals>
-            <configuration>
-              <url>${eea-url}</url>
-              <fromFile>${eea-dir}/${eea-file}</fromFile>
-              <toDir>${basedirRoot}/targetplatform/eea/</toDir>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.commonjava.maven.plugins</groupId>
         <artifactId>directory-maven-plugin</artifactId>
         <version>0.2</version>
@@ -221,12 +202,18 @@
                 <artifactId>org.eclipse.jdt.annotation</artifactId>
                 <version>${jdt-annotations.version}</version>
               </extraClasspathElement>
+              <extraClasspathElement>
+                <!-- TODO: insert one project that contains ALL annotations here-->
+                <groupId>org.lastnpe.eea</groupId>
+                <artifactId>jdk-eea</artifactId>
+                <version>0.0.1</version>
+              </extraClasspathElement>
             </extraClasspathElements>
             <compilerArgs>
               <arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot</arg>
               <arg>-warn:+null,+inheritNullAnnot,+nullAnnotConflict,+nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
               <arg>-annotationpath</arg>
-              <arg>${basedirRoot}/targetplatform/eea/${eea-file}</arg>
+              <arg>CLASSPATH</arg>
             </compilerArgs>
           </configuration>
         </plugin>
@@ -606,5 +593,15 @@
       </snapshots>
     </repository>
   </repositories>
+
+  <dependencies>
+    <dependency>
+      <!-- TODO: insert one project that contains ALL annotations here-->
+      <groupId>org.lastnpe.eea</groupId>
+      <artifactId>jdk-eea</artifactId>
+      <version>0.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+ </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,9 @@
     <build.helper.maven.plugin.version>1.8</build.helper.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sat.version>0.4.1</sat.version>
+    <eea-url>http://www.TODO.tld</eea-url>
+    <eea-dir>path/to/file/on/server</eea-dir>
+    <eea-file>jdk.zip</eea-file>
   </properties>
 
   <packaging>pom</packaging>
@@ -70,6 +73,25 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>wagon-maven-plugin</artifactId>
+        <version>1.0</version>
+        <executions>
+          <execution>
+            <id>download-eea-zip</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>download-single</goal>
+            </goals>
+            <configuration>
+              <url>${eea-url}</url>
+              <fromFile>${eea-dir}/${eea-file}</fromFile>
+              <toDir>${basedirRoot}/targetplatform/eea/</toDir>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.commonjava.maven.plugins</groupId>
         <artifactId>directory-maven-plugin</artifactId>
@@ -201,8 +223,10 @@
               </extraClasspathElement>
             </extraClasspathElements>
             <compilerArgs>
-              <!--<arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot</arg>-->
-              <arg>-warn:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+null,+inheritNullAnnot,+nullAnnotConflict,+nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
+              <arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot</arg>
+              <arg>-warn:+null,+inheritNullAnnot,+nullAnnotConflict,+nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
+              <arg>-annotationpath</arg>
+              <arg>${basedirRoot}/targetplatform/eea/${eea-file}</arg>
             </compilerArgs>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -211,8 +211,8 @@
               </extraClasspathElement>
             </extraClasspathElements>
             <compilerArgs>
-              <arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot</arg>
-              <arg>-warn:+null,+inheritNullAnnot,+nullAnnotConflict,+nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
+              <!--<arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot</arg>-->
+              <arg>-warn:+null,+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot,+nullAnnotConflict,+nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
               <arg>-annotationpath</arg>
               <arg>CLASSPATH</arg>
             </compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,10 @@
     <build.helper.maven.plugin.version>1.8</build.helper.maven.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sat.version>0.4.1</sat.version>
-    <eea-url>http://www.TODO.tld</eea-url>
-    <eea-dir>path/to/file/on/server</eea-dir>
-    <eea-file>jdk.zip</eea-file>
+    <!-- TODO: insert one project that contains ALL annotations here-->
+    <eea-groupId>org.lastnpe.eea</eea-groupId>
+    <eea-artifactId>jdk-eea</eea-artifactId>
+    <eea-version>0.0.1</eea-version>
   </properties>
 
   <packaging>pom</packaging>
@@ -204,9 +205,9 @@
               </extraClasspathElement>
               <extraClasspathElement>
                 <!-- TODO: insert one project that contains ALL annotations here-->
-                <groupId>org.lastnpe.eea</groupId>
-                <artifactId>jdk-eea</artifactId>
-                <version>0.0.1</version>
+                <groupId>${eea-groupId}</groupId>
+                <artifactId>${eea-artifactId}</artifactId>
+                <version>${eea-version}</version>
               </extraClasspathElement>
             </extraClasspathElements>
             <compilerArgs>
@@ -596,10 +597,9 @@
 
   <dependencies>
     <dependency>
-      <!-- TODO: insert one project that contains ALL annotations here-->
-      <groupId>org.lastnpe.eea</groupId>
-      <artifactId>jdk-eea</artifactId>
-      <version>0.0.1</version>
+      <groupId>${eea-groupId}</groupId>
+      <artifactId>${eea-artifactId}</artifactId>
+      <version>${eea-version}</version>
       <scope>provided</scope>
     </dependency>
  </dependencies>

--- a/targetplatform/.gitignore
+++ b/targetplatform/.gitignore
@@ -1,0 +1,1 @@
+/eeas.jar

--- a/targetplatform/DownloadEEAs.launch
+++ b/targetplatform/DownloadEEAs.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="process-resources"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JRE for JavaSE-1.8"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:/targetplatform}"/>
+</launchConfiguration>

--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -124,7 +124,7 @@
       <setupTask
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.nullUncheckedConversion"
-          value="ignore"/>
+          value="warning"/>
       <setupTask
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.core/org.eclipse.jdt.core.compiler.problem.parameterAssignment"
@@ -2447,6 +2447,10 @@
         content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;lifecycleMappingMetadata>&#xA;  &lt;pluginExecutions>&#xA;    &lt;pluginExecution>&#xA;      &lt;pluginExecutionFilter>&#xA;        &lt;groupId>org.codehaus.mojo&lt;/groupId>&#xA;        &lt;artifactId>build-helper-maven-plugin&lt;/artifactId>&#xA;        &lt;versionRange>1.8&lt;/versionRange>&#xA;        &lt;goals>&#xA;          &lt;goal>add-source&lt;/goal>&#xA;          &lt;goal>add-test-source&lt;/goal>&#xA;        &lt;/goals>&#xA;      &lt;/pluginExecutionFilter>&#xA;      &lt;action>&#xA;        &lt;ignore />&#xA;      &lt;/action>&#xA;    &lt;/pluginExecution>&#xA;  &lt;/pluginExecutions>&#xA;&lt;/lifecycleMappingMetadata>&#xA;"
         targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml"
         encoding="UTF-8"/>
+    <setupTask
+        xsi:type="setup:ResourceCopyTask"
+        sourceURL="http://www.TODO.tld/path/to/file/on/server/jdk.zip"
+        targetURL="${git.clone.eclipsesmarthome.location|uri}/targetplatform/eea/jdk.zip"/>
     <stream
         name="master"/>
   </project>

--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -2423,6 +2423,12 @@
           locateNestedProjects="true"/>
     </setupTask>
     <setupTask
+        xsi:type="launching:LaunchTask"
+        id="launch.smarthome.downloadEEAs"
+        launcher="DownloadEEAs">
+      <description>Downloads Eclipse External Annotations and places them into eeas.jar in targetplatform</description>
+    </setupTask>
+    <setupTask
         xsi:type="pde:TargetPlatformTask"
         id="smarthome.target"
         name="SmartHome">
@@ -2447,10 +2453,6 @@
         content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>&#xA;&lt;lifecycleMappingMetadata>&#xA;  &lt;pluginExecutions>&#xA;    &lt;pluginExecution>&#xA;      &lt;pluginExecutionFilter>&#xA;        &lt;groupId>org.codehaus.mojo&lt;/groupId>&#xA;        &lt;artifactId>build-helper-maven-plugin&lt;/artifactId>&#xA;        &lt;versionRange>1.8&lt;/versionRange>&#xA;        &lt;goals>&#xA;          &lt;goal>add-source&lt;/goal>&#xA;          &lt;goal>add-test-source&lt;/goal>&#xA;        &lt;/goals>&#xA;      &lt;/pluginExecutionFilter>&#xA;      &lt;action>&#xA;        &lt;ignore />&#xA;      &lt;/action>&#xA;    &lt;/pluginExecution>&#xA;  &lt;/pluginExecutions>&#xA;&lt;/lifecycleMappingMetadata>&#xA;"
         targetURL="${workspace.location|uri}/.metadata/.plugins/org.eclipse.m2e.core/lifecycle-mapping-metadata.xml"
         encoding="UTF-8"/>
-    <setupTask
-        xsi:type="setup:ResourceCopyTask"
-        sourceURL="http://www.TODO.tld/path/to/file/on/server/jdk.zip"
-        targetURL="${git.clone.eclipsesmarthome.location|uri}/targetplatform/eea/jdk.zip"/>
     <stream
         name="master"/>
   </project>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -18,6 +18,35 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>download-copy-eeas</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>${eea-groupId}</groupId>
+                  <artifactId>${eea-artifactId}</artifactId>
+                  <version>${eea-version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${basedir}</outputDirectory>
+                  <destFileName>eeas.jar</destFileName>
+                </artifactItem>
+              </artifactItems>
+              <overWriteReleases>false</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>1.3</version>


### PR DESCRIPTION
This PR is similar to #4217 but instead of creating a project that
contains the annotations in a directory it sets up the IDE to read the
annotations from a jar file.

The reason behind this is that the IDE should be for the every day
developer who will not create external annotations. Nevertheless he
should benefit from them which is why they are provided in a zip file.

This jar file should be hosted externally, maybe together with
lastnpe.org (on maven central as a maven dependency). That is also
the place to add new annotations, i.e.
download the project from there, change the IDE to use this project as a
directory, add your annotations and afterwards the project releases a
new jar file on maven central.

In this PR I created a setup task for the IDE to download the
annotations file and place it as  "eeas.jar" in the targetplatform
folder via a maven task. For maven I am using the maven-dependency-plugin
which enables downloading a maven dependency project and copying
its jar file into a place where the IDE an access it. The compile task
of maven uses the CLASSPATH as "annotationpath", because the annotations
are added as a maven dependency and put on the classpath.

Also I reactivated the "Unchecked conversion from non-annotated type to
@nonnull type" check by setting it to warning level, otherwise (if set
to ignore) external annotations are not needed.

As an example I updated the ".classpath" file of the yahoo binding to
use the downloaded jar file.

The parts which are still valid from PR #4217 are:
* all created external annotations
* all updated .classpath files (IF adjusted to use the zip file instead
of a directory)

We still need one central project on maven central that contains all 
external annotations which is why this PR is WIP for now.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>