### PR TITLE
[WIP / RFC] move generic UID stuff to a seperate class

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/UID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/UID.java
@@ -12,89 +12,49 @@
  */
 package org.eclipse.smarthome.core.thing;
 
-import java.util.Arrays;
-import java.util.stream.Collectors;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.common.GenericUID;
 
 /**
- * {@link UID} is the base class for unique identifiers within the SmartHome
- * framework. A UID must always start with a binding ID.
+ * Base class for binding related unique identifiers within the SmartHome framework.
+ * A UID must always start with a binding ID.
  *
  * @author Dennis Nobel - Initial contribution
  * @author Oliver Libutzki - Added possibility to define UIDs with variable amount of segments
  * @author Jochen Hiller - Bugfix 455434: added default constructor, object is now mutable
+ * @author Markus Rathgeb - Moved base non binding / thing related UID stuff to a base class
  */
-public abstract class UID {
-
-    public static final String SEGMENT_PATTERN = "[A-Za-z0-9_-]*";
-    public static final String SEPARATOR = ":";
-    private final String[] segments;
+@NonNullByDefault
+public abstract class UID extends GenericUID {
 
     /**
+     * For reflection only.
      * Constructor must be public, otherwise it can not be called by subclasses from another package.
      */
     public UID() {
-        this.segments = null;
+        super();
     }
 
     /**
      * Parses a UID for a given string. The UID must be in the format
      * 'bindingId:segment:segment:...'.
      *
-     * @param uid
-     *            uid in form a string (must not be null)
+     * @param uid uid in form a string (must not be null)
      */
     public UID(String uid) {
-        this(splitToSegments(uid));
-    }
-
-    private static String[] splitToSegments(String uid) {
-        if (uid == null) {
-            throw new IllegalArgumentException("Given uid must not be null.");
-        }
-        return uid.split(SEPARATOR);
+        super(uid);
     }
 
     /**
      * Creates a UID for list of segments.
      *
-     * @param segments
-     *            segments (must not be null)
+     * @param segments segments (must not be null)
      */
     public UID(String... segments) {
-        if (segments == null) {
-            throw new IllegalArgumentException("Given segments argument must not be null.");
-        }
-        int numberOfSegments = getMinimalNumberOfSegments();
-        if (segments.length < numberOfSegments) {
-            throw new IllegalArgumentException("UID must have at least " + numberOfSegments + " segments.");
-        }
-        for (int i = 0; i < segments.length; i++) {
-            String segment = segments[i];
-            validateSegment(segment, i, segments.length);
-        }
-        this.segments = segments;
-    }
-
-    /**
-     * Specifies how many segments the UID has to have at least.
-     *
-     * @return
-     */
-    protected abstract int getMinimalNumberOfSegments();
-
-    protected String[] getSegments() {
-        return this.segments;
-    }
-
-    protected String getSegment(int segment) {
-        return this.segments[segment];
-    }
-
-    protected void validateSegment(String segment, int index, int length) {
-        if (!segment.matches(SEGMENT_PATTERN)) {
-            throw new IllegalArgumentException("UID segment '" + segment
-                    + "' contains invalid characters. Each segment of the UID must match the pattern [A-Za-z0-9_-]*.");
-        }
+        super(segments);
     }
 
     /**
@@ -103,38 +63,32 @@ public abstract class UID {
      * @return binding id
      */
     public String getBindingId() {
-        return segments[0];
+        return getSegment(0);
+    }
+
+    protected String[] getSegments() {
+        final List<String> segments = super.getAllSegments();
+        return segments.toArray(new String[segments.size()]);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+        return super.equals(other);
     }
 
     @Override
     public String toString() {
-        return getAsString();
+        return super.toString();
     }
 
+    @Override
     public String getAsString() {
-        return Arrays.stream(segments).collect(Collectors.joining(SEPARATOR));
+        return super.getAsString();
     }
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Arrays.hashCode(segments);
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        UID other = (UID) obj;
-        if (!Arrays.equals(segments, other.segments))
-            return false;
-        return true;
+        return super.hashCode();
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/GenericUID.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/GenericUID.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.common;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * A non specific base class for unique identifiers within the SmartHome framework.
+ *
+ * @author Markus Rathgeb - Splitted from the Thing's UID class
+ */
+@NonNullByDefault
+public abstract class GenericUID {
+
+    public static final String SEGMENT_PATTERN = "[A-Za-z0-9_-]*";
+    public static final String SEPARATOR = ":";
+    private final List<String> segments;
+
+    /**
+     * For reflection only.
+     */
+    protected GenericUID() {
+        segments = Collections.emptyList();
+    }
+
+    /**
+     * Parses an UID for a given string.
+     *
+     * @param uid id in form a string
+     */
+    public GenericUID(final String uid) {
+        this(splitToSegments(uid));
+    }
+
+    /**
+     * Creates a UID for list of segments.
+     *
+     * @param segments the id segments
+     */
+    public GenericUID(final String... segments) {
+        this(Arrays.asList(segments));
+    }
+
+    /**
+     * Creates a UID for list of segments.
+     *
+     * @param segments the id segments
+     */
+    public GenericUID(final List<String> segments) {
+        final int minNumberOfSegments = getMinimalNumberOfSegments();
+        final int numberOfSegments = segments.size();
+
+        if (numberOfSegments < minNumberOfSegments) {
+            throw new IllegalArgumentException(
+                    String.format("UID must have at least %d segments.", minNumberOfSegments));
+        }
+
+        for (int i = 0; i < numberOfSegments; i++) {
+            final String segment = segments.get(i);
+            validateSegment(segment, i, numberOfSegments);
+        }
+
+        this.segments = segments;
+    }
+
+    /**
+     * Specifies how many segments the UID has to have at least.
+     *
+     * @return the minimum nuber of segments
+     */
+    protected abstract int getMinimalNumberOfSegments();
+
+    protected List<String> getAllSegments() {
+        return segments;
+    }
+
+    protected String getSegment(final int segment) {
+        return segments.get(segment);
+    }
+
+    protected void validateSegment(final String segment, final int index, final int length) {
+        if (!segment.matches(SEGMENT_PATTERN)) {
+            throw new IllegalArgumentException(String.format(
+                    "ID segment '%s' contains invalid characters. Each segment of the ID must match the pattern %s.",
+                    segment, SEGMENT_PATTERN));
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getAsString();
+    }
+
+    /**
+     * Return the ID as string.
+     *
+     * @return the ID as string
+     */
+    public String getAsString() {
+        return String.join(SEPARATOR, segments);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + segments.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(final @Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final GenericUID other = (GenericUID) obj;
+        if (!segments.equals(other.segments)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static List<String> splitToSegments(final String id) {
+        return Arrays.asList(id.split(SEPARATOR));
+    }
+
+}


### PR DESCRIPTION
Currently the UID is part of the core.thing bundle and states that every UID must start with the binding ID.
To reuse the non-binding, non-thing related UID implementation a new base class for a generic UID has been created.
It is part of the core bundle. So no need to depend on the thing bundle or to start the UID with a binding ID.
