### PR TITLE
PaperUI: Fix config description binding error

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/directives/directive.configDescription.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/directives/directive.configDescription.js
@@ -3,6 +3,9 @@ angular.module('PaperUI.directive.configDescription', []) //
 
     var controller = function($scope) {
         $scope.getName = function(parameter, option) {
+            if (!option) {
+                return undefined;
+            }
             return option.name ? option.name : parameter.context == 'thing' ? option.UID : parameter.context == 'channel' ? option.id : undefined;
         }
     }


### PR DESCRIPTION
This fixes massive JavaScript console error logging when AngularJS recalculates the digest loop.

Signed-off-by: Henning Treu <henning.treu@telekom.de>