### PR TITLE
Added generating thing parameter sample configuration class.

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/ESH-INF/thing/thing-types.xml
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/ESH-INF/thing/thing-types.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="${bindingId}"
-						  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-						  xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
-						  xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+<thing:thing-descriptions bindingId="${bindingId}" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
 	<!-- Sample Thing Type -->
 	<thing-type id="sample">
@@ -10,8 +9,16 @@
 		<description>Sample thing for ${bindingIdCamelCase} Binding</description>
 
 		<channels>
-			<channel id="channel1" typeId="sample-channel"/>
+			<channel id="channel1" typeId="sample-channel" />
 		</channels>
+
+		<config-description>
+			<parameter name="config1" type="text" required="true">
+				<label>Sample parameter</label>
+				<description>This is a sample text configuration parameter.</description>
+			</parameter>
+		</config-description>
+
 	</thing-type>
 
 	<!-- Sample Channel Type -->

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/handler/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/handler/__bindingIdCamelCase__Handler.java
@@ -22,11 +22,13 @@ package ${package}.handler;
 import static ${package}.${bindingIdCamelCase}BindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
+import ${package}.internal.${bindingIdCamelCase}Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +42,9 @@ import org.slf4j.LoggerFactory;
 public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
 
     private final Logger logger = LoggerFactory.getLogger(${bindingIdCamelCase}Handler.class);
+
+    @Nullable
+    private ${bindingIdCamelCase}Configuration config;
 
     public ${bindingIdCamelCase}Handler(Thing thing) {
         super(thing);
@@ -59,6 +64,8 @@ public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
 
     @Override
     public void initialize() {
+        config = getConfigAs(${bindingIdCamelCase}Configuration.class);
+
         // TODO: Initialize the thing. If done set status to ONLINE to indicate proper working.
         // Long running initialization should be done asynchronously in background.
         updateStatus(ThingStatus.ONLINE);

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Configuration.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Configuration.java
@@ -1,0 +1,33 @@
+#set( $dt = $package.getClass().forName("java.util.Date").newInstance() )
+#set( $year = $dt.getYear() + 1900 )
+#if( $vendorName == "Eclipse.org/SmartHome" )
+    #set( $copyright = "Contributors to the Eclipse Foundation" )
+#else
+    #set( $copyright = "by the respective copyright holders." )
+#end
+/**
+ * Copyright (c) ${startYear},${year} ${copyright}
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package ${package}.internal;
+
+/**
+ * The {@link ${bindingIdCamelCase}Configuration} class contains fields mapping thing configuration paramters.
+ *
+ * @author ${author} - Initial contribution
+ */
+public class ${bindingIdCamelCase}Configuration {
+
+    /**
+     * Sample configuration parameter. Replace with you own.
+     */
+    public String config1;
+}


### PR DESCRIPTION
To get access to thing configuration parameters a class can be used. Very often new bindings don't know this feature and use the properties class directly and implement their own parsing of the parameters. By using a configuration class this is all not needed. This change adds a sample configuration file so people directly see what is possible.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>