### PR TITLE
prevent duplicate interfaces

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
@@ -35,7 +35,6 @@ import org.eclipse.smarthome.core.common.QueueingThreadPoolExecutor;
 import org.eclipse.smarthome.test.java.JavaTest;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -75,6 +74,9 @@ public class SafeCallerImplTest extends JavaTest {
         public String method() {
             return "Hello";
         }
+    }
+
+    public static class DerivedTarget extends Target implements ITarget {
     }
 
     @Before
@@ -494,6 +496,12 @@ public class SafeCallerImplTest extends JavaTest {
         for (int actual : q) {
             assertThat(actual, is(expected++));
         }
+    }
+
+    @Test
+    public void testDuplicateInterface() {
+        ITarget target = new DerivedTarget();
+        safeCaller.create(target).build().method();
     }
 
     private void assertDurationBelow(long high, Runnable runnable) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerImpl.java
@@ -12,10 +12,10 @@
  */
 package org.eclipse.smarthome.core.internal.common;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -86,7 +86,7 @@ public class SafeCallerImpl implements SafeCaller {
     }
 
     private static <T> Class<?>[] getAllInterfaces(T target) {
-        List<Class<?>> ret = new ArrayList<>();
+        Set<Class<?>> ret = new HashSet<>();
         Class<?> clazz = target.getClass();
         while (clazz != null) {
             ret.addAll(Arrays.asList(clazz.getInterfaces()));


### PR DESCRIPTION
...when auto-detecting them for proxy creation in the safe caller.

fixes #4713
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>