### PR TITLE
switched to next snapshot version

### DIFF
--- a/bundles/auth/org.eclipse.smarthome.auth.jaas/META-INF/MANIFEST.MF
+++ b/bundles/auth/org.eclipse.smarthome.auth.jaas/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome JAAS Auth
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.auth.jaas
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.auth,

--- a/bundles/auth/org.eclipse.smarthome.auth.jaas/pom.xml
+++ b/bundles/auth/org.eclipse.smarthome.auth.jaas/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>auth</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/auth/pom.xml
+++ b/bundles/auth/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.api/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Automation API
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.api
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.dto,

--- a/bundles/automation/org.eclipse.smarthome.automation.api/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.commands/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.commands/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Automation commands
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.commands
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/automation/org.eclipse.smarthome.automation.commands/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.commands/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Automation Core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.core.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.automation.core
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Core
 Bundle-SymbolicName: org.eclipse.smarthome.automation.core
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.automation.core.util
 Import-Package: 
  com.google.gson,

--- a/bundles/automation/org.eclipse.smarthome.automation.core/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.event.test;singlet
  on:=true
 Bundle-Vendor: Eclipse/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.google.common.collect,
  groovy.lang,

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.integration.test;s
  ingleton:=true
 Bundle-Vendor: Eclipse/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.google.common.collect,
  groovy.lang,

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.core.test;s
  ingleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Module Core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.core
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.automation.module.core.factory,
  org.eclipse.smarthome.automation.module.core.handler

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.media/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.media/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Eclipse SmartHome Automation Media Modules
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.media
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.automation.module.media.handler
 Import-Package: 
  com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.media/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.media/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.defa
  ultscope
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.io,
  org.apache.commons.lang,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.rule
  support
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.automation.module.script.rulesupport.shared,
  org.eclipse.smarthome.automation.module.script.rulesupport.shared.facto

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome JSR233 Automation Module Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.automation.module.script
 Import-Package: 
  com.google.common.collect,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Automation Module Script
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.script
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 DynamicImport-Package: *
 Export-Package: org.eclipse.smarthome.automation.module.script
 Import-Package: 

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer.test;
  singleton:=true
 Bundle-Vendor: Eclipse/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.google.common.collect,
  groovy.lang,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Name: Eclipse SmartHome Automation Module Timer
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.automation.module.timer.factory,
  org.eclipse.smarthome.automation.module.timer.handler

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Automation GSON Parser
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.parser.gson
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.google.gson,
  com.google.gson.reflect,

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.provider.file/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.provider.file/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Automation File Provider
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.provider.file
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/automation/org.eclipse.smarthome.automation.provider.file/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.provider.file/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Automation Providers
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.providers
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Automation REST API
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.rest
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  io.swagger.annotations;resolution:=optional,
  javax.ws.rs,

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Sample Extension Java - Welcome Home Application
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.java
 Bundle-Activator: org.eclipse.smarthome.automation.sample.extension.java.internal.Activator
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.j
  son
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Automation Java Demo
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.java.demo
 Bundle-Vendor: Bosch Software Innovations GmbH
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.bundles</groupId>
 		<artifactId>automation</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Automation Json Demo
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.json.demo
 Bundle-Vendor: Bosch Software Innovations GmbH
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: org.eclipse.jdt.annotation;resolution:=optional
 Service-Component: OSGI-INF/*.xml

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.bundles</groupId>
 		<artifactId>automation</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Automation Module Type Demo
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.moduletype.
  demo
 Bundle-Vendor: Bosch Software Innovations GmbH
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.bundles</groupId>
 		<artifactId>automation</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Automation Sample REST API
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.rest.api
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  javax.servlet,
  javax.servlet.http,

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>automation</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/automation/pom.xml
+++ b/bundles/automation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.core.test;singleton:=t
  rue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.config.core
 Import-Package: 
  groovy.lang,

--- a/bundles/config/org.eclipse.smarthome.config.core.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Config Core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.core
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.core.dto,

--- a/bundles/config/org.eclipse.smarthome.config.core/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.discovery.mdns/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.mdns/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Configuration mDNS Discovery
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.discovery.mdns
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.config.discovery.mdns
 Import-Package: 

--- a/bundles/config/org.eclipse.smarthome.config.discovery.mdns/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.mdns/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.discovery.test;singlet
  on:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.config.discovery
 Import-Package: 
  com.google.gson,

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/config/org.eclipse.smarthome.config.discovery.upnp/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.upnp/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Configuration UPnP Discovery
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.discovery.upnp
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.config.discovery.upnp
 Import-Package: 

--- a/bundles/config/org.eclipse.smarthome.config.discovery.upnp/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.upnp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Configuration Discovery
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.discovery
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.config.discovery.dto,

--- a/bundles/config/org.eclipse.smarthome.config.discovery/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Config Dispatcher Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.dispatch.test
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.config.dispatch
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
   
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Config Dispatcher
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.dispatch
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: com.google.gson,
  com.google.gson.annotations,
  org.apache.commons.io,

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.serial/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.serial/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Config Serial
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.serial
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  gnu.io,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/config/org.eclipse.smarthome.config.serial/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.serial/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.xml.test;singleton:=tr
  ue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.config.xml
 Import-Package: 
  groovy.lang,

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Config XML
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.config.xml
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  com.thoughtworks.xstream,
  com.thoughtworks.xstream.annotations,

--- a/bundles/config/org.eclipse.smarthome.config.xml/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>config</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/config/pom.xml
+++ b/bundles/config/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Smarthome Audio Test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.audio.test
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.audio
 Import-Package: 
  groovy.lang,

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.audio/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.audio/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Core Audio
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.audio
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.core.audio,
  org.eclipse.smarthome.core.audio.utils

--- a/bundles/core/org.eclipse.smarthome.core.audio/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.audio/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Eclipse SmartHome AutoUpdate Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.autoupdate
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.core.autoupdate
 Ignore-Package: org.eclipse.smarthome.core.autoupdate.internal
 Import-Package: 

--- a/bundles/core/org.eclipse.smarthome.core.autoupdate/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.autoupdate/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.binding.xml.test;singlet
  on:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.binding.xml
 Import-Package: 
  groovy.lang,

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Core Binding XML
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.binding.xml
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.thoughtworks.xstream,
  com.thoughtworks.xstream.converters,

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Sample Extension Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.extension.sample
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome ID Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.id.test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.id
 Import-Package: 
  groovy.lang,

--- a/bundles/core/org.eclipse.smarthome.core.id.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.id.test/pom.xml
@@ -4,12 +4,12 @@
   <groupId>org.eclipse.smarthome.core</groupId>
   <artifactId>org.eclipse.smarthome.core.id.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <name>Eclipse SmartHome ID Tests</name>
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/bundles/core/org.eclipse.smarthome.core.id/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Core ID
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.id
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.core.id
 Import-Package: 
  io.swagger.annotations;resolution:=optional,

--- a/bundles/core/org.eclipse.smarthome.core.id/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.id/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/core/org.eclipse.smarthome.core.persistence/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Eclipse SmartHome Core Persistence
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.persistence
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.core.persistence,
  org.eclipse.smarthome.core.persistence.config,

--- a/bundles/core/org.eclipse.smarthome.core.persistence/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.scheduler/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.scheduler/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Name: Eclipse SmartHome Scheduler Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.scheduler
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.quartz,
  org.quartz.commonj,

--- a/bundles/core/org.eclipse.smarthome.core.scheduler/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.scheduler/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Eclipse SmartHome Core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core
 Import-Package: 
  groovy.lang,

--- a/bundles/core/org.eclipse.smarthome.core.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.thing.test;singleton:=tr
  ue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.thing
 Import-Package: 
  com.google.gson,

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
@@ -4,12 +4,12 @@
   <groupId>org.eclipse.smarthome.core</groupId>
   <artifactId>org.eclipse.smarthome.core.thing.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <name>Eclipse SmartHome Thing Tests</name>
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.thing.xml.test;singleton
  :=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.thing.xml
 Import-Package: org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Core Thing XML
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.thing.xml
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.thoughtworks.xstream,
  com.thoughtworks.xstream.converters,

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Core Thing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.thing
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,

--- a/bundles/core/org.eclipse.smarthome.core.thing/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.transform/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.transform/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Name: Eclipse SmartHome Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.transform
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.core.transform,
  org.eclipse.smarthome.core.transform.actions

--- a/bundles/core/org.eclipse.smarthome.core.transform/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.transform/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.voice.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.voice.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Core Voice Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.voice.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.voice
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/core/org.eclipse.smarthome.core.voice.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.voice.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core.voice/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.voice/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Core Voice
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.voice
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.core.voice,
  org.eclipse.smarthome.core.voice.text

--- a/bundles/core/org.eclipse.smarthome.core.voice/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.voice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.core.auth,
  org.eclipse.smarthome.core.binding,

--- a/bundles/core/org.eclipse.smarthome.core/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>core</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/designer/org.eclipse.smarthome.designer.core/META-INF/MANIFEST.MF
+++ b/bundles/designer/org.eclipse.smarthome.designer.core/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Designer Core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.designer.core;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.designer.core,
  org.eclipse.smarthome.designer.core.config

--- a/bundles/designer/org.eclipse.smarthome.designer.core/pom.xml
+++ b/bundles/designer/org.eclipse.smarthome.designer.core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>designer</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/designer/org.eclipse.smarthome.designer.ui/META-INF/MANIFEST.MF
+++ b/bundles/designer/org.eclipse.smarthome.designer.ui/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Designer UI
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.designer.ui;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.designer.ui
 Import-Package: 
  org.apache.commons.lang,

--- a/bundles/designer/org.eclipse.smarthome.designer.ui/pom.xml
+++ b/bundles/designer/org.eclipse.smarthome.designer.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>designer</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/designer/pom.xml
+++ b/bundles/designer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/io/org.eclipse.smarthome.io.console.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.eclipse/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Console for OSGi framework Eclipse Equino
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.eclipse
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.console.eclipse/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.eclipse/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.console.karaf/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.karaf/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Console for OSGi runtime Karaf
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.karaf
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.karaf.shell.api.action.lifecycle;version="4.0.0",
  org.apache.karaf.shell.api.action;version="4.0.0",

--- a/bundles/io/org.eclipse.smarthome.io.console.karaf/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.karaf/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.console.rfc147/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.rfc147/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Console for OSGi Console RFC 147
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.console.rfc147
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.io.console,

--- a/bundles/io/org.eclipse.smarthome.io.console.rfc147/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.rfc147/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Console
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.console
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.io.console,
  org.eclipse.smarthome.io.console.extensions

--- a/bundles/io/org.eclipse.smarthome.io.console/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Eclipse SmartHome Monitor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.monitor
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Ignore-Package: org.eclipse.smarthome.core.monitor.internal
 Import-Package: 
  com.google.common.collect,

--- a/bundles/io/org.eclipse.smarthome.io.monitor/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Network I/O bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.net.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.net
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.net.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.net/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Net I/O Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.net
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.io.net.exec,
  org.eclipse.smarthome.io.net.http

--- a/bundles/io/org.eclipse.smarthome.io.net/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.net/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.auth.basic/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.auth.basic/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Basic Auth Support for REST Interface
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.auth.basic
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.eclipsesource.jaxrs.provider.security,
  javax.ws.rs.container,

--- a/bundles/io/org.eclipse.smarthome.io.rest.auth.basic/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.auth.basic/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/io/org.eclipse.smarthome.io.rest.auth/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.auth/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Authentication Support for the REST Inter
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.auth
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.io.rest.auth
 Import-Package: 
  com.eclipsesource.jaxrs.provider.security,

--- a/bundles/io/org.eclipse.smarthome.io.rest.auth/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.auth/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.core.test;singleton:=
  true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.rest.core
 Import-Package: 
  com.jayway.jsonpath,

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.io</groupId>

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Core REST API
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.core
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.io.rest.core.config,
  org.eclipse.smarthome.io.rest.core.item,

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome UI Logging Handler
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.log;singleton:=true
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  io.swagger.annotations;resolution:=optional,
  javax.ws.rs,

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.bundles</groupId>
 		<artifactId>io</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.mdns/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.mdns/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome REST mDNS Announcer
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.mdns
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.net,

--- a/bundles/io/org.eclipse.smarthome.io.rest.mdns/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.mdns/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/io/org.eclipse.smarthome.io.rest.optimize/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.optimize/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.optimize;singleton:=t
  rue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.eclipsesource.jaxrs.publisher,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.rest.optimize/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.optimize/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Sitemap REST API
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sitemap
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.io.rest.sitemap
 Import-Package: 
  com.google.common.collect,

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sse.test;singleton:=t
  rue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.rest.sse
 Import-Package: 
  groovy.lang,

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome SSE REST API
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.sse
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.io.rest.sse,
  org.eclipse.smarthome.io.rest.sse.beans

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome IO REST Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.rest
 Import-Package: 
  com.google.gson.annotations,

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.io</groupId>

--- a/bundles/io/org.eclipse.smarthome.io.rest.voice/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.voice/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Voice REST API
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest.voice
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  io.swagger.annotations;resolution:=optional,
  javax.annotation.security;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.rest.voice/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.voice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome REST Interface Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.rest
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.io.rest
 Import-Package: 
  com.google.common.base,

--- a/bundles/io/org.eclipse.smarthome.io.rest/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.transport.dbus/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.dbus/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome DBus Transport Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.dbus
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  cx.ath.matthew.debug,
  cx.ath.matthew.unix,

--- a/bundles/io/org.eclipse.smarthome.io.transport.dbus/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.dbus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Eclipse SmartHome Bonjour/MDS Service Discovery Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mdns
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.io.transport.mdns,
  org.eclipse.smarthome.io.transport.mdns.discovery

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Mqtt transport I/O bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mqtt.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.transport.mqtt
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mqtt;singleton:=
  true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.io.transport.mqtt,
  org.eclipse.smarthome.io.transport.mqtt.reconnect,

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.upnp.test;single
  ton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.transport.upnp
 Import-Package: 
  groovy.lang,

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.io</groupId>

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome UPnP Transport Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.upnp
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.io.transport.upnp
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>io</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/io/pom.xml
+++ b/bundles/io/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/model/org.eclipse.smarthome.model.core.test/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Model Core Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.core.test
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.model.core
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/model/org.eclipse.smarthome.model.core.test/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Eclipse SmartHome Model Core
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.core;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.model.core,
  org.eclipse.smarthome.model.core.valueconverter
 Import-Package: 

--- a/bundles/model/org.eclipse.smarthome.model.core/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.item.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.ide/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Item Model IDE
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.item.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.ide,
  org.eclipse.smarthome.model.ide.contentassist.antlr,

--- a/bundles/model/org.eclipse.smarthome.model.item.ide/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.ide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.model</groupId>

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.item.runtime;singleton:
  =true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.model.core,

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.item.tests; singleton:=
  true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.model.item
 Import-Package: 
  groovy.lang,

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.item.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.ui/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Item Editor UI
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.item.ui;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.item.ui.internal,
  org.eclipse.smarthome.model.item.ui.internal,

--- a/bundles/model/org.eclipse.smarthome.model.item.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Item Model
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.item;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model,
  org.eclipse.smarthome.model.formatting,

--- a/bundles/model/org.eclipse.smarthome.model.item/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Model Lazy Generation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.lazygen
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.lsp.test/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lsp.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Language Server Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.lsp.test
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.model.lsp
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/model/org.eclipse.smarthome.model.lsp.test/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.lsp.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/model/org.eclipse.smarthome.model.lsp/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lsp/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Language Server
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.lsp;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: com.google.inject,
  javax.inject,
  org.eclipse.emf.common.util,

--- a/bundles/model/org.eclipse.smarthome.model.lsp/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.lsp/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ide/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Persistence Model IDE
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.persistence.ide,
  org.eclipse.smarthome.model.persistence.ide.contentassist.antlr,

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ide/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.model</groupId>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.runtime;sin
  gleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.model.core,

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Persistence Model Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.tests
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.persistence.extensions,
  org.eclipse.smarthome.model.persistence.tests

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ui/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.ui;singleto
  n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.persistence.ui.contentassist,
  org.eclipse.smarthome.model.persistence.ui.internal,

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence;singleton:=
  true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.persistence,
  org.eclipse.smarthome.model.persistence.extensions,

--- a/bundles/model/org.eclipse.smarthome.model.persistence/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.rule.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ide/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Rule Model IDE
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.rule.ide,
  org.eclipse.smarthome.model.rule.ide.contentassist.antlr,

--- a/bundles/model/org.eclipse.smarthome.model.rule.ide/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.model</groupId>

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.runtime;singleton:
  =true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.model.rule.runtime
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.tests;singleton:=t
  rue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.rule.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ui/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Eclipse SmartHome Rule Model UI
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule.ui;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.rule.ui.contentassist,
  org.eclipse.smarthome.model.rule.ui.internal,

--- a/bundles/model/org.eclipse.smarthome.model.rule.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Rule Model
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.rule;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.rule,
  org.eclipse.smarthome.model.rule.formatting,

--- a/bundles/model/org.eclipse.smarthome.model.rule/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.script.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.ide/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Script Model IDE
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.script.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.script.ide,
  org.eclipse.smarthome.model.script.ide.contentassist.antlr,

--- a/bundles/model/org.eclipse.smarthome.model.script.ide/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.ide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.model</groupId>

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.script.runtime;singleto
  n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.items,

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.script.tests;singleton:
  =true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  groovy.lang,
  org.codehaus.groovy.reflection,

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.script.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.ui/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.script.ui;singleton:=tr
  ue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.script.ui.contentassist,
  org.eclipse.smarthome.model.script.ui.internal,

--- a/bundles/model/org.eclipse.smarthome.model.script.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Script
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.script;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.script,
  org.eclipse.smarthome.model.script.actions,

--- a/bundles/model/org.eclipse.smarthome.model.script/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ide/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Sitemap Model IDE
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.ide,
  org.eclipse.smarthome.model.ide.contentassist.antlr,

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ide/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.model</groupId>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.runtime;singlet
  on:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.model.core,

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ui/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap.ui;singleton:=t
  rue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.sitemap.ui.internal,
  org.eclipse.smarthome.model.ui.contentassist,

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Sitemap Model
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.sitemap;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model,
  org.eclipse.smarthome.model.formatting,

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.thing.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ide/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Thing Model IDE
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing.ide
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.thing.ide,
  org.eclipse.smarthome.model.thing.ide.contentassist.antlr,

--- a/bundles/model/org.eclipse.smarthome.model.thing.ide/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ide/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.model</groupId>

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing.runtime;singleton
  :=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.model.core,

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing.tests; singleton:
  =true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.model.thing
 Fragment-Host: org.eclipse.smarthome.model.thing
 Import-Package: 

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.thing.ui/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ui/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing.ui; singleton:=tr
  ue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.thing.ui.contentassist,
  org.eclipse.smarthome.model.thing.ui.internal,

--- a/bundles/model/org.eclipse.smarthome.model.thing.ui/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ui/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Thing Model
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.thing; singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.model.thing,
  org.eclipse.smarthome.model.thing.formatting,

--- a/bundles/model/org.eclipse.smarthome.model.thing/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>model</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/model/pom.xml
+++ b/bundles/model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/storage/org.eclipse.smarthome.storage.json.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.json.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Eclipse SmartHome Json Storage
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.storage.json.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.storage.json
 Import-Package: 
  groovy.lang,

--- a/bundles/storage/org.eclipse.smarthome.storage.json.test/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.json.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>storage</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/storage/org.eclipse.smarthome.storage.json/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Json Storage Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.storage.json;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.google.gson,
  com.google.gson.annotations,

--- a/bundles/storage/org.eclipse.smarthome.storage.json/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>storage</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <name>Eclipse SmartHome JSON Storage</name>

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Eclipse SmartHome MapDB Storage
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.storage.mapdb.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.storage.mapdb
 Import-Package: 
  groovy.lang,

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>storage</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome MapDB Storage Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.storage.mapdb;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.google.gson,
  com.google.gson.annotations,

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>storage</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <name>Eclipse SmartHome MapDB Storage</name>

--- a/bundles/storage/pom.xml
+++ b/bundles/storage/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/test/org.eclipse.smarthome.magic.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Magic Bundle Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.magic.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.magic.binding
 Fragment-Host: org.eclipse.smarthome.magic
 Import-Package: 

--- a/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
@@ -6,11 +6,11 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>test</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.magic.test</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <name>Magic Bundle Tests</name>

--- a/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Magic Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.magic;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.magic.binding,
  org.eclipse.smarthome.magic.binding.handler

--- a/bundles/test/org.eclipse.smarthome.magic/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/pom.xml
@@ -7,11 +7,11 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>test</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.magic</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Magic Bundle</name>
   <packaging>eclipse-plugin</packaging>

--- a/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.test.java,
  org.eclipse.smarthome.test.storage,

--- a/bundles/test/org.eclipse.smarthome.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>test</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/test/pom.xml
+++ b/bundles/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome UI Icons Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.ui.icon.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.ui.icon
 Import-Package: 
  groovy.lang,

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/pom.xml
@@ -4,12 +4,12 @@
   <groupId>org.eclipse.smarthome.ui</groupId>
   <artifactId>org.eclipse.smarthome.ui.icon.test</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <name>Eclipse SmartHome UI Icon Tests</name>
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>ui</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <build>

--- a/bundles/ui/org.eclipse.smarthome.ui.icon/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome UI Icons
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.ui.icon
 Bundle-Vendor: Eclipse.org
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.ui.icon
 Import-Package: 
  javax.servlet,

--- a/bundles/ui/org.eclipse.smarthome.ui.icon/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>ui</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome UI Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.ui.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.ui
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/ui/org.eclipse.smarthome.ui.test/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>ui</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/ui/org.eclipse.smarthome.ui/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Name: Eclipse SmartHome UI
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.ui
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.ui.chart,
  org.eclipse.smarthome.ui.items

--- a/bundles/ui/org.eclipse.smarthome.ui/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>
     <artifactId>ui</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/bundles/ui/pom.xml
+++ b/bundles/ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>bundles</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>eclipsesmarthome-incubation</artifactId>

--- a/docs/documentation/development/testing.md
+++ b/docs/documentation/development/testing.md
@@ -17,7 +17,7 @@ In general tests are implemented in a separate fragment bundle, which host is th
     Bundle-ManifestVersion: 2
     Bundle-Name: Tests for the Eclipse SmartHome Core
     Bundle-SymbolicName: org.eclipse.smarthome.core.test
-    Bundle-Version: 0.9.0.qualifier
+    Bundle-Version: 0.10.0.qualifier
     Bundle-Vendor: Eclipse.org/SmartHome
     Fragment-Host: org.eclipse.smarthome.core
     Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/binding/create_binding_skeleton.cmd
+++ b/extensions/binding/create_binding_skeleton.cmd
@@ -16,9 +16,9 @@ SET BindingIdInLowerCase=%BindingIdInCamelCase%
 
 CALL :LoCase BindingIdInLowerCase
 
-call mvn archetype:generate -N -DinteractiveMode=false -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding -DarchetypeVersion=0.9.0-SNAPSHOT -DgroupId=org.eclipse.smarthome.binding -DartifactId=org.eclipse.smarthome.binding.%BindingIdInLowerCase% -Dpackage=org.eclipse.smarthome.binding.%BindingIdInLowerCase% -Dversion=0.9.0-SNAPSHOT -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -Dauthor=%2
+call mvn archetype:generate -N -DinteractiveMode=false -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding -DarchetypeVersion=0.10.0-SNAPSHOT -DgroupId=org.eclipse.smarthome.binding -DartifactId=org.eclipse.smarthome.binding.%BindingIdInLowerCase% -Dpackage=org.eclipse.smarthome.binding.%BindingIdInLowerCase% -Dversion=0.10.0-SNAPSHOT -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -Dauthor=%2
 
-call mvn archetype:generate -N -DinteractiveMode=false -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=0.9.0-SNAPSHOT -DgroupId=org.eclipse.smarthome.binding -DartifactId=org.eclipse.smarthome.binding.%BindingIdInLowerCase%.test -Dpackage=org.eclipse.smarthome.binding.%BindingIdInLowerCase% -Dversion=0.9.0-SNAPSHOT -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -Dauthor=%2
+call mvn archetype:generate -N -DinteractiveMode=false -DarchetypeGroupId=org.eclipse.smarthome.archetype -DarchetypeArtifactId=org.eclipse.smarthome.archetype.binding.test -DarchetypeVersion=0.10.0-SNAPSHOT -DgroupId=org.eclipse.smarthome.binding -DartifactId=org.eclipse.smarthome.binding.%BindingIdInLowerCase%.test -Dpackage=org.eclipse.smarthome.binding.%BindingIdInLowerCase% -Dversion=0.10.0-SNAPSHOT -DbindingId=%BindingIdInLowerCase% -DbindingIdCamelCase=%BindingIdInCamelCase% -Dauthor=%2
 
 
 SET BindingIdInLowerCase=

--- a/extensions/binding/create_binding_skeleton.sh
+++ b/extensions/binding/create_binding_skeleton.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-bindingVersion=0.9.0-SNAPSHOT
-archetypeVersion=0.9.0-SNAPSHOT
+bindingVersion=0.10.0-SNAPSHOT
+archetypeVersion=0.10.0-SNAPSHOT
 
 camelcaseId=$1
 author="$2"

--- a/extensions/binding/org.eclipse.smarthome.binding.astro.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.astro.test;singleton:
  =true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.binding.astro
 Import-Package: 
  groovy.lang,

--- a/extensions/binding/org.eclipse.smarthome.binding.astro.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro.test/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.archetype</groupId>
   <artifactId>org.eclipse.smarthome.binding.astro.test</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <name>Eclipse SmartHome Astro Binding Tests</name>

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Astro Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.astro;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.astro,
  org.eclipse.smarthome.binding.astro.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.binding</groupId>
 		<artifactId>pom</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.digitalstrom;singleto
  n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.digitalstrom,
  org.eclipse.smarthome.binding.digitalstrom.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -16,7 +16,7 @@
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.digitalstrom</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome DigitalSTROM Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.dmx.test;singleton:=t
  rue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.dmx.test;x-internal:=true,
  org.eclipse.smarthome.binding.dmx;uses:="org.eclipse.smarthome.test"

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.archetype</groupId>
   <artifactId>org.eclipse.smarthome.binding.dmx.test</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <name>Eclipse Smarthome DMX Binding Tests</name>

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: DMX Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.dmx;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.dmx,
  org.eclipse.smarthome.binding.dmx.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.dmx</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse Smarthome DMX Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse Smarthome FSInternetRadio Binding Test
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.fsinternetradio.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.binding.fsinternetradio
 Require-Bundle: org.mockito,
  org.hamcrest

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.binding</groupId>
 		<artifactId>pom</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.fsinternetradio;singl
  eton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.fsinternetradio,
  org.eclipse.smarthome.binding.fsinternetradio.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.fsinternetradio</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome FSInternetRadio Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.hue.test;singleton:=t
  rue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.binding.hue
 Import-Package: 
  com.google.gson,

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome hue Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.hue;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.hue,
  org.eclipse.smarthome.binding.hue.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome LIFX Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.lifx;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.lifx,
  org.eclipse.smarthome.binding.lifx.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>
@@ -16,7 +16,7 @@
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.lifx</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome LIFX Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.lirc/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.lirc/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome LIRC Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.lirc;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.lirc,
  org.eclipse.smarthome.binding.lirc.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.lirc/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lirc/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.lirc</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome LIRC Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome NTP Binding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.ntp.test
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.binding.ntp
 Import-Package: 
  groovy.lang,

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
 

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: ntp Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.ntp;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.ntp,
  org.eclipse.smarthome.binding.ntp.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.ntp</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome NTP Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.serialbutton/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.serialbutton/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: SerialButton Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.serialbutton;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.serialbutton,
  org.eclipse.smarthome.binding.serialbutton.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.serialbutton/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.serialbutton/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.binding</groupId>
 		<artifactId>pom</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.smarthome.binding.serialbutton</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
+	<version>0.10.0-SNAPSHOT</version>
 
 	<name>SerialButton Binding</name>
 	<packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Sonos Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.sonos
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.io,
  org.apache.commons.lang,

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri.test;singleto
  n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.binding.tradfri;uses:="org.eclipse
  .smarthome.test"
 Fragment-Host: org.eclipse.smarthome.binding.tradfri

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.archetype</groupId>
   <artifactId>org.eclipse.smarthome.binding.tradfri.test</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <name>TRÅDFRI Binding Tests</name>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri;singleton:=tr
  ue
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.tradfri,
  org.eclipse.smarthome.binding.tradfri.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/pom.xml
@@ -7,11 +7,11 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.binding</groupId>
 		<artifactId>pom</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.smarthome.binding.tradfri</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
+	<version>0.10.0-SNAPSHOT</version>
 
 	<name>TRÅDFRI Binding</name>
 	<packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.weatherunderground;si
  ngleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.weatherunderground,
  org.eclipse.smarthome.binding.weatherunderground.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.weatherunderground</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>WeatherUnderground Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse SmartHome Wemo Binding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.wemo.test
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.binding.wemo
 Import-Package: 
  groovy.json,

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.eclipse.smarthome.binding</groupId>
 		<artifactId>pom</artifactId>
-		<version>0.9.0-SNAPSHOT</version>
+		<version>0.10.0-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Wemo Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.wemo;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.wemo,
  org.eclipse.smarthome.binding.wemo.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.wemo</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome WeMo Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.yahooweather;singleto
  n:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.yahooweather,
  org.eclipse.smarthome.binding.yahooweather.handler

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.binding</groupId>
   <artifactId>org.eclipse.smarthome.binding.yahooweather</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome YahooWeather Binding</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/binding/pom.xml
+++ b/extensions/binding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace.
  automation;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/pom.xml
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extensionservice</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.extensionservice.marketplace.automation</artifactId>

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace.
  test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.extensionservice.marketplace
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/pom.xml
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extensionservice</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.extensionservice.marketplace.test</artifactId>

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.extensionservice.marketplace;
  singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.extensionservice.marketplace
 Import-Package: 
  com.thoughtworks.xstream,

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/pom.xml
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extensionservice</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.extensionservice.marketplace</artifactId>

--- a/extensions/extensionservice/pom.xml
+++ b/extensions/extensionservice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/io/org.eclipse.smarthome.io.javasound/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.javasound/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome JavaSound I/O
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.javasound
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  javax.sound.sampled,
  org.apache.commons.collections,

--- a/extensions/io/org.eclipse.smarthome.io.javasound/pom.xml
+++ b/extensions/io/org.eclipse.smarthome.io.javasound/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.io</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.io.javasound</artifactId>

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Web Audio Support
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.webaudio
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  javax.sound.sampled,
  org.apache.commons.collections,

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/pom.xml
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.io</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.io.webaudio</artifactId>

--- a/extensions/io/pom.xml
+++ b/extensions/io/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Exec Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.exec
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.transform,

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome JavaScript Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.javascript
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  javax.script,
  org.apache.commons.io,

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the JSonPath Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.jsonpath.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.transform.jsonpath
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome JSonPath Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.jsonpath
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.jayway.jsonpath,
  net.minidev.json,

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Map Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.map.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.transform.map
 Import-Package: 
  org.apache.commons.io,

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.map/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Map Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.map
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.i18n,

--- a/extensions/transform/org.eclipse.smarthome.transform.map/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the RegEx Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.regex.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.transform.regex
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome RegEx Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.regex
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Scale Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.scale.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.transform.scale
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Scale Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.scale
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.i18n,

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the XPath Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.transform.xpath
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome XPath Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  javax.xml.parsers,
  javax.xml.xpath,

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Tests for the Xslt Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.transform.xslt
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Xslt Transformation Service
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  javax.xml.transform,
  javax.xml.transform.stream,

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/pom.xml
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.transform</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.transform</groupId>

--- a/extensions/transform/pom.xml
+++ b/extensions/transform/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/META-INF/MANIFEST.MF
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Eclipse SmartHome Classic IconSet
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.ui.iconset.classic
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.i18n,

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/pom.xml
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui.iconset</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.extension.ui.iconset</groupId>

--- a/extensions/ui/iconset/pom.xml
+++ b/extensions/ui/iconset/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Name: Eclipse SmartHome Basic UI
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.ui.basic
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.ui.basic.render
 Import-Package: 
  com.google.gson,

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.eclipse.smarthome.ui.basic",
-  "version": "0.9.0",
-  "description": "Eclipse Smarthome BasicUI",
+  "version": "0.10.0",
+  "description": "Eclipse Smarthome Basic UI",
   "scripts": {
     "build": "gulp default"
   },

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Name: Eclipse SmartHome WebApp UI
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.ui.classic
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.ui.classic.render
 Ignore-Package: org.eclipse.smarthome.ui.webapp.internal
 Import-Package: 

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.smarthome.ui.classic</artifactId>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: Eclipse SmartHome Paper UI
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.ui.paper;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  javax.servlet.http,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.eclipse.smarthome.ui.paperui",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "start": "gulp serve --development",

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension.ui</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/extensions/ui/pom.xml
+++ b/extensions/ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Name: Eclipse SmartHome Mac TTS Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.voice.mactts.test
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.voice.mactts
 Import-Package: 
  org.apache.commons.io,

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/pom.xml
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.voice</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Name: MacOS Text-to-Speech
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.voice.mactts;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
-Bundle-Version: 0.9.0.qualifier
+Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/pom.xml
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/pom.xml
@@ -6,12 +6,12 @@
   <parent>
     <groupId>org.eclipse.smarthome.voice</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.voice</groupId>
   <artifactId>org.eclipse.smarthome.voice.mactts</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome MacOS TTS</name>
   <packaging>eclipse-plugin</packaging>

--- a/extensions/voice/pom.xml
+++ b/extensions/voice/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.extension</groupId>
     <artifactId>pom</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/karaf/esh-core/pom.xml
+++ b/features/karaf/esh-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>karaf-features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>esh-core</artifactId>

--- a/features/karaf/esh-ext/pom.xml
+++ b/features/karaf/esh-ext/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>karaf-features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>esh-ext</artifactId>

--- a/features/karaf/esh-tp/pom.xml
+++ b/features/karaf/esh-tp/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>karaf-features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>esh-tp</artifactId>

--- a/features/karaf/pom.xml
+++ b/features/karaf/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/karaf/verify/pom.xml
+++ b/features/karaf/verify/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>karaf-features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>verify</artifactId>

--- a/features/org.eclipse.smarthome.feature.runtime.automation/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.automation/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.automation"
       label="Eclipse SmartHome Automation Support"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.automation/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.automation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.binding/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.binding/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.binding"
       label="Eclipse SmartHome Binding"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.binding/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.binding/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.console.equinox/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.equinox/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.console.equinox"
       label="Eclipse SmartHome Equinox Console"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.console.equinox/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.equinox/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.console.rfc147/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.rfc147/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.console.rfc147"
       label="Eclipse SmartHome RfC147 Console"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.console.rfc147/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.rfc147/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.core"
       label="Eclipse SmartHome Core"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.core/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.model/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.model/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.model"
       label="Eclipse SmartHome Model Support"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.model/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.rest/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.rest/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.rest"
       label="Eclipse SmartHome REST Support"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.rest/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.rest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.runtime.ui/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.ui/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.runtime.ui"
       label="Eclipse SmartHome UI"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org/SmartHome">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.runtime.ui/pom.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.ui/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/org.eclipse.smarthome.feature.test/feature.xml
+++ b/features/org.eclipse.smarthome.feature.test/feature.xml
@@ -16,7 +16,7 @@
 <feature
       id="org.eclipse.smarthome.feature.test"
       label="Eclipse SmartHome Test Bundles"
-      version="0.9.0.qualifier"
+      version="0.10.0.qualifier"
       provider-name="Eclipse.org">
 
    <description>

--- a/features/org.eclipse.smarthome.feature.test/pom.xml
+++ b/features/org.eclipse.smarthome.feature.test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>features</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.eclipse.smarthome</groupId>
   <artifactId>smarthome</artifactId>
-  <version>0.9.0-SNAPSHOT</version>
+  <version>0.10.0-SNAPSHOT</version>
 
   <name>Eclipse SmartHome</name>
 

--- a/products/org.eclipse.smarthome.repo/category.xml
+++ b/products/org.eclipse.smarthome.repo/category.xml
@@ -1,57 +1,57 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.smarthome.feature.test_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.test" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.test_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.test" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.test.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.test.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.test.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.test.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.core_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.core" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.core_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.core" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.core.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.core.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.core.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.core.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.model_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.model" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.model_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.model" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.model.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.model.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.model.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.model.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.rest_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.rest" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.rest_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.rest" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.rest.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.rest.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.rest.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.rest.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.ui_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.ui" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.ui_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.ui" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.ui.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.ui.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.ui.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.ui.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.binding_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.binding" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.binding_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.binding" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.binding.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.binding.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.binding.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.binding.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.automation_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.automation" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.automation_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.automation" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.automation.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.automation.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.automation.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.automation.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.console.equinox_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.equinox" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.console.equinox_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.equinox" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.console.equinox.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.equinox.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.console.equinox.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.equinox.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.console.rfc147_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.rfc147" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.console.rfc147_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.rfc147" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
-   <feature url="features/org.eclipse.smarthome.feature.runtime.console.rfc147.source_0.9.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.rfc147.source" version="0.9.0.qualifier">
+   <feature url="features/org.eclipse.smarthome.feature.runtime.console.rfc147.source_0.10.0.qualifier.jar" id="org.eclipse.smarthome.feature.runtime.console.rfc147.source" version="0.10.0.qualifier">
       <category name="org.eclipse.smarthome"/>
    </feature>
    <category-def name="org.eclipse.smarthome" label="Eclipse SmartHome">

--- a/products/org.eclipse.smarthome.repo/pom.xml
+++ b/products/org.eclipse.smarthome.repo/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>products</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/products/pom.xml
+++ b/products/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome</groupId>

--- a/tools/archetype/binding.test/pom.xml
+++ b/tools/archetype/binding.test/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.tools</groupId>
     <artifactId>archetype</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.archetype</groupId>

--- a/tools/archetype/binding/pom.xml
+++ b/tools/archetype/binding/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.smarthome.tools</groupId>
     <artifactId>archetype</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.smarthome.archetype</groupId>

--- a/tools/archetype/pom.xml
+++ b/tools/archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>tools</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.eclipse.smarthome</groupId>
     <artifactId>smarthome</artifactId>
-    <version>0.9.0-SNAPSHOT</version>
+    <version>0.10.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
@maggu2810 @sjka & @adimova, I have pushed the [0.9.0 ref-tag](https://github.com/eclipse/smarthome/tree/ref-0.9.0) to the repo and am waiting for the official review approval through Eclipse before running the release build.

This PR switches our master to the next snapshot version (0.10.0), so that we can afterwards continue with merging PRs.

Signed-off-by: Kai Kreuzer <kai@openhab.org>