### PR TITLE
point to groovy-eclipse release repository directly

### DIFF
--- a/targetplatform/smarthome.target
+++ b/targetplatform/smarthome.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="SmartHome" sequenceNumber="122">
+<?pde version="3.8"?><target name="SmartHome" sequenceNumber="124">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.inject" version="3.0.0.v201312141243"/>
@@ -102,7 +102,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.codehaus.groovy23.feature.feature.group" version="2.9.1.xx-201411061335-e44-RELEASE"/>
-<repository location="http://dist.springsource.org/release/GRECLIPSE/e4.4/"/>
+<repository location="http://dist.springsource.org/release/GRECLIPSE/2.9.1/e4.4"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.equinox.sdk.feature.group" version="3.13.0.v20170531-1133"/>


### PR DESCRIPTION
...instead of using the composite repository URL which they
apparently do not intend to keep stable.

Content stays the same, hence no versions change anywhere,
therefore no surprises expected ;-)

see https://github.com/groovy/groovy-eclipse/issues/406

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>