### PR TITLE
Revert "added dependency="true" where missing"

### DIFF
--- a/features/karaf/esh-tp/src/main/feature/feature.xml
+++ b/features/karaf/esh-tp/src/main/feature/feature.xml
@@ -79,7 +79,7 @@
   </feature>
 
   <feature name="esh-kat.cpy-jersey-min-2.22.2" version="${project.version}">
-    <feature dependency="true">http</feature>
+    <feature>http</feature>
     <bundle start-level="36">mvn:org.glassfish.jersey.containers/jersey-container-servlet/2.22.2</bundle>
     <bundle start-level="36">mvn:org.glassfish.jersey.media/jersey-media-sse/2.22.2</bundle>
     <bundle start-level="36">mvn:org.glassfish.jersey.media/jersey-media-multipart/2.22.2</bundle>
@@ -177,7 +177,7 @@
   <feature name="esh-tp-serial" version="${project.version}">
     <capability>esh.tp;feature=serial;version=3.12.0</capability>
 
-    <bundle dependency="true">mvn:org.openhab/nrjavaserial/3.12.0.OH</bundle>
+    <bundle>mvn:org.openhab/nrjavaserial/3.12.0.OH</bundle>
   </feature>
 
   <feature name="esh-tp-xtext" description="Xtext - Language Engineering Made Easy" version="${project.version}">


### PR DESCRIPTION
Reverts eclipse/smarthome#4585

Should fix https://github.com/openhab/openhab-distro/issues/571

Signed-off-by: Kai Kreuzer <kai@openhab.org>