### PR TITLE
added deprecation info on bundleContext as bindings must not use it

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -69,6 +69,8 @@ public abstract class BaseThingHandler implements ThingHandler {
 
     protected ThingRegistry thingRegistry;
     protected ItemChannelLinkRegistry linkRegistry;
+
+    @Deprecated // this must not be used by bindings!
     protected BundleContext bundleContext;
 
     protected @NonNull Thing thing;


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>