### PR TITLE
PaperUI: display parameter options regardless of context type

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/directives/directive.configDescription.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/directives/directive.configDescription.js
@@ -1,5 +1,12 @@
 angular.module('PaperUI.directive.configDescription', []) //
 .directive('configDescription', function() {
+
+    var controller = function($scope) {
+        $scope.getName = function(parameter, option) {
+            return option.name ? option.name : parameter.context == 'thing' ? option.UID : parameter.context == 'channel' ? option.id : undefined;
+        }
+    }
+
     return {
         restrict : 'E',
         scope : {
@@ -9,6 +16,7 @@ angular.module('PaperUI.directive.configDescription', []) //
             configArray : '=?',
             form : '=?'
         },
-        templateUrl : 'partials/directive.configDescription.html'
+        templateUrl : 'partials/directive.configDescription.html',
+        controller : controller
     }
 });

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/directive.configDescription.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/directive.configDescription.html
@@ -40,9 +40,9 @@
 								</div>
 								<div ng-switch-when="select" ng-show="(part==='normal' && !parameter.advanced) || (part==='advance' && parameter.advanced && isAdvanced)">
 									<label class="config-textInput">{{parameter.label}}</label>
-									<md-input-container class="col-xs-12 configContainer no-animation"> <md-select class="config-select" isrequired="{{parameter.required}}" ng-init="focus=false" name="{{parameter.name}}" ng-model="configuration[parameter.name]" placeholder="Select a value" ng-focus="focus=true" ng-blur="focus=false" ng-required="parameter.required" aria-label="parameter.label"> <md-option ng-value="parameter.context=='item'? option.name:parameter.context=='thing'?option.UID:option.value" ng-repeat="option in parameter.options" ng-finish-render> <span style="display: inline-block;" ng-if="parameter.context=='item' || parameter.context=='thing' || parameter.context=='channel'|| parameter.context=='rule'">
+									<md-input-container class="col-xs-12 configContainer no-animation"> <md-select class="config-select" isrequired="{{parameter.required}}" ng-init="focus=false" name="{{parameter.name}}" ng-model="configuration[parameter.name]" placeholder="Select a value" ng-focus="focus=true" ng-blur="focus=false" ng-required="parameter.required" aria-label="parameter.label"> <md-option ng-value="parameter.context=='item'? option.name:parameter.context=='thing'?option.UID:option.value" ng-repeat="option in parameter.options" ng-finish-render> <span style="display: inline-block;" ng-if="parameter.context">
 										{{ option.label?option.label:option.name }}
-										<span class="md-caption" style="color: grey;">({{ option.name?option.name: parameter.context=='thing'?option.UID:parameter.context=='channel'?option.id:'' }}) </span>
+										<span class="md-caption" style="color: grey;" ng-if="getName(parameter, option)" )>({{ getName(parameter, option) }}) </span>
 									</span> <span ng-if="!parameter.context">{{option.label}}</span> </md-option> </md-select>
 									<div ng-messages="form.configForm[parameter.name].$error" ng-show="focus">
 										<div ng-message="required">Field is required</div>


### PR DESCRIPTION
Fixes: For unknown contexts of config description parameters the drop down selection did not display the label and name for the options.

Signed-off-by: Henning Treu <henning.treu@telekom.de>