### PR TITLE
fixes NPE if no network interface is present

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -73,20 +73,24 @@ public class NetUtil implements NetworkAddressService {
     public String getPrimaryIpv4HostAddress() {
         String primaryIP;
 
-        String[] addrString = primaryAddress.split("/");
-        if (addrString.length > 1) {
-            String ip = getIPv4inSubnet(addrString[0], addrString[1]);
-            if (ip == null) {
-                // an error has occurred, using first interface like nothing has been configured
-                LOGGER.warn("Invalid address '{}', will use first interface instead.", primaryAddress);
-                primaryIP = getFirstLocalIPv4Address();
+        if (primaryAddress != null) {
+            String[] addrString = primaryAddress.split("/");
+            if (addrString.length > 1) {
+                String ip = getIPv4inSubnet(addrString[0], addrString[1]);
+                if (ip == null) {
+                    // an error has occurred, using first interface like nothing has been configured
+                    LOGGER.warn("Invalid address '{}', will use first interface instead.", primaryAddress);
+                    primaryIP = getFirstLocalIPv4Address();
+                } else {
+                    primaryIP = ip;
+                }
             } else {
-                primaryIP = ip;
+                primaryIP = addrString[0];
             }
         } else {
-            primaryIP = addrString[0];
+            // we do not seem to have any network interfaces
+            primaryIP = null;
         }
-
         return primaryIP;
     }
 


### PR DESCRIPTION
This prevents NPEs like
```
java.lang.NullPointerException: null
	at org.eclipse.smarthome.core.net.NetUtil.getPrimaryIpv4HostAddress(NetUtil.java:76) [109:org.eclipse.smarthome.core:0.10.0.201712111157]
```

Signed-off-by: Kai Kreuzer <kai@openhab.org>