### PR TITLE
Replaced IAE by a simply "not linked" answer to make API more robust

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -619,18 +619,17 @@ public abstract class BaseThingHandler implements ThingHandler {
     /**
      * Returns whether at least on item is linked for the given channel ID.
      *
-     * @param channelId
-     *            channel ID (must not be null)
+     * @param channelId channel ID (must not be null)
      * @return true if at least one item is linked, false otherwise
-     * @throws IllegalArgumentException
-     *             if no channel with the given ID exists
      */
     protected boolean isLinked(String channelId) {
         Channel channel = thing.getChannel(channelId);
         if (channel != null) {
             return linkRegistry != null ? !linkRegistry.getLinks(channel.getUID()).isEmpty() : false;
         } else {
-            throw new IllegalArgumentException("Channel with ID '" + channelId + "' does not exists.");
+            logger.debug("Channel with ID '{},' does not exists in thing '{}' and is therefore not linked.", channelId,
+                    thing.getUID());
+            return false;
         }
     }
 


### PR DESCRIPTION
We currently throw an IAE, if this method is called with an ID for which no channel exists on a thing.

This can lead to errors like:
```
2017-12-01 16:01:46.428 [ERROR] [ome.core.thing.link.ThingLinkManager] - Exception occurred while informing handler: Channel with ID 'signalstrength' does not exists.
java.lang.IllegalArgumentException: Channel with ID 'signalstrength' does not exists.
	at org.eclipse.smarthome.core.thing.binding.BaseThingHandler.isLinked(BaseThingHandler.java:609) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler.startOrStopSignalStrengthUpdates(LifxLightHandler.java:377) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler.channelLinked(LifxLightHandler.java:368) ~[?:?]
	at org.eclipse.smarthome.core.thing.link.ThingLinkManager.lambda$0(ThingLinkManager.java:290) ~[?:?]
```

It is very unlikely that bindings will always catch and handle this runtime exception themselves and our framework therefore currently provokes such errors.

The situation here is simply that a channel has been in a newer version, which might not yet exist on Things that have been created in the past already (or which have been created some other way). Imho it is perfectly valid that cahnnels are missing on a concrete thing, and an "isLinked" call from the binding should simply consider this situation.

Signed-off-by: Kai Kreuzer <kai@openhab.org>