### PR TITLE
[LIFX] Correct Mini product names

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Products.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Products.java
@@ -44,8 +44,8 @@ public enum Products {
     LPA19_2(1, 45, "LIFX+ A19", true, true, false),
     LPBR30_2(1, 46, "LIFX+ BR30", true, true, false),
     LM(1, 49, "LIFX Mini", true, false, false),
-    LMW(1, 50, "LIFX Mini White", false, false, false),
-    LMWDD(1, 51, "LIFX Mini Day and Dusk", false, false, false),
+    LMDD(1, 50, "LIFX Mini Day and Dusk", false, false, false),
+    LMW(1, 51, "LIFX Mini White", false, false, false),
     LGU10(1, 52, "LIFX GU10", true, false, false);
 
     private final long vendorID;


### PR DESCRIPTION
LIFX had the mini day dusk and mini white the wrong way around.

See https://github.com/LIFX/products/commit/bd9a27e09f8be003441f0371b8c60625e082c894.