### PR TITLE
Support channels without type again

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactoryTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactoryTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2014,2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+public class SystemProfileFactoryTest {
+
+    private ChannelTypeRegistry channelTypeRegistry;
+    private SystemProfileFactory factory;
+
+    @Before
+    public void setup() {
+        channelTypeRegistry = new ChannelTypeRegistry();
+
+        factory = new SystemProfileFactory();
+        factory.setChannelTypeRegistry(channelTypeRegistry);
+    }
+
+    @Test
+    public void testGetSuggestedProfileTypeUID_nullChannelType1() {
+        factory.getSuggestedProfileTypeUID((ChannelType) null, CoreItemFactory.SWITCH);
+    }
+
+    @Test
+    public void testGetSuggestedProfileTypeUID_nullChannelType2() {
+        Channel channel = ChannelBuilder.create(new ChannelUID("test:test:test:test"), CoreItemFactory.SWITCH).build();
+        factory.getSuggestedProfileTypeUID(channel, CoreItemFactory.SWITCH);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -86,7 +86,10 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
 
     @Nullable
     @Override
-    public ProfileTypeUID getSuggestedProfileTypeUID(ChannelType channelType, @Nullable String itemType) {
+    public ProfileTypeUID getSuggestedProfileTypeUID(@Nullable ChannelType channelType, @Nullable String itemType) {
+        if (channelType == null) {
+            return null;
+        }
         switch (channelType.getKind()) {
             case STATE:
                 return SystemProfiles.DEFAULT;

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeProvider.java
@@ -15,6 +15,9 @@ package org.eclipse.smarthome.core.thing.type;
 import java.util.Collection;
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * The {@link ChannelTypeProvider} is responsible for providing channel types.
  *
@@ -22,25 +25,28 @@ import java.util.Locale;
  *
  * @author Dennis Nobel - Initial contribution
  */
+@NonNullByDefault
 public interface ChannelTypeProvider {
 
     /**
      * @see ChannelTypeRegistry#getChannelTypes(Locale)
      */
-    Collection<ChannelType> getChannelTypes(Locale locale);
+    Collection<ChannelType> getChannelTypes(@Nullable Locale locale);
 
     /**
      * @see ChannelTypeRegistry#getChannelType(ChannelTypeUID, Locale)
      */
-    ChannelType getChannelType(ChannelTypeUID channelTypeUID, Locale locale);
+    @Nullable
+    ChannelType getChannelType(@Nullable ChannelTypeUID channelTypeUID, @Nullable Locale locale);
 
     /**
      * @see ChannelTypeRegistry#getChannelGroupType(ChannelGroupTypeUID, Locale)
      */
-    ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID, Locale locale);
+    @Nullable
+    ChannelGroupType getChannelGroupType(@Nullable ChannelGroupTypeUID channelGroupTypeUID, @Nullable Locale locale);
 
     /**
      * @see ChannelTypeRegistry#getChannelGroupTypes(Locale)
      */
-    Collection<ChannelGroupType> getChannelGroupTypes(Locale locale);
+    Collection<ChannelGroupType> getChannelGroupTypes(@Nullable Locale locale);
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelTypeRegistry.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -30,10 +32,11 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Dennis Nobel - Initial contribution
  *
  */
+@NonNullByDefault
 @Component(immediate = true, service = ChannelTypeRegistry.class)
 public class ChannelTypeRegistry {
 
-    private List<ChannelTypeProvider> channelTypeProviders = new CopyOnWriteArrayList<>();
+    private final List<ChannelTypeProvider> channelTypeProviders = new CopyOnWriteArrayList<>();
 
     /**
      * Returns all channel types with the default {@link Locale}.
@@ -50,7 +53,7 @@ public class ChannelTypeRegistry {
      * @param locale (can be null)
      * @return all channel types or empty list if no channel type exists
      */
-    public List<ChannelType> getChannelTypes(Locale locale) {
+    public List<ChannelType> getChannelTypes(@Nullable Locale locale) {
         List<ChannelType> channelTypes = new ArrayList<>();
         for (ChannelTypeProvider channelTypeProvider : channelTypeProviders) {
             channelTypes.addAll(channelTypeProvider.getChannelTypes(locale));
@@ -63,7 +66,8 @@ public class ChannelTypeRegistry {
      *
      * @return channel type or null if no channel type for the given UID exists
      */
-    public ChannelType getChannelType(ChannelTypeUID channelTypeUID) {
+    @Nullable
+    public ChannelType getChannelType(@Nullable ChannelTypeUID channelTypeUID) {
         return getChannelType(channelTypeUID, null);
     }
 
@@ -73,7 +77,11 @@ public class ChannelTypeRegistry {
      * @param locale (can be null)
      * @return channel type or null if no channel type for the given UID exists
      */
-    public ChannelType getChannelType(ChannelTypeUID channelTypeUID, Locale locale) {
+    @Nullable
+    public ChannelType getChannelType(@Nullable ChannelTypeUID channelTypeUID, @Nullable Locale locale) {
+        if (channelTypeUID == null) {
+            return null;
+        }
         for (ChannelTypeProvider channelTypeProvider : channelTypeProviders) {
             ChannelType channelType = channelTypeProvider.getChannelType(channelTypeUID, locale);
             if (channelType != null) {
@@ -98,7 +106,7 @@ public class ChannelTypeRegistry {
      * @param locale (can be null)
      * @return all channel group types or empty list if no channel group type exists
      */
-    public List<ChannelGroupType> getChannelGroupTypes(Locale locale) {
+    public List<ChannelGroupType> getChannelGroupTypes(@Nullable Locale locale) {
         List<ChannelGroupType> channelGroupTypes = new ArrayList<>();
         for (ChannelTypeProvider channelTypeProvider : channelTypeProviders) {
             channelGroupTypes.addAll(channelTypeProvider.getChannelGroupTypes(locale));
@@ -111,7 +119,8 @@ public class ChannelTypeRegistry {
      *
      * @return channel group type or null if no channel group type for the given UID exists
      */
-    public ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID) {
+    @Nullable
+    public ChannelGroupType getChannelGroupType(@Nullable ChannelGroupTypeUID channelGroupTypeUID) {
         return getChannelGroupType(channelGroupTypeUID, null);
     }
 
@@ -121,7 +130,12 @@ public class ChannelTypeRegistry {
      * @param locale (can be null)
      * @return channel group type or null if no channel group type for the given UID exists
      */
-    public ChannelGroupType getChannelGroupType(ChannelGroupTypeUID channelGroupTypeUID, Locale locale) {
+    @Nullable
+    public ChannelGroupType getChannelGroupType(@Nullable ChannelGroupTypeUID channelGroupTypeUID,
+            @Nullable Locale locale) {
+        if (channelGroupTypeUID == null) {
+            return null;
+        }
         for (ChannelTypeProvider channelTypeProvider : channelTypeProviders) {
             ChannelGroupType channelGroupType = channelTypeProvider.getChannelGroupType(channelGroupTypeUID, locale);
             if (channelGroupType != null) {

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/providers/DsChannelTypeProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/providers/DsChannelTypeProvider.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.binding.digitalstrom.internal.providers;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -241,6 +242,6 @@ public class DsChannelTypeProvider implements ChannelTypeProvider {
 
     @Override
     public Collection<ChannelGroupType> getChannelGroupTypes(Locale locale) {
-        return null;
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
...in the SystemProfileFactory. Or rather: in the ChannelTypeRegistry.

The Channel.getChannelTypeUID() may return null and one of the major use-cases
for the ChannelTypeRegistry is to resolve such references to the actual
ChannelType instance, therefore IMHO it makes sense to also accept null
here as an input.

fixes #4733
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>