### PR TITLE
don't block event admin on OSGi event handling

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2014,2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.events;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.common.SafeCaller;
+import org.eclipse.smarthome.core.events.Event;
+import org.eclipse.smarthome.core.events.EventFactory;
+import org.eclipse.smarthome.core.events.EventFilter;
+import org.eclipse.smarthome.core.events.EventSubscriber;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.SetMultimap;
+
+/**
+ * Handle Eclipse SmartHome events encapsulated by OSGi events.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+public class EventHandler {
+
+    private final Logger logger = LoggerFactory.getLogger(EventHandler.class);
+
+    private final SetMultimap<String, EventSubscriber> typedEventSubscribers;
+    private final Map<String, EventFactory> typedEventFactories;
+    private final SafeCaller safeCaller;
+
+    /**
+     * Create a new event handler.
+     *
+     * @param typedEventSubscribers the event subscribers indexed by the event type
+     * @param typedEventFactories the event factories indexed by the event type
+     * @param safeCaller the safe caller to use
+     */
+    public EventHandler(final SetMultimap<String, EventSubscriber> typedEventSubscribers,
+            final Map<String, EventFactory> typedEventFactories, final SafeCaller safeCaller) {
+        this.typedEventSubscribers = typedEventSubscribers;
+        this.typedEventFactories = typedEventFactories;
+        this.safeCaller = safeCaller;
+    }
+
+    public void handleEvent(org.osgi.service.event.Event osgiEvent) {
+        logger.trace("Handle OSGi event (event: {})", osgiEvent);
+
+        Object typeObj = osgiEvent.getProperty("type");
+        Object payloadObj = osgiEvent.getProperty("payload");
+        Object topicObj = osgiEvent.getProperty("topic");
+        Object sourceObj = osgiEvent.getProperty("source");
+
+        if (typeObj instanceof String && payloadObj instanceof String && topicObj instanceof String) {
+            String typeStr = (String) typeObj;
+            String payloadStr = (String) payloadObj;
+            String topicStr = (String) topicObj;
+            String sourceStr = (sourceObj instanceof String) ? (String) sourceObj : null;
+            if (!typeStr.isEmpty() && !payloadStr.isEmpty() && !topicStr.isEmpty()) {
+                handleEvent(typeStr, payloadStr, topicStr, sourceStr);
+            }
+        } else {
+            logger.error(
+                    "The handled OSGi event is invalid. Expect properties as string named 'type', 'payload' and 'topic'. "
+                            + "Received event properties are: {}",
+                    Arrays.toString(osgiEvent.getPropertyNames()));
+        }
+    }
+
+    private void handleEvent(final String type, final String payload, final String topic, final String source) {
+        final EventFactory eventFactory = typedEventFactories.get(type);
+        if (eventFactory == null) {
+            logger.warn("Could not find an Event Factory for the event type '{}'.", type);
+            return;
+        }
+
+        final Set<EventSubscriber> eventSubscribers = getEventSubscribers(type);
+        if (eventSubscribers.isEmpty()) {
+            return;
+        }
+
+        final Event eshEvent = createESHEvent(eventFactory, type, payload, topic, source);
+        if (eshEvent == null) {
+            return;
+        }
+
+        dispatchESHEvent(eventSubscribers, eshEvent);
+    }
+
+    private Set<EventSubscriber> getEventSubscribers(String eventType) {
+        Set<EventSubscriber> eventTypeSubscribers = typedEventSubscribers.get(eventType);
+        Set<EventSubscriber> allEventTypeSubscribers = typedEventSubscribers.get(EventSubscriber.ALL_EVENT_TYPES);
+
+        Set<EventSubscriber> subscribers = new HashSet<EventSubscriber>();
+        if (eventTypeSubscribers != null) {
+            subscribers.addAll(eventTypeSubscribers);
+        }
+        if (allEventTypeSubscribers != null) {
+            subscribers.addAll(allEventTypeSubscribers);
+        }
+        return subscribers;
+    }
+
+    private Event createESHEvent(final EventFactory eventFactory, final String type, final String payload,
+            final String topic, final String source) {
+        Event eshEvent = null;
+        try {
+            eshEvent = eventFactory.createEvent(type, topic, payload, source);
+        } catch (Exception e) {
+            logger.error(
+                    "Creation of ESH-Event failed, "
+                            + "because one of the registered event factories has thrown an exception: {}",
+                    e.getMessage(), e);
+        }
+        return eshEvent;
+    }
+
+    private synchronized void dispatchESHEvent(final Set<EventSubscriber> eventSubscribers, final Event event) {
+        for (final EventSubscriber eventSubscriber : eventSubscribers) {
+            EventFilter filter = eventSubscriber.getEventFilter();
+            if (filter == null || filter.apply(event)) {
+                safeCaller.create(eventSubscriber).withAsync().onTimeout(() -> {
+                    logger.warn("Dispatching event to subscriber '{}' takes more than {}ms.",
+                            eventSubscriber.toString(), SafeCaller.DEFAULT_TIMEOUT);
+                }).onException(e -> {
+                    logger.error("Dispatching/filtering event for subscriber '{}' failed: {}",
+                            EventSubscriber.class.getName(), e.getMessage(), e);
+                }).build().receive(event);
+            }
+        }
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
@@ -16,8 +16,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -39,7 +37,7 @@ public class EventHandler {
 
     private final Logger logger = LoggerFactory.getLogger(EventHandler.class);
 
-    private final ConcurrentHashMap<String, CopyOnWriteArraySet<EventSubscriber>> typedEventSubscribers;
+    private final Map<String, Set<EventSubscriber>> typedEventSubscribers;
     private final Map<String, EventFactory> typedEventFactories;
     private final SafeCaller safeCaller;
 
@@ -50,7 +48,7 @@ public class EventHandler {
      * @param typedEventFactories the event factories indexed by the event type
      * @param safeCaller the safe caller to use
      */
-    public EventHandler(final ConcurrentHashMap<String, CopyOnWriteArraySet<EventSubscriber>> typedEventSubscribers,
+    public EventHandler(final Map<String, Set<EventSubscriber>> typedEventSubscribers,
             final Map<String, EventFactory> typedEventFactories, final SafeCaller safeCaller) {
         this.typedEventSubscribers = typedEventSubscribers;
         this.typedEventFactories = typedEventFactories;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
@@ -85,7 +85,7 @@ public class EventHandler {
             final @Nullable String source) {
         final EventFactory eventFactory = typedEventFactories.get(type);
         if (eventFactory == null) {
-            logger.warn("Could not find an Event Factory for the event type '{}'.", type);
+            logger.debug("Could not find an Event Factory for the event type '{}'.", type);
             return;
         }
 
@@ -106,7 +106,7 @@ public class EventHandler {
         Set<EventSubscriber> eventTypeSubscribers = typedEventSubscribers.get(eventType);
         Set<EventSubscriber> allEventTypeSubscribers = typedEventSubscribers.get(EventSubscriber.ALL_EVENT_TYPES);
 
-        Set<EventSubscriber> subscribers = new HashSet<EventSubscriber>();
+        Set<EventSubscriber> subscribers = new HashSet<>();
         if (eventTypeSubscribers != null) {
             subscribers.addAll(eventTypeSubscribers);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
@@ -15,9 +15,7 @@ package org.eclipse.smarthome.core.internal.events;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Arrays;
 import java.util.Dictionary;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
@@ -26,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.smarthome.core.common.SafeCaller;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFactory;
-import org.eclipse.smarthome.core.events.EventFilter;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.events.EventSubscriber;
 import org.osgi.framework.BundleContext;
@@ -41,8 +38,6 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.event.EventAdmin;
 import org.osgi.service.event.EventHandler;
 import org.osgi.util.tracker.ServiceTracker;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
@@ -60,6 +55,7 @@ import com.google.common.collect.SetMultimap;
  * Events are send in an asynchronous way via OSGi Event Admin mechanism.
  *
  * @author Stefan Bußweiler - Initial contribution
+ * @author Markus Rathgeb - Return on received events as fast as possible (handle event in another thread)
  */
 @Component(immediate = true, property = { "event.topics:String=smarthome" })
 public class OSGiEventManager implements EventHandler, EventPublisher {
@@ -91,21 +87,23 @@ public class OSGiEventManager implements EventHandler, EventPublisher {
 
     }
 
-    private final Logger logger = LoggerFactory.getLogger(OSGiEventManager.class);
-
-    private EventAdmin osgiEventAdmin;
-
     private final Map<String, EventFactory> typedEventFactories = new ConcurrentHashMap<String, EventFactory>();
 
     private final SetMultimap<String, EventSubscriber> typedEventSubscribers = Multimaps
             .synchronizedSetMultimap(HashMultimap.<String, EventSubscriber> create());
 
+    private ThreadedEventHandler eventHandler;
+
     private EventSubscriberServiceTracker eventSubscriberServiceTracker;
+
+    private EventAdmin osgiEventAdmin;
 
     private SafeCaller safeCaller;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
+        eventHandler = new ThreadedEventHandler(typedEventSubscribers, typedEventFactories, safeCaller);
+
         eventSubscriberServiceTracker = new EventSubscriberServiceTracker(componentContext.getBundleContext());
         eventSubscriberServiceTracker.open();
     }
@@ -114,6 +112,12 @@ public class OSGiEventManager implements EventHandler, EventPublisher {
     protected void deactivate(ComponentContext componentContext) {
         if (eventSubscriberServiceTracker != null) {
             eventSubscriberServiceTracker.close();
+            eventSubscriberServiceTracker = null;
+        }
+
+        if (eventHandler != null) {
+            eventHandler.close();
+            eventHandler = null;
         }
     }
 
@@ -158,84 +162,7 @@ public class OSGiEventManager implements EventHandler, EventPublisher {
 
     @Override
     public void handleEvent(org.osgi.service.event.Event osgiEvent) {
-        Object typeObj = osgiEvent.getProperty("type");
-        Object payloadObj = osgiEvent.getProperty("payload");
-        Object topicObj = osgiEvent.getProperty("topic");
-        Object sourceObj = osgiEvent.getProperty("source");
-
-        if (typeObj instanceof String && payloadObj instanceof String && topicObj instanceof String) {
-            String typeStr = (String) typeObj;
-            String payloadStr = (String) payloadObj;
-            String topicStr = (String) topicObj;
-            String sourceStr = (sourceObj instanceof String) ? (String) sourceObj : null;
-            if (!typeStr.isEmpty() && !payloadStr.isEmpty() && !topicStr.isEmpty()) {
-                handleEvent(typeStr, payloadStr, topicStr, sourceStr);
-            }
-        } else {
-            logger.error(
-                    "The handled OSGi event is invalid. Expect properties as string named 'type', 'payload' and 'topic'. "
-                            + "Received event properties are: {}",
-                    Arrays.toString(osgiEvent.getPropertyNames()));
-        }
-    }
-
-    private void handleEvent(final String type, final String payload, final String topic, final String source) {
-        EventFactory eventFactory = typedEventFactories.get(type);
-
-        if (eventFactory != null) {
-            Set<EventSubscriber> eventSubscribers = getEventSubscribers(type);
-            if (!eventSubscribers.isEmpty()) {
-                Event eshEvent = createESHEvent(eventFactory, type, payload, topic, source);
-                if (eshEvent != null) {
-                    dispatchESHEvent(eventSubscribers, eshEvent);
-                }
-            }
-        } else {
-            logger.debug("Could not find an Event Factory for the event type '{}'.", type);
-        }
-    }
-
-    private Event createESHEvent(final EventFactory eventFactory, final String type, final String payload,
-            final String topic, final String source) {
-        Event eshEvent = null;
-        try {
-            eshEvent = eventFactory.createEvent(type, topic, payload, source);
-        } catch (Exception e) {
-            logger.error(
-                    "Creation of ESH-Event failed, "
-                            + "because one of the registered event factories has thrown an exception: {}",
-                    e.getMessage(), e);
-        }
-        return eshEvent;
-    }
-
-    private synchronized void dispatchESHEvent(final Set<EventSubscriber> eventSubscribers, final Event event) {
-        for (final EventSubscriber eventSubscriber : eventSubscribers) {
-            EventFilter filter = eventSubscriber.getEventFilter();
-            if (filter == null || filter.apply(event)) {
-                safeCaller.create(eventSubscriber).withAsync().onTimeout(() -> {
-                    logger.warn("Dispatching event to subscriber '{}' takes more than {}ms.",
-                            eventSubscriber.toString(), SafeCaller.DEFAULT_TIMEOUT);
-                }).onException(e -> {
-                    logger.error("Dispatching/filtering event for subscriber '{}' failed: {}",
-                            EventSubscriber.class.getName(), e.getMessage(), e);
-                }).build().receive(event);
-            }
-        }
-    }
-
-    private Set<EventSubscriber> getEventSubscribers(String eventType) {
-        Set<EventSubscriber> eventTypeSubscribers = typedEventSubscribers.get(eventType);
-        Set<EventSubscriber> allEventTypeSubscribers = typedEventSubscribers.get(EventSubscriber.ALL_EVENT_TYPES);
-
-        Set<EventSubscriber> subscribers = new HashSet<EventSubscriber>();
-        if (eventTypeSubscribers != null) {
-            subscribers.addAll(eventTypeSubscribers);
-        }
-        if (allEventTypeSubscribers != null) {
-            subscribers.addAll(allEventTypeSubscribers);
-        }
-        return subscribers;
+        eventHandler.handleEvent(osgiEvent);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
@@ -88,9 +88,6 @@ public class OSGiEventManager implements EventHandler, EventPublisher {
 
     private final ConcurrentHashMap<String, CopyOnWriteArraySet<EventSubscriber>> typedEventSubscribers = new ConcurrentHashMap<>();
 
-    // private final SetMultimap<String, EventSubscriber> typedEventSubscribers = Multimaps
-    // .synchronizedSetMultimap(HashMultimap.<String, EventSubscriber> create());
-
     private ThreadedEventHandler eventHandler;
 
     private EventSubscriberServiceTracker eventSubscriberServiceTracker;
@@ -215,7 +212,7 @@ public class OSGiEventManager implements EventHandler, EventPublisher {
 
     private void assertValidState(EventAdmin eventAdmin) throws IllegalStateException {
         if (eventAdmin == null) {
-            throw new IllegalArgumentException("The event bus module is not available!");
+            throw new IllegalStateException("The event bus module is not available!");
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
@@ -70,6 +70,8 @@ public class ThreadedEventHandler implements Closeable {
                     }
                 } catch (InterruptedException ex) {
                     Thread.currentThread().interrupt();
+                } catch (RuntimeException ex) {
+                    logger.error("Error on event handling.", ex);
                 }
             }
         }, "ESH-OSGiEventManager");

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
@@ -72,7 +72,7 @@ public class ThreadedEventHandler implements Closeable {
                     Thread.currentThread().interrupt();
                 }
             }
-        });
+        }, "ESH-OSGiEventManager");
         thread.start();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/ThreadedEventHandler.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2014,2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.events;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.smarthome.core.common.SafeCaller;
+import org.eclipse.smarthome.core.events.EventFactory;
+import org.eclipse.smarthome.core.events.EventSubscriber;
+import org.osgi.service.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.SetMultimap;
+
+/**
+ * Handle Eclipse SmartHome events encapsulated by OSGi events in a separate thread.
+ *
+ * @author Markus Rathgeb - Initial contribution
+ */
+public class ThreadedEventHandler implements Closeable {
+
+    private final Logger logger = LoggerFactory.getLogger(ThreadedEventHandler.class);
+
+    private final Thread thread;
+
+    private final BlockingQueue<Event> queue = new LinkedBlockingQueue<>();
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
+    /**
+     * Create a new threaded event handler.
+     *
+     * @param typedEventSubscribers the event subscribers indexed by the event type
+     * @param typedEventFactories the event factories indexed by the event type
+     * @param safeCaller the safe caller to use
+     */
+    public ThreadedEventHandler(final SetMultimap<String, EventSubscriber> typedEventSubscribers,
+            final Map<String, EventFactory> typedEventFactories, final SafeCaller safeCaller) {
+        thread = new Thread(() -> {
+            final EventHandler worker = new EventHandler(typedEventSubscribers, typedEventFactories, safeCaller);
+            while (running.get()) {
+                try {
+                    final Event event = queue.poll(1, TimeUnit.HOURS);
+                    if (event != null) {
+                        worker.handleEvent(event);
+                    } else {
+                        if (running.get()) {
+                            logger.debug("Hey, you have really very few events.");
+                        }
+                    }
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+        thread.start();
+    }
+
+    @Override
+    public void close() {
+        running.set(false);
+        queue.add(null);
+        thread.interrupt();
+        try {
+            thread.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void handleEvent(Event event) {
+        queue.add(event);
+    }
+}


### PR DESCRIPTION
We do not want to block the event admin while handling the received OSGi
events.
So, we consume the OSGi events and add them to a internal queue.
A separate handler thread will then proceed the elements of that queue
in order.

Fixes: https://github.com/eclipse/smarthome/issues/4697