### PR TITLE
Revert NetUtil Component immediate = true.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -41,9 +41,9 @@ import org.slf4j.LoggerFactory;
  * @author Mark Herwege - Added methods to find broadcast address(es)
  * @author Stefan Triller - Converted to OSGi service with primary ipv4 conf
  */
-@Component(immediate = true, configurationPid = "org.eclipse.smarthome.network", property = {
-        "service.pid=org.eclipse.smarthome.network", "service.config.description.uri=system:network",
-        "service.config.label=Network Settings", "service.config.category=system" })
+@Component(configurationPid = "org.eclipse.smarthome.network", property = { "service.pid=org.eclipse.smarthome.network",
+        "service.config.description.uri=system:network", "service.config.label=Network Settings",
+        "service.config.category=system" })
 public class NetUtil implements NetworkAddressService {
 
     private static final String PRIMARY_ADDRESS = "primaryAddress";


### PR DESCRIPTION
Reverted incorrect change introduced in [PR#4848](https://github.com/eclipse/smarthome/pull/4848#discussion-diff-160047936R44)

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>