### PR TITLE
correctly register mDNS as a discovery service

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.mdns/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.mdns/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryService.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Improved startup behavior and background discovery
  * @author Andre Fuechsel - make {@link #startScan()} asynchronous
  */
-@Component(immediate = true)
+@Component(immediate = true, service = DiscoveryService.class, configurationPid = "discovery.mdns")
 public class MDNSDiscoveryService extends AbstractDiscoveryService implements ServiceListener {
     private final Logger logger = LoggerFactory.getLogger(MDNSDiscoveryService.class);
 


### PR DESCRIPTION
The mDNSDiscoveryService is currently not at all considered by the framework as it is merely registered as a `ServiceListener` but not as a `DiscoveryService` without this change.

Signed-off-by: Kai Kreuzer <kai@openhab.org>