### PR TITLE
Remove version tag from template binding in generated poms.

### DIFF
--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/pom.xml
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/pom.xml
@@ -15,12 +15,6 @@
 
   <name>${bindingIdCamelCase} Binding Tests</name>
 
-  <properties>
-    <bundle.symbolicName>${rootArtifactId}</bundle.symbolicName>
-    <bundle.namespace>${package}</bundle.namespace>
-  </properties>
-
-
   <build>
     <plugins>
       <plugin>

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/pom.xml
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,6 @@
 
   <groupId>@${groupId}</groupId>
   <artifactId>${rootArtifactId}</artifactId>
-  <version>@${version}</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <name>${bindingIdCamelCase} Binding Tests</name>

--- a/tools/archetype/binding/src/main/resources/archetype-resources/pom.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/pom.xml
@@ -11,7 +11,6 @@
 	</parent>
 
 	<artifactId>${rootArtifactId}</artifactId>
-	<version>@${version}</version>
 
 	<name>${bindingIdCamelCase} Binding</name>
 	<packaging>eclipse-plugin</packaging>


### PR DESCRIPTION
The version tag is very likely the same as the parent class and therefore can be omitted. Having the version here leads to lots of review comments in openhab2 bindings to remove it. So by not generating it in the first place this would reduce review and committer load.

P.s The test pom also contains some properties. I don't know if these are useful. I got a request to remove them in my binding test project. So can they be removed also or do they have added value? If they can be removed I can create another pull request and remove them.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>