### PR TITLE
WIP: Provide information about multiple instance services for UIs

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/MultipleInstanceServiceInfo.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/MultipleInstanceServiceInfo.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2014,2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.config.core;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Interface marking the service with service.pid as one that can be instantiated multiple times with different
+ * configurations
+ *
+ * @author Stefan Triller - initial contribution
+ *
+ */
+@NonNullByDefault
+public interface MultipleInstanceServiceInfo {
+
+    /**
+     * Get the human readable label of the service
+     *
+     * @return label of the service
+     */
+    String getLabel();
+
+    /**
+     * Obtain the service category
+     *
+     * @return Category this service is in
+     */
+    String getCategory();
+
+    /**
+     * Get the real service.pid of the service that can be created multiple times with different configurations
+     *
+     * @return service.pid of the service
+     */
+    String getServicePID();
+
+    /**
+     * Get the description URI of this service
+     *
+     * @return the URI description of this service
+     */
+    String getDescriptionURI();
+
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/service/ConfigurableServiceResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/service/ConfigurableServiceResource.java
@@ -37,6 +37,7 @@ import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
 import org.eclipse.smarthome.config.core.ConfigUtil;
 import org.eclipse.smarthome.config.core.ConfigurableService;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.config.core.MultipleInstanceServiceInfo;
 import org.eclipse.smarthome.core.auth.Role;
 import org.eclipse.smarthome.io.rest.RESTResource;
 import org.eclipse.smarthome.io.rest.core.config.ConfigurationService;
@@ -217,7 +218,20 @@ public class ConfigurableServiceResource implements RESTResource {
                             .getProperty(ConfigurableService.SERVICE_PROPERTY_CATEGORY);
                     String configDescriptionURI = (String) serviceReference
                             .getProperty(ConfigurableService.SERVICE_PROPERTY_DESCRIPTION_URI);
-                    services.add(new ConfigurableServiceDTO(id, label, category, configDescriptionURI));
+                    services.add(new ConfigurableServiceDTO(id, label, category, configDescriptionURI, false));
+                }
+            }
+
+            // obtain the list of services holding metadata on how to create multiple services with different configs
+            ServiceReference<?>[] multiServiceReferences = RESTCoreActivator.getBundleContext()
+                    .getServiceReferences(MultipleInstanceServiceInfo.class.getName(), null);
+            if (multiServiceReferences != null) {
+                for (ServiceReference<?> serviceReference : multiServiceReferences) {
+                    MultipleInstanceServiceInfo mis = (MultipleInstanceServiceInfo) RESTCoreActivator.getBundleContext()
+                            .getService(serviceReference);
+
+                    services.add(new ConfigurableServiceDTO(mis.getServicePID(), mis.getLabel(), mis.getCategory(),
+                            mis.getDescriptionURI(), true));
                 }
             }
         } catch (InvalidSyntaxException ex) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/service/ConfigurableServiceDTO.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/service/ConfigurableServiceDTO.java
@@ -23,12 +23,15 @@ public class ConfigurableServiceDTO {
     public String label;
     public String category;
     public String configDescriptionURI;
+    public boolean multiple;
 
-    public ConfigurableServiceDTO(String id, String label, String category, String configDescriptionURI) {
+    public ConfigurableServiceDTO(String id, String label, String category, String configDescriptionURI,
+            boolean multiple) {
         this.id = id;
         this.label = label;
         this.category = category;
         this.configDescriptionURI = configDescriptionURI;
+        this.multiple = multiple;
     }
 
 }

--- a/bundles/test/org.eclipse.smarthome.magic/ESH-INF/config/multipleConfig.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/ESH-INF/config/multipleConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0
+        http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="test:multipleMagic">
+		<parameter name="text" type="text">
+			<label>Text</label>
+			<description>A text parameter.</description>
+			<default>myDefaultText</default>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/service/MagicMultiInstanceService.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/service/MagicMultiInstanceService.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014,2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.magic.service;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author Stefan Triller - Initial contribution
+ *
+ */
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, service = MagicMultiInstanceService.class, configurationPid = "org.eclipse.smarthome.magicMultiInstance")
+public class MagicMultiInstanceService {
+
+    private final Logger logger = LoggerFactory.getLogger(MagicMultiInstanceService.class);
+
+    @Activate
+    public void activate(Map<String, Object> properties) {
+        logger.debug("\nactivate");
+        for (Entry<String, Object> e : properties.entrySet()) {
+            logger.debug(e.getKey() + " : " + e.getValue());
+        }
+    }
+
+    @Modified
+    public void modified(Map<String, Object> properties) {
+        logger.debug("\nmodified");
+        for (Entry<String, Object> e : properties.entrySet()) {
+            logger.debug(e.getKey() + " : " + e.getValue());
+        }
+    }
+}

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/service/MagicMultiInstanceServiceDummy.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/service/MagicMultiInstanceServiceDummy.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2014,2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.magic.service;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.config.core.MultipleInstanceServiceInfo;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ *
+ * @author Stefan Triller - Initial contribution
+ *
+ */
+@Component(immediate = true)
+@NonNullByDefault
+public class MagicMultiInstanceServiceDummy implements MultipleInstanceServiceInfo {
+
+    @Override
+    public String getLabel() {
+        return "MagicMultiInstanceServiceDummy";
+    }
+
+    @Override
+    public String getCategory() {
+        return "test";
+    }
+
+    @Override
+    public String getServicePID() {
+        // we are responsible of creating multiple instances of MagicMultiInstanceService
+        return "org.eclipse.smarthome.magicMultiInstance";
+    }
+
+    @Override
+    public String getDescriptionURI() {
+        return "test:multipleMagic";
+    }
+
+}


### PR DESCRIPTION
The newly introduced MultipleInstanceServiceInfo interface serves as a
marker service for the service pid returned by its getServicePID()
method.

Every service that should be configured multiple times with different
configurations should have the configurationPolicy
ConfigurationPolicy.REQUIRE and thus it will not be started without a
proper configuration.

In addition one service implementing MultipleInstanceServiceInfo is
neccessary that is started immediately which announces the availability
of the forementioned-service by returning the configurationPid of it in
its getServicePID() method.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>