### PR TITLE
[WIP] Toggle profile

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -102,7 +102,11 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
         }
         switch (channelType.getKind()) {
             case STATE:
-                return SystemProfiles.DEFAULT;
+                if (SystemToggleProfile.SUPPORTED_ITEM_TYPES.contains(itemType)) {
+                    return SystemProfiles.TOGGLE;
+                } else {
+                    return SystemProfiles.DEFAULT;
+                }
             case TRIGGER:
                 if (DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID().equals(channelType.getUID())) {
                     if (CoreItemFactory.SWITCH.equalsIgnoreCase(itemType)) {
@@ -129,7 +133,11 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
         if (channelType == null) {
             switch (channel.getKind()) {
                 case STATE:
-                    return SystemProfiles.DEFAULT;
+                    if (SystemToggleProfile.SUPPORTED_ITEM_TYPES.contains(itemType)) {
+                        return SystemProfiles.TOGGLE;
+                    } else {
+                        return SystemProfiles.DEFAULT;
+                    }
                 case TRIGGER:
                     return null;
                 default:

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -59,6 +59,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
     private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Stream.of( //
             SystemProfiles.DEFAULT_TYPE, //
             SystemProfiles.FOLLOW_TYPE, //
+            SystemProfiles.TOGGLE_TYPE, //
             SystemProfiles.RAWBUTTON_TOGGLE_SWITCH_TYPE, //
             SystemProfiles.RAWROCKER_ON_OFF_TYPE, //
             SystemProfiles.RAWROCKER_DIMMER_TYPE //
@@ -67,6 +68,7 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
     private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream.of( //
             SystemProfiles.DEFAULT, //
             SystemProfiles.FOLLOW, //
+            SystemProfiles.TOGGLE, //
             SystemProfiles.RAWBUTTON_TOGGLE_SWITCH, //
             SystemProfiles.RAWROCKER_ON_OFF, //
             SystemProfiles.RAWROCKER_DIMMER //
@@ -79,6 +81,8 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
             return new SystemDefaultProfile(callback);
         } else if (SystemProfiles.FOLLOW.equals(profileTypeUID)) {
             return new SystemFollowProfile(callback);
+        } else if (SystemProfiles.TOGGLE.equals(profileTypeUID)) {
+            return new SystemToggleProfile(callback);
         } else if (SystemProfiles.RAWBUTTON_TOGGLE_SWITCH.equals(profileTypeUID)) {
             return new RawButtonToggleSwitchProfile(callback);
         } else if (SystemProfiles.RAWROCKER_ON_OFF.equals(profileTypeUID)) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemProfileFactory.java
@@ -56,15 +56,21 @@ public class SystemProfileFactory implements ProfileFactory, ProfileAdvisor, Pro
     @NonNullByDefault({})
     private ChannelTypeRegistry channelTypeRegistry;
 
-    private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Stream
-            .of(SystemProfiles.DEFAULT_TYPE, SystemProfiles.FOLLOW_TYPE, SystemProfiles.RAWBUTTON_TOGGLE_SWITCH_TYPE,
-                    SystemProfiles.RAWROCKER_ON_OFF_TYPE, SystemProfiles.RAWROCKER_DIMMER_TYPE)
-            .collect(Collectors.toSet());
+    private static final Set<ProfileType> SUPPORTED_PROFILE_TYPES = Stream.of( //
+            SystemProfiles.DEFAULT_TYPE, //
+            SystemProfiles.FOLLOW_TYPE, //
+            SystemProfiles.RAWBUTTON_TOGGLE_SWITCH_TYPE, //
+            SystemProfiles.RAWROCKER_ON_OFF_TYPE, //
+            SystemProfiles.RAWROCKER_DIMMER_TYPE //
+    ).collect(Collectors.toSet());
 
-    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream
-            .of(SystemProfiles.DEFAULT, SystemProfiles.FOLLOW, SystemProfiles.RAWBUTTON_TOGGLE_SWITCH,
-                    SystemProfiles.RAWROCKER_ON_OFF, SystemProfiles.RAWROCKER_DIMMER)
-            .collect(Collectors.toSet());
+    private static final Set<ProfileTypeUID> SUPPORTED_PROFILE_TYPE_UIDS = Stream.of( //
+            SystemProfiles.DEFAULT, //
+            SystemProfiles.FOLLOW, //
+            SystemProfiles.RAWBUTTON_TOGGLE_SWITCH, //
+            SystemProfiles.RAWROCKER_ON_OFF, //
+            SystemProfiles.RAWROCKER_DIMMER //
+    ).collect(Collectors.toSet());
 
     @Nullable
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemToggleProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemToggleProfile.java
@@ -12,8 +12,14 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PlayPauseType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
@@ -43,6 +49,14 @@ import org.eclipse.smarthome.core.types.UnDefType;
  */
 @NonNullByDefault
 public class SystemToggleProfile extends SystemDefaultProfile implements TriggerProfile {
+
+    public static final Set<String> SUPPORTED_ITEM_TYPES = Stream.of(//
+            CoreItemFactory.SWITCH, //
+            CoreItemFactory.DIMMER, //
+            CoreItemFactory.COLOR, //
+            CoreItemFactory.ROLLERSHUTTER, //
+            CoreItemFactory.PLAYER //
+    ).collect(toSet());
 
     private State previousState = UnDefType.NULL;
     private final ProfileCallback callback;

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemToggleProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemToggleProfile.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.internal.profiles;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PlayPauseType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
+import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
+import org.eclipse.smarthome.core.thing.profiles.SystemProfiles;
+import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
+import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.UnDefType;
+
+/**
+ * This extends the {@link SystemDefaultProfile} by a "toggle" functionality.
+ * <p>
+ * In addition to what the {@link SystemDefaultProfile} does, this class also implements {@link TriggerProfile} so that
+ * it can handle trigger events. Whenever it receives a "TOGGLE" event, it inverts the last known state (if any) and
+ * sends a corresponding command to the linked item.
+ * <p>
+ * This works for all items which accept any of
+ * <ul>
+ * <li>{@link OnOffType}
+ * <li>{@link UpDownType}
+ * <li>{@link PlayPauseType}
+ * </ul>
+ *
+ * @author Simon Kaufmann - initial contribution and API.
+ *
+ */
+@NonNullByDefault
+public class SystemToggleProfile extends SystemDefaultProfile implements TriggerProfile {
+
+    private State previousState = UnDefType.NULL;
+    private final ProfileCallback callback;
+
+    public SystemToggleProfile(ProfileCallback callback) {
+        super(callback);
+        this.callback = callback;
+    }
+
+    @Override
+    public ProfileTypeUID getProfileTypeUID() {
+        return SystemProfiles.TOGGLE;
+    }
+
+    @Override
+    public void onStateUpdateFromItem(@NonNull State state) {
+        super.onStateUpdateFromItem(state);
+        this.previousState = state;
+    }
+
+    @Override
+    public void onStateUpdateFromHandler(@NonNull State state) {
+        super.onStateUpdateFromHandler(state);
+        this.previousState = state;
+    }
+
+    @Override
+    public void onTriggerFromHandler(@NonNull String event) {
+        if ("TOGGLE".equalsIgnoreCase(event)) {
+            if (OnOffType.ON.equals(previousState.as(OnOffType.class))) {
+                callback.sendCommand(OnOffType.OFF);
+            } else if (OnOffType.OFF.equals(previousState.as(OnOffType.class))) {
+                callback.sendCommand(OnOffType.ON);
+            } else if (UpDownType.UP.equals(previousState.as(UpDownType.class))) {
+                callback.sendCommand(UpDownType.DOWN);
+            } else if (UpDownType.DOWN.equals(previousState.as(UpDownType.class))) {
+                callback.sendCommand(UpDownType.UP);
+            } else if (PlayPauseType.PAUSE.equals(previousState.as(PlayPauseType.class))) {
+                callback.sendCommand(PlayPauseType.PLAY);
+            } else if (PlayPauseType.PLAY.equals(previousState.as(PlayPauseType.class))) {
+                callback.sendCommand(PlayPauseType.PAUSE);
+            }
+        }
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -39,12 +39,11 @@ public interface SystemProfiles {
             .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle").withSupportedItemTypes(CoreItemFactory.SWITCH)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
 
-    TriggerProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")
+    TriggerProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")
             .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 
-    TriggerProfileType RAWROCKER_DIMMER_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_DIMMER, "Raw Rocker To Dimmer").withSupportedItemTypes(CoreItemFactory.DIMMER)
+    TriggerProfileType RAWROCKER_DIMMER_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_DIMMER, "Raw Rocker To Dimmer")
+            .withSupportedItemTypes(CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -27,6 +27,7 @@ public interface SystemProfiles {
 
     ProfileTypeUID DEFAULT = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "default");
     ProfileTypeUID FOLLOW = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "follow");
+    ProfileTypeUID TOGGLE = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "toggle");
     ProfileTypeUID RAWBUTTON_TOGGLE_SWITCH = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawbutton-toggle-switch");
     ProfileTypeUID RAWROCKER_ON_OFF = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawrocker-to-on-off");
     ProfileTypeUID RAWROCKER_DIMMER = new ProfileTypeUID(ProfileTypeUID.SYSTEM_SCOPE, "rawrocker-to-dimmer");
@@ -34,6 +35,8 @@ public interface SystemProfiles {
     StateProfileType DEFAULT_TYPE = ProfileTypeBuilder.newState(DEFAULT, "Default").build();
 
     StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
+
+    StateProfileType TOGGLE_TYPE = ProfileTypeBuilder.newState(TOGGLE, "Toggle").build();
 
     TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle").withSupportedItemTypes(CoreItemFactory.SWITCH)


### PR DESCRIPTION
This PR introduces a "toggle" profile, inspired by the discussion in #4638 in order to formalize the current (hacky) solution for receiving `toggle`-"commands" via the REST API.  

It extends the `SystemDefaultProfile` by _also_ implementing the `TriggerProfile` interface, allowing state channels to also receive trigger events. 

Such events don't necessary need to come from a binding - the REST API could also be extended to also fire events from the outside (not yet implemented). 

This actually makes the conceptual misuse by this approach surface, as for the use-cases discussed in #4638 the natural way for users would be to fire such "toggle"-trigger-events for items, not for channels, while _normally_ trigger events are only sent by handlers for channels. Should we still "misuse" the `ChannelTriggeredEvent` for this? Or introduce a new `ItemTriggeredEvent` event for this purpose, which the `CommunicationManager` then listens to? And if so, should it then still call `TriggerProfile.onTriggerFromHandler(...)` for it (wrong profile type and wrong direction) or rather introduce a new method like `StateProfile.onTriggerFromItem(...)`? 

This seems to be lots of stuff-to-be-added just for this one use-case. And at least currently I don't really have any other use-cases on stock for sending arbitrary events to items. One other question would remain: How should such an `ItemTriggeredEvent` be handled, keeping in mind that there is one profile per `ItemChannelLink`, not per `Item`? So if there are two channel linked to the same item it doesn't make sense to involve all profiles, because then the state would be toggled twice... 

This doesn't really seem the natural way to go. Therefore, before continuing with this (or dropping it again), I'd like to first get it conceptually right and see if it makes sense at all...

#### Open Topics
- [x] implement a toggle profile
- [ ] decide whether it is viable to use it by default on applicable items
- [ ] decide what are the "toggle-able" items (i.e. including Color/Dimmer or not?)
- [ ] implement tests
- [ ] clarify sending events for items should be done conceptually
- [ ] extend the REST API accordingly

relates to #4638
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>