### PR TITLE
On adding Thing from Inbox check for missing settings (#3657)

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.setup.js
@@ -60,21 +60,27 @@ angular.module('PaperUI.controllers.setup', []).controller('SetupPageController'
                 var thingType = thingTypeRepository.find(function(thingType) {
                     return thingTypeUID === thingType.UID;
                 });
-
-                var thing = thingRepository.find(function(thing) {
+                
+                var configRequired = false;
+                thingRepository.getOne(function(thing) {
                     return thing.UID === thingUID;
-                });
-
-                if (thing) {
-                    var configRequired = false;
+                }, function(thing) {
                     configDescriptionService.getByUri({
-                        uri : 'thing-type:' + thing.thingTypeUID
+                        uri : 'thing-type:' + thingType.UID
                     }, function(configDescription) {
                         if (configDescription.parameters) {
                             for (var i = 0; i < configDescription.parameters.length; i++) {
-                                if (configDescription.parameters[i]['defaultValue'] === '' && configDescription.parameters[i]['required']) {
-                                    configRequired = true;
-                                    break;
+                                var parameter = configDescription.parameters[i]; 
+                                if (parameter.required) {
+                                    if (thing.configuration.hasOwnProperty(parameter.name)) {
+                                        if (thing.configuration[parameter.name] === '') {
+                                            configRequired = true;
+                                            break;
+                                        }                                        
+                                    } else {                                        
+                                        configRequired = true;
+                                        break;
+                                    }
                                 }
                             }
                         }
@@ -91,7 +97,7 @@ angular.module('PaperUI.controllers.setup', []).controller('SetupPageController'
                             }
                         }
                     });
-                }
+                });
             });
         });
     };


### PR DESCRIPTION
Implementation of the issue #3657:

After adding a Thing from Inbox an additional check is performed:
- is the Thing **OFFLINE** and has **CONFIGURATION_ERROR** _or_
- is the Thing _not_ **ONLINE** and has some empty configuration entries
If so, user will be redirected to the Thing Edit page automatically.

This implementation present a seamless experience for a user, for
example allowing to discover a bridge, be prompted to enter its
credentials and to discover connected Things in a same workflow.

Small drawback: if a Thing takes long to become **ONLINE** _and_ has some
empty non-mandatory configuration entries, user still will be
redirected.

To reduce this risk, this method could be applied to bridges only,
feedback is welcome.