### PR TITLE
Delayed model processing

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/osgi/XmlDocumentBundleTracker.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/osgi/XmlDocumentBundleTracker.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
  */
 public class XmlDocumentBundleTracker<T> extends BundleTracker<Bundle> {
 
-    public static final String THREAD_POOL_NAME = "xml-processing";
+    public static final String THREAD_POOL_NAME = "file-processing";
 
     private final Logger logger = LoggerFactory.getLogger(XmlDocumentBundleTracker.class);
     private final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(THREAD_POOL_NAME);
@@ -73,7 +73,7 @@ public class XmlDocumentBundleTracker<T> extends BundleTracker<Bundle> {
 
     @SuppressWarnings("rawtypes")
     private BundleTracker relevantBundlesTracker;
-    private ReadyService readyService;
+    private final ReadyService readyService;
 
     /**
      * Creates a new instance of this class with the specified parameters.

--- a/bundles/model/org.eclipse.smarthome.model.core.test/src/test/java/org/eclipse/smarthome/model/core/internal/folder/FolderObserverTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/src/test/java/org/eclipse/smarthome/model/core/internal/folder/FolderObserverTest.java
@@ -170,7 +170,8 @@ public class FolderObserverTest extends JavaOSGiTest {
         }
 
         waitForAssert(() -> assertThat(file.exists(), is(true)));
-        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)));
+        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)), DFL_TIMEOUT * 2,
+                DFL_SLEEP_TIME);
         waitForAssert(() -> assertThat(modelRepo.isRemoveModelMethodCalled, is(false)));
         waitForAssert(() -> assertThat(modelRepo.calledFileName, is(file.getName())));
     }
@@ -210,14 +211,16 @@ public class FolderObserverTest extends JavaOSGiTest {
         }
 
         waitForAssert(() -> assertThat(file.exists(), is(true)));
-        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)));
+        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)), DFL_TIMEOUT * 2,
+                DFL_SLEEP_TIME);
 
         modelRepo.clean();
 
         String text = "Additional content";
         FileUtils.writeStringToFile(file, text, true);
 
-        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)));
+        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)), DFL_TIMEOUT * 2,
+                DFL_SLEEP_TIME);
         waitForAssert(() -> assertThat(modelRepo.calledFileName, is(file.getName())));
 
         String finalFileContent;
@@ -352,12 +355,14 @@ public class FolderObserverTest extends JavaOSGiTest {
             FileUtils.writeStringToFile(mockFileWithValidExt, INITIAL_FILE_CONTENT);
         }
 
-        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)));
+        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)), DFL_TIMEOUT * 2,
+                DFL_SLEEP_TIME);
 
         modelRepo.clean();
         FileUtils.writeStringToFile(mockFileWithValidExt, "Additional content", true);
 
-        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)));
+        waitForAssert(() -> assertThat(modelRepo.isAddOrRefreshModelMethodCalled, is(true)), DFL_TIMEOUT * 2,
+                DFL_SLEEP_TIME);
     }
 
     /**

--- a/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
@@ -25,6 +25,7 @@ Import-Package:
  org.eclipse.emf.ecore.util,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.core.common,
  org.eclipse.smarthome.core.service,
  org.eclipse.smarthome.model.core,
  org.eclipse.xtext.common.types.impl,


### PR DESCRIPTION
...in order to skip duplicate file system events or intermediate
states where the file technically is empty for a very short
moment.

fixes #4824
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>