### PR TITLE
add profile to use tycho snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -540,6 +540,23 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>tycho-snapshot</id>
+      <activation>
+        <property>
+          <name>tycho-snapshot</name>
+        </property>
+      </activation>
+      <properties>
+        <tycho-version>1.1.0-SNAPSHOT</tycho-version>
+      </properties>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>tycho-snapshots</id>
+          <url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
   </profiles>
 
   <pluginRepositories>


### PR DESCRIPTION
Let's use the SNAPSHOT temporary as long as there is no more recent
release.
We need to use a more recent Tycho version (>1.0.0) to use a more recent
JDT compiler.
A more recent JDT compiler is necessary because of better nullness
handling.
