### PR TITLE
(Sonos) Added note to ReadMe about the handling of the 'notificationsoundvolume'

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
@@ -88,7 +88,7 @@ The devices support the following channels:
 
 All supported Sonos devices are registered as an audio sink in the framework.
 Audio streams are treated as notifications, i.e. they are fed into the `notificationsound` channel and changing the volume of the audio sink will change the `notificationvolume`, not the `volume`.
-Note that the 'notificationsoundvolume' is set by the binding during each start of the system to equal the master volume (resulting in a barely audible level), making the use of a persistance policy obsolete. In order to control the 'notificationsoundvolume' users have to set it manually or by a rule.
+Note that the `notificationvolume` is set by the binding during each start of the system to equal the master volume (resulting in a barely audible level), making the use of a persistence policy obsolete. In order to control the `notificationvolume` users have to set it manually or by a rule.
 Note that the Sonos binding has a limit of 20 seconds for notification sounds. Any sound that is longer than that will be cut off.
 
 URL audio streams (e.g. an Internet radio stream) are an exception and do not get sent to the `notificationsound` channel. Instead, these will be sent to the `playuri` channel.

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/README.md
@@ -88,6 +88,7 @@ The devices support the following channels:
 
 All supported Sonos devices are registered as an audio sink in the framework.
 Audio streams are treated as notifications, i.e. they are fed into the `notificationsound` channel and changing the volume of the audio sink will change the `notificationvolume`, not the `volume`.
+Note that the 'notificationsoundvolume' is set by the binding during each start of the system to equal the master volume (resulting in a barely audible level), making the use of a persistance policy obsolete. In order to control the 'notificationsoundvolume' users have to set it manually or by a rule.
 Note that the Sonos binding has a limit of 20 seconds for notification sounds. Any sound that is longer than that will be cut off.
 
 URL audio streams (e.g. an Internet radio stream) are an exception and do not get sent to the `notificationsound` channel. Instead, these will be sent to the `playuri` channel.


### PR DESCRIPTION
As discussed in this OH community thread (https://community.openhab.org/t/sonos-notificationvolume-after-restart/19055), the 'notificationsoundvolume' has to be set by the user. 
The binding does set this volume to equal the master volume, however the observed sound volume of an notification with the same setting as the master volume is barely audible ( I use a master volume of about 5 and a 'notificationsoundvolume' of 20!).
The automatic setting of that value to the master volume after each restart of the system makes the use of a persistence service obsolete.
IMHO users should be noted to take care of that setting themself.

Signed-off-by: Jürgen Baginski <opus42@gmx.de> (github:JueBag)