### PR TITLE
Fix GroupItem state calculation

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/GroupItemTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/GroupItemTest.java
@@ -33,10 +33,12 @@ import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.RollershutterItem;
 import org.eclipse.smarthome.core.library.items.SwitchItem;
 import org.eclipse.smarthome.core.library.types.ArithmeticGroupFunction;
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.RawType;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -197,6 +199,47 @@ public class GroupItemTest extends JavaOSGiTest {
     }
 
     @Test
+    public void testGetMembersFilteringGroups() {
+        GroupItem rootGroupItem = new GroupItem("root");
+
+        TestItem member1 = new TestItem("member1");
+        member1.setLabel("mem1");
+        rootGroupItem.addMember(member1);
+
+        GroupItem subGroup = new GroupItem("subGroup1");
+        subGroup.setLabel("subGrp1");
+        TestItem subMember1 = new TestItem("subGroup member 1");
+        subMember1.setLabel("subMem1");
+        subGroup.addMember(subMember1);
+
+        rootGroupItem.addMember(subGroup);
+
+        Set<Item> members = rootGroupItem
+                .getMembers(i -> !(i instanceof GroupItem) && i.getGroupNames().contains(rootGroupItem.getName()));
+        assertThat(members.size(), is(1));
+    }
+
+    @Test
+    public void testGetMembersFilteringGroupsTransient() {
+        GroupItem rootGroupItem = new GroupItem("root");
+
+        TestItem member1 = new TestItem("member1");
+        member1.setLabel("mem1");
+        rootGroupItem.addMember(member1);
+
+        GroupItem subGroup = new GroupItem("subGroup1");
+        subGroup.setLabel("subGrp1");
+        TestItem subMember1 = new TestItem("subGroup member 1");
+        subMember1.setLabel("subMem1");
+        subGroup.addMember(subMember1);
+
+        rootGroupItem.addMember(subGroup);
+
+        Set<Item> members = rootGroupItem.getMembers(i -> !(i instanceof GroupItem));
+        assertThat(members.size(), is(2));
+    }
+
+    @Test
     public void testGetStateAs_shouldEqualStateUpdate() {
         // Main group uses AND function
         GroupItem rootGroupItem = new GroupItem("root", new SwitchItem("baseItem"),
@@ -229,6 +272,52 @@ public class GroupItemTest extends JavaOSGiTest {
 
         assertThat(getStateAsState, is(OnOffType.ON));
         assertThat(stateUpdatedState, is(OnOffType.ON));
+    }
+
+    @Test
+    public void assertCyclicGroupItemsCalculateState() {
+        GroupFunction countFn = new ArithmeticGroupFunction.Count(new StringType(".*"));
+        GroupItem rootGroup = new GroupItem("rootGroup", new SwitchItem("baseItem"), countFn);
+        TestItem rootMember = new TestItem("rootMember");
+        rootGroup.addMember(rootMember);
+
+        GroupItem group1 = new GroupItem("group1");
+        GroupItem group2 = new GroupItem("group2");
+
+        rootGroup.addMember(group1);
+        group1.addMember(group2);
+        group2.addMember(group1);
+
+        group1.addMember(new TestItem("sub1"));
+        group2.addMember(new TestItem("sub2-1"));
+        group2.addMember(new TestItem("sub2-2"));
+        group2.addMember(new TestItem("sub2-3"));
+
+        // count: rootMember, sub1, sub2-1, sub2-2, sub2-3
+        assertThat(rootGroup.getStateAs(DecimalType.class), is(new DecimalType(5)));
+    }
+
+    @Test
+    public void assertCyclicGroupItemsCalculateStateWithSubGroupFunction() {
+        GroupFunction countFn = new ArithmeticGroupFunction.Count(new StringType(".*"));
+        GroupItem rootGroup = new GroupItem("rootGroup", new SwitchItem("baseItem"), countFn);
+        TestItem rootMember = new TestItem("rootMember");
+        rootGroup.addMember(rootMember);
+
+        GroupItem group1 = new GroupItem("group1");
+        GroupItem group2 = new GroupItem("group2", new SwitchItem("baseItem"), new ArithmeticGroupFunction.Sum());
+
+        rootGroup.addMember(group1);
+        group1.addMember(group2);
+        group2.addMember(group1);
+
+        group1.addMember(new TestItem("sub1"));
+        group2.addMember(new TestItem("sub2-1"));
+        group2.addMember(new TestItem("sub2-2"));
+        group2.addMember(new TestItem("sub2-3"));
+
+        // count: rootMember, sub1, group2
+        assertThat(rootGroup.getStateAs(DecimalType.class), is(new DecimalType(3)));
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -157,7 +157,14 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         if (item == null) {
             throw new IllegalArgumentException("Item must not be null!");
         }
-        members.addIfAbsent(item);
+
+        boolean added = members.addIfAbsent(item);
+
+        // in case membership is constructed programmatically this sanitises
+        // the group names on the item:
+        if (added && item instanceof GenericItem) {
+            ((GenericItem) item).addGroupName(this.getName());
+        }
         registerStateListener(item);
     }
 
@@ -279,7 +286,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         // if a group does not have a function it cannot have a state
         State newState = null;
         if (function != null) {
-            newState = function.getStateAs(getMembers(), typeClass);
+            newState = function.getStateAs(getStateMembers(getMembers()), typeClass);
         }
 
         if (newState == null && baseItem != null) {
@@ -341,7 +348,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     public void stateUpdated(Item item, State state) {
         State oldState = this.state;
         if (function != null && baseItem != null) {
-            State calculatedState = function.calculate(getMembers());
+            State calculatedState = function.calculate(getStateMembers(getMembers()));
             calculatedState = ItemUtil.convertToAcceptedState(calculatedState, baseItem);
             setState(calculatedState);
         }
@@ -367,6 +374,36 @@ public class GroupItem extends GenericItem implements StateChangeListener {
             eventPublisher.post(
                     ItemEventFactory.createGroupStateChangedEvent(this.getName(), memberName, newState, oldState));
         }
+    }
+
+    private Set<Item> getStateMembers(Set<Item> items) {
+        Set<Item> result = new HashSet<>();
+        collectStateMembers(result, items);
+
+        // filter out group items w/o state. we had those in to detect cyclic membership.
+        return result.stream().filter(i -> !isGroupItem(i) || hasOwnState((GroupItem) i)).collect(Collectors.toSet());
+    }
+
+    private void collectStateMembers(Set<Item> result, Set<Item> items) {
+        for (Item item : items) {
+            if (result.contains(item)) {
+                continue;
+            }
+            if (!isGroupItem(item) || (isGroupItem(item) && hasOwnState((GroupItem) item))) {
+                result.add(item);
+            } else {
+                result.add(item); // also add group items w/o state to detect cyclic membership.
+                collectStateMembers(result, ((GroupItem) item).getMembers());
+            }
+        }
+    }
+
+    private boolean isGroupItem(Item item) {
+        return item instanceof GroupItem;
+    }
+
+    private boolean hasOwnState(GroupItem item) {
+        return item.getFunction() != null && item.getBaseItem() != null;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -279,7 +279,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         // if a group does not have a function it cannot have a state
         State newState = null;
         if (function != null) {
-            newState = function.getStateAs(getAllMembers(), typeClass);
+            newState = function.getStateAs(getMembers(), typeClass);
         }
 
         if (newState == null && baseItem != null) {

--- a/docs/documentation/concepts/items.md
+++ b/docs/documentation/concepts/items.md
@@ -35,32 +35,32 @@ Group items can themselves be members of other group items.
 Cyclic membership is not forbidden but strongly not recommended.
 User interfaces might display group items as single entries and provide navigation to its members.
 
-Example for a Group item simply collection other items:
+Example for a Group item as a simple collection of other items:
 ```
     Group groundFloor
     Switch kitchenLight (groundFloor)
     Switch livingroomLight (groundFloor)
 ``` 
 
-In addition Group items can calculate their own state derived from their members using a specific group function.
+### Derive Group State from Member Items
 
-### Derive group state from member items
-
-Group items can derive their own state depending on their member items.
+Group items can derive their own state from their member items.
 To derive a state the group item must be constructed using a base item and a group function.
-When calculating state, group functions will recursively traverse the group's members and also take members of subgroups into account.
+When calculating the state, group functions recursively traverse the group's members and also take members of subgroups into account.
 If a subgroup however defines a state on its own (having base item & group function set) traversal stops and the state of the subgroup member is taken. 
 
 Available group functions:
 
-| Function           | Parameters  | Base Item | Description |
-|--------------------|-------------|-----------|-------------|
-| EQUALITY           | - | \<all\> | Sets the state of the members if all have equal state. Otherwise UNDEF is set |
-| AND, OR, NAND, NOR | \<activeState\>, \<passiveState\> | \<all\> (must match active & passive state) | Sets the <activeState> if the member state <activeState> evaluates to `true` under the boolean term. Otherwise the <passiveState> is set. |
-| SUM, AVG, MIN, MAX | - | Number | Sets the state according to the arithmetic function over all member states. |
-| COUNT              | \<regular expression\> | Number | Sets the state to the number of members matching the given regular expression with their states. |
+| Function           | Parameters                    | Base Item                                   | Description                                                                                                                                     |
+|--------------------|-------------------------------|---------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| EQUALITY           | -                             | \<all\>                                     | Sets the state of the members if all have equal state. Otherwise UNDEF is set.                                                                  |
+| AND, OR, NAND, NOR | <activeState>, <passiveState> | \<all\> (must match active & passive state) | Sets the \<activeState\>, if the member state \<activeState\> evaluates to `true` under the boolean term. Otherwise the \<passiveState\> is set.|
+| SUM, AVG, MIN, MAX | -                             | Number                                      | Sets the state according to the arithmetic function over all member states.                                                                     |
+| COUNT              | <regular expression>          | Number                                      | Sets the state to the number of members matching the given regular expression with their states.                                                |
+
 
 Examples for derived states on group items when declared in the item DSL:
+
 - `Group:Number:COUNT(".*")` counts all members of the group matching the given regular expression, here any character or state (simply count all members).
 - `Group:Number:AVG` calculates the average value over all member states which can be interpreted as `DecimalTypes`.
 - `Group:Switch:OR(ON,OFF)` sets the group state to `ON` if any of its members has the state `ON`, `OFF` if all are off.    

--- a/docs/documentation/concepts/items.md
+++ b/docs/documentation/concepts/items.md
@@ -28,11 +28,43 @@ The following item types are currently available (alphabetical order):
 | String         | Stores texts | String |
 | Switch         | Typically used for lights (on/off) | OnOff |
 
-Group Items can derive their own state depending on their member items.
+## Group Items
 
-- AVG displays the average of the item states in the group.
-- OR displays an OR of the group, typically used to display whether any item in a group has been set.
-- other aggregations: AND, SUM, MIN, MAX, NAND, NOR
+Group items collect other items into groups.
+Group items can themselves be members of other group items.
+Cyclic membership is not forbidden but strongly not recommended.
+User interfaces might display group items as single entries and provide navigation to its members.
+
+Example for a Group item simply collection other items:
+```
+    Group groundFloor
+    Switch kitchenLight (groundFloor)
+    Switch livingroomLight (groundFloor)
+``` 
+
+In addition Group items can calculate their own state derived from their members using a specific group function.
+
+### Derive group state from member items
+
+Group items can derive their own state depending on their member items.
+To derive a state the group item must be constructed using a base item and a group function.
+When calculating state, group functions will recursively traverse the group's members and also take members of subgroups into account.
+If a subgroup however defines a state on its own (having base item & group function set) traversal stops and the state of the subgroup member is taken. 
+
+Available group functions:
+
+| Function           | Parameters  | Base Item | Description |
+|--------------------|-------------|-----------|-------------|
+| EQUALITY           | - | \<all\> | Sets the state of the members if all have equal state. Otherwise UNDEF is set |
+| AND, OR, NAND, NOR | \<activeState\>, \<passiveState\> | \<all\> (must match active & passive state) | Sets the <activeState> if the member state <activeState> evaluates to `true` under the boolean term. Otherwise the <passiveState> is set. |
+| SUM, AVG, MIN, MAX | - | Number | Sets the state according to the arithmetic function over all member states. |
+| COUNT              | \<regular expression\> | Number | Sets the state to the number of members matching the given regular expression with their states. |
+
+Examples for derived states on group items when declared in the item DSL:
+- `Group:Number:COUNT(".*")` counts all members of the group matching the given regular expression, here any character or state (simply count all members).
+- `Group:Number:AVG` calculates the average value over all member states which can be interpreted as `DecimalTypes`.
+- `Group:Switch:OR(ON,OFF)` sets the group state to `ON` if any of its members has the state `ON`, `OFF` if all are off.    
+- `Group:Switch:AND(ON,OFF)` sets the group state to `ON` if all of its members have the state `ON`, `OFF` if any of the group members has a different state than `ON`.
 
 ## State and Command Type Formatting
 


### PR DESCRIPTION
GroupItem calculates its state over all direct members. For sub-groups the state of the sub-group is taken into the calculation.
The `GroupItem#getStateAs` method however did calculate the state over all non-GroupItem members and sub-members.

Also: Unit test added.

Signed-off-by: Henning Treu <henning.treu@telekom.de>