### PR TITLE
Fix LSP content assist

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.ide/src/org/eclipse/smarthome/model/rule/ide/RulesIdeModule.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ide/src/org/eclipse/smarthome/model/rule/ide/RulesIdeModule.xtend
@@ -3,9 +3,16 @@
  */
 package org.eclipse.smarthome.model.rule.ide
 
+import org.eclipse.xtext.xbase.typesystem.internal.IFeatureScopeTracker
+import org.eclipse.smarthome.model.script.OptimizingFeatureScopeTrackerProvider2
 
 /**
  * Use this class to register ide components.
  */
 class RulesIdeModule extends AbstractRulesIdeModule {
+    
+    override Class<? extends IFeatureScopeTracker.Provider> bindIFeatureScopeTrackerProvider() {
+        return OptimizingFeatureScopeTrackerProvider2
+    }    
+    
 }

--- a/bundles/model/org.eclipse.smarthome.model.script.ide/src/org/eclipse/smarthome/model/script/ide/ScriptIdeModule.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.script.ide/src/org/eclipse/smarthome/model/script/ide/ScriptIdeModule.xtend
@@ -3,9 +3,16 @@
  */
 package org.eclipse.smarthome.model.script.ide
 
+import org.eclipse.smarthome.model.script.OptimizingFeatureScopeTrackerProvider2
+import org.eclipse.xtext.xbase.typesystem.internal.IFeatureScopeTracker
 
 /**
  * Use this class to register ide components.
  */
 class ScriptIdeModule extends AbstractScriptIdeModule {
+    
+    override Class<? extends IFeatureScopeTracker.Provider> bindIFeatureScopeTrackerProvider() {
+        return OptimizingFeatureScopeTrackerProvider2
+    }    
+    
 }

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/OptimizingFeatureScopeTrackerProvider2.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/OptimizingFeatureScopeTrackerProvider2.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.model.script;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.xbase.typesystem.internal.FeatureScopeTracker;
+import org.eclipse.xtext.xbase.typesystem.internal.IFeatureScopeTracker;
+import org.eclipse.xtext.xbase.typesystem.internal.OptimizingFeatureScopeTrackerProvider;
+
+/**
+ * {@link OptimizingFeatureScopeTrackerProvider} implementation
+ *
+ * ...with a workaround for https://github.com/eclipse/xtext-extras/issues/144
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+public class OptimizingFeatureScopeTrackerProvider2 extends OptimizingFeatureScopeTrackerProvider {
+
+    @Override
+    public IFeatureScopeTracker track(EObject root) {
+        return new FeatureScopeTracker() {
+        };
+    }
+
+}


### PR DESCRIPTION
...as the registry mismatch prevented the IDE features to work properly
before.

At the same time, a workaround for eclipse/xtext-extras#144 was required.

It remains rocket-science with a hint of pure magic though. 

fixes openhab/openhab-vscode#41
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>