### PR TITLE
Enhancement of Profiles with two new profile types

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemCommandProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemCommandProfile.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2014,2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.StateProfile;
+import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+
+/**
+ * This is the default implementation for a follow profile.
+ *
+ * In contrast to the {@link SystemDefaultProfile} it does not forward any state updates from the framework to the
+ * ThingHandler. Instead, it only accepts {@link Command}s and then forwards those to the {@link ThingHandler}.
+ * <p>
+ * This allows devices to be operated in an "execution-only" mode, whereby they only take commands that are explicitly
+ * given by the framework and ignore state updates that might come from the Item that is for example linked to other
+ * Channels that are used to feed back a State
+ * <p>
+ * The ThingHandler may send commands to the framework, but no state updates are forwarded.
+ *
+ * @author Karel Goderis - initial contribution and API.
+ *
+ */
+@NonNullByDefault
+public class SystemCommandProfile implements StateProfile {
+
+    private final ProfileCallback callback;
+
+    public SystemCommandProfile(ProfileCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.COMMAND;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        // no-op
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        callback.sendCommand(command);
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        callback.handleCommand(command);
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        // no-op
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemPassiveProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemPassiveProfile.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2014,2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.StateProfile;
+import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.State;
+
+/**
+ * This is the default implementation for a passive profile.
+ *
+ * In contrast to the {@link SystemDefaultProfile} it does not forward any commands or updates to the ThingHandler.
+ * Instead, it takes
+ * {@link State} and {@link Command}s received from the {@link ThingHandler} to send to the {@link Item}.
+ * <p>
+ * This allows devices to be operated as "passive informers" for information they receive from Things
+ * <p>
+ * The ThingHandler may send commands and updates to the framework, but nothing is forwarded from the framework to the
+ * ThingHandler.
+ *
+ * @author Karel Goderis - initial contribution and API.
+ *
+ */
+@NonNullByDefault
+public class SystemPassiveProfile implements StateProfile {
+
+    private final ProfileCallback callback;
+
+    public SystemPassiveProfile(ProfileCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.PASSIVE;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(State state) {
+        // no-op
+    }
+
+    @Override
+    public void onCommandFromHandler(Command command) {
+        callback.sendCommand(command);
+    }
+
+    @Override
+    public void onCommandFromItem(Command command) {
+        // no-op
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(State state) {
+        callback.sendUpdate(state);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -51,22 +51,27 @@ import org.osgi.service.component.annotations.Component;
 public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, ProfileTypeProvider {
 
     private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Stream
-            .of(SystemProfiles.DEFAULT_TYPE, SystemProfiles.FOLLOW_TYPE, SystemProfiles.RAWBUTTON_TOGGLE_SWITCH_TYPE,
+            .of(SystemProfiles.COMMAND_TYPE, SystemProfiles.DEFAULT_TYPE, SystemProfiles.FOLLOW_TYPE,
+                    SystemProfiles.PASSIVE_TYPE, SystemProfiles.RAWBUTTON_TOGGLE_SWITCH_TYPE,
                     SystemProfiles.RAWROCKER_ON_OFF_TYPE, SystemProfiles.RAWROCKER_DIMMER_TYPE)
             .collect(Collectors.toSet());
 
-    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream
-            .of(SystemProfiles.DEFAULT, SystemProfiles.FOLLOW, SystemProfiles.RAWBUTTON_TOGGLE_SWITCH,
-                    SystemProfiles.RAWROCKER_ON_OFF, SystemProfiles.RAWROCKER_DIMMER)
+    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream.of(SystemProfiles.COMMAND,
+            SystemProfiles.DEFAULT, SystemProfiles.FOLLOW, SystemProfiles.PASSIVE,
+            SystemProfiles.RAWBUTTON_TOGGLE_SWITCH, SystemProfiles.RAWROCKER_ON_OFF, SystemProfiles.RAWROCKER_DIMMER)
             .collect(Collectors.toSet());
 
     @Nullable
     @Override
     public Profile createProfile(ProfileTypeUID profileTypeUID, ProfileCallback callback, ProfileContext context) {
-        if (SystemProfiles.DEFAULT.equals(profileTypeUID)) {
+        if (SystemProfiles.COMMAND.equals(profileTypeUID)) {
+            return new SystemCommandProfile(callback);
+        } else if (SystemProfiles.DEFAULT.equals(profileTypeUID)) {
             return new SystemDefaultProfile(callback);
         } else if (SystemProfiles.FOLLOW.equals(profileTypeUID)) {
             return new SystemFollowProfile(callback);
+        } else if (SystemProfiles.PASSIVE.equals(profileTypeUID)) {
+            return new SystemPassiveProfile(callback);
         } else if (SystemProfiles.RAWBUTTON_TOGGLE_SWITCH.equals(profileTypeUID)) {
             return new RawButtonToggleSwitchProfile(callback);
         } else if (SystemProfiles.RAWROCKER_ON_OFF.equals(profileTypeUID)) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -25,26 +25,31 @@ import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
 @NonNullByDefault
 public interface SystemProfiles {
 
+    ProfileTypeUID COMMAND = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "command");
     ProfileTypeUID DEFAULT = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "default");
     ProfileTypeUID FOLLOW = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "follow");
+    ProfileTypeUID PASSIVE = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "passive");
     ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawbutton-toggle-switch");
     ProfileTypeUID RAWROCKER_ON_OFF = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawrocker-to-on-off");
     ProfileTypeUID RAWROCKER_DIMMER = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawrocker-to-dimmer");
+
+    StateProfileType COMMAND_TYPE = ProfileTypeBuilder.newState(COMMAND, "Command").build();
 
     StateProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT, "Default").build();
 
     StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
 
+    StateProfileType PASSIVE_TYPE = ProfileTypeBuilder.newState(PASSIVE, "Passive").build();
+
     TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle").withSupportedItemTypes(CoreItemFactory.SWITCH)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
 
-    TriggerProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")
+    TriggerProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")
             .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 
-    TriggerProfileType RAWROCKER_DIMMER_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_DIMMER, "Raw Rocker To Dimmer").withSupportedItemTypes(CoreItemFactory.DIMMER)
+    TriggerProfileType RAWROCKER_DIMMER_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_DIMMER, "Raw Rocker To Dimmer")
+            .withSupportedItemTypes(CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 }


### PR DESCRIPTION
 “PassiveProfile" is a profile with only communication from the ThingHandler to the Item enabled, and “CommandProfile” is a profile whereby only Commands can flow between ThingHandlers and Items (but States are filtered out)

Signed-Off-By: Karel Goderis <karel.goderis@me.com>