### PR TITLE
add missing test bundle to Maven build

### DIFF
--- a/extensions/extensionservice/pom.xml
+++ b/extensions/extensionservice/pom.xml
@@ -18,6 +18,7 @@
   <modules>
     <module>org.eclipse.smarthome.extensionservice.marketplace</module>
     <module>org.eclipse.smarthome.extensionservice.marketplace.automation</module>
+    <module>org.eclipse.smarthome.extensionservice.marketplace.test</module>
  </modules>
 
 </project>


### PR DESCRIPTION
The "Eclipse SmartHome IoT Marketplace Extension Service Test" should be considered on the Maven build, too.
