### PR TITLE
reduced log level

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
@@ -191,7 +191,7 @@ public class OSGiEventManager implements EventHandler, EventPublisher {
                 }
             }
         } else {
-            logger.warn("Could not find an Event Factory for the event type '{}'.", type);
+            logger.debug("Could not find an Event Factory for the event type '{}'.", type);
         }
     }
 


### PR DESCRIPTION
As long as we do not have an orderly system startup and shutdown process in place, it is a perfectly normal situation that ItemFactories are unregistered on a shutdown before the very last event is sent. This currently results in ugly logs like this on a regular shutdown:

```
2017-12-13 07:55:58.783 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ThingRemovedEvent'.
2017-12-13 07:55:58.783 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ThingRemovedEvent'.
2017-12-13 07:55:58.784 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ThingRemovedEvent'.
2017-12-13 07:55:58.784 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ThingRemovedEvent'.
2017-12-13 07:55:58.786 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.786 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.787 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.787 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.787 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.787 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.787 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.788 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.788 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
2017-12-13 07:55:58.788 [WARN ] [ore.internal.events.OSGiEventManager] - Could not find an Event Factory for the event type 'ItemChannelLinkRemovedEvent'.
```

As long as this is our expected behavior, I'd suggest to reduce the log level of that message.

Signed-off-by: Kai Kreuzer <kai@openhab.org>