### PR TITLE
Add missing @Nullable annotations to archetype classes

### DIFF
--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/handler/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/handler/__bindingIdCamelCase__Handler.java
@@ -22,6 +22,7 @@ package ${package}.handler;
 import static ${package}.${bindingIdCamelCase}BindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -46,7 +47,7 @@ public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
     }
 
     @Override
-    public void handleCommand(ChannelUID channelUID, Command command) {
+    public void handleCommand(ChannelUID channelUID, @Nullable Command command) {
         if (channelUID.getId().equals(CHANNEL_1)) {
             // TODO: handle command
 

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -52,7 +52,7 @@ public class ${bindingIdCamelCase}HandlerFactory extends BaseThingHandlerFactory
     }
 
     @Override
-    protected @Nullable ThingHandler createHandler(Thing thing) {
+    protected @Nullable ThingHandler createHandler(@Nullable Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (thingTypeUID.equals(THING_TYPE_SAMPLE)) {


### PR DESCRIPTION
Fixes initial compile errors in newly created binding skeleton.

Signed-off-by: Henning Treu <henning.treu@telekom.de>