### PR TITLE
Fix getExistingDiscoveryResult no longer filtering on Thing UID

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceRegistryOSGITest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/groovy/org/eclipse/smarthome/config/setup/test/discovery/DiscoveryServiceRegistryOSGITest.groovy
@@ -438,6 +438,10 @@ class DiscoveryServiceRegistryOSGITest extends OSGiTest {
 
         // verify that the existing DiscoveryResult can be accessed
         assertNotNull extendedDiscoveryServiceMock.discoveryServiceCallback.getExistingDiscoveryResult(thingUID)
+
+        // verify that a non-existing DiscoveryResult can not be accessed
+        thingUID = new ThingUID(EXTENDED_BINDING_ID, EXTENDED_THING_TYPE, "bar")
+        assertNull extendedDiscoveryServiceMock.discoveryServiceCallback.getExistingDiscoveryResult(thingUID)
     }
 
     @Test

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -7,7 +7,7 @@
  */
 package org.eclipse.smarthome.config.discovery.internal;
 
-import static org.eclipse.smarthome.config.discovery.inbox.InboxPredicates.withFlag;
+import static org.eclipse.smarthome.config.discovery.inbox.InboxPredicates.*;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -154,7 +154,8 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
                 return null;
             }
             List<DiscoveryResult> ret = new ArrayList<>();
-            ret = inboxReference.stream().filter(withFlag((DiscoveryResultFlag.NEW))).collect(Collectors.toList());
+            ret = inboxReference.stream().filter(withFlag(DiscoveryResultFlag.NEW).and(forThingUID(thingUID)))
+                    .collect(Collectors.toList());
             if (ret.size() > 0) {
                 return ret.get(0);
             } else {


### PR DESCRIPTION
This PR fixes a regression introduced by #3899 where `DiscoveryServiceCallback.getExistingDiscoveryResult(thingUID)` returns any NEW discovery result instead of a result matching the Thing UID parameter.

Discovery in bindings that skip existing results using this method should now work again! These bindings are:
* Bigassfan 
* GlobalCache
* Plugwise
* RFXCom
* Xiaomi Mi Smart Home