### PR TITLE
drop joda-time from script automation scope

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
@@ -20,6 +20,5 @@ Import-Package:
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.types,
- org.joda.time;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
@@ -40,8 +40,6 @@ import org.eclipse.smarthome.core.library.types.UpDownType;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
-import org.joda.time.DateTime;
-import org.joda.time.LocalTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,12 +105,6 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
         elements = new HashMap<>();
         elements.put("State", State.class);
         elements.put("Command", Command.class);
-        try {
-            elements.put("DateTime", DateTime.class);
-            elements.put("LocalTime", LocalTime.class);
-        } catch (NoClassDefFoundError e) {
-            logger.debug("Jodatime not present, therefore no support for Date/Time in scripts");
-        }
         elements.put("StringUtils", StringUtils.class);
         elements.put("URLEncoder", URLEncoder.class);
         elements.put("FileUtils", FileUtils.class);


### PR DESCRIPTION
...as there is the java.time.* package since Java 8.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>