### PR TITLE
reduce debug level if no client connection is established

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.lsp/src/main/java/org/eclipse/smarthome/model/lsp/internal/ModelServer.java
+++ b/bundles/model/org.eclipse.smarthome.model.lsp/src/main/java/org/eclipse/smarthome/model/lsp/internal/ModelServer.java
@@ -51,11 +51,8 @@ public class ModelServer {
     private ScriptEngine scriptEngine;
     private Injector injector;
 
-    private boolean isShuttingDown = false;
-
     @Activate
     public void activate() {
-        isShuttingDown = false;
         injector = Guice.createInjector(new RuntimeServerModule(scriptServiceUtil, scriptEngine));
         new Thread(() -> {
             listen();
@@ -64,7 +61,6 @@ public class ModelServer {
 
     @Deactivate
     public void deactivate() {
-        isShuttingDown = true;
         try {
             if (socket != null && !socket.isClosed()) {
                 socket.close();
@@ -86,8 +82,8 @@ public class ModelServer {
                         handleConnection(client);
                     }, "Client " + client.getRemoteSocketAddress()).start();
                 } catch (IOException e) {
-                    if (!isShuttingDown) {
-                        logger.error("Error opening socket for client connections: {}", e.getMessage());
+                    if (!socket.isClosed()) {
+                        logger.error("Error accepting client connection: {}", e.getMessage());
                     }
                 }
             }

--- a/bundles/model/org.eclipse.smarthome.model.lsp/src/main/java/org/eclipse/smarthome/model/lsp/internal/ModelServer.java
+++ b/bundles/model/org.eclipse.smarthome.model.lsp/src/main/java/org/eclipse/smarthome/model/lsp/internal/ModelServer.java
@@ -82,7 +82,7 @@ public class ModelServer {
                         handleConnection(client);
                     }, "Client " + client.getRemoteSocketAddress()).start();
                 } catch (IOException e) {
-                    logger.error("Error accepting the client connection", e);
+                    logger.debug("Error accepting the client connection: {}", e.getMessage());
                 }
             }
         } catch (IOException e) {


### PR DESCRIPTION
It is completely normal and expected that an IOException occurs, if the server is shutdown, so there is no reason to log in error level here.

fixes #4667

Signed-off-by: Kai Kreuzer <kai@openhab.org>