### PR TITLE
Cancelled Firmware Update Does not Wait for the Update to Finish

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServiceTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServiceTest.java
@@ -67,6 +67,7 @@ import org.osgi.framework.Bundle;
  *
  * @author Thomas Höfer - Initial contribution
  * @author Simon Kaufmann - converted to standalone Java tests
+ * @author Dimitar Ivanov - added a test for valid cancel execution during firmware update
  */
 public class FirmwareUpdateServiceTest extends JavaOSGiTest {
 
@@ -317,6 +318,38 @@ public class FirmwareUpdateServiceTest extends JavaOSGiTest {
             verify(handler2, times(0)).cancel();
             verify(handler3, times(1)).cancel();
         });
+    }
+    
+    @Test
+    public void testCancelFirmwareUpdateIntheMiddleOfUpdate() {
+        final long stepsTime = 10;
+        final int numberOfSteps = SEQUENCE.length;
+        final AtomicBoolean isUpdateFinished = new AtomicBoolean(false);
+
+        doAnswer(invocation -> {
+            ProgressCallback progressCallback = (ProgressCallback) invocation.getArguments()[1];
+            progressCallback.defineSequence(SEQUENCE);
+
+            // Simulate update steps with delay
+            for (int updateStepsCount = 0; updateStepsCount < numberOfSteps; updateStepsCount++) {
+                progressCallback.next();
+                Thread.sleep(stepsTime);
+            }
+            progressCallback.success();
+            isUpdateFinished.set(true);
+            return null;
+        }).when(handler1).updateFirmware(any(Firmware.class), any(ProgressCallback.class));
+
+        // Execute update and cancel it immediately
+        firmwareUpdateService.updateFirmware(THING1_UID, FW112_EN.getUID(), null);
+        firmwareUpdateService.cancelFirmwareUpdate(THING1_UID);
+
+        // Be sure that the cancel is executed before the completion of the update
+        waitForAssert(() -> {
+            verify(handler1, times(1)).cancel();
+        }, stepsTime * numberOfSteps, stepsTime);
+
+        assertThat(isUpdateFinished.get(), is(false));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
@@ -12,7 +12,10 @@
  */
 package org.eclipse.smarthome.core.thing.firmware;
 
-import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.*;
+import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.createUnknownInfo;
+import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.createUpToDateInfo;
+import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.createUpdateAvailableInfo;
+import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.createUpdateExecutableInfo;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -64,6 +67,7 @@ import com.google.common.collect.ImmutableSet;
  * central instance to start a firmware update.
  *
  * @author Thomas Höfer - Initial contribution
+ * @authot Dimitar Ivanov - update and cancel operations are run with different safe caller identifiers in order to execute asynchronously
  */
 @Component(immediate = true, service = { EventSubscriber.class, FirmwareUpdateService.class })
 public final class FirmwareUpdateService implements EventSubscriber {
@@ -267,7 +271,7 @@ public final class FirmwareUpdateService implements EventSubscriber {
             logger.error("Unexpected exception occurred while cancelling firmware update of thing with UID {}.",
                     thingUID, e.getCause());
             progressCallback.failedInternal("unexpected-handler-error-during-cancel");
-        }).build().cancel();
+        }).withIdentifier(new Object()).build().cancel();
     }
 
     @Override


### PR DESCRIPTION
The firmware update service operations 'update' and 'cancel' should not be executed with the same identifier for the context of the async safe caller. When the identifier is not specified, the default identifier is the target object (in this case the handler) which causes the 'cancel' operation to be executed when the 'update' operation is finished. 
Implemented unit tests to reproduce the problem, which are passing with the provided fix.

Signed-off-by: Dimitar Ivanov <dstivanov@gmail.com>