### PR TITLE
Maven tycho plugin warning

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
@@ -23,7 +23,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>
       </plugin>

--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
@@ -25,7 +25,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
       </plugin>
     </plugins>
   </build>

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
@@ -22,7 +22,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
         <configuration>
           <dependencies>
             <dependency>

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
@@ -20,7 +20,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
@@ -22,7 +22,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
         <configuration>
           <dependencies>
             <dependency>

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
@@ -20,7 +20,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
@@ -22,7 +22,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
         <configuration>
           <dependencies>
             <dependency>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
@@ -20,7 +20,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/pom.xml
@@ -123,7 +123,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/pom.xml
@@ -125,7 +125,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
         <configuration>
           <bundleStartLevel>
             <bundle>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/pom.xml
@@ -97,7 +97,7 @@
         </configuration>
       </plugin>    
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>
         <configuration>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/pom.xml
@@ -99,7 +99,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
-        <version>${tycho-version}</version>
         <configuration>
           <bundleStartLevel>
             <bundle>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -31,7 +31,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-source-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -33,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-source-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>plugin-source</id>

--- a/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
@@ -24,7 +24,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
           <environments combine.self="override"></environments>
@@ -60,7 +60,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
           <dependencies>

--- a/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
@@ -9,7 +9,6 @@
     <version>0.9.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>org.eclipse.smarthome.archetype</groupId>
   <artifactId>org.eclipse.smarthome.magic.test</artifactId>
   <version>0.9.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>

--- a/bundles/test/org.eclipse.smarthome.magic/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.eclipse.smarthome.bundles</groupId>
-		<artifactId>test</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
-	</parent>
+  <parent>
+    <groupId>org.eclipse.smarthome.bundles</groupId>
+    <artifactId>test</artifactId>
+    <version>0.9.0-SNAPSHOT</version>
+  </parent>
 
-	<artifactId>org.eclipse.smarthome.magic</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
+  <artifactId>org.eclipse.smarthome.magic</artifactId>
+  <version>0.9.0-SNAPSHOT</version>
 
-	<name>Magic Bundle</name>
-	<packaging>eclipse-plugin</packaging>
+  <name>Magic Bundle</name>
+  <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/pom.xml
@@ -22,7 +22,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
+				<groupId>${tycho-groupid}</groupId>
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/pom.xml
@@ -24,7 +24,6 @@
 			<plugin>
 				<groupId>${tycho-groupid}</groupId>
 				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho-version}</version>
 				<configuration>
 					<filters>
 						<filter>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -29,7 +29,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-source-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>plugin-source</id>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -27,7 +27,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-source-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.automation/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.automation/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.automation/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.automation/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/org.eclipse.smarthome.feature.runtime.binding/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.binding/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.binding/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.binding/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/org.eclipse.smarthome.feature.runtime.console.equinox/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.equinox/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.console.equinox/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.equinox/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/org.eclipse.smarthome.feature.runtime.console.rfc147/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.rfc147/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.console.rfc147/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.rfc147/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/org.eclipse.smarthome.feature.runtime.core/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.core/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/org.eclipse.smarthome.feature.runtime.model/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.model/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.model/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.model/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/org.eclipse.smarthome.feature.runtime.rest/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.rest/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.rest/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.rest/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/org.eclipse.smarthome.feature.runtime.ui/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.ui/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.runtime.ui/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.ui/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/org.eclipse.smarthome.feature.test/pom.xml
+++ b/features/org.eclipse.smarthome.feature.test/pom.xml
@@ -32,7 +32,7 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/features/org.eclipse.smarthome.feature.test/pom.xml
+++ b/features/org.eclipse.smarthome.feature.test/pom.xml
@@ -20,7 +20,6 @@
       <plugin>
         <groupId>org.eclipse.tycho.extras</groupId>
         <artifactId>tycho-source-feature-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>source-feature</id>
@@ -34,7 +33,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>attach-p2-metadata</id>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -32,7 +32,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.eclipse.tycho</groupId>
+          <groupId>${tycho-groupid}</groupId>
           <artifactId>tycho-p2-plugin</artifactId>
           <version>${tycho-version}</version>
           <configuration>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -34,7 +34,6 @@
         <plugin>
           <groupId>${tycho-groupid}</groupId>
           <artifactId>tycho-p2-plugin</artifactId>
-          <version>${tycho-version}</version>
           <configuration>
             <!-- fix to prevent double upload of p2metadata artifacts  -->
             <defaultP2Metadata>false</defaultP2Metadata>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
-        <version>${tycho-version}</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>
@@ -166,6 +165,26 @@
       <plugins>
         <plugin>
           <groupId>${tycho-groupid}</groupId>
+          <artifactId>target-platform-configuration</artifactId>
+          <version>${tycho-version}</version>
+          <configuration>
+            <!--
+            <resolver>p2</resolver>
+            <ignoreTychoRepositories>true</ignoreTychoRepositories>
+            -->
+            <pomDependencies>consider</pomDependencies>
+            <target>
+              <artifact>
+                <groupId>org.eclipse.smarthome</groupId>
+                <artifactId>targetplatform</artifactId>
+                <version>${project.version}</version>
+                <classifier>smarthome</classifier>
+              </artifact>
+            </target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>${tycho-groupid}</groupId>
           <artifactId>tycho-compiler-plugin</artifactId>
           <version>${tycho-version}</version>
           <configuration>
@@ -189,23 +208,18 @@
         </plugin>
         <plugin>
           <groupId>${tycho-groupid}</groupId>
-          <artifactId>target-platform-configuration</artifactId>
+          <artifactId>tycho-maven-plugin</artifactId>
           <version>${tycho-version}</version>
-          <configuration>
-            <!--
-            <resolver>p2</resolver>
-            <ignoreTychoRepositories>true</ignoreTychoRepositories>
-            -->
-            <pomDependencies>consider</pomDependencies>
-            <target>
-              <artifact>
-                <groupId>org.eclipse.smarthome</groupId>
-                <artifactId>targetplatform</artifactId>
-                <version>${project.version}</version>
-                <classifier>smarthome</classifier>
-              </artifact>
-            </target>
-          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>${tycho-groupid}</groupId>
+          <artifactId>tycho-source-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho.extras</groupId>
+          <artifactId>tycho-source-feature-plugin</artifactId>
+          <version>${tycho-version}</version>
         </plugin>
         <plugin>
           <groupId>${tycho-groupid}</groupId>
@@ -214,6 +228,16 @@
           <configuration>
             <failIfNoTests>false</failIfNoTests>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>${tycho-groupid}</groupId>
+          <artifactId>tycho-p2-plugin</artifactId>
+          <version>${tycho-version}</version>
+        </plugin>
+        <plugin>
+          <groupId>${tycho-groupid}</groupId>
+          <artifactId>tycho-versions-plugin</artifactId>
+          <version>${tycho-version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>
@@ -357,11 +381,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>${tycho-groupid}</groupId>
-          <artifactId>tycho-versions-plugin</artifactId>
-          <version>${tycho-version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,7 +22,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.tycho</groupId>
+        <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-source-plugin</artifactId>
         <version>${tycho-version}</version>
         <executions>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -24,7 +24,6 @@
       <plugin>
         <groupId>${tycho-groupid}</groupId>
         <artifactId>tycho-source-plugin</artifactId>
-        <version>${tycho-version}</version>
         <executions>
           <execution>
             <id>plugin-source</id>


### PR DESCRIPTION
Get rid of 

```text
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.eclipse.smarthome.archetype:org.eclipse.smarthome.magic.test:eclipse-test-plugin:0.9.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.eclipse.tycho:target-platform-configuration is missing. @ line 27, column 15
[WARNING] 'build.plugins.plugin.version' for org.eclipse.tycho:tycho-surefire-plugin is missing. @ line 63, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

on every Maven build.