### PR TITLE
Default import of static Collectors members

### DIFF
--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -440,7 +440,7 @@
       <setupTask
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.ui/content_assist_favorite_static_members"
-          value="org.junit.Assert.*;org.mockito.Mockito.*;org.mockito.MockitoAnnotations.*;org.hamcrest.CoreMatchers.*"/>
+          value="org.junit.Assert.*;org.mockito.Mockito.*;org.mockito.MockitoAnnotations.*;org.hamcrest.CoreMatchers.*;java.util.stream.Collectors.*"/>
       <setupTask
           xsi:type="setup:PreferenceTask"
           key="/instance/org.eclipse.jdt.ui/editor_save_participant_org.eclipse.jdt.ui.postsavelistener.cleanup"


### PR DESCRIPTION
On the aftermath of having of having worked with Java streams a bit, IMHO especially the `Collectors.*` is superfluous and makes it hard to read - thanks @htreu for pointing this out! Therefore, this allows easy typing of

```java
return stream().collect(toList());
```

instead of

```java
return stream().collect(Collectors.toList());
```

and then needing to fight the automatic import organizer.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>