### PR TITLE
[Sonos] Improve handling of stop channel

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/ESH-INF/thing/channels.xml
@@ -253,7 +253,7 @@
 	<channel-type id="stop" advanced="true">
 		<item-type>Switch</item-type>
 		<label>Stop</label>
-		<description>Stop the Zone Player</description>
+		<description>Stop the Zone Player. ON if the player is stopped.</description>
 	</channel-type>
 
 	<channel-type id="tuneinstationid" advanced="true">

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
@@ -36,53 +36,53 @@ Thing sonos:PLAY1:1 [ udn="RINCON_000E58D8403A0XXXX", refresh=60]
 
 The devices support the following channels:
 
-| Channel Type ID     | Item Type | Access Mode | Description  | Thing types |
-|---------------------|-----------|-------------|--------------|-------------|
-| add                 | String    | W      | Add the given Zone Player to the group of this Zone Player | all |
-| alarm               | Switch    | W      | Set the first occurring alarm either ON or OFF. Alarms first have to be defined through the Sonos Controller app | all |
-| alarmproperties     | String    | R      | Properties of the alarm currently running | all |
-| alarmrunning        | Switch    | R      | Set to ON if the alarm was triggered | all |
-| clearqueue          | Switch    | W      | Suppress all songs from the current queue | all |
-| control             | Player    | RW     | Control the Zone Player, e.g. start/stop/next/previous/ffward/rewind | all |
-| coordinator         | String    | R      | UDN of the coordinator for the current group | all |
-| currentalbum        | String    | R      | Name of the album currently playing | all |
-| currentalbumart     | Image     | R      | Cover art of the album currently playing | all |
-| currentalbumarturl  | String    | R      | Cover art URL of the album currently playing | all |
-| currentartist       | String    | R      | Name of the artist currently playing | all |
-| currenttitle        | String    | R      | Title of the song currently playing | all |
-| currenttrack        | String    | R      | Name of the current track or radio station currently playing | all |
-| currenttrackuri     | String    | R      | URI of the current track | all |
-| currenttransporturi | String    | R      | URI of the current AV transport | all |
-| favorite            | String    | W      | Play the given favorite entry. The favorite entry has to be predefined in the Sonos Controller app | all |
-| led                 | Switch    | RW     | Set or get the status of the white led on the front of the Zone Player | all |
-| linein              | Switch    | R      | Indicator set to ON when the line-in of the Zone Player is connected | PLAY5, CONNECT, CONNECTAMP, PLAYBASE |
-| localcoordinator    | Switch    | R      | Indicator set to ON if the this Zone Player is the Zone Group Coordinator | all |
-| mute                | Switch    | RW     | Set or get the mute state of the master volume of the Zone Player | all |
-| notificationsound   | String    | W      | Play a notification sound by a given URI | all |
-| notificationvolume  | Dimmer    | RW     | Set the volume applied to a notification sound | all |
-| playlinein          | String    | W      | This channel supports playing the audio source connected to the line-in of the zoneplayer identified by the Thing UID or UPnP UDN provided by the String. | PLAY5, CONNECT, CONNECTAMP, PLAYBASE |
-| playlist            | String    | W      | Play the given playlist. The playlist has to predefined in the Sonos Controller app | all |
-| playqueue           | Switch    | W      | Play the songs from the current queue | all |
-| playtrack           | Number    | W      | Play the given track number from the current queue | all |
-| playuri             | String    | W      | Play the given URI | all |
-| publicaddress       | Switch    | W      | Put all Zone Players in one group, and stream audio from the line-in from the Zone Player that triggered the command | all |
-| radio               | String    | W      | Play the given radio station. The radio station has to be predefined in the Sonos Controller app | all |
-| remove              | String    | W      | Remove the given Zone Player from the group of this Zone Player | all |
-| repeat              | String    | RW     | Repeat the track or queue playback. The accepted values are OFF, ONE and ALL | all |
-| restore             | Switch    | W      | Restore the state of the Zone Player | all |
-| restoreall          | Switch    | W      | Restore the state of all the Zone Players | all |
-| save                | Switch    | W      | Save the state of the Zone Player | all |
-| saveall             | Switch    | W      | Save the state of all the Zone Players | all |
-| shuffle             | Switch    | RW     | Shuffle the queue playback | all |
-| sleeptimer          | Number    | RW     | Set/show the duration of the SleepTimer in seconds | all |
-| snooze              | Number    | W      | Snooze the running alarm, if any, with the given number of minutes | all |
-| standalone          | Switch    | W      | Make the Zone Player leave its Group and become a standalone Zone Player | all |
-| state               | String    | R      | The State channel contains state of the Zone Player, e.g. PLAYING, STOPPED,... | all |
-| stop                | Switch    | W      | Stop the Zone Player | all |
-| tuneinstationid     | String    | RW     | Provide the current TuneIn station id or play the TuneIn radio given by its station id | all |
-| volume              | Dimmer    | RW     | Set or get the master volume of the Zone Player | all |
-| zonegroupid         | String    | R      | Id of the Zone Group the Zone Player belongs to | all |
-| zonename            | String    | R      | Name of the Zone associated to the Zone Player | all |
+| Channel Type ID     | Item Type | Access Mode | Description                                                                                                                                               | Thing types                          |
+|---------------------|-----------|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| add                 | String    | W           | Add the given Zone Player to the group of this Zone Player                                                                                                | all                                  |
+| alarm               | Switch    | W           | Set the first occurring alarm either ON or OFF. Alarms first have to be defined through the Sonos Controller app                                          | all                                  |
+| alarmproperties     | String    | R           | Properties of the alarm currently running                                                                                                                 | all                                  |
+| alarmrunning        | Switch    | R           | Set to ON if the alarm was triggered                                                                                                                      | all                                  |
+| clearqueue          | Switch    | W           | Suppress all songs from the current queue                                                                                                                 | all                                  |
+| control             | Player    | RW          | Control the Zone Player, e.g. start/stop/next/previous/ffward/rewind                                                                                      | all                                  |
+| coordinator         | String    | R           | UDN of the coordinator for the current group                                                                                                              | all                                  |
+| currentalbum        | String    | R           | Name of the album currently playing                                                                                                                       | all                                  |
+| currentalbumart     | Image     | R           | Cover art of the album currently playing                                                                                                                  | all                                  |
+| currentalbumarturl  | String    | R           | Cover art URL of the album currently playing                                                                                                              | all                                  |
+| currentartist       | String    | R           | Name of the artist currently playing                                                                                                                      | all                                  |
+| currenttitle        | String    | R           | Title of the song currently playing                                                                                                                       | all                                  |
+| currenttrack        | String    | R           | Name of the current track or radio station currently playing                                                                                              | all                                  |
+| currenttrackuri     | String    | R           | URI of the current track                                                                                                                                  | all                                  |
+| currenttransporturi | String    | R           | URI of the current AV transport                                                                                                                           | all                                  |
+| favorite            | String    | W           | Play the given favorite entry. The favorite entry has to be predefined in the Sonos Controller app                                                        | all                                  |
+| led                 | Switch    | RW          | Set or get the status of the white led on the front of the Zone Player                                                                                    | all                                  |
+| linein              | Switch    | R           | Indicator set to ON when the line-in of the Zone Player is connected                                                                                      | PLAY5, CONNECT, CONNECTAMP, PLAYBASE |
+| localcoordinator    | Switch    | R           | Indicator set to ON if the this Zone Player is the Zone Group Coordinator                                                                                 | all                                  |
+| mute                | Switch    | RW          | Set or get the mute state of the master volume of the Zone Player                                                                                         | all                                  |
+| notificationsound   | String    | W           | Play a notification sound by a given URI                                                                                                                  | all                                  |
+| notificationvolume  | Dimmer    | RW          | Set the volume applied to a notification sound                                                                                                            | all                                  |
+| playlinein          | String    | W           | This channel supports playing the audio source connected to the line-in of the zoneplayer identified by the Thing UID or UPnP UDN provided by the String. | PLAY5, CONNECT, CONNECTAMP, PLAYBASE |
+| playlist            | String    | W           | Play the given playlist. The playlist has to predefined in the Sonos Controller app                                                                       | all                                  |
+| playqueue           | Switch    | W           | Play the songs from the current queue                                                                                                                     | all                                  |
+| playtrack           | Number    | W           | Play the given track number from the current queue                                                                                                        | all                                  |
+| playuri             | String    | W           | Play the given URI                                                                                                                                        | all                                  |
+| publicaddress       | Switch    | W           | Put all Zone Players in one group, and stream audio from the line-in from the Zone Player that triggered the command                                      | all                                  |
+| radio               | String    | W           | Play the given radio station. The radio station has to be predefined in the Sonos Controller app                                                          | all                                  |
+| remove              | String    | W           | Remove the given Zone Player from the group of this Zone Player                                                                                           | all                                  |
+| repeat              | String    | RW          | Repeat the track or queue playback. The accepted values are OFF, ONE and ALL                                                                              | all                                  |
+| restore             | Switch    | W           | Restore the state of the Zone Player                                                                                                                      | all                                  |
+| restoreall          | Switch    | W           | Restore the state of all the Zone Players                                                                                                                 | all                                  |
+| save                | Switch    | W           | Save the state of the Zone Player                                                                                                                         | all                                  |
+| saveall             | Switch    | W           | Save the state of all the Zone Players                                                                                                                    | all                                  |
+| shuffle             | Switch    | RW          | Shuffle the queue playback                                                                                                                                | all                                  |
+| sleeptimer          | Number    | RW          | Set/show the duration of the SleepTimer in seconds                                                                                                        | all                                  |
+| snooze              | Number    | W           | Snooze the running alarm, if any, with the given number of minutes                                                                                        | all                                  |
+| standalone          | Switch    | W           | Make the Zone Player leave its Group and become a standalone Zone Player                                                                                  | all                                  |
+| state               | String    | R           | The State channel contains state of the Zone Player, e.g. PLAYING, STOPPED, ...                                                                           | all                                  |
+| stop                | Switch    | W           | Write `ON` to this channel: Stops the Zone Player player.                                                                                                 | all                                  |
+| tuneinstationid     | String    | RW          | Provide the current TuneIn station id or play the TuneIn radio given by its station id                                                                    | all                                  |
+| volume              | Dimmer    | RW          | Set or get the master volume of the Zone Player                                                                                                           | all                                  |
+| zonegroupid         | String    | R           | Id of the Zone Group the Zone Player belongs to                                                                                                           | all                                  |
+| zonename            | String    | R           | Name of the Zone associated to the Zone Player                                                                                                            | all                                  |
 
 ## Audio Support
 


### PR DESCRIPTION
After this change, the stop channel represents the correct state: it is `ON` if the player is stopped, `OFF` otherwise.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>