### PR TITLE
changed to static and mandatory service references

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
@@ -123,6 +123,9 @@ class ThingManagerOSGiTest extends OSGiTest {
         waitForAssert {
             assertThat getBundleContext().getServiceReferences(ReadyMarker, "(" + ThingManager.XML_THING_TYPE + "=" + getBundleContext().getBundle().getSymbolicName() + ")"), is(notNullValue())
         }
+        waitForAssert {
+            assertThat getBundleContext().getServiceReferences(ChannelItemProvider, null), is(notNullValue())
+        }
     }
 
     @After
@@ -684,6 +687,7 @@ class ThingManagerOSGiTest extends OSGiTest {
             }
         ] as ThingHandlerFactory
         registerService(thingHandlerFactory)
+        waitForAssert { assertThat itemRegistry.get(itemName), is(notNullValue()) }
 
         callback.statusUpdated(THING, ThingStatusInfoBuilder.create(ThingStatus.ONLINE).build())
 
@@ -1568,6 +1572,7 @@ class ThingManagerOSGiTest extends OSGiTest {
         registerService(thingHandlerFactory)
 
         itemChannelLinkRegistry.add(new ItemChannelLink("testItem", new ChannelUID(THING.getUID(), "channel")))
+        waitForAssert { assertThat itemRegistry.get("testItem"), is(notNullValue()) }
 
         eventPublisher.post(ItemEventFactory.createCommandEvent("testItem", new StringType("TEST")))
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
@@ -130,7 +130,7 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
         this.itemRegistry = null;
     }
 
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC, name = "ManagedItemChannelLinkProvider")
+    @Reference
     protected void setManagedProvider(ManagedItemChannelLinkProvider provider) {
         super.setManagedProvider(provider);
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemChannelLinkProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemChannelLinkProvider.java
@@ -51,7 +51,7 @@ public class ManagedItemChannelLinkProvider extends DefaultAbstractManagedProvid
         }
     }
 
-    @Reference(policy = ReferencePolicy.DYNAMIC)
+    @Reference(policy = ReferencePolicy.STATIC)
     @Override
     protected void setStorageService(StorageService storageService) {
         super.setStorageService(storageService);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemChannelLinkProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ManagedItemChannelLinkProvider.java
@@ -19,7 +19,6 @@ import org.eclipse.smarthome.core.storage.StorageService;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
  *
@@ -51,7 +50,7 @@ public class ManagedItemChannelLinkProvider extends DefaultAbstractManagedProvid
         }
     }
 
-    @Reference(policy = ReferencePolicy.STATIC)
+    @Reference
     @Override
     protected void setStorageService(StorageService storageService) {
         super.setStorageService(storageService);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ThingLinkManager.java
@@ -63,9 +63,9 @@ public class ThingLinkManager extends AbstractTypedEventSubscriber<ThingStatusIn
 
     private static final String THREADPOOL_NAME = "thingLinkManager";
 
-    private Logger logger = LoggerFactory.getLogger(ThingLinkManager.class);
+    private final Logger logger = LoggerFactory.getLogger(ThingLinkManager.class);
 
-    private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool("thingLinkManager");
+    private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(THREADPOOL_NAME);
 
     private ThingRegistry thingRegistry;
     private ManagedThingProvider managedThingProvider;

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericItemChannelLinkProviderJavaTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericItemChannelLinkProviderJavaTest.java
@@ -64,6 +64,8 @@ public class GenericItemChannelLinkProviderJavaTest extends JavaOSGiTest {
 
     @Before
     public void setUp() {
+        registerVolatileStorageService();
+
         initMocks(this);
 
         thingRegistry = getService(ThingRegistry.class);

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericItemChannelLinkProviderTest.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericItemChannelLinkProviderTest.groovy
@@ -21,89 +21,90 @@ import org.eclipse.smarthome.core.thing.ThingRegistry
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkProvider;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry
 import org.eclipse.smarthome.model.core.ModelRepository
-import org.eclipse.smarthome.model.thing.internal.GenericItemChannelLinkProvider;
 import org.eclipse.smarthome.test.OSGiTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test;
 
 class GenericItemChannelLinkProviderTest extends OSGiTest {
-	
-	private final static String THINGS_TESTMODEL_NAME = "test.things"
-	private final static String ITEMS_TESTMODEL_NAME = "test.items"
-	
-	ModelRepository modelRepository
-	ThingRegistry thingRegistry
-	ItemRegistry itemRegistry
-	ItemChannelLinkRegistry itemChannelLinkRegistry
+
+    private final static String THINGS_TESTMODEL_NAME = "test.things"
+    private final static String ITEMS_TESTMODEL_NAME = "test.items"
+
+    ModelRepository modelRepository
+    ThingRegistry thingRegistry
+    ItemRegistry itemRegistry
+    ItemChannelLinkRegistry itemChannelLinkRegistry
     ItemChannelLinkProvider itemChannelLinkProvider
-	
-	@Before
-	void setUp() {
-		thingRegistry = getService ThingRegistry
-		assertThat thingRegistry, is(notNullValue())
-		modelRepository = getService ModelRepository
-		assertThat modelRepository, is(notNullValue())
-		itemRegistry = getService ItemRegistry
-		assertThat itemRegistry, is(notNullValue())
-		itemChannelLinkRegistry = getService ItemChannelLinkRegistry
-		assertThat itemChannelLinkRegistry, is(notNullValue())
+
+    @Before
+    void setUp() {
+        registerVolatileStorageService();
+
+        thingRegistry = getService ThingRegistry
+        assertThat thingRegistry, is(notNullValue())
+        modelRepository = getService ModelRepository
+        assertThat modelRepository, is(notNullValue())
+        itemRegistry = getService ItemRegistry
+        assertThat itemRegistry, is(notNullValue())
+        itemChannelLinkRegistry = getService ItemChannelLinkRegistry
+        assertThat itemChannelLinkRegistry, is(notNullValue())
         itemChannelLinkProvider = getService ItemChannelLinkProvider
         assertThat itemChannelLinkProvider, is(notNullValue())
-		modelRepository.removeModel(THINGS_TESTMODEL_NAME)
-		modelRepository.removeModel(ITEMS_TESTMODEL_NAME)
-	}
-	
-	@After
-	void tearDown() {
-		modelRepository.removeModel(THINGS_TESTMODEL_NAME)
-		modelRepository.removeModel(ITEMS_TESTMODEL_NAME)
-	}
+        modelRepository.removeModel(THINGS_TESTMODEL_NAME)
+        modelRepository.removeModel(ITEMS_TESTMODEL_NAME)
+    }
 
-	@Test
-	void 'test that an ItemChannelLink was created for a thing and an item'() {
-		def things = thingRegistry.all
-		assertThat things.size(), is(0)
+    @After
+    void tearDown() {
+        modelRepository.removeModel(THINGS_TESTMODEL_NAME)
+        modelRepository.removeModel(ITEMS_TESTMODEL_NAME)
+    }
 
-		String thingsModel =
-			'''
+    @Test
+    void 'test that an ItemChannelLink was created for a thing and an item'() {
+        def things = thingRegistry.all
+        assertThat things.size(), is(0)
+
+        String thingsModel =
+                '''
 			Bridge hue:bridge:huebridge [ ipAddress = "192.168.3.84", userName = "19fc3fa6fc870a4280a55f21315631f" ] {
 				LCT001 bulb3 [ lightId = "3"	]
 				LCT001 bulb4 [ lightId = "3" ]
 			}
 			'''
-		modelRepository.addOrRefreshModel(THINGS_TESTMODEL_NAME, new ByteArrayInputStream(thingsModel.bytes))
-		def actualThings = thingRegistry.all
+        modelRepository.addOrRefreshModel(THINGS_TESTMODEL_NAME, new ByteArrayInputStream(thingsModel.bytes))
+        def actualThings = thingRegistry.all
 
-		assertThat actualThings.size(), is(3)
-		
-		def items = itemRegistry.items
-		assertThat items.size(), is(0)
-		
-		def itemChannelLinks = itemChannelLinkRegistry.all
-		assertThat itemChannelLinks.size(), is(0)
+        assertThat actualThings.size(), is(3)
 
-		String itemsModel =
-			'''
+        def items = itemRegistry.items
+        assertThat items.size(), is(0)
+
+        def itemChannelLinks = itemChannelLinkRegistry.all
+        assertThat itemChannelLinks.size(), is(0)
+
+        String itemsModel =
+                '''
 			Color	Light3Color					"Light3 Color"		{ channel="hue:LCT001:huebridge:bulb3:color" }
 			'''
-		modelRepository.addOrRefreshModel(ITEMS_TESTMODEL_NAME, new ByteArrayInputStream(itemsModel.bytes))
-		def actualItems = itemRegistry.items
-		
-		assertThat actualItems.size(), is(1)
-			
-		def actualItemChannelLinks = itemChannelLinkRegistry.all
-		assertThat actualItemChannelLinks.size(), is(1)
-		assertThat actualItemChannelLinks.first().toString(), is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb3:color"))
-	}
-	
+        modelRepository.addOrRefreshModel(ITEMS_TESTMODEL_NAME, new ByteArrayInputStream(itemsModel.bytes))
+        def actualItems = itemRegistry.items
+
+        assertThat actualItems.size(), is(1)
+
+        def actualItemChannelLinks = itemChannelLinkRegistry.all
+        assertThat actualItemChannelLinks.size(), is(1)
+        assertThat actualItemChannelLinks.first().toString(), is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb3:color"))
+    }
+
     @Test
     void 'test that multiple links are created'() {
         def things = thingRegistry.all
         assertThat things.size(), is(0)
 
         String thingsModel =
-            '''
+                '''
             Bridge hue:bridge:huebridge [ ipAddress = "192.168.3.84", userName = "19fc3fa6fc870a4280a55f21315631f" ] {
                 LCT001 bulb3 [ lightId = "3" ]
                 LCT001 bulb4 [ lightId = "3" ]
@@ -113,22 +114,22 @@ class GenericItemChannelLinkProviderTest extends OSGiTest {
         def actualThings = thingRegistry.all
 
         assertThat actualThings.size(), is(3)
-        
+
         def items = itemRegistry.items
         assertThat items.size(), is(0)
-        
+
         def itemChannelLinks = itemChannelLinkRegistry.all
         assertThat itemChannelLinks.size(), is(0)
 
         String itemsModel =
-            '''
+                '''
             Color   Light3Color                 "Light3 Color"      { channel="hue:LCT001:huebridge:bulb3:color, hue:LCT001:huebridge:bulb4:color" }
             '''
         modelRepository.addOrRefreshModel(ITEMS_TESTMODEL_NAME, new ByteArrayInputStream(itemsModel.bytes))
         def actualItems = itemRegistry.items
-        
+
         assertThat actualItems.size(), is(1)
-            
+
         def actualItemChannelLinks = itemChannelLinkRegistry.all
         assertThat actualItemChannelLinks.size(), is(2)
         assertThat actualItemChannelLinks.first().toString(),   is(equalTo("Light3Color -> hue:LCT001:huebridge:bulb3:color"))

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest4.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest4.groovy
@@ -107,6 +107,8 @@ class GenericThingProviderTest4 extends OSGiTest{
 
     @Before
     public void setUp() {
+        registerVolatileStorageService();
+
         readyService = getService ReadyService
         assertThat readyService, is(notNullValue())
         thingRegistry = getService ThingRegistry


### PR DESCRIPTION
Should hopefully fix #4620 as the ItemChannelLinkRegistry won't be registered without a managed provider anymore.

Signed-off-by: Kai Kreuzer <kai@openhab.org>