### PR TITLE
Remove Guavas ImmutableSet from GroupItem

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
 
 /**
  *
@@ -112,7 +111,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @return the direct members of this {@link GroupItem}
      */
     public Set<Item> getMembers() {
-        return ImmutableSet.copyOf(members);
+        return Collections.unmodifiableSet(new HashSet<Item>(members));
     }
 
     /**
@@ -123,7 +122,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @return all members of this and all contained {@link GroupItem}s
      */
     public Set<Item> getAllMembers() {
-        return ImmutableSet.copyOf(getMembers((Item i) -> !(i instanceof GroupItem)));
+        return Collections.unmodifiableSet(getMembers((Item i) -> !(i instanceof GroupItem)));
     }
 
     private void collectMembers(Collection<Item> allMembers, Collection<Item> members) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -111,7 +112,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @return the direct members of this {@link GroupItem}
      */
     public Set<Item> getMembers() {
-        return Collections.unmodifiableSet(new HashSet<Item>(members));
+        return Collections.unmodifiableSet(new LinkedHashSet<Item>(members));
     }
 
     /**
@@ -122,7 +123,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @return all members of this and all contained {@link GroupItem}s
      */
     public Set<Item> getAllMembers() {
-        return Collections.unmodifiableSet(getMembers((Item i) -> !(i instanceof GroupItem)));
+        return Collections.unmodifiableSet(new LinkedHashSet<Item>(getMembers((Item i) -> !(i instanceof GroupItem))));
     }
 
     private void collectMembers(Collection<Item> allMembers, Collection<Item> members) {


### PR DESCRIPTION
Inspired by #4743 this is a first attempt to remove the left overs.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>