### PR TITLE
Update WallSwitch and add RemoteControl

### DIFF
--- a/docs/_data/categories_thing.csv
+++ b/docs/_data/categories_thing.csv
@@ -18,12 +18,13 @@ PowerOutlet,"Small devices to be plugged into a power socket in a wall which sti
 Projector,"Devices that project a picture somewhere",projector.png
 RadiatorControl,"Controls on radiators used to heat up rooms",
 Receiver,"Audio/Video receivers, i.e. radio receivers, satelite or cable receivers, recorders, etc.",receiver.png
+RemoteControl,"Any portable or hand-held device that controls the status of something, e.g. remote control, keyfob etc."
 Screen,"Devices that are able to show a picture",screen.png
 Sensor,"Device used to measure something",
 Siren,"Siren used by Alarm systems",siren.png
 SmokeDetector,"Smoke detectors",
 Speaker,"Devices that are able to play sounds",
-WallSwitch,"Any device attached to the wall that controls a binary status of something, for ex. a light switch",wallswitch.png
+WallSwitch,"Any device attached to the wall that controls the status of something, for ex. a light switch, dimmer",wallswitch.png
 WebService,"Account with credentials for a website",
 Window,"Window",window.png
 WhiteGood,"Devices that look like Waschingmachines, Dishwashers, Dryers, Fridges, Ovens, etc.",whitegood.png


### PR DESCRIPTION
This clarifies that wall switches are not just for binary devices but could (for example) also be for dimmers.
It also adds a RemoteControl for portable / hand-held controllers.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>