### PR TITLE
Fixes potential NPE if no httpService is (yet) registered

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/HttpServiceUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/HttpServiceUtil.java
@@ -59,28 +59,30 @@ public class HttpServiceUtil {
             return -1;
         }
 
-        int candidate = Integer.MIN_VALUE;
-        for (final ServiceReference<?> ref : refs) {
-            value = ref.getProperty(propertyName);
-            if (value == null) {
-                continue;
-            }
-            final int servicePort;
-            try {
-                servicePort = Integer.parseInt(value.toString());
-            } catch (final NumberFormatException ex) {
-                continue;
-            }
-            value = ref.getProperty(Constants.SERVICE_RANKING);
-            final int serviceRanking;
-            if (value == null || !(value instanceof Integer)) {
-                serviceRanking = 0;
-            } else {
-                serviceRanking = (Integer) value;
-            }
-            if (serviceRanking >= candidate) {
-                candidate = serviceRanking;
-                port = servicePort;
+        if (refs != null) {
+            int candidate = Integer.MIN_VALUE;
+            for (final ServiceReference<?> ref : refs) {
+                value = ref.getProperty(propertyName);
+                if (value == null) {
+                    continue;
+                }
+                final int servicePort;
+                try {
+                    servicePort = Integer.parseInt(value.toString());
+                } catch (final NumberFormatException ex) {
+                    continue;
+                }
+                value = ref.getProperty(Constants.SERVICE_RANKING);
+                final int serviceRanking;
+                if (value == null || !(value instanceof Integer)) {
+                    serviceRanking = 0;
+                } else {
+                    serviceRanking = (Integer) value;
+                }
+                if (serviceRanking >= candidate) {
+                    candidate = serviceRanking;
+                    port = servicePort;
+                }
             }
         }
         if (port > 0) {


### PR DESCRIPTION
JavaDoc of BundleContext.getAllServiceReferences(...) states:
> Returns: 
> An array of ServiceReference objects or null if no services are registered which satisfy the search.

Signed-off-by: Kai Kreuzer <kai@openhab.org>