### PR TITLE
Increased timeout for item commands and updates to 30 seconds

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
@@ -20,6 +20,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.common.SafeCaller;
@@ -246,8 +247,8 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
                 if (handler != null) {
                     Profile profile = getProfile(link, item, thing);
                     if (profile instanceof StateProfile) {
-                        safeCaller.create(((StateProfile) profile)).withAsync().withIdentifier(thing).build()
-                                .onCommandFromItem(command);
+                        safeCaller.create(((StateProfile) profile)).withAsync().withIdentifier(thing)
+                                .withTimeout(TimeUnit.SECONDS.toMillis(30)).build().onCommandFromItem(command);
                     }
                 }
             }
@@ -276,8 +277,8 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
                 ThingHandler handler = thing.getHandler();
                 if (handler != null) {
                     Profile profile = getProfile(link, item, thing);
-                    safeCaller.create(profile).withAsync().withIdentifier(handler).build()
-                            .onStateUpdateFromItem(newState);
+                    safeCaller.create(profile).withAsync().withIdentifier(handler)
+                            .withTimeout(TimeUnit.SECONDS.toMillis(30)).build().onStateUpdateFromItem(newState);
                 }
             }
         });

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
@@ -74,6 +74,9 @@ import org.slf4j.LoggerFactory;
 @Component(service = { EventSubscriber.class, CommunicationManager.class }, immediate = true)
 public class CommunicationManager implements EventSubscriber, RegistryChangeListener<ItemChannelLink> {
 
+    // the timeout to use for any item event processing
+    public static final long THINGHANDLER_EVENT_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
+
     private static final Set<String> SUBSCRIBED_EVENT_TYPES = Collections.unmodifiableSet(
             new HashSet<>(Arrays.asList(ItemStateEvent.TYPE, ItemCommandEvent.TYPE, ChannelTriggeredEvent.TYPE)));
 
@@ -248,7 +251,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
                     Profile profile = getProfile(link, item, thing);
                     if (profile instanceof StateProfile) {
                         safeCaller.create(((StateProfile) profile)).withAsync().withIdentifier(thing)
-                                .withTimeout(TimeUnit.SECONDS.toMillis(30)).build().onCommandFromItem(command);
+                                .withTimeout(THINGHANDLER_EVENT_TIMEOUT).build().onCommandFromItem(command);
                     }
                 }
             }
@@ -278,7 +281,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
                 if (handler != null) {
                     Profile profile = getProfile(link, item, thing);
                     safeCaller.create(profile).withAsync().withIdentifier(handler)
-                            .withTimeout(TimeUnit.SECONDS.toMillis(30)).build().onStateUpdateFromItem(newState);
+                            .withTimeout(THINGHANDLER_EVENT_TIMEOUT).build().onStateUpdateFromItem(newState);
                 }
             }
         });

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.eclipse.smarthome.core.common.SafeCaller;
@@ -64,7 +65,7 @@ public class ProfileCallbackImpl implements ProfileCallback {
                 if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                     logger.debug("Delegating command '{}' for item '{}' to handler for channel '{}'", command,
                             link.getItemName(), link.getLinkedUID());
-                    safeCaller.create(handler).onTimeout(() -> {
+                    safeCaller.create(handler).withTimeout(TimeUnit.SECONDS.toMillis(30)).onTimeout(() -> {
                         logger.warn("Handler for thing '{}' takes more than {}ms for handling a command",
                                 handler.getThing().getUID(), SafeCaller.DEFAULT_TIMEOUT);
                     }).build().handleCommand(link.getLinkedUID(), command);
@@ -95,7 +96,7 @@ public class ProfileCallbackImpl implements ProfileCallback {
                 if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                     logger.debug("Delegating update '{}' for item '{}' to handler for channel '{}'", state,
                             link.getItemName(), link.getLinkedUID());
-                    safeCaller.create(handler).onTimeout(() -> {
+                    safeCaller.create(handler).withTimeout(TimeUnit.SECONDS.toMillis(30)).onTimeout(() -> {
                         logger.warn("Handler for thing '{}' takes more than {}ms for handling an update",
                                 handler.getThing().getUID(), SafeCaller.DEFAULT_TIMEOUT);
                     }).build().handleUpdate(link.getLinkedUID(), state);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -68,7 +68,7 @@ public class ProfileCallbackImpl implements ProfileCallback {
                     safeCaller.create(handler).withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT)
                             .onTimeout(() -> {
                                 logger.warn("Handler for thing '{}' takes more than {}ms for handling a command",
-                                        handler.getThing().getUID(), SafeCaller.DEFAULT_TIMEOUT);
+                                        handler.getThing().getUID(), CommunicationManager.THINGHANDLER_EVENT_TIMEOUT);
                             }).build().handleCommand(link.getLinkedUID(), command);
                 } else {
                     logger.debug("Not delegating command '{}' for item '{}' to handler for channel '{}', "
@@ -100,7 +100,7 @@ public class ProfileCallbackImpl implements ProfileCallback {
                     safeCaller.create(handler).withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT)
                             .onTimeout(() -> {
                                 logger.warn("Handler for thing '{}' takes more than {}ms for handling an update",
-                                        handler.getThing().getUID(), SafeCaller.DEFAULT_TIMEOUT);
+                                        handler.getThing().getUID(), CommunicationManager.THINGHANDLER_EVENT_TIMEOUT);
                             }).build().handleUpdate(link.getLinkedUID(), state);
                 } else {
                     logger.debug("Not delegating update '{}' for item '{}' to handler for channel '{}', "

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import org.eclipse.smarthome.core.common.SafeCaller;
@@ -23,6 +22,7 @@ import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.internal.CommunicationManager;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
 import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
@@ -65,10 +65,11 @@ public class ProfileCallbackImpl implements ProfileCallback {
                 if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                     logger.debug("Delegating command '{}' for item '{}' to handler for channel '{}'", command,
                             link.getItemName(), link.getLinkedUID());
-                    safeCaller.create(handler).withTimeout(TimeUnit.SECONDS.toMillis(30)).onTimeout(() -> {
-                        logger.warn("Handler for thing '{}' takes more than {}ms for handling a command",
-                                handler.getThing().getUID(), SafeCaller.DEFAULT_TIMEOUT);
-                    }).build().handleCommand(link.getLinkedUID(), command);
+                    safeCaller.create(handler).withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT)
+                            .onTimeout(() -> {
+                                logger.warn("Handler for thing '{}' takes more than {}ms for handling a command",
+                                        handler.getThing().getUID(), SafeCaller.DEFAULT_TIMEOUT);
+                            }).build().handleCommand(link.getLinkedUID(), command);
                 } else {
                     logger.debug("Not delegating command '{}' for item '{}' to handler for channel '{}', "
                             + "because handler is not initialized (thing must be in status UNKNOWN, ONLINE or OFFLINE but was {}).",
@@ -96,10 +97,11 @@ public class ProfileCallbackImpl implements ProfileCallback {
                 if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                     logger.debug("Delegating update '{}' for item '{}' to handler for channel '{}'", state,
                             link.getItemName(), link.getLinkedUID());
-                    safeCaller.create(handler).withTimeout(TimeUnit.SECONDS.toMillis(30)).onTimeout(() -> {
-                        logger.warn("Handler for thing '{}' takes more than {}ms for handling an update",
-                                handler.getThing().getUID(), SafeCaller.DEFAULT_TIMEOUT);
-                    }).build().handleUpdate(link.getLinkedUID(), state);
+                    safeCaller.create(handler).withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT)
+                            .onTimeout(() -> {
+                                logger.warn("Handler for thing '{}' takes more than {}ms for handling an update",
+                                        handler.getThing().getUID(), SafeCaller.DEFAULT_TIMEOUT);
+                            }).build().handleUpdate(link.getLinkedUID(), state);
                 } else {
                     logger.debug("Not delegating update '{}' for item '{}' to handler for channel '{}', "
                             + "because handler is not initialized (thing must be in status UNKNOWN, ONLINE or OFFLINE but was {}).",

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeCaller.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeCaller.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.common;
 
+import java.util.concurrent.TimeUnit;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
@@ -28,7 +30,7 @@ public interface SafeCaller {
     /**
      * Default timeout for actions in milliseconds.
      */
-    int DEFAULT_TIMEOUT = 5000 /* milliseconds */;
+    long DEFAULT_TIMEOUT = TimeUnit.SECONDS.toMillis(5);
 
     /**
      * Create a safe call builder for the given object.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeCallerBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeCallerBuilder.java
@@ -40,7 +40,7 @@ public interface SafeCallerBuilder<T> {
      * @param timeout the timeout in milliseconds.
      * @return the SafeCallerBuilder itself
      */
-    SafeCallerBuilder<T> withTimeout(int timeout);
+    SafeCallerBuilder<T> withTimeout(long timeout);
 
     /**
      * Specifies the identifier for the context in which only one thread may be occupied at the same time.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerBuilderImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerBuilderImpl.java
@@ -33,7 +33,7 @@ public class SafeCallerBuilderImpl<T> implements SafeCallerBuilder<T> {
 
     private final T target;
     private final Class<?>[] interfaceTypes;
-    private int timeout;
+    private long timeout;
     private Object identifier;
     @Nullable
     private Consumer<Throwable> exceptionHandler;
@@ -66,7 +66,7 @@ public class SafeCallerBuilderImpl<T> implements SafeCallerBuilder<T> {
     }
 
     @Override
-    public SafeCallerBuilder<T> withTimeout(int timeout) {
+    public SafeCallerBuilder<T> withTimeout(long timeout) {
         this.timeout = timeout;
         return this;
     }


### PR DESCRIPTION
We so far always allowed handlers up to 30 s to process a handleCommand call - this change brings backward compatibility and avoids too many warnings in the logs on existing bindings.

I also changed the timeout from int to long, so that it is easier to use it with TimeUnits.

Signed-off-by: Kai Kreuzer <kai@openhab.org>