### PR TITLE
[LIFX] Fix status updated to OFFLINE (COMMUNICATION_ERROR) during initialization

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCommunicationHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightCommunicationHandler.java
@@ -246,11 +246,15 @@ public class LifxLightCommunicationHandler {
     }
 
     public void sendPacket(Packet packet) {
-        wrappedPacketSend((s, p) -> LifxSelectorUtil.sendPacket(s, p), packet);
+        if (host != null) {
+            wrappedPacketSend((s, p) -> LifxSelectorUtil.sendPacket(s, p), packet);
+        }
     }
 
     public void resendPacket(Packet packet) {
-        wrappedPacketSend((s, p) -> LifxSelectorUtil.resendPacket(s, p), packet);
+        if (host != null) {
+            wrappedPacketSend((s, p) -> LifxSelectorUtil.resendPacket(s, p), packet);
+        }
     }
 
     private void wrappedPacketSend(BiFunction<LifxSelectorContext, Packet, Boolean> function, Packet packet) {


### PR DESCRIPTION
When the LifxLightHandler is initialized packets may get sent to a light while its InetSocketAddress is not yet known. This would result in 'OFFLINE (COMMUNICATION_ERROR)' status update while no actual communication took place, e.g.:

```
10:14:05.011 [INFO ] [ome.event.ThingStatusInfoChangedEvent] - 'lifx:colorlight:test' changed from UNINITIALIZED to INITIALIZING
10:14:05.024 [INFO ] [ome.event.ThingStatusInfoChangedEvent] - 'lifx:colorlight:test' changed from INITIALIZING to OFFLINE
10:14:05.176 [INFO ] [ome.event.ThingStatusInfoChangedEvent] - 'lifx:colorlight:test' changed from OFFLINE to OFFLINE (COMMUNICATION_ERROR)
10:14:05.379 [INFO ] [ome.event.ThingStatusInfoChangedEvent] - 'lifx:colorlight:test' changed from OFFLINE (COMMUNICATION_ERROR) to ONLINE
```

With this fix the ThingStatus of lights will be update as follows during initialization: 
UNINITIALIZED -> INITIALIZING -> OFFLINE -> ONLINE

For instance:

```
10:36:29.346 [INFO ] [ome.event.ThingStatusInfoChangedEvent] - 'lifx:colorlight:test' changed from UNINITIALIZED to INITIALIZING
10:36:29.347 [INFO ] [ome.event.ThingStatusInfoChangedEvent] - 'lifx:colorlight:test' changed from INITIALIZING to OFFLINE
10:36:29.950 [INFO ] [ome.event.ThingStatusInfoChangedEvent] - 'lifx:colorlight:test' changed from OFFLINE to ONLINE
```

With this fix the light status will still be updated to OFFLINE (COMMUNICATION_ERROR) when the host is known but the light is no longer responding. E.g. when disconnecting the power.