### PR TITLE
Allow profiles to access a scheduler

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/CommunicationManagerTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/CommunicationManagerTest.java
@@ -15,7 +15,6 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.items.events.ItemEventFactory;
@@ -35,6 +34,7 @@ import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.profiles.ProfileAdvisor;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
 import org.eclipse.smarthome.core.thing.profiles.ProfileFactory;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
 import org.eclipse.smarthome.core.thing.profiles.StateProfile;
@@ -118,7 +118,7 @@ public class CommunicationManagerTest {
             }
             return null;
         }).when(mockProfileFactory).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
 
         when(mockProfileFactory.getSupportedProfileTypeUIDs()).thenReturn(Stream
                 .of(new ProfileTypeUID("test:state"), new ProfileTypeUID("test:trigger")).collect(Collectors.toList()));
@@ -252,7 +252,7 @@ public class CommunicationManagerTest {
         }
 
         verify(mockProfileFactory, times(2)).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
         verify(mockProfileFactory, atLeast(0)).getSupportedProfileTypeUIDs();
         verify(mockProfileAdvisor, atLeast(0)).getSuggestedProfileTypeUID(any(), any());
         verifyNoMoreInteractions(mockProfileFactory);
@@ -265,7 +265,7 @@ public class CommunicationManagerTest {
             manager.receive(ThingEventFactory.createTriggerEvent(EVENT, TRIGGER_CHANNEL_UID_2));
         }
         verify(mockProfileFactory, times(2)).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
 
         manager.removeProfileFactory(mockProfileFactory);
         manager.addProfileFactory(mockProfileFactory);
@@ -275,7 +275,7 @@ public class CommunicationManagerTest {
         }
 
         verify(mockProfileFactory, times(4)).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
         verify(mockProfileFactory, atLeast(0)).getSupportedProfileTypeUIDs();
         verify(mockProfileAdvisor, atLeast(0)).getSuggestedProfileTypeUID(any(), any());
         verifyNoMoreInteractions(mockProfileFactory);
@@ -288,7 +288,7 @@ public class CommunicationManagerTest {
             manager.receive(ThingEventFactory.createTriggerEvent(EVENT, TRIGGER_CHANNEL_UID_2));
         }
         verify(mockProfileFactory, times(2)).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
 
         manager.removed(LINK_2_T2);
         manager.added(LINK_2_T2);
@@ -298,7 +298,7 @@ public class CommunicationManagerTest {
         }
 
         verify(mockProfileFactory, times(3)).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
         verify(mockProfileFactory, atLeast(0)).getSupportedProfileTypeUIDs();
         verify(mockProfileAdvisor, atLeast(0)).getSuggestedProfileTypeUID(any(), any());
         verifyNoMoreInteractions(mockProfileFactory);
@@ -319,7 +319,7 @@ public class CommunicationManagerTest {
         }
 
         verify(mockProfileFactory, times(2)).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
         verify(mockProfileFactory, atLeast(0)).getSupportedProfileTypeUIDs();
         verify(mockProfileAdvisor, atLeast(0)).getSuggestedProfileTypeUID(any(), any());
         verifyNoMoreInteractions(mockProfileFactory);
@@ -332,7 +332,7 @@ public class CommunicationManagerTest {
             manager.receive(ThingEventFactory.createTriggerEvent(EVENT, TRIGGER_CHANNEL_UID_2));
         }
         verify(mockProfileFactory, times(2)).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
 
         manager.updated(LINK_2_T2, LINK_2_T2);
 
@@ -341,7 +341,7 @@ public class CommunicationManagerTest {
         }
 
         verify(mockProfileFactory, times(3)).createProfile(isA(ProfileTypeUID.class), isA(ProfileCallback.class),
-                isA(Configuration.class));
+                isA(ProfileContext.class));
         verify(mockProfileFactory, atLeast(0)).getSupportedProfileTypeUIDs();
         verify(mockProfileAdvisor, atLeast(0)).getSuggestedProfileTypeUID(any(), any());
         verifyNoMoreInteractions(mockProfileFactory);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
@@ -191,15 +191,16 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
 
     private Profile getProfileFromFactories(ProfileTypeUID profileTypeUID, ItemChannelLink link,
             ProfileCallback callback) {
+        ProfileContextImpl context = new ProfileContextImpl(link.getConfiguration());
         if (supportsProfileTypeUID(defaultProfileFactory, profileTypeUID)) {
             logger.trace("using the default ProfileFactory to create profile '{}'", profileTypeUID);
-            return defaultProfileFactory.createProfile(profileTypeUID, callback, link.getConfiguration());
+            return defaultProfileFactory.createProfile(profileTypeUID, callback, context);
         }
         for (Entry<ProfileFactory, Set<String>> entry : profileFactories.entrySet()) {
             ProfileFactory factory = entry.getKey();
             if (supportsProfileTypeUID(factory, profileTypeUID)) {
                 logger.trace("using ProfileFactory '{}' to create profile '{}'", factory, profileTypeUID);
-                Profile profile = factory.createProfile(profileTypeUID, callback, link.getConfiguration());
+                Profile profile = factory.createProfile(profileTypeUID, callback, context);
                 if (profile == null) {
                     logger.error("ProfileFactory {} returned 'null' although it claimed it supports {}", factory,
                             profileTypeUID);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ProfileContextImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ProfileContextImpl.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.internal;
+
+import java.util.concurrent.ExecutorService;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.common.ThreadPoolManager;
+import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
+
+/**
+ * {@link ProfileContext} implementation.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+@NonNullByDefault
+public class ProfileContextImpl implements ProfileContext {
+
+    private static final String THREAD_POOL_NAME = "profiles";
+    private final Configuration configuration;
+
+    public ProfileContextImpl(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        return ThreadPoolManager.getPool(THREAD_POOL_NAME);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -16,13 +16,13 @@ import java.util.stream.Stream;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.profiles.Profile;
 import org.eclipse.smarthome.core.thing.profiles.ProfileAdvisor;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileContext;
 import org.eclipse.smarthome.core.thing.profiles.ProfileFactory;
 import org.eclipse.smarthome.core.thing.profiles.ProfileType;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeProvider;
@@ -55,7 +55,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
 
     @Nullable
     @Override
-    public Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback, Configuration configuration) {
+    public Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback, ProfileContext context) {
         if (SystemProfiles.DEFAULT.equals(profileTypeUID)) {
             return new SystemDefaultProfile(callback);
         } else if (SystemProfiles.FOLLOW.equals(profileTypeUID)) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileContext.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileContext.java
@@ -7,37 +7,34 @@
  */
 package org.eclipse.smarthome.core.thing.profiles;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.concurrent.ExecutorService;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.smarthome.core.common.registry.Identifiable;
+import org.eclipse.smarthome.config.core.Configuration;
 
 /**
- * Describes a profile type.
+ * The profile's context
+ *
+ * It gives access to related information like the profile's configuration or a scheduler.
  *
  * @author Simon Kaufmann - initial contribution and API.
  *
  */
 @NonNullByDefault
-public interface ProfileType extends Identifiable<ProfileTypeUID> {
+public interface ProfileContext {
 
     /**
-     * Constant for matching *ANY* item type.
-     */
-    Collection<String> ANY_ITEM_TYPE = new ArrayList<>(0);
-
-    /**
+     * Get the profile's configuration object
      *
-     * @return a collection of item types or {@link #ANY_ITEM_TYPE}.
+     * @return the configuration
      */
-    Collection<String> getSupportedItemTypes();
+    Configuration getConfiguration();
 
     /**
-     * Get a human readable description.
+     * Get a scheduler to be used within profiles (if needed at all)
      *
-     * @return the label
+     * @return the scheduler
      */
-    String getLabel();
+    ExecutorService getExecutorService();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileFactory.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.config.core.Configuration;
 
 /**
  * Implementors are capable of creating a {@link Profile} instances.
@@ -27,11 +26,11 @@ public interface ProfileFactory {
      *
      * @param profileTypeUID the profile identifier
      * @param callback the ProfileCallback instance to be used by the {@link Profile} instance
-     * @param configuration the configuration
+     * @param profileContext giving access to the profile's context like configuration, scheduler, etc.
      * @return the profile instance or {@code null} if this factory cannot handle the given link
      */
     @Nullable
-    Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback, Configuration configuration);
+    Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback, ProfileContext profileContext);
 
     /**
      * Return the identifiers of all supported profile types


### PR DESCRIPTION
...by providing a ProfileContext.

It is designed in a way that it can be extended in future without
breaking the ProfileFactory API (again).

fixes #4544
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>