### PR TITLE
increased times in SafeCallerTest

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
@@ -50,13 +50,13 @@ public class SafeCallerImplTest extends JavaTest {
     private static final int THREAD_POOL_SIZE = 3;
 
     // the duration that the called object should block for
-    private static final int BLOCK = 500;
+    private static final int BLOCK = 1500;
 
     // the standard timeout for the safe-caller used in most tests
-    private static final int TIMEOUT = 200;
+    private static final int TIMEOUT = 600;
 
     // the grace period allowed for processing before a timing assertion should fail
-    private static final int GRACE = 100;
+    private static final int GRACE = 300;
 
     @Mock
     private Runnable mockRunnable;


### PR DESCRIPTION
...in order to stabilize the builds on the CI build server.
The variance due to the server being busy will have a smaller impact then.

See e.g. https://ci.eclipse.org/smarthome/job/SmartHomeDistribution-Nightly/2428/

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>