### PR TITLE
Fix Channel default constructor to not create an invalid UID

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/ChannelTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/ChannelTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing;
+
+import org.junit.Test;
+
+/**
+ * Test cases for the {@link Channel} class.
+ *
+ * @author Henning Treu - initial contribution
+ *
+ */
+public class ChannelTest {
+
+    @Test
+    public void testDefaultConstructor() {
+        new Channel();
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
@@ -45,7 +45,8 @@ public class Channel {
 
     private final ChannelKind kind;
 
-    private final ChannelUID uid;
+    @NonNullByDefault({}) // uid might not have been initialized by the default constructor.
+    private ChannelUID uid;
 
     private @Nullable ChannelTypeUID channelTypeUID;
 
@@ -63,7 +64,6 @@ public class Channel {
      * Package protected default constructor to allow reflective instantiation.
      */
     Channel() {
-        this.uid = new ChannelUID("DummyUID");
         this.kind = ChannelKind.STATE;
         this.configuration = new Configuration();
         this.properties = Collections.unmodifiableMap(new HashMap<String, String>(0));


### PR DESCRIPTION
This commit (3e8e91ef39dc31fff63e75d) introduced a bug when the default constructor for Channel is reflectively invoked by a storage engine. The ChannelUID must not be created with less then 4 segments.
Imho we should not create a dummy uid in this case but live with the fact that uid might not have been initialized (so not final and not covered by null annotations).

Signed-off-by: Henning Treu <henning.treu@telekom.de>
  