### PR TITLE
Fixes NPE in ThingResource when thing has no configuration

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistry.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistry.java
@@ -22,6 +22,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * {@link ConfigDescriptionRegistry} provides access to {@link ConfigDescription}s.
  * It tracks {@link ConfigDescriptionProvider} OSGi services to collect all {@link ConfigDescription}s.
@@ -143,7 +145,7 @@ public class ConfigDescriptionRegistry {
      * @return config description or null if no config description exists for
      *         the given name
      */
-    public ConfigDescription getConfigDescription(URI uri, Locale locale) {
+    public @Nullable ConfigDescription getConfigDescription(URI uri, Locale locale) {
         List<ConfigDescriptionParameter> parameters = new ArrayList<ConfigDescriptionParameter>();
         List<ConfigDescriptionParameterGroup> parameterGroups = new ArrayList<ConfigDescriptionParameterGroup>();
 
@@ -184,7 +186,7 @@ public class ConfigDescriptionRegistry {
      * @return config description or null if no config description exists for
      *         the given name
      */
-    public ConfigDescription getConfigDescription(URI uri) {
+    public @Nullable ConfigDescription getConfigDescription(URI uri) {
         return getConfigDescription(uri, null);
     }
 

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
@@ -732,14 +732,21 @@ public class ThingResource implements RESTResource {
         }
 
         List<ConfigDescription> configDescriptions = new ArrayList<>(2);
-        ConfigDescription typeConfigDesc = configDescRegistry.getConfigDescription(thingType.getConfigDescriptionURI());
-        if (typeConfigDesc != null) {
-            configDescriptions.add(typeConfigDesc);
+        if (thingType.getConfigDescriptionURI() != null) {
+            ConfigDescription typeConfigDesc = configDescRegistry
+                    .getConfigDescription(thingType.getConfigDescriptionURI());
+            if (typeConfigDesc != null) {
+                configDescriptions.add(typeConfigDesc);
+            }
         }
-        ConfigDescription thingConfigDesc = configDescRegistry.getConfigDescription(getConfigDescriptionURI(thingUID));
-        if (thingConfigDesc != null) {
-            configDescriptions.add(thingConfigDesc);
+        if (getConfigDescriptionURI(thingUID) != null) {
+            ConfigDescription thingConfigDesc = configDescRegistry
+                    .getConfigDescription(getConfigDescriptionURI(thingUID));
+            if (thingConfigDesc != null) {
+                configDescriptions.add(thingConfigDesc);
+            }
         }
+
         if (configDescriptions.isEmpty()) {
             return properties;
         }


### PR DESCRIPTION
As seen [here](https://github.com/openhab/org.openhab.binding.zwave/issues/802), ```ThingType.getConfigDescriptionURI``` will return null if there is no configuration, and ```ConfigDescriptionRegistry. getConfigDescription``` can not be passed a null.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>