### PR TITLE
Create state description merging service

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GenericItemTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/groovy/org/eclipse/smarthome/core/items/GenericItemTest.groovy
@@ -132,7 +132,7 @@ class GenericItemTest {
         def item = new TestItem("test");
         item.setEventPublisher(mock(EventPublisher.class));
         item.setItemStateConverter(mock(ItemStateConverter.class));
-        item.setStateDescriptionProviders(Collections.emptyList());
+        item.setStateDescriptionService(null);
         item.setUnitProvider(mock(UnitProvider.class));
 
         item.addStateChangeListener(mock(StateChangeListener.class));

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/service/StateDescriptionServiceImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/service/StateDescriptionServiceImplTest.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.smarthome.core.internal.service.StateDescriptionServiceImpl;
+import org.eclipse.smarthome.core.library.items.NumberItem;
+import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateDescriptionProvider;
+import org.eclipse.smarthome.core.types.StateOption;
+import org.junit.Test;
+
+/**
+ * Tests for the StateDescriptionService implementation
+ * 
+ * @author Lyubomir Papazov
+ *
+ */
+public class StateDescriptionServiceImplTest {
+
+	private static final String ITEM_NAME = "Item1";
+	private static final int STATE_DESCRIPTION_PROVIDER_DEFAULT_SERVICE_RANKING = 0;
+	private static final BigDecimal STATE_DESCRIPTION_PROVIDER_DEFAULT_MIN_VALUE = new BigDecimal("0");
+	private static final BigDecimal STATE_DESCRIPTION_PROVIDER_DEFAULT_MAX_VALUE = new BigDecimal("0");
+	private static final BigDecimal STATE_DESCRIPTION_PROVIDER_DEFAULT_STEP = new BigDecimal("0");
+	private static final String STATE_DESCRIPTION_PROVIDER_DEFAULT_PATTERN = "pattern1";
+	private static final boolean STATE_DESCRIPTION_PROVIDER_DEFAULT_IS_READONLY = false;
+	private static final List<StateOption> STATE_DESCRIPTION_PROVIDER_DEFAULT_OPTIONS = Collections.emptyList();
+
+	private StateDescriptionServiceImpl mergingService = new StateDescriptionServiceImpl();
+	private NumberItem item;
+
+	@Test
+	public void testServiceWithOneStateDescriptionProvider() {
+		StateDescriptionProvider stateDescriptionProviderDefault = mock(StateDescriptionProvider.class);
+		when(stateDescriptionProviderDefault.getRank()).thenReturn(STATE_DESCRIPTION_PROVIDER_DEFAULT_SERVICE_RANKING);
+		StateDescription stateDescription1 = new StateDescription(STATE_DESCRIPTION_PROVIDER_DEFAULT_MIN_VALUE,
+				STATE_DESCRIPTION_PROVIDER_DEFAULT_MAX_VALUE, STATE_DESCRIPTION_PROVIDER_DEFAULT_STEP,
+				STATE_DESCRIPTION_PROVIDER_DEFAULT_PATTERN, STATE_DESCRIPTION_PROVIDER_DEFAULT_IS_READONLY,
+				STATE_DESCRIPTION_PROVIDER_DEFAULT_OPTIONS);
+		when(stateDescriptionProviderDefault.getStateDescription(ITEM_NAME, null)).thenReturn(stateDescription1);
+
+		mergingService.addStateDescriptionProvider(stateDescriptionProviderDefault);
+
+		item = new NumberItem(ITEM_NAME);
+		item.setStateDescriptionService(mergingService);
+		StateDescription finalStateDescription = item.getStateDescription();
+
+		assertThat(finalStateDescription.getMinimum(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_MIN_VALUE));
+		assertThat(finalStateDescription.getMaximum(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_MAX_VALUE));
+		assertThat(finalStateDescription.getStep(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_STEP));
+		assertThat(finalStateDescription.getPattern(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_PATTERN));
+		assertThat(finalStateDescription.isReadOnly(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_IS_READONLY));
+		assertThat(finalStateDescription.getOptions(), is(STATE_DESCRIPTION_PROVIDER_DEFAULT_OPTIONS));
+	}
+
+	@Test
+	public void testMinValueMaxValueStepAndPatternTwoDescriptionProviders() {
+
+		StateDescription stateDescription1 = new StateDescription(new BigDecimal("-1"), new BigDecimal("-1"),
+				new BigDecimal("-1"), "pattern1", false, null);
+		StateDescription stateDescription2 = new StateDescription(new BigDecimal("-2"), new BigDecimal("-2"),
+				new BigDecimal("-2"), "pattern2", false, null);
+
+		int stateDescriptionProvider1ServiceRanking = -1;
+		int stateDescriptionProvider2ServiceRanking = -2;
+
+		StateDescription finalStateDescription = mergeStateDescriptions(stateDescription1, stateDescription2,
+				stateDescriptionProvider1ServiceRanking, stateDescriptionProvider2ServiceRanking);
+
+		assertThat(finalStateDescription.getMinimum(), is(stateDescription1.getMinimum()));
+		assertThat(finalStateDescription.getMaximum(), is(stateDescription1.getMaximum()));
+		assertThat(finalStateDescription.getStep(), is(stateDescription1.getStep()));
+		assertThat(finalStateDescription.getPattern(), is(stateDescription1.getPattern()));
+	}
+
+	@Test
+	public void testCorrectIsReadOnlyWhenTwoDescriptionProvidersHigherRankingIsNotReadOnly() {
+		StateDescription stateDescription1 = new StateDescription(null, null, null, null, false, null);
+		StateDescription stateDescription2 = new StateDescription(null, null, null, null, true, null);
+
+		int stateDescriptionProvider1ServiceRanking = -1;
+		int stateDescriptionProvider2ServiceRanking = -2;
+
+		StateDescription finalStateDescription = mergeStateDescriptions(stateDescription1, stateDescription2,
+				stateDescriptionProvider1ServiceRanking, stateDescriptionProvider2ServiceRanking);
+
+		assertThat(finalStateDescription.isReadOnly(), is(stateDescription1.isReadOnly()));
+	}
+
+	@Test
+	public void testCorrectIsReadOnlyWhenTwoDescriptionProvidersHigherRankingIsReadOnly() {
+		StateDescription stateDescription1 = new StateDescription(null, null, null, null,
+				true, null);
+		StateDescription stateDescription2 = new StateDescription(null, null, null, null,
+				false, null);
+		
+		int stateDescriptionProvider1ServiceRanking = -1;
+		int stateDescriptionProvider2ServiceRanking = -2;
+
+		StateDescription finalStateDescription = mergeStateDescriptions(stateDescription1, stateDescription2,
+				stateDescriptionProvider1ServiceRanking, stateDescriptionProvider2ServiceRanking);
+
+		assertThat(finalStateDescription.isReadOnly(), is(stateDescription1.isReadOnly()));
+	}
+
+	@Test
+	public void testCorrectOptionsWhenTwoDescriptionProvidersHigherRankingProvidesOptions() {
+		StateDescription stateDescription1 = new StateDescription(null, null, null, null, false,
+				Arrays.asList(new StateOption("value", "label")));
+		StateDescription stateDescription2 = new StateDescription(null, null, null, null, false,
+				Collections.emptyList());
+		
+		int stateDescriptionProvider1ServiceRanking = -1;
+		int stateDescriptionProvider2ServiceRanking = -2;
+
+		StateDescription finalStateDescription = mergeStateDescriptions(stateDescription1, stateDescription2,
+				stateDescriptionProvider1ServiceRanking, stateDescriptionProvider2ServiceRanking);
+
+		assertThat(finalStateDescription.getOptions(), is(stateDescription1.getOptions()));
+	}
+
+	@Test
+	public void testCorrectOptionsWhenTwoDescriptionProvidersHigherRankingDoesntProvideOptions() {
+		StateDescription stateDescription1 = new StateDescription(null, null, null, null, false,
+				Collections.emptyList());
+		StateDescription stateDescription2 = new StateDescription(null, null, null, null, false,
+				Arrays.asList(new StateOption("value", "label")));
+		
+		int stateDescriptionProvider1ServiceRanking = -1;
+		int stateDescriptionProvider2ServiceRanking = -2;
+
+		StateDescription finalStateDescription = mergeStateDescriptions(stateDescription1, stateDescription2,
+				stateDescriptionProvider1ServiceRanking, stateDescriptionProvider2ServiceRanking);
+
+		assertThat(finalStateDescription.getOptions(), is(stateDescription2.getOptions()));
+	}
+
+	private StateDescription mergeStateDescriptions(StateDescription stateDescription1,
+			StateDescription stateDescription2, int stateDescriptionProvider1ServiceRanking,
+			int stateDescriptionProvider2ServiceRanking) {
+		StateDescriptionProvider stateDescriptionProvider1 = mock(StateDescriptionProvider.class);
+		StateDescriptionProvider stateDescriptionProvider2 = mock(StateDescriptionProvider.class);
+
+		when(stateDescriptionProvider1.getRank()).thenReturn(stateDescriptionProvider1ServiceRanking);
+		when(stateDescriptionProvider2.getRank()).thenReturn(stateDescriptionProvider2ServiceRanking);
+
+		when(stateDescriptionProvider1.getStateDescription(ITEM_NAME, null)).thenReturn(stateDescription1);
+		when(stateDescriptionProvider2.getStateDescription(ITEM_NAME, null)).thenReturn(stateDescription2);
+
+		mergingService.addStateDescriptionProvider(stateDescriptionProvider1);
+		mergingService.addStateDescriptionProvider(stateDescriptionProvider2);
+		item = new NumberItem(ITEM_NAME);
+		item.setStateDescriptionService(mergingService);
+
+		StateDescription finalStateDescription = item.getStateDescription();
+		return finalStateDescription;
+	}
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/service/StateDescriptionServiceImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/service/StateDescriptionServiceImpl.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.service;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.service.StateDescriptionService;
+import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateDescriptionProvider;
+import org.eclipse.smarthome.core.types.StateOption;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+/**
+ * This service contains different StateDescriptionProviders and provides a
+ * getStateDescription method that returns a single StateDescription using all
+ * of the providers.
+ * 
+ * @author Lyubomir Papazov - Initial contribution
+ *
+ */
+@Component
+public class StateDescriptionServiceImpl implements StateDescriptionService {
+
+    private final Set<StateDescriptionProvider> stateDescriptionProviders = Collections
+            .synchronizedSet(new TreeSet<StateDescriptionProvider>(new Comparator<StateDescriptionProvider>() {
+                @Override
+                public int compare(StateDescriptionProvider provider1, StateDescriptionProvider provider2) {
+                    return provider2.getRank().compareTo(provider1.getRank());
+                }
+            }));
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    public void addStateDescriptionProvider(StateDescriptionProvider provider) {
+        stateDescriptionProviders.add(provider);
+    }
+
+    public void removeStateDescriptionProvider(StateDescriptionProvider provider) {
+        stateDescriptionProviders.remove(provider);
+    }
+
+    @Override
+    public @Nullable StateDescription getStateDescription(String itemName, Locale locale) {
+        StateDescription result = null;
+        List<StateOption> stateOptions = Collections.emptyList();
+        if (stateDescriptionProviders != null) {
+            for (StateDescriptionProvider stateDescriptionProvider : stateDescriptionProviders) {
+                StateDescription stateDescription = stateDescriptionProvider.getStateDescription(itemName, locale);
+
+                // as long as no valid StateDescription is provided we reassign here:
+                if (result == null) {
+                    result = stateDescription;
+                }
+
+                // if the current StateDescription does provide options and we don't already
+                // have some, we pick them up
+                // here
+                if (stateDescription != null && !stateDescription.getOptions().isEmpty() && stateOptions.isEmpty()) {
+                    stateOptions = stateDescription.getOptions();
+                }
+            }
+        }
+
+        // we recreate the StateDescription if we found a valid one and state options
+        // are given:
+        if (result != null && !stateOptions.isEmpty()) {
+            result = new StateDescription(result.getMinimum(), result.getMaximum(), result.getStep(),
+                    result.getPattern(), result.isReadOnly(), stateOptions);
+        }
+
+        return result;
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -31,12 +31,11 @@ import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.i18n.UnitProvider;
 import org.eclipse.smarthome.core.items.events.ItemEventFactory;
+import org.eclipse.smarthome.core.service.StateDescriptionService;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
-import org.eclipse.smarthome.core.types.StateDescriptionProvider;
-import org.eclipse.smarthome.core.types.StateOption;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +76,7 @@ public abstract class GenericItem implements ActiveItem {
 
     protected @Nullable String category;
 
-    private @Nullable List<StateDescriptionProvider> stateDescriptionProviders;
+    private @Nullable StateDescriptionService stateDescriptionService;
 
     protected @Nullable UnitProvider unitProvider;
 
@@ -170,7 +169,7 @@ public abstract class GenericItem implements ActiveItem {
     public void dispose() {
         this.listeners.clear();
         this.eventPublisher = null;
-        this.stateDescriptionProviders = null;
+        this.stateDescriptionService = null;
         this.unitProvider = null;
         this.itemStateConverter = null;
     }
@@ -179,8 +178,8 @@ public abstract class GenericItem implements ActiveItem {
         this.eventPublisher = eventPublisher;
     }
 
-    public void setStateDescriptionProviders(@Nullable List<StateDescriptionProvider> stateDescriptionProviders) {
-        this.stateDescriptionProviders = stateDescriptionProviders;
+    public void setStateDescriptionService(@Nullable StateDescriptionService stateDescriptionService) {
+        this.stateDescriptionService = stateDescriptionService;
     }
 
     public void setUnitProvider(@Nullable UnitProvider unitProvider) {
@@ -396,32 +395,10 @@ public abstract class GenericItem implements ActiveItem {
 
     @Override
     public @Nullable StateDescription getStateDescription(@Nullable Locale locale) {
-        StateDescription result = null;
-        List<StateOption> stateOptions = Collections.emptyList();
-        if (stateDescriptionProviders != null) {
-            for (StateDescriptionProvider stateDescriptionProvider : stateDescriptionProviders) {
-                StateDescription stateDescription = stateDescriptionProvider.getStateDescription(this.name, locale);
-
-                // as long as no valid StateDescription is provided we reassign here:
-                if (result == null) {
-                    result = stateDescription;
-                }
-
-                // if the current StateDescription does provide options and we don't already have some, we pick them up
-                // here
-                if (stateDescription != null && !stateDescription.getOptions().isEmpty() && stateOptions.isEmpty()) {
-                    stateOptions = stateDescription.getOptions();
-                }
-            }
+        if (stateDescriptionService != null) {
+            return stateDescriptionService.getStateDescription(this.name, locale);
         }
-
-        // we recreate the StateDescription if we found a valid one and state options are given:
-        if (result != null && !stateOptions.isEmpty()) {
-            result = new StateDescription(result.getMinimum(), result.getMaximum(), result.getStep(),
-                    result.getPattern(), result.isReadOnly(), stateOptions);
-        }
-
-        return result;
+        return null;
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/StateDescriptionService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/service/StateDescriptionService.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.service;
+
+import java.util.Locale;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.types.StateDescription;
+
+/**
+ * Implementations of this service provide strategies for merging info from
+ * different StateDescriptionProviders into one StateDescription.
+ * 
+ * @author Lyubomir Papazov - Initial contribution
+ *
+ */
+@NonNullByDefault
+public interface StateDescriptionService {
+
+    /**
+     * Implementations of this method merge the StateDescriptions provided from
+     * multiple StateDescriptionProviders into one final StateDescription.
+     * 
+     * @param itemName the item for which to get the StateDescription (must not be null)
+     * @param locale locale (can be null)
+     * @return state description or null if no state description could be found
+     */
+    @Nullable
+    StateDescription getStateDescription(String itemName, @Nullable Locale locale);
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
@@ -25,6 +25,7 @@ Import-Package:
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.items.dto,
  org.eclipse.smarthome.core.items.events,
+ org.eclipse.smarthome.core.service,
  org.eclipse.smarthome.core.library,
  org.eclipse.smarthome.core.storage,
  org.eclipse.smarthome.core.thing,

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/internal/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/internal/item/EnrichedItemDTOMapperWithTransformOSGiTest.java
@@ -12,19 +12,19 @@
  */
 package org.eclipse.smarthome.io.rest.core.internal.item;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.math.BigDecimal;
 import java.util.Collections;
-import java.util.List;
 
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.service.StateDescriptionService;
 import org.eclipse.smarthome.core.types.StateDescription;
-import org.eclipse.smarthome.core.types.StateDescriptionProvider;
 import org.eclipse.smarthome.core.types.StateOption;
 import org.eclipse.smarthome.io.rest.core.item.EnrichedItemDTO;
 import org.eclipse.smarthome.io.rest.core.item.EnrichedItemDTOMapper;
@@ -37,10 +37,8 @@ public class EnrichedItemDTOMapperWithTransformOSGiTest extends JavaOSGiTest {
 
     private static final String ITEM_NAME = "Item1";
 
-    private List<StateDescriptionProvider> stateDescriptionProviders;
-
     @Mock
-    private StateDescriptionProvider stateDescriptionProvider;
+    private StateDescriptionService stateDescriptionService;
 
     @Before
     public void setup() {
@@ -48,16 +46,14 @@ public class EnrichedItemDTOMapperWithTransformOSGiTest extends JavaOSGiTest {
 
         StateDescription stateDescription = new StateDescription(BigDecimal.ZERO, BigDecimal.valueOf(100),
                 BigDecimal.TEN, "%d °C", true, Collections.singletonList(new StateOption("SOUND", "My great sound.")));
-        when(stateDescriptionProvider.getStateDescription(ITEM_NAME, null)).thenReturn(stateDescription);
-
-        stateDescriptionProviders = Collections.singletonList(stateDescriptionProvider);
+        when(stateDescriptionService.getStateDescription(ITEM_NAME, null)).thenReturn(stateDescription);
     }
 
     @Test
     public void shouldConsiderTraformationWhenPresent() {
         NumberItem item1 = new NumberItem("Item1");
         item1.setState(new DecimalType("12.34"));
-        item1.setStateDescriptionProviders(stateDescriptionProviders);
+        item1.setStateDescriptionService(stateDescriptionService);
 
         EnrichedItemDTO enrichedDTO = EnrichedItemDTOMapper.map(item1, false, null, null, null);
         assertThat(enrichedDTO, is(notNullValue()));
@@ -72,5 +68,4 @@ public class EnrichedItemDTOMapperWithTransformOSGiTest extends JavaOSGiTest {
         assertThat(sd.getOptions().get(0).getValue(), is("SOUND"));
         assertThat(sd.getOptions().get(0).getLabel(), is("My great sound."));
     }
-
 }


### PR DESCRIPTION
Created as a fix for #2267.

As suggested in this [discussion](https://github.com/eclipse/smarthome/pull/4428#issuecomment-340480706), created a **StateDescriptionService** that has a **getStateDescription** method, which iterates over all **StateDescriptionProviders** and sets the **StateDescription**'s fields if they haven't been set by a **StateDescriptionProvider** with higher ranking.

The list of **stateDescriptionProviders** is moved from the **ItemRegistryImpl** class to the **StateDescriptionService** and a **StateDescriptionService** reference is added to the **ItemRegistryImpl** which is later passed to the **GenericItem** class. 

Changed **GenericItem**'s **getStateDescription** method implementation to use **StateDescriptionService**'s **getStateDescription** method.

Added tests for the StateDescription service in the **StateDescriptionServiceImplTest** class.


Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>