### PR TITLE
the bundle context is a nullable member of the base thing handler

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
@@ -45,8 +45,8 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
 
     protected @Nullable BundleContext bundleContext;
 
-    private Map<String, ServiceRegistration<ConfigStatusProvider>> configStatusProviders = new ConcurrentHashMap<>();
-    private Map<String, ServiceRegistration<FirmwareUpdateHandler>> firmwareUpdateHandlers = new ConcurrentHashMap<>();
+    private final Map<String, ServiceRegistration<ConfigStatusProvider>> configStatusProviders = new ConcurrentHashMap<>();
+    private final Map<String, ServiceRegistration<FirmwareUpdateHandler>> firmwareUpdateHandlers = new ConcurrentHashMap<>();
 
     private @Nullable ServiceTracker<ThingTypeRegistry, ThingTypeRegistry> thingTypeRegistryServiceTracker;
     private @Nullable ServiceTracker<ConfigDescriptionRegistry, ConfigDescriptionRegistry> configDescriptionRegistryServiceTracker;
@@ -90,6 +90,22 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
         configStatusProviders.clear();
         firmwareUpdateHandlers.clear();
         bundleContext = null;
+    }
+
+    /**
+     * Get the bundle context.
+     *
+     * @return the bundle context
+     * @throws IllegalArgumentException if the bundle thing handler is not active
+     */
+    protected BundleContext getBundleContext() {
+        final BundleContext bundleContext = this.bundleContext;
+        if (bundleContext != null) {
+            return bundleContext;
+        } else {
+            throw new IllegalStateException(
+                    "The bundle context is missing (it seems your thing handler is used but not active).");
+        }
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandlerFactory.java
@@ -104,7 +104,7 @@ public abstract class BaseThingHandlerFactory implements ThingHandlerFactory {
             return bundleContext;
         } else {
             throw new IllegalStateException(
-                    "The bundle context is missing (it seems your thing handler is used but not active).");
+                    "The bundle context is missing (it seems your thing handler factory is used but not active).");
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriHandlerFactory.java
@@ -43,7 +43,7 @@ public class TradfriHandlerFactory extends BaseThingHandlerFactory {
                     Stream.concat(SUPPORTED_LIGHT_TYPES_UIDS.stream(), SUPPORTED_CONTROLLER_TYPES_UIDS.stream()))
             .collect(Collectors.toSet());
 
-    private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -79,14 +79,14 @@ public class TradfriHandlerFactory extends BaseThingHandlerFactory {
     private void registerDiscoveryService(TradfriGatewayHandler bridgeHandler) {
         TradfriDiscoveryService discoveryService = new TradfriDiscoveryService(bridgeHandler);
         discoveryService.activate();
-        this.discoveryServiceRegs.put(bridgeHandler.getThing().getUID(), bundleContext
+        this.discoveryServiceRegs.put(bridgeHandler.getThing().getUID(), getBundleContext()
                 .registerService(DiscoveryService.class.getName(), discoveryService, new Hashtable<String, Object>()));
     }
 
     private void unregisterDiscoveryService(TradfriGatewayHandler bridgeHandler) {
         ServiceRegistration<?> serviceReg = this.discoveryServiceRegs.get(bridgeHandler.getThing().getUID());
         if (serviceReg != null) {
-            TradfriDiscoveryService service = (TradfriDiscoveryService) bundleContext
+            TradfriDiscoveryService service = (TradfriDiscoveryService) getBundleContext()
                     .getService(serviceReg.getReference());
             if (service != null) {
                 service.deactivate();


### PR DESCRIPTION
The bundle context member of the base thing handler itself is nullable.
If the thing handler is active, the bundle context should not be null.
Add a method to get the bundle context (non-null) or a illegal state exception if this method is called if the member variable is null / the handler is not active.

As we rely on the most usage that the handler has been activated, we should rely on a non-null member. But as we cannot really ensure that the handler has been activated an IllegalStateException with a understandable message is much better then a NPE.