### PR TITLE
fix condition in ProgressCallbackImpl

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackTest.groovy
@@ -117,6 +117,14 @@ public final class ProgressCallbackTest {
         sut.success()
     }
 
+    @Test
+    void 'assert success at 100 percent even if there is a remaining progress step'(){
+        sut.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING)
+        sut.next()
+        sut.update(100)
+        sut.success()
+    }
+
     @Test(expected=IllegalArgumentException)
     void 'assert that update throws IllegalArgumentException if progress smaller 0'(){
         sut.update(-1)

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackImpl.java
@@ -120,8 +120,8 @@ final class ProgressCallbackImpl implements ProgressCallback {
         if (this.state == InternalState.FINISHED) {
             throw new IllegalStateException("Update is finished.");
         }
-        if ((this.progress != null && this.progress < 100)
-                || (this.progressIterator != null && progressIterator.hasNext())) {
+        if ((this.progress == null || this.progress < 100)
+                && (this.progressIterator == null || progressIterator.hasNext())) {
             throw new IllegalStateException(
                     "Update can't be successfully finished until progress is 100% or last progress step is reached");
         }


### PR DESCRIPTION
This fixes a mistake I did in #4743:

Original:

```java
Preconditions.checkState((this.progress != null && this.progress == 100) || 
    (this.progressIterator!=null && !progressIterator.hasNext()), "...")
```

Current version:

```java
if ((this.progress != null && this.progress < 100)
    || (this.progressIterator != null && progressIterator.hasNext())) {
```

This PR now replaces it by the correct negation:

```java
if ((this.progress == null || this.progress < 100)
    && (this.progressIterator == null || progressIterator.hasNext())) {
```



Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>