### PR TITLE
PaperUI: Fix switch state for dimmer item with category 'DimmableLight'

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.control.js
@@ -350,6 +350,10 @@ angular.module('PaperUI.controllers.control', []) //
         sendCommand(brightness);
     }
 
+    $scope.$watch("item.state", function(brightness) {
+        $scope.state.switchState = brightness > 0;
+    })
+
     var commandTimeout = undefined;
 
     var sendCommand = function(command) {


### PR DESCRIPTION
Fixes a bug where the UI switch state for a dimmer item with category "DimmableLight" does not get updated. When the state change is not initiated by PaperUI but from the backend the switch will now also display the correct On/Off state.

Signed-off-by: Henning Treu <henning.treu@telekom.de>