### PR TITLE
extend HSBType

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -166,15 +166,15 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
                 | ((convertPercentToByte(rgb[1]) & 0xFF) << 8) | ((convertPercentToByte(rgb[2]) & 0xFF) << 0);
     }
 
-    public HSBType withHue(DecimalType h) {
+    public HSBType setHue(DecimalType h) {
         return new HSBType(h, getSaturation(), getBrightness());
     }
 
-    public HSBType withSaturation(PercentType s) {
+    public HSBType setSaturation(PercentType s) {
         return new HSBType(getHue(), s, getBrightness());
     }
 
-    public HSBType withBrightness(PercentType b) {
+    public HSBType setBrightness(PercentType b) {
         return new HSBType(getHue(), getSaturation(), b);
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -166,16 +166,16 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
                 | ((convertPercentToByte(rgb[1]) & 0xFF) << 8) | ((convertPercentToByte(rgb[2]) & 0xFF) << 0);
     }
 
-    public void setHue(DecimalType h) {
-        this.hue = h.toBigDecimal();
+    public HSBType withHue(DecimalType h) {
+        return new HSBType(h, getSaturation(), getBrightness());
     }
 
-    public void setSaturation(PercentType s) {
-        this.saturation = s.toBigDecimal();
+    public HSBType withSaturation(PercentType s) {
+        return new HSBType(getHue(), s, getBrightness());
     }
 
-    public void setBrightness(PercentType b) {
-        this.value = b.toBigDecimal();
+    public HSBType withBrightness(PercentType b) {
+        return new HSBType(getHue(), getSaturation(), b);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -166,6 +166,18 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
                 | ((convertPercentToByte(rgb[1]) & 0xFF) << 8) | ((convertPercentToByte(rgb[2]) & 0xFF) << 0);
     }
 
+    public void setHue(DecimalType h) {
+        this.hue = h.toBigDecimal();
+    }
+
+    public void setSaturation(PercentType s) {
+        this.saturation = s.toBigDecimal();
+    }
+
+    public void setBrightness(PercentType b) {
+        this.value = b.toBigDecimal();
+    }
+
     @Override
     public String toString() {
         return toFullString();


### PR DESCRIPTION
The HSBType is useful for dimming with the same color, because it is easy to change the brightness channel. However, the HSBType currently only has get, not set methods for hue, saturation and brightness. So changing the brightness requires the creation of a new object. This PR adds the missing set methods.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>