### PR TITLE
Print details on missing service references in tests

### DIFF
--- a/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
@@ -31,6 +31,9 @@ Import-Package: com.google.common.collect,
  org.junit.matchers;version="4.0.0",
  org.mockito,
  org.osgi.framework,
+ org.osgi.framework.dto,
  org.osgi.service.cm;resolution:=optional,
+ org.osgi.service.component.runtime,
+ org.osgi.service.component.runtime.dto,
  org.slf4j
 Require-Bundle: org.junit, org.mockito, org.hamcrest

--- a/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/internal/java/MissingServiceAnalyzer.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/internal/java/MissingServiceAnalyzer.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.test.internal.java;
+
+import static java.util.stream.Collectors.*;
+
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentConfigurationDTO;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.service.component.runtime.dto.ReferenceDTO;
+
+/**
+ * Utility class to analyze and print possible reasons for a service being not present.
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ *
+ */
+public class MissingServiceAnalyzer {
+
+    private final PrintStream ps;
+    private final BundleContext bundleContext;
+
+    public MissingServiceAnalyzer(PrintStream ps, BundleContext bundleContext) {
+        this.ps = ps;
+        this.bundleContext = bundleContext;
+    }
+
+    public <T> void printMissingServiceDetails(Class<T> clazz) {
+        ServiceReference<@NonNull ServiceComponentRuntime> scrReference = bundleContext
+                .getServiceReference(ServiceComponentRuntime.class);
+        if (scrReference != null) {
+            ServiceComponentRuntime scr = bundleContext.getService(scrReference);
+            if (scr != null) {
+                ps.println("Components implementing " + clazz.getName() + ":");
+                printUnsatisfiedServices(scr, clazz.getName(), "");
+            }
+        } else {
+            ps.println("SCR is not started!");
+        }
+    }
+
+    private <T> void printUnsatisfiedServices(ServiceComponentRuntime scr, String interfaceName, String prefix) {
+        Bundle[] allBundlesArrays = getAllBundles();
+        List<ComponentDescriptionDTO> descriptions = getComponentDescriptions(scr, interfaceName, allBundlesArrays);
+        if (descriptions.isEmpty()) {
+            ps.println(prefix + "No component implementing " + interfaceName + " is currently registered.");
+        } else {
+            for (ComponentDescriptionDTO description : descriptions) {
+                Collection<ComponentConfigurationDTO> configurations = scr.getComponentConfigurationDTOs(description);
+                for (ComponentConfigurationDTO configuration : configurations) {
+                    ps.println(prefix + configuration.id + " [" + getState(configuration.state) + "] "
+                            + description.implementationClass + " in " + description.bundle.symbolicName);
+                    for (ReferenceDTO ref : getUnsatisfiedReferences(description, configuration)) {
+                        ps.println(prefix + "\t" + ref.name + " (" + ref.interfaceName + ")");
+                        printUnsatisfiedServices(scr, ref.interfaceName, prefix + "\t\t");
+                    }
+                }
+            }
+        }
+    }
+
+    private List<ReferenceDTO> getUnsatisfiedReferences(ComponentDescriptionDTO description,
+            ComponentConfigurationDTO configuration) {
+        Set<String> unsatisfiedRefNames = Stream.of(configuration.unsatisfiedReferences)//
+                .map(ref -> ref.name) //
+                .collect(toSet());
+        return Stream.of(description.references) //
+                .filter(ref -> unsatisfiedRefNames.contains(ref.name)) //
+                .collect(toList());
+    }
+
+    private List<ComponentDescriptionDTO> getComponentDescriptions(ServiceComponentRuntime scr, String interfaceName,
+            Bundle[] allBundlesArrays) {
+        return scr.getComponentDescriptionDTOs(allBundlesArrays).stream()
+                .filter(description -> Stream.of(description.serviceInterfaces).anyMatch(s -> s.equals(interfaceName)))
+                .collect(toList());
+    }
+
+    private Bundle[] getAllBundles() {
+        List<Bundle> allBundles = Arrays.stream(bundleContext.getBundles())
+                .filter(b -> b.getHeaders().get(Constants.FRAGMENT_HOST) == null).collect(toList());
+        return allBundles.toArray(new Bundle[allBundles.size()]);
+    }
+
+    private String getState(int state) {
+        switch (state) {
+            case ComponentConfigurationDTO.UNSATISFIED_CONFIGURATION:
+                return "UNSATISFIED_CONFIGURATION";
+            case ComponentConfigurationDTO.UNSATISFIED_REFERENCE:
+                return "UNSATISFIED_REFERENCE";
+            case ComponentConfigurationDTO.SATISFIED:
+                return "SATISFIED";
+            case ComponentConfigurationDTO.ACTIVE:
+                return "ACTIVE";
+            default:
+                return state + "";
+        }
+    }
+
+}

--- a/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/java/JavaOSGiTest.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/java/JavaOSGiTest.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 
 import org.eclipse.smarthome.core.autoupdate.AutoUpdateBindingConfigProvider;
 import org.eclipse.smarthome.test.OSGiTest;
+import org.eclipse.smarthome.test.internal.java.MissingServiceAnalyzer;
 import org.eclipse.smarthome.test.storage.VolatileStorageService;
 import org.junit.After;
 import org.junit.Assert;
@@ -88,6 +89,11 @@ public class JavaOSGiTest extends JavaTest {
         @SuppressWarnings("unchecked")
         final ServiceReference<T> serviceReference = (ServiceReference<T>) bundleContext
                 .getServiceReference(clazz.getName());
+
+        if (serviceReference == null) {
+            new MissingServiceAnalyzer(System.out, bundleContext).printMissingServiceDetails(clazz);
+            return null;
+        }
 
         return unrefService(serviceReference);
     }


### PR DESCRIPTION
When tidying up my repository I found this little piece of code which came in handy a couple of times already. It helps immediately spotting the reason why a service was not available (i.e. whenever `getService(...)` returns `null`) during test execution, e.g.:

```
Components implementing org.eclipse.smarthome.core.thing.ManagedThingProvider:
23 [UNSATISFIED_REFERENCE] org.eclipse.smarthome.core.thing.ManagedThingProvider in org.eclipse.smarthome.core.thing
	StorageService (org.eclipse.smarthome.core.storage.StorageService)
		No component implementing org.eclipse.smarthome.core.storage.StorageService is currently registered.
```

Before I spend any more time cleaning it up and making it nicer to read - do you agree that this would be helpful? And if so, where should it print it to? Is sysout okay?

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>