### PR TITLE
improved error handling in ChartServlet

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/ChartServlet.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/chart/ChartServlet.java
@@ -295,12 +295,22 @@ public class ChartServlet extends HttpServlet {
             BufferedImage chart = provider.createChart(serviceName, req.getParameter("theme"), timeBegin, timeEnd,
                     height, width, req.getParameter("items"), req.getParameter("groups"), dpi, legend);
             ImageIO.write(chart, provider.getChartType().toString(), imageOutputStream);
+            logger.debug("Chart successfully generated and written to the response.");
         } catch (ItemNotFoundException e) {
             logger.debug("{}", e.getMessage());
+            res.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
         } catch (IllegalArgumentException e) {
             logger.warn("Illegal argument in chart: {}", e.getMessage());
+            res.sendError(HttpServletResponse.SC_BAD_REQUEST, "Illegal argument in chart: " + e.getMessage());
+        } catch (RuntimeException e) {
+            if (logger.isDebugEnabled()) {
+                // we also attach the stack trace
+                logger.warn("Chart generation failed: {}", e.getMessage(), e);
+            } else {
+                logger.warn("Chart generation failed: {}", e.getMessage());
+            }
+            res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
         }
-        logger.debug("chart built");
     }
 
     /**


### PR DESCRIPTION
fixes #4521

The servlet itself should not let exceptions bubble up to the HTTP service itself - instead it should create a HTTP 500 response and return without an exception.

Signed-off-by: Kai Kreuzer <kai@openhab.org>