### PR TITLE
Did little improvements to the NTP binding

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Bundle-ActivationPolicy: lazy

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/NtpBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/NtpBindingConstants.java
@@ -22,28 +22,31 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * the whole binding.
  *
  * @author Marcel Verpaalen - Initial contribution
+ * @author Alexander Kostadinov - Little binding improvements
  *
  */
 public class NtpBindingConstants {
+    
+    private NtpBindingConstants() {}
 
     public static final String BINDING_ID = "ntp";
 
     // List of all Thing Type UIDs
-    public final static ThingTypeUID THING_TYPE_NTP = new ThingTypeUID(BINDING_ID, "ntp");
+    public static final ThingTypeUID THING_TYPE_NTP = new ThingTypeUID(BINDING_ID, "ntp");
 
     // List of all Channel ids
-    public final static String CHANNEL_DATE_TIME = "dateTime";
-    public final static String CHANNEL_STRING = "string";
+    public static final String CHANNEL_DATE_TIME = "dateTime";
+    public static final String CHANNEL_STRING = "string";
 
     // Custom Properties
-    public final static String PROPERTY_NTP_SERVER_HOST = "hostname";
-    public final static String PROPERTY_REFRESH_INTERVAL = "refreshInterval";
-    public final static String PROPERTY_REFRESH_NTP = "refreshNtp";
-    public final static String PROPERTY_TIMEZONE = "timeZone";
-    public final static String PROPERTY_LOCALE = "locale";
-    public final static String PROPERTY_DATE_TIME_FORMAT = "DateTimeFormat";
-    public final static String PROPERTY_NTP_SERVER_PORT = "serverPort";
+    public static final String PROPERTY_NTP_SERVER_HOST = "hostname";
+    public static final String PROPERTY_REFRESH_INTERVAL = "refreshInterval";
+    public static final String PROPERTY_REFRESH_NTP = "refreshNtp";
+    public static final String PROPERTY_TIMEZONE = "timeZone";
+    public static final String PROPERTY_LOCALE = "locale";
+    public static final String PROPERTY_DATE_TIME_FORMAT = "DateTimeFormat";
+    public static final String PROPERTY_NTP_SERVER_PORT = "serverPort";
 
-    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_NTP);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_NTP);
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/handler/NtpHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/handler/NtpHandler.java
@@ -25,6 +25,7 @@ import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory;
  * @author Thomas.Eichstaedt-Engelen OH1 ntp binding (getTime routine)
  * @author Markus Rathgeb - Add locale provider
  * @author Erdoan Hadzhiyusein - Adapted the class to work with the new DateTimeType
+ * @author Alexander Kostadinov - Little binding improvements
  */
 
 public class NtpHandler extends BaseThingHandler {
@@ -118,21 +120,21 @@ public class NtpHandler extends BaseThingHandler {
             logger.debug("Initializing NTP handler for '{}'.", getThing().getUID());
 
             Configuration config = getThing().getConfiguration();
-            hostname = (String) config.get(PROPERTY_NTP_SERVER_HOST);
+            hostname = Objects.toString(config.get(PROPERTY_NTP_SERVER_HOST));
             port = (BigDecimal) config.get(PROPERTY_NTP_SERVER_PORT);
             refreshInterval = (BigDecimal) config.get(PROPERTY_REFRESH_INTERVAL);
             refreshNtp = (BigDecimal) config.get(PROPERTY_REFRESH_NTP);
             refreshNtpCount = 0;
 
             try {
-                timeZone = TimeZone.getTimeZone((String) config.get(PROPERTY_TIMEZONE));
+                timeZone = TimeZone.getTimeZone(Objects.toString(config.get(PROPERTY_TIMEZONE)));
             } catch (Exception e) {
                 timeZone = TimeZone.getDefault();
                 logger.debug("{} using default TZ: {}", getThing().getUID(), timeZone);
             }
 
             try {
-                String localeString = (String) config.get(PROPERTY_LOCALE);
+                String localeString = Objects.toString(config.get(PROPERTY_LOCALE));
                 locale = new Locale(localeString);
             } catch (Exception e) {
                 locale = localeProvider.getLocale();
@@ -144,7 +146,7 @@ public class NtpHandler extends BaseThingHandler {
                 Channel stringChannel = getThing().getChannel(stringChannelUID.getId());
                 if (stringChannel != null) {
                     Configuration cfg = stringChannel.getConfiguration();
-                    String dateTimeFormatString = (String) cfg.get(PROPERTY_DATE_TIME_FORMAT);
+                    String dateTimeFormatString = Objects.toString(cfg.get(PROPERTY_DATE_TIME_FORMAT));
                     if (!(dateTimeFormatString == null || dateTimeFormatString.isEmpty())) {
                         dateTimeFormat = new SimpleDateFormat(dateTimeFormatString);
                     } else {

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/NtpHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/NtpHandlerFactory.java
@@ -30,6 +30,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Marcel Verpaalen - Initial contribution
  * @author Markus Rathgeb - Add locale provider support
+ * @author Alexander Kostadinov - Little binding improvements
  */
 @Component(service = ThingHandlerFactory.class, immediate = true)
 public class NtpHandlerFactory extends BaseThingHandlerFactory {
@@ -55,7 +56,7 @@ public class NtpHandlerFactory extends BaseThingHandlerFactory {
 
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(THING_TYPE_NTP)) {
+        if (THING_TYPE_NTP.equals(thingTypeUID)) {
             return new NtpHandler(thing, localeProvider);
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/discovery/NtpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/discovery/NtpDiscovery.java
@@ -35,22 +35,13 @@ import org.osgi.service.component.annotations.Reference;
  * *
  *
  * @author Marcel Verpaalen - Initial contribution
+ * @author Alexander Kostadinov - Little binding improvements
  */
 @Component(service = DiscoveryService.class, immediate = true, configurationPid = "discovery.ntp")
 public class NtpDiscovery extends AbstractDiscoveryService {
 
-    public NtpDiscovery() throws IllegalArgumentException {
+    public NtpDiscovery() {
         super(SUPPORTED_THING_TYPES_UIDS, 10);
-    }
-
-    @Override
-    protected void activate(Map<String, Object> configProperties) {
-        super.activate(configProperties);
-    }
-
-    @Override
-    protected void modified(Map<String, Object> configProperties) {
-        super.modified(configProperties);
     }
 
     @Override


### PR DESCRIPTION
Changes include:
- `MANIFEST.MF` - added lazy activation policy (should be used with `Service-Component`).
- `NtpBindingConstants.java` - reordered the modifiers to comply with the Java Language Specification. Added a private constructor to hide the implicit public one.
- `NtpHandlerFactory.java` - little logical improvement.
- `NtpDiscovery.java` - Removed the unnecessary declaration of thrown exception 'java.lang.IllegalArgumentException' since it is a runtime exception. Removed unnecessary overrided methods which simply called the `super` method.