### PR TITLE
nail down groovy compiler level to 2.3

### DIFF
--- a/targetplatform/EclipseSmartHome.setup
+++ b/targetplatform/EclipseSmartHome.setup
@@ -22,6 +22,14 @@
         source="http://www.eclipse.org/oomph/setup/UserPreferences"/>
     <setupTask
         xsi:type="setup:CompoundTask"
+        name="org.codehaus.groovy.eclipse.compilerResolver">
+      <setupTask
+          xsi:type="setup:PreferenceTask"
+          key="/instance/org.codehaus.groovy.eclipse.compilerResolver/groovy.compiler.level"
+          value="23"/>
+    </setupTask>
+    <setupTask
+        xsi:type="setup:CompoundTask"
         name="org.eclipse.core.resources">
       <setupTask
           xsi:type="setup:PreferenceTask"


### PR DESCRIPTION
...in the workspace configuration so that it matches the target platform.

At least mine was set to 2.4 after one of the recent restarts, which led to compiler version mismatch exceptions. Can anybody confirm this?

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>