### PR TITLE
Expose the item triggering the execution of a rule

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
@@ -200,7 +200,7 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
         if (!starting && triggerManager != null) {
             Iterable<Rule> rules = triggerManager.getRules(CHANGE, item, oldState, newState);
 
-            executeRules(rules, oldState);
+            executeRules(rules, item, oldState);
         }
     }
 
@@ -208,7 +208,7 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
     public void stateUpdated(Item item, State state) {
         if (!starting && triggerManager != null) {
             Iterable<Rule> rules = triggerManager.getRules(UPDATE, item, state);
-            executeRules(rules);
+            executeRules(rules, item);
         }
     }
 
@@ -220,7 +220,7 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
                 Item item = itemRegistry.getItem(itemName);
                 Iterable<Rule> rules = triggerManager.getRules(COMMAND, item, command);
 
-                executeRules(rules, command);
+                executeRules(rules, item, command);
             } catch (ItemNotFoundException e) {
                 // ignore commands for non-existent items
             }
@@ -362,17 +362,27 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
         }
     }
 
-    protected synchronized void executeRules(Iterable<Rule> rules, Command command) {
+    protected synchronized void executeRules(Iterable<Rule> rules, Item item) {
         for (Rule rule : rules) {
             RuleEvaluationContext context = new RuleEvaluationContext();
+            context.newValue(QualifiedName.create(RulesJvmModelInferrer.VAR_TRIGGERING_ITEM), item);
+            executeRule(rule, context);
+        }
+    }
+
+    protected synchronized void executeRules(Iterable<Rule> rules, Item item, Command command) {
+        for (Rule rule : rules) {
+            RuleEvaluationContext context = new RuleEvaluationContext();
+            context.newValue(QualifiedName.create(RulesJvmModelInferrer.VAR_TRIGGERING_ITEM), item);
             context.newValue(QualifiedName.create(RulesJvmModelInferrer.VAR_RECEIVED_COMMAND), command);
             executeRule(rule, context);
         }
     }
 
-    protected synchronized void executeRules(Iterable<Rule> rules, State oldState) {
+    protected synchronized void executeRules(Iterable<Rule> rules, Item item, State oldState) {
         for (Rule rule : rules) {
             RuleEvaluationContext context = new RuleEvaluationContext();
+            context.newValue(QualifiedName.create(RulesJvmModelInferrer.VAR_TRIGGERING_ITEM), item);
             context.newValue(QualifiedName.create(RulesJvmModelInferrer.VAR_PREVIOUS_STATE), oldState);
             executeRule(rule, context);
         }

--- a/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/jvmmodel/RulesJvmModelInferrer.xtend
@@ -9,6 +9,7 @@ package org.eclipse.smarthome.model.rule.jvmmodel
 
 import com.google.inject.Inject
 import java.util.Set
+import org.eclipse.smarthome.core.items.Item
 import org.eclipse.smarthome.core.items.ItemRegistry
 import org.eclipse.smarthome.core.thing.ThingRegistry
 import org.eclipse.smarthome.core.thing.events.ChannelTriggeredEvent
@@ -21,6 +22,7 @@ import org.eclipse.smarthome.model.rule.rules.EventTrigger
 import org.eclipse.smarthome.model.rule.rules.Rule
 import org.eclipse.smarthome.model.rule.rules.RuleModel
 import org.eclipse.smarthome.model.rule.rules.ThingStateChangedEventTrigger
+import org.eclipse.smarthome.model.rule.rules.UpdateEventTrigger
 import org.eclipse.smarthome.model.script.jvmmodel.ScriptJvmModelInferrer
 import org.eclipse.smarthome.model.script.scoping.StateAndCommandProvider
 import org.eclipse.xtext.naming.IQualifiedNameProvider
@@ -41,6 +43,9 @@ import org.slf4j.LoggerFactory
 class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
 
     private final Logger logger = LoggerFactory.getLogger(RulesJvmModelInferrer)
+
+    /** Variable name for the item in a "state triggered" or "command triggered" rule */
+    public static final String VAR_TRIGGERING_ITEM = "triggeringItem";
 
     /** Variable name for the previous state of an item in a "changed state triggered" rule */
     public static final String VAR_PREVIOUS_STATE = "previousState";
@@ -126,6 +131,10 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
             members += ruleModel.rules.map [ rule |
                 rule.toMethod("_" + rule.name, ruleModel.newTypeRef(Void.TYPE)) [
                     static = true
+                    if ((containsCommandTrigger(rule)) || (containsStateChangeTrigger(rule)) || (containsStateUpdateTrigger(rule))) {
+                        val itemTypeRef = ruleModel.newTypeRef(Item)
+                        parameters += rule.toParameter(VAR_TRIGGERING_ITEM, itemTypeRef)
+                    }
                     if (containsCommandTrigger(rule)) {
                         val commandTypeRef = ruleModel.newTypeRef(Command)
                         parameters += rule.toParameter(VAR_RECEIVED_COMMAND, commandTypeRef)
@@ -161,6 +170,15 @@ class RulesJvmModelInferrer extends ScriptJvmModelInferrer {
     def private boolean containsStateChangeTrigger(Rule rule) {
         for (EventTrigger trigger : rule.getEventtrigger()) {
             if (trigger instanceof ChangedEventTrigger) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    def private boolean containsStateUpdateTrigger(Rule rule) {
+        for (EventTrigger trigger : rule.getEventtrigger()) {
+            if (trigger instanceof UpdateEventTrigger) {
                 return true;
             }
         }


### PR DESCRIPTION
This PR adds the implicit variable "triggeringItem" to text file based rules. The variable is useful to identify which item triggered a rule when the rule can be triggered by more than one item. The implementation is consistent with the existing implicit variables "receivedCommand" and "previousState".

This change is only useful for rules with multiple conditions.
```
Item Switch01 changed or
Item Switch02 changed
```
The plan is to extend this further to support rules bound to groups (future PR).

Some discussions about the kind of problem I am trying to solve:
[https://community.openhab.org/t/which-item-updated-my-group-item/25273](https://community.openhab.org/t/which-item-updated-my-group-item/25273)
[https://community.openhab.org/t/more-efficient-rule/4730](https://community.openhab.org/t/more-efficient-rule/4730)

Signed-off-by: Jason Jones <jmsjones@gmail.com>