### PR TITLE
notify handlers asynchronously so that longer running operations do not block us

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -107,7 +107,8 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
 
     private Logger logger = LoggerFactory.getLogger(ThingManager.class);
 
-    private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool("thingManager");
+    private final ScheduledExecutorService scheduler = ThreadPoolManager
+            .getScheduledPool(THING_MANAGER_THREADPOOL_NAME);
 
     private EventPublisher eventPublisher;
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
@@ -276,50 +276,43 @@ public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusIn
     };
 
     private void informHandlerAboutLinkedChannel(Thing thing, Channel channel) {
-        // Don't notify the thing if the thing isn't initialised
-        if (!ThingHandlerHelper.isHandlerInitialized(thing)) {
-            return;
-        }
-
-        ThingHandler handler = thing.getHandler();
-        if (handler != null) {
-            scheduler.submit(() -> {
-                try {
-                    handler.channelLinked(channel.getUID());
-                } catch (Exception ex) {
-                    logger.error("Exception occurred while informing handler: {}", ex.getMessage(), ex);
+        scheduler.submit(() -> {
+            // Don't notify the thing if the thing isn't initialised
+            if (ThingHandlerHelper.isHandlerInitialized(thing)) {
+                ThingHandler handler = thing.getHandler();
+                if (handler != null) {
+                    try {
+                        handler.channelLinked(channel.getUID());
+                    } catch (Exception ex) {
+                        logger.error("Exception occurred while informing handler: {}", ex.getMessage(), ex);
+                    }
+                } else {
+                    logger.trace(
+                            "Can not inform handler about linked channel, because no handler is assigned to the thing {}.",
+                            thing.getUID());
                 }
-            });
-        } else {
-            logger.trace("Can not inform handler about linked channel, because no handler is assigned to the thing {}.",
-                    thing.getUID());
-        }
+            }
+        });
     }
 
     private void informHandlerAboutUnlinkedChannel(Thing thing, Channel channel) {
-        // Don't notify the thing if the thing isn't initialised
-        if (!ThingHandlerHelper.isHandlerInitialized(thing)) {
-            return;
-        }
-
-        ThingHandler handler = thing.getHandler();
-        if (handler != null) {
-            try {
-                scheduler.submit(() -> {
+        scheduler.submit(() -> {
+            // Don't notify the thing if the thing isn't initialised
+            if (ThingHandlerHelper.isHandlerInitialized(thing)) {
+                ThingHandler handler = thing.getHandler();
+                if (handler != null) {
                     try {
                         handler.channelUnlinked(channel.getUID());
                     } catch (Exception ex) {
                         logger.error("Exception occurred while informing handler: {}", ex.getMessage(), ex);
                     }
-                });
-            } catch (Exception ex) {
-                logger.error("Exception occurred while informing handler: {}", ex.getMessage(), ex);
+                } else {
+                    logger.trace(
+                            "Can not inform handler about unlinked channel, because no handler is assigned to the thing {}.",
+                            thing.getUID());
+                }
             }
-        } else {
-            logger.trace(
-                    "Can not inform handler about unlinked channel, because no handler is assigned to the thing {}.",
-                    thing.getUID());
-        }
+        });
     }
 
     @Override


### PR DESCRIPTION
Currently, the ThingLinkManager might process events very slowly, which can be a cause for the issue described in #4591. Notifying the handlers asynchronously should solve this.

Signed-off-by: Kai Kreuzer <kai@openhab.org>