### PR TITLE
allow NULL as a legal outcome of the jsonpath transformation

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
@@ -43,7 +43,7 @@ public class JSonPathTransformationServiceTest {
     }
 
     private static final String jsonArray = "[" + //
-            "{ \"id\":1, \"name\":\"bob\" }," + //
+            "{ \"id\":1, \"name\":\"bob\", \"empty\":null }," + //
             "{ \"id\":2, \"name\":\"alice\" }" + //
             "]";
 
@@ -72,6 +72,12 @@ public class JSonPathTransformationServiceTest {
     @Test(expected = TransformationException.class)
     public void testInvalidJsonReturnNull() throws TransformationException {
         processor.transform("$", "{id:");
+    }
+
+    @Test
+    public void testNullValue() throws TransformationException {
+        String transformedResponse = processor.transform("$[0].empty", jsonArray);
+        assertEquals("NULL", transformedResponse);
     }
 
 }

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
@@ -16,5 +16,6 @@ Import-Package:
  net.minidev.json.writer,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.transform,
+ org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.transform.jsonpath.internal;
 
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +55,7 @@ public class JSonPathTransformationService implements TransformationService {
         try {
             Object transformationResult = JsonPath.read(source, jsonPathExpression);
             logger.debug("transformation resulted in '{}'", transformationResult);
-            return (transformationResult != null) ? transformationResult.toString() : source;
+            return (transformationResult != null) ? transformationResult.toString() : UnDefType.NULL.toFullString();
         } catch (PathNotFoundException e) {
             throw new TransformationException("Invalid path '" + jsonPathExpression + "' in '" + source + "'");
         } catch (InvalidPathException | InvalidJsonException e) {


### PR DESCRIPTION
...in case the element really exists and is set to `null`.

It doesn't return `null` though (so #4379 is not reverted), but returns the string representation of `UndefType.NULL` instead (i.e. `"NULL"`). 

This still does not address the problem which @martinvw's [mentioned](https://github.com/eclipse/smarthome/pull/4379#issuecomment-334825726) that in JSON often null-attributes are left out completely. I have no idea how to solve that, except to return always `"NULL"` in case the element was not found (and maybe log a warning). 

fixes #4870
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>