### PR TITLE
Inbox: Representation properties are unique per binding

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessorTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessorTest.java
@@ -306,6 +306,27 @@ public class AutomaticInboxProcessorTest {
     }
 
     @Test
+    public void testOneThingOutOfTwoWithSameRepresentationPropertyButDifferentBindingIdIsBeingRemoved() {
+        inbox.add(DiscoveryResultBuilder.create(THING_UID).withProperty(DEVICE_ID_KEY, DEVICE_ID)
+                .withRepresentationProperty(DEVICE_ID_KEY).build());
+        inbox.setFlag(THING_UID, DiscoveryResultFlag.IGNORED);
+
+        inbox.add(DiscoveryResultBuilder.create(THING_UID3).withProperty(DEVICE_ID_KEY, DEVICE_ID)
+                .withRepresentationProperty(DEVICE_ID_KEY).build());
+        inbox.setFlag(THING_UID3, DiscoveryResultFlag.IGNORED);
+
+        List<DiscoveryResult> results = inbox.stream().filter(withFlag(DiscoveryResultFlag.IGNORED))
+                .collect(Collectors.toList());
+        assertThat(results.size(), is(2));
+
+        inboxAutoIgnore.removed(thing);
+
+        results = inbox.getAll();
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getThingUID(), is(equalTo(THING_UID3)));
+    }
+
+    @Test
     public void testThingWithConfigWentOnline() {
         inbox.add(DiscoveryResultBuilder.create(THING_UID2).withProperty(CONFIG_KEY, CONFIG_VALUE)
                 .withRepresentationProperty(CONFIG_KEY).build());

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessorTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessorTest.java
@@ -59,19 +59,31 @@ public class AutomaticInboxProcessorTest {
 
     private static final String DEVICE_ID = "deviceId";
     private static final String DEVICE_ID_KEY = "deviceIdKey";
+    private static final String OTHER_KEY = "otherKey";
+    private static final String OTHER_VALUE = "deviceId";
     private static final String CONFIG_KEY = "configKey";
     private static final String CONFIG_VALUE = "configValue";
 
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("test", "test");
     private static final ThingTypeUID THING_TYPE_UID2 = new ThingTypeUID("test2", "test2");
+    private static final ThingTypeUID THING_TYPE_UID3 = new ThingTypeUID("test3", "test3");
+
     private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "test");
     private static final ThingUID THING_UID2 = new ThingUID(THING_TYPE_UID, "test2");
+    private static final ThingUID THING_UID3 = new ThingUID(THING_TYPE_UID3, "test3");
+
     private static final ThingType THING_TYPE = ThingTypeBuilder.instance(THING_TYPE_UID, "label").isListed(true)
             .withRepresentationProperty(DEVICE_ID_KEY).build();
     private static final ThingType THING_TYPE2 = ThingTypeBuilder.instance(THING_TYPE_UID2, "label").isListed(true)
             .withRepresentationProperty(CONFIG_KEY).build();
+    private static final ThingType THING_TYPE3 = ThingTypeBuilder.instance(THING_TYPE_UID3, "label").isListed(true)
+            .withRepresentationProperty(OTHER_KEY).build();
+
     private final static Map<String, String> THING_PROPERTIES = new ImmutableMap.Builder<String, String>()
             .put(DEVICE_ID_KEY, DEVICE_ID).build();
+    private final static Map<String, String> OTHER_THING_PROPERTIES = new ImmutableMap.Builder<String, String>()
+            .put(OTHER_KEY, OTHER_VALUE).build();
+
     private final static Configuration CONFIG = new Configuration(
             new ImmutableMap.Builder<String, Object>().put(CONFIG_KEY, CONFIG_VALUE).build());
 
@@ -89,6 +101,9 @@ public class AutomaticInboxProcessorTest {
 
     @Mock
     private Thing thing2;
+
+    @Mock
+    private Thing thing3;
 
     @Mock
     private ThingStatusInfoChangedEvent thingStatusInfoChangedEvent;
@@ -118,10 +133,17 @@ public class AutomaticInboxProcessorTest {
         when(thing2.getStatus()).thenReturn(ThingStatus.ONLINE);
         when(thing2.getUID()).thenReturn(THING_UID2);
 
+        when(thing3.getConfiguration()).thenReturn(CONFIG);
+        when(thing3.getThingTypeUID()).thenReturn(THING_TYPE_UID3);
+        when(thing3.getProperties()).thenReturn(OTHER_THING_PROPERTIES);
+        when(thing3.getStatus()).thenReturn(ThingStatus.ONLINE);
+        when(thing3.getUID()).thenReturn(THING_UID3);
+
         when(thingRegistry.stream()).thenReturn(Stream.empty());
 
         when(thingTypeRegistry.getThingType(THING_TYPE_UID)).thenReturn(THING_TYPE);
         when(thingTypeRegistry.getThingType(THING_TYPE_UID2)).thenReturn(THING_TYPE2);
+        when(thingTypeRegistry.getThingType(THING_TYPE_UID3)).thenReturn(THING_TYPE3);
 
         when(thingHandlerFactory.supportsThingType(eq(THING_TYPE_UID))).thenReturn(true);
         when(thingHandlerFactory.createThing(eq(THING_TYPE_UID), any(Configuration.class), eq(THING_UID),
@@ -141,6 +163,41 @@ public class AutomaticInboxProcessorTest {
         inboxAutoIgnore.setThingRegistry(thingRegistry);
         inboxAutoIgnore.setThingTypeRegistry(thingTypeRegistry);
         inboxAutoIgnore.setInbox(inbox);
+    }
+
+    /**
+     * This test is just like the test testThingWentOnline in the AutomaticInboxProcessorTest, but in contrast to the
+     * above test (where a thing with the same thing type and the same representation property value went online) here a
+     * thing with another thing type and the same representation property value goes online.
+     * <p/>
+     * In this case, the discovery result should not be ignored, since it has a different thing type.
+     */
+    @Test
+    public void testThingWithOtherThingTypeButSameRepresentationPropertyWentOnline() {
+        // Add discovery result with thing type THING_TYPE_UID and representation property value DEVICE_ID
+        inbox.add(DiscoveryResultBuilder.create(THING_UID).withProperty(DEVICE_ID_KEY, DEVICE_ID)
+                .withRepresentationProperty(DEVICE_ID_KEY).build());
+
+        // Then there is a discovery result which is NEW
+        List<DiscoveryResult> results = inbox.stream().filter(withFlag(DiscoveryResultFlag.NEW))
+                .collect(Collectors.toList());
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getThingUID(), is(equalTo(THING_UID)));
+
+        // Now a thing with thing type THING_TYPE_UID3 goes online, with representation property value being also the
+        // device id
+        when(thingRegistry.get(THING_UID3)).thenReturn(thing3);
+        when(thingStatusInfoChangedEvent.getStatusInfo())
+                .thenReturn(new ThingStatusInfo(ThingStatus.ONLINE, ThingStatusDetail.NONE, null));
+        when(thingStatusInfoChangedEvent.getThingUID()).thenReturn(THING_UID3);
+        inboxAutoIgnore.receive(thingStatusInfoChangedEvent);
+
+        // Then there should still be the NEW discovery result, but no IGNORED discovery result
+        results = inbox.stream().filter(withFlag(DiscoveryResultFlag.NEW)).collect(Collectors.toList());
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getThingUID(), is(equalTo(THING_UID)));
+        results = inbox.stream().filter(withFlag(DiscoveryResultFlag.IGNORED)).collect(Collectors.toList());
+        assertThat(results.size(), is(0));
     }
 
     @Test

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessorTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessorTest.java
@@ -167,13 +167,13 @@ public class AutomaticInboxProcessorTest {
 
     /**
      * This test is just like the test testThingWentOnline in the AutomaticInboxProcessorTest, but in contrast to the
-     * above test (where a thing with the same thing type and the same representation property value went online) here a
-     * thing with another thing type and the same representation property value goes online.
+     * above test (where a thing with the same binding ID and the same representation property value went online) here a
+     * thing with another binding ID and the same representation property value goes online.
      * <p/>
      * In this case, the discovery result should not be ignored, since it has a different thing type.
      */
     @Test
-    public void testThingWithOtherThingTypeButSameRepresentationPropertyWentOnline() {
+    public void testThingWithOtherBindingIDButSameRepresentationPropertyWentOnline() {
         // Add discovery result with thing type THING_TYPE_UID and representation property value DEVICE_ID
         inbox.add(DiscoveryResultBuilder.create(THING_UID).withProperty(DEVICE_ID_KEY, DEVICE_ID)
                 .withRepresentationProperty(DEVICE_ID_KEY).build());
@@ -198,6 +198,27 @@ public class AutomaticInboxProcessorTest {
         assertThat(results.get(0).getThingUID(), is(equalTo(THING_UID)));
         results = inbox.stream().filter(withFlag(DiscoveryResultFlag.IGNORED)).collect(Collectors.toList());
         assertThat(results.size(), is(0));
+    }
+
+    @Test
+    public void testThingWithOtherBindingIDButSameRepresentationPropertyIsDiscovered() {
+        // insert thing with thing type THING_TYPE_UID3 and representation property value DEVICE_ID in registry
+        when(thingRegistry.get(THING_UID)).thenReturn(thing);
+        when(thingRegistry.stream()).thenReturn(Stream.of(thing));
+
+        // Add discovery result with thing type THING_TYPE_UID3 and representation property value DEVICE_ID
+        inbox.add(DiscoveryResultBuilder.create(THING_UID3).withProperty(DEVICE_ID_KEY, DEVICE_ID)
+                .withRepresentationProperty(DEVICE_ID_KEY).build());
+
+        // Do NOT ignore this discovery result because it has a different binding ID
+        List<DiscoveryResult> results = inbox.stream().filter(withFlag(DiscoveryResultFlag.IGNORED))
+                .collect(Collectors.toList());
+        assertThat(results.size(), is(0));
+
+        // Then there is a discovery result which is NEW
+        results = inbox.stream().filter(withFlag(DiscoveryResultFlag.NEW)).collect(Collectors.toList());
+        assertThat(results.size(), is(1));
+        assertThat(results.get(0).getThingUID(), is(equalTo(THING_UID3)));
     }
 
     @Test

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/InboxPredicates.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/InboxPredicates.java
@@ -57,4 +57,8 @@ public class InboxPredicates {
     public static Predicate<DiscoveryResult> withRepresentationPropertyValue(@Nullable String propertyValue) {
         return r -> propertyValue != null && propertyValue.equals(r.getProperties().get(r.getRepresentationProperty()));
     }
+
+    public static Predicate<DiscoveryResult> withBindingId(@Nullable String bindingId) {
+        return r -> bindingId != null && bindingId.equals(r.getBindingId());
+    }
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
@@ -96,7 +96,8 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
             String value = getRepresentationValue(result);
             if (value != null) {
                 Thing thing = thingRegistry.stream()
-                        .filter(t -> Objects.equals(value, getRepresentationPropertyValueForThing(t))).findFirst()
+                        .filter(t -> Objects.equals(value, getRepresentationPropertyValueForThing(t)))
+                        .filter(t -> Objects.equals(t.getUID().getBindingId(), result.getBindingId())).findFirst()
                         .orElse(null);
                 if (thing != null) {
                     logger.debug("Auto-ignoring the inbox entry for the representation value {}", value);

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
@@ -164,7 +164,7 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
         if (thing != null) {
             String representationValue = getRepresentationPropertyValueForThing(thing);
             if (representationValue != null) {
-                removeFromInbox(representationValue);
+                removeFromInbox(thing.getUID().getBindingId(), representationValue);
             }
         }
     }
@@ -188,9 +188,10 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
         return null;
     }
 
-    private void removeFromInbox(String representationValue) {
+    private void removeFromInbox(String bindingId, String representationValue) {
         List<DiscoveryResult> results = inbox.stream().filter(withRepresentationPropertyValue(representationValue))
-                .filter(withFlag(DiscoveryResultFlag.IGNORED)).collect(Collectors.toList());
+                .filter(withBindingId(bindingId)).filter(withFlag(DiscoveryResultFlag.IGNORED))
+                .collect(Collectors.toList());
         if (results.size() == 1) {
             logger.debug("Removing the ignored result from the inbox for the representation value {}",
                     representationValue);

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/AutomaticInboxProcessor.java
@@ -146,14 +146,14 @@ public class AutomaticInboxProcessor extends AbstractTypedEventSubscriber<ThingS
         if (thing != null) {
             String representationValue = getRepresentationPropertyValueForThing(thing);
             if (representationValue != null) {
-                ignoreInInbox(representationValue);
+                ignoreInInbox(thing.getUID().getBindingId(), representationValue);
             }
         }
     }
 
-    private void ignoreInInbox(String representationValue) {
+    private void ignoreInInbox(String bindingId, String representationValue) {
         List<DiscoveryResult> results = inbox.stream().filter(withRepresentationPropertyValue(representationValue))
-                .collect(Collectors.toList());
+                .filter(withBindingId(bindingId)).collect(Collectors.toList());
         if (results.size() == 1) {
             logger.debug("Auto-ignoring the inbox entry for the representation value {}", representationValue);
             inbox.setFlag(results.get(0).getThingUID(), DiscoveryResultFlag.IGNORED);


### PR DESCRIPTION
Do not ignore a discovery result if it has the same
representation property as a thing that already exists, if
their bindingId differs.

Fixes #4191

Also-by: Henning Sudbrock <henning.sudbrock@telekom.de>
Signed-off-by: Stefan Triller <stefan.triller@telekom.de>