### PR TITLE
Profile type builder

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/link/ItemChannelLinkConfigDescriptionProvider.java
@@ -102,12 +102,12 @@ public class ItemChannelLinkConfigDescriptionProvider implements ConfigDescripti
     }
 
     private boolean isSupportedItemType(ProfileType profileType, Item item) {
-        return profileType.getSupportedItemTypes() == ProfileType.ANY_ITEM_TYPE
+        return profileType.getSupportedItemTypes().isEmpty()
                 || profileType.getSupportedItemTypes().contains(item.getType());
     }
 
     private boolean isSupportedChannelType(TriggerProfileType profileType, Channel channel) {
-        return profileType.getSupportedChannelTypeUIDs() == TriggerProfileType.ANY_CHANNEL_TYPE
+        return profileType.getSupportedChannelTypeUIDs().isEmpty()
                 || profileType.getSupportedChannelTypeUIDs().contains(channel.getChannelTypeUID());
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileTypeRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileTypeRegistry.java
@@ -10,6 +10,8 @@ package org.eclipse.smarthome.core.thing.internal.profiles;
 import java.util.List;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.profiles.ProfileType;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeProvider;
 
@@ -20,10 +22,22 @@ import org.eclipse.smarthome.core.thing.profiles.ProfileTypeProvider;
  * @author Simon Kaufmann - initial contribution and API.
  *
  */
+@NonNullByDefault
 public interface ProfileTypeRegistry {
 
+    /**
+     * Get the available {@link ProfileType}s from all providers using the default locale.
+     *
+     * @return all profile types
+     */
     public List<ProfileType> getProfileTypes();
 
-    public List<ProfileType> getProfileTypes(Locale locale);
+    /**
+     * Get the available {@link ProfileType}s from all providers.
+     *
+     * @param locale the language to use (may be null)
+     * @return all profile types
+     */
+    public List<ProfileType> getProfileTypes(@Nullable Locale locale);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/StateProfileTypeImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/StateProfileTypeImpl.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.StateProfileType;
+
+/**
+ * Default implementation of a {@link StateProfileType}.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+@NonNullByDefault
+public class StateProfileTypeImpl implements StateProfileType {
+
+    private final ProfileTypeUID profileTypeUID;
+    private final String label;
+    private final Collection<String> supportedItemTypes;
+
+    public StateProfileTypeImpl(ProfileTypeUID profileTypeUID, String label, Collection<String> supportedItemTypes) {
+        this.profileTypeUID = profileTypeUID;
+        this.label = label;
+        this.supportedItemTypes = supportedItemTypes;
+    }
+
+    @Override
+    public @NonNull ProfileTypeUID getUID() {
+        return profileTypeUID;
+    }
+
+    @Override
+    public @NonNull Collection<@NonNull String> getSupportedItemTypes() {
+        return supportedItemTypes;
+    }
+
+    @Override
+    public @NonNull String getLabel() {
+        return label;
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/StateProfileTypeImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/StateProfileTypeImpl.java
@@ -9,7 +9,6 @@ package org.eclipse.smarthome.core.thing.internal.profiles;
 
 import java.util.Collection;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
 import org.eclipse.smarthome.core.thing.profiles.StateProfileType;
@@ -34,17 +33,17 @@ public class StateProfileTypeImpl implements StateProfileType {
     }
 
     @Override
-    public @NonNull ProfileTypeUID getUID() {
+    public ProfileTypeUID getUID() {
         return profileTypeUID;
     }
 
     @Override
-    public @NonNull Collection<@NonNull String> getSupportedItemTypes() {
+    public Collection<String> getSupportedItemTypes() {
         return supportedItemTypes;
     }
 
     @Override
-    public @NonNull String getLabel() {
+    public String getLabel() {
         return label;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/TriggerProfileTypeImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/TriggerProfileTypeImpl.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.TriggerProfileType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+
+/**
+ * Default implementation of a {@link TriggerProfileTypeImpl}.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+@NonNullByDefault
+public class TriggerProfileTypeImpl extends StateProfileTypeImpl implements TriggerProfileType {
+
+    private final Collection<ChannelTypeUID> supportedChannelTypeUIDs;
+
+    public TriggerProfileTypeImpl(ProfileTypeUID profileTypeUID, String label, Collection<String> supportedItemTypes,
+            Collection<ChannelTypeUID> supportedChannelTypeUIDs) {
+        super(profileTypeUID, label, supportedItemTypes);
+        this.supportedChannelTypeUIDs = supportedChannelTypeUIDs;
+    }
+
+    @Override
+    public Collection<ChannelTypeUID> getSupportedChannelTypeUIDs() {
+        return supportedChannelTypeUIDs;
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/Profile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/Profile.java
@@ -25,12 +25,17 @@ import org.eclipse.smarthome.core.types.State;
 @NonNullByDefault
 public interface Profile {
 
+    /**
+     * Get the {@link ProfileTypeUID} of this profile.
+     *
+     * @return the UID of the profile type
+     */
     ProfileTypeUID getProfileTypeUID();
 
     /**
      * Will be called if an item has changed its state and this information should be forwarded to the binding.
      *
-     * @param state
+     * @param state the new state
      */
     void onStateUpdateFromItem(State state);
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileType.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.smarthome.core.thing.profiles;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -23,13 +22,8 @@ import org.eclipse.smarthome.core.common.registry.Identifiable;
 public interface ProfileType extends Identifiable<ProfileTypeUID> {
 
     /**
-     * Constant for matching *ANY* item type.
-     */
-    Collection<String> ANY_ITEM_TYPE = new ArrayList<>(0);
-
-    /**
      *
-     * @return a collection of item types or {@link #ANY_ITEM_TYPE}.
+     * @return a collection of item types (may be empty if all are supported)
      */
     Collection<String> getSupportedItemTypes();
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeBuilder.java
@@ -12,7 +12,6 @@ import java.util.Collection;
 import java.util.HashSet;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.internal.profiles.StateProfileTypeImpl;
 import org.eclipse.smarthome.core.thing.internal.profiles.TriggerProfileTypeImpl;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
@@ -39,23 +38,23 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
     private final ProfileTypeUID profileTypeUID;
     private final Collection<String> supportedItemTypes = new HashSet<>();
     private final Collection<ChannelTypeUID> supportedChannelTypeUIDs = new HashSet<>();
+    private final String label;
 
-    @Nullable
-    private String label;
-
-    private ProfileTypeBuilder(ProfileTypeUID profileTypeUID, ProfileTypeFactory<T> profileTypeFactory) {
+    private ProfileTypeBuilder(ProfileTypeUID profileTypeUID, String label, ProfileTypeFactory<T> profileTypeFactory) {
         this.profileTypeFactory = profileTypeFactory;
         this.profileTypeUID = profileTypeUID;
+        this.label = label;
     }
 
     /**
      * Obtain a new builder for a {@link StateProfileType} instance.
      *
      * @param profileTypeUID the {@link ProfileTypeUID}
+     * @param label a human-readable label
      * @return the new builder instance
      */
-    public static ProfileTypeBuilder<StateProfileType> newState(ProfileTypeUID profileTypeUID) {
-        return new ProfileTypeBuilder<>(profileTypeUID,
+    public static ProfileTypeBuilder<StateProfileType> newState(ProfileTypeUID profileTypeUID, String label) {
+        return new ProfileTypeBuilder<>(profileTypeUID, label,
                 (leProfileTypeUID, leLabel, leSupportedItemTypes,
                         leSupportedChannelTypeUIDs) -> new StateProfileTypeImpl(leProfileTypeUID, leLabel,
                                 leSupportedItemTypes));
@@ -65,24 +64,14 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
      * Obtain a new builder for a {@link TriggerProfileType} instance.
      *
      * @param profileTypeUID the {@link ProfileTypeUID}
+     * @param label a human-readable label
      * @return the new builder instance
      */
-    public static ProfileTypeBuilder<TriggerProfileType> newTrigger(ProfileTypeUID profileTypeUID) {
-        return new ProfileTypeBuilder<>(profileTypeUID,
+    public static ProfileTypeBuilder<TriggerProfileType> newTrigger(ProfileTypeUID profileTypeUID, String label) {
+        return new ProfileTypeBuilder<>(profileTypeUID, label,
                 (leProfileTypeUID, leLabel, leSupportedItemTypes,
                         leSupportedChannelTypeUIDs) -> new TriggerProfileTypeImpl(leProfileTypeUID, leLabel,
                                 leSupportedItemTypes, leSupportedChannelTypeUIDs));
-    }
-
-    /**
-     * Define the human-readable label
-     *
-     * @param label
-     * @return the builder itself
-     */
-    public ProfileTypeBuilder<T> withLabel(String label) {
-        this.label = label;
-        return this;
     }
 
     /**
@@ -135,11 +124,7 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
      * @return the according subtype of
      */
     public T build() {
-        final String lbl = label;
-        if (lbl == null) {
-            throw new IllegalStateException("The label has not been set yet");
-        }
-        return profileTypeFactory.create(profileTypeUID, lbl, supportedItemTypes, supportedChannelTypeUIDs);
+        return profileTypeFactory.create(profileTypeUID, label, supportedItemTypes, supportedChannelTypeUIDs);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeBuilder.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2014-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.core.thing.profiles;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.internal.profiles.StateProfileTypeImpl;
+import org.eclipse.smarthome.core.thing.internal.profiles.TriggerProfileTypeImpl;
+import org.eclipse.smarthome.core.thing.type.ChannelKind;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
+
+/**
+ * Builder for {@link ProfileType} instances.
+ *
+ * It can be used to obtain instances instead of implementing any of the interfaces derived from {@link ProfileType}.
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ * @param <T> the concrete {@link ProfileType} sub-interface.
+ */
+@NonNullByDefault
+public final class ProfileTypeBuilder<T extends ProfileType> {
+
+    private final ChannelKind channelKind;
+    private final ProfileTypeUID profileTypeUID;
+    private final Collection<String> supportedItemTypes = new HashSet<>();
+    private final Collection<ChannelTypeUID> supportedChannelTypeUIDs = new HashSet<>();
+
+    @Nullable
+    private String label;
+
+    private ProfileTypeBuilder(ProfileTypeUID profileTypeUID, ChannelKind channelKind) {
+        this.profileTypeUID = profileTypeUID;
+        this.channelKind = channelKind;
+    }
+
+    /**
+     * Obtain a new builder for a {@link StateProfileType} instance.
+     *
+     * @param profileTypeUID the {@link ProfileTypeUID}
+     * @return the new builder instance
+     */
+    public static ProfileTypeBuilder<StateProfileType> newState(ProfileTypeUID profileTypeUID) {
+        ProfileTypeBuilder<StateProfileType> ret = new ProfileTypeBuilder<>(profileTypeUID, ChannelKind.STATE);
+        return ret;
+    }
+
+    /**
+     * Obtain a new builder for a {@link TriggerProfileType} instance.
+     *
+     * @param profileTypeUID the {@link ProfileTypeUID}
+     * @return the new builder instance
+     */
+    public static ProfileTypeBuilder<TriggerProfileType> newTrigger(ProfileTypeUID profileTypeUID) {
+        ProfileTypeBuilder<TriggerProfileType> ret = new ProfileTypeBuilder<>(profileTypeUID, ChannelKind.TRIGGER);
+        return ret;
+    }
+
+    /**
+     * Define the human-readable label
+     *
+     * @param label
+     * @return the builder itself
+     */
+    public ProfileTypeBuilder<T> withLabel(String label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
+     * Declare that the given item type(s) are supported by a profile of this type.
+     *
+     * @param itemType
+     * @return the builder itself
+     */
+    public ProfileTypeBuilder<T> withSupportedItemTypes(String... itemType) {
+        supportedItemTypes.addAll(Arrays.asList(itemType));
+        return this;
+    }
+
+    /**
+     * Declare that the given item type(s) are supported by a profile of this type.
+     *
+     * @param itemType
+     * @return the builder itself
+     */
+    public ProfileTypeBuilder<T> withSupportedItemTypes(Collection<String> itemTypes) {
+        supportedItemTypes.addAll(itemTypes);
+        return this;
+    }
+
+    /**
+     * Declare that the given channel type(s) are supported by a profile of this type.
+     *
+     * @param channelTypeUIDs
+     * @return the builder itself
+     */
+    public ProfileTypeBuilder<T> withSupportedChannelTypeUIDs(ChannelTypeUID... channelTypeUIDs) {
+        supportedChannelTypeUIDs.addAll(Arrays.asList(channelTypeUIDs));
+        return this;
+    }
+
+    /**
+     * Declare that the given channel type(s) are supported by a profile of this type.
+     *
+     * @param channelTypeUIDs
+     * @return the builder itself
+     */
+    public ProfileTypeBuilder<T> withSupportedChannelTypeUIDs(Collection<ChannelTypeUID> channelTypeUIDs) {
+        supportedChannelTypeUIDs.addAll(channelTypeUIDs);
+        return this;
+    }
+
+    /**
+     * Create a profile type instance with the previously given parameters.
+     *
+     * @return the according subtype of
+     */
+    @SuppressWarnings("unchecked")
+    public T build() {
+        final String lbl = label;
+        if (lbl == null) {
+            throw new IllegalStateException("The label has not been set yet");
+        }
+        switch (channelKind) {
+            case STATE:
+                return (T) new StateProfileTypeImpl(profileTypeUID, lbl, supportedItemTypes);
+            case TRIGGER:
+                return (T) new TriggerProfileTypeImpl(profileTypeUID, lbl, supportedItemTypes,
+                        supportedChannelTypeUIDs);
+            default:
+                throw new IllegalArgumentException("Unknown type " + channelKind);
+        }
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -24,12 +24,12 @@ public interface SystemProfiles {
     ProfileTypeUID FOLLOW = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "follow");
     ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawbutton-toggle-switch");
 
-    StateProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT).withLabel("Default").build();
+    StateProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT, "Default").build();
 
-    StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW).withLabel("Follow").build();
+    StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
 
-    TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder.newTrigger(RAWBUTTON_TOGGLE_SWITCH)
-            .withLabel("Raw Button Toggle").withSupportedItemTypes(CoreItemFactory.SWITCH)
+    TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
+            .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle").withSupportedItemTypes(CoreItemFactory.SWITCH)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -7,13 +7,9 @@
  */
 package org.eclipse.smarthome.core.thing.profiles;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
-import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 
 /**
  * System profile constants.
@@ -28,60 +24,12 @@ public interface SystemProfiles {
     ProfileTypeUID FOLLOW = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "follow");
     ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawbutton-toggle-switch");
 
-    StateProfileType DEFAULT_TYPE = new StateProfileType() {
-        @Override
-        public ProfileTypeUID getUID() {
-            return DEFAULT;
-        }
+    StateProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT).withLabel("Default").build();
 
-        @Override
-        public Collection<String> getSupportedItemTypes() {
-            return ANY_ITEM_TYPE;
-        }
+    StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW).withLabel("Follow").build();
 
-        @Override
-        public String getLabel() {
-            return "Default";
-        }
-    };
-
-    StateProfileType FOLLOW_TYPE = new StateProfileType() {
-        @Override
-        public ProfileTypeUID getUID() {
-            return FOLLOW;
-        }
-
-        @Override
-        public Collection<String> getSupportedItemTypes() {
-            return ANY_ITEM_TYPE;
-        }
-
-        @Override
-        public String getLabel() {
-            return "Follow";
-        }
-    };
-
-    TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = new TriggerProfileType() {
-        @Override
-        public ProfileTypeUID getUID() {
-            return RAWBUTTON_TOGGLE_SWITCH;
-        }
-
-        @Override
-        public Collection<String> getSupportedItemTypes() {
-            return Collections.singleton(CoreItemFactory.SWITCH);
-        }
-
-        @Override
-        public Collection<ChannelTypeUID> getSupportedChannelTypeUIDs() {
-            return Collections.singleton(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID());
-        }
-
-        @Override
-        public String getLabel() {
-            return "Raw Button Toggle";
-        }
-    };
+    TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder.newTrigger(RAWBUTTON_TOGGLE_SWITCH)
+            .withLabel("Raw Button Toggle").withSupportedItemTypes(CoreItemFactory.SWITCH)
+            .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/TriggerProfileType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/TriggerProfileType.java
@@ -23,7 +23,7 @@ public interface TriggerProfileType extends ProfileType {
 
     /**
      *
-     * @return a collection of ChannelTypeUIDs (may be empty all are supported).
+     * @return a collection of ChannelTypeUIDs (may be empty if all are supported).
      */
     Collection<ChannelTypeUID> getSupportedChannelTypeUIDs();
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/TriggerProfileType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/TriggerProfileType.java
@@ -7,7 +7,6 @@
  */
 package org.eclipse.smarthome.core.thing.profiles;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -23,13 +22,8 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 public interface TriggerProfileType extends ProfileType {
 
     /**
-     * Constant for matching *ANY* channel type.
-     */
-    Collection<ChannelTypeUID> ANY_CHANNEL_TYPE = new ArrayList<>(0);
-
-    /**
      *
-     * @return a collection of ChannelTypeUIDs or {@link #ANY_CHANNEL_TYPE}.
+     * @return a collection of ChannelTypeUIDs (may be empty all are supported).
      */
     Collection<ChannelTypeUID> getSupportedChannelTypeUIDs();
 


### PR DESCRIPTION
I wonder whether a builder pattern would be more convenient (in terms of implementation as well as future extensibility) for creating profile types (see [SystemProfiles.java](https://github.com/eclipse/smarthome/compare/master...sjka:profileTypeBuilder?expand=1#diff-2eea43cbaf238cd83f8550390ec9098b) for the effect).

cc: @kungfoolfighting, @maggu2810 