### PR TITLE
Add WAITING step for firmware update

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/ProgressStep.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/ProgressStep.java
@@ -17,6 +17,7 @@ package org.eclipse.smarthome.core.thing.binding.firmware;
  * of the firmware update is defined by the operation {@link ProgressCallback#defineSequence(ProgressStep...)}.
  *
  * @author Thomas Höfer - Initial contribution
+ * @author Chris Jackson - Add WAITING
  */
 public enum ProgressStep {
 
@@ -25,6 +26,12 @@ public enum ProgressStep {
      * {@link Firmware#getBytes()}.
      */
     DOWNLOADING,
+
+    /**
+     * The {@link FirmwareUpdateHandler} is waiting for the device to initiate the transfer. For battery devices that
+     * may wake up periodically, this may take some time. For mains devices this step may be very short or omitted.
+     */
+    WAITING,
 
     /** The {@link FirmwareUpdateHandler} is going to transfer the firmware to the actual device. */
     TRANSFERRING,

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/filters/filter.firmware.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/filters/filter.firmware.js
@@ -9,6 +9,7 @@ firmwareFilterModule.constant('FIRMWARE_STATUS', {
 
 firmwareFilterModule.constant('UPDATE_STEP', {
     DOWNLOADING : 'DOWNLOADING',
+    WAITING : 'WAITING',
     TRANSFERRING : 'TRANSFERRING',
     UPDATING : 'UPDATING',
     REBOOTING : 'REBOOTING'
@@ -45,6 +46,8 @@ firmwareFilterModule.filter('firmwareStatusFormat', [ 'FIRMWARE_STATUS', functio
         switch (updateStep) {
             case UPDATE_STEP.DOWNLOADING:
                 return 'Downloading';
+            case UPDATE_STEP.WAITING:
+                return 'Waiting';
             case UPDATE_STEP.TRANSFERRING:
                 return 'Transfering';
             case UPDATE_STEP.UPDATING:

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/filters/filter.firmware.spec.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/filters/filter.firmware.spec.js
@@ -49,6 +49,7 @@ describe('module PaperUI.filters.firmware', function() {
 
         it('should map firmware update step to readable text', function() {
             expect(firmwareUpdateStep(updateStep.DOWNLOADING)).toBe('Downloading');
+            expect(firmwareUpdateStep(updateStep.WAITING)).toBe('Waiting');
             expect(firmwareUpdateStep(updateStep.TRANSFERRING)).toBe('Transfering');
             expect(firmwareUpdateStep(updateStep.UPDATING)).toBe('Updating');
             expect(firmwareUpdateStep(updateStep.REBOOTING)).toBe('Rebooting');


### PR DESCRIPTION
RF devices may wait for a significant amount of time before the transfer actually begins so this adds the possibility to indicate this to the user.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>