### PR TITLE
Added wrapping of threads in ThreadPoolManager to log errors.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -17,7 +17,6 @@ import java.util.Map.Entry;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
@@ -25,6 +24,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.eclipse.smarthome.core.internal.common.WrappedScheduledExecutorService;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,7 +114,7 @@ public class ThreadPoolManager {
                 pool = pools.get(poolName);
                 if (pool == null) {
                     int cfg = getConfig(poolName);
-                    pool = Executors.newScheduledThreadPool(cfg, new NamedThreadFactory(poolName));
+                    pool = new WrappedScheduledExecutorService(cfg, new NamedThreadFactory(poolName));
                     ((ThreadPoolExecutor) pool).setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
                     ((ThreadPoolExecutor) pool).allowCoreThreadTimeOut(true);
                     pools.put(poolName, pool);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/WrappedScheduledExecutorService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/WrappedScheduledExecutorService.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.common;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class wraps the ScheduledThreadPoolExecutor to implement the {@link #afterExecute(Runnable, Throwable)} method
+ * and log the exception in case the scheduled runnable threw an exception. The error will otherwise go unnoticed
+ * because an exception thrown in the runnable will simply end with no logging unless the user handles it. This
+ * wrapper removes the burden for the user to always catch errors in scheduled runnables for logging, and it also
+ * catches unchecked exceptions that can be the cause of very hard to catch bugs because no error is ever shown if the
+ * user doesn't catch the error in the runnable itself.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+public class WrappedScheduledExecutorService extends ScheduledThreadPoolExecutor {
+
+    final static Logger logger = LoggerFactory.getLogger(WrappedScheduledExecutorService.class);
+
+    public WrappedScheduledExecutorService(int corePoolSize, ThreadFactory threadFactory) {
+        super(corePoolSize, threadFactory);
+    }
+
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        Throwable actualThrowable = t;
+        if (actualThrowable == null && r instanceof Future<?>) {
+            try {
+                ((Future<?>) r).get();
+            } catch (CancellationException ce) {
+                actualThrowable = ce;
+            } catch (ExecutionException ee) {
+                actualThrowable = ee.getCause();
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        if (actualThrowable != null) {
+            logger.warn("Scheduled runnable ended with an exception", actualThrowable);
+        }
+    }
+}


### PR DESCRIPTION
This change will log errors in the scheduled threads. This removed the burden of the user of the scheduler to log just for logging, but also catches possible bugs that are caused by unchecked exceptions that are not handled and will silently cause a failure.

This is related to the discussion in #4543. It only handles wrapping in ThreadPoolManager, so it might be on other places in wrapping could be done.  But the ThreadPoolManager is the most relevant for binding developers were the problems this solves are very relevant and help simplifying binding development.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>