### PR TITLE
Improve delayed initialization of ChannelItemProvider

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
@@ -16,10 +16,13 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.i18n.LocaleProvider;
@@ -66,16 +69,10 @@ public class ChannelItemProviderTest {
     public void setup() throws Exception {
         initMocks(this);
 
-        provider = new ChannelItemProvider();
-        provider.setItemRegistry(itemRegistry);
-        provider.setThingRegistry(thingRegistry);
-        provider.setItemChannelLinkRegistry(linkRegistry);
-        provider.addItemFactory(itemFactory);
-        provider.setLocaleProvider(localeProvider);
-        provider.addProviderChangeListener(listener);
+        provider = createProvider();
 
         Map<String, Object> props = new HashMap<>();
-        props.put("enable", "true");
+        props.put("enabled", "true");
         props.put("initialDelay", "false");
         provider.activate(props);
 
@@ -120,6 +117,38 @@ public class ChannelItemProviderTest {
         verify(listener, never()).added(same(provider), same(ITEM));
     }
 
+    @Test
+    public void testDisableBeforeDelayedInitialization() throws Exception {
+        provider = createProvider();
+        reset(linkRegistry);
+
+        // Set the initialization delay to 40ms so we don't have to wait 2000ms to do the assertion
+        Field field = ChannelItemProvider.class.getDeclaredField("INITIALIZATION_DELAY_NANOS");
+        field.setAccessible(true);
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+        field.set(provider, TimeUnit.MILLISECONDS.toNanos(40));
+
+        Map<String, Object> props = new HashMap<>();
+        props.put("enabled", "true");
+        provider.activate(props);
+
+        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+        verify(listener, never()).added(same(provider), same(ITEM));
+        verify(linkRegistry, never()).getAll();
+
+        props = new HashMap<>();
+        props.put("enabled", "false");
+        provider.modified(props);
+
+        Thread.sleep(100);
+
+        provider.linkRegistryListener.added(new ItemChannelLink(ITEM_NAME, CHANNEL_UID));
+        verify(listener, never()).added(same(provider), same(ITEM));
+        verify(linkRegistry, never()).getAll();
+    }
+
     @SuppressWarnings("unchecked")
     private void resetAndPrepareListener() {
         reset(listener);
@@ -136,6 +165,18 @@ public class ChannelItemProviderTest {
         when(linkRegistry.getBoundChannels(eq(ITEM_NAME))).thenReturn(Collections.singleton(CHANNEL_UID));
         when(linkRegistry.getLinks(eq(CHANNEL_UID)))
                 .thenReturn(Collections.singleton(new ItemChannelLink(ITEM_NAME, CHANNEL_UID)));
+    }
+
+    private ChannelItemProvider createProvider() {
+        ChannelItemProvider provider = new ChannelItemProvider();
+        provider.setItemRegistry(itemRegistry);
+        provider.setThingRegistry(thingRegistry);
+        provider.setItemChannelLinkRegistry(linkRegistry);
+        provider.addItemFactory(itemFactory);
+        provider.setLocaleProvider(localeProvider);
+        provider.addProviderChangeListener(listener);
+
+        return provider;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProvider.java
@@ -64,6 +64,8 @@ public class ChannelItemProvider implements ItemProvider {
 
     private final Logger logger = LoggerFactory.getLogger(ChannelItemProvider.class);
 
+    private final long INITIALIZATION_DELAY_NANOS = TimeUnit.SECONDS.toNanos(2);
+
     private final Set<ProviderChangeListener<Item>> listeners = new HashSet<>();
 
     private LocaleProvider localeProvider;
@@ -75,22 +77,16 @@ public class ChannelItemProvider implements ItemProvider {
     private ChannelTypeRegistry channelTypeRegistry;
 
     private boolean enabled = true;
-    private boolean initialized = false;
+    private volatile boolean initialized = false;
     private volatile long lastUpdate = System.nanoTime();
+    private ScheduledExecutorService executor;
 
     @Override
     public Collection<Item> getAll() {
         if (!enabled || !initialized) {
             return Collections.emptySet();
         } else {
-            synchronized (this) {
-                if (items == null) {
-                    items = new ConcurrentHashMap<>();
-                    for (ItemChannelLink link : linkRegistry.getAll()) {
-                        createItemForLink(link);
-                    }
-                }
-            }
+            initializeItems();
             return new HashSet<>(items.values());
         }
     }
@@ -179,15 +175,23 @@ public class ChannelItemProvider implements ItemProvider {
         }
 
         if (enabled) {
+            addRegistryChangeListeners();
+
             boolean initialDelay = properties == null
                     || !"false".equalsIgnoreCase((String) properties.get("initialDelay"));
             if (initialDelay) {
-                delayedInitialize(Executors.newSingleThreadScheduledExecutor());
+                executor = Executors.newSingleThreadScheduledExecutor();
+                delayedInitialize();
             } else {
                 initialize();
             }
         } else {
             logger.debug("Disabling channel item provider.");
+            if (executor != null) {
+                executor.shutdownNow();
+                executor = null;
+            }
+
             for (ProviderChangeListener<Item> listener : listeners) {
                 for (Item item : getAll()) {
                     listener.removed(this, item);
@@ -197,24 +201,36 @@ public class ChannelItemProvider implements ItemProvider {
         }
     }
 
-    private void delayedInitialize(ScheduledExecutorService executor) {
+    private synchronized void delayedInitialize() {
+        if (Thread.currentThread().isInterrupted()) {
+            return;
+        }
         // we wait until no further new links or items are announced in order to avoid creation of
         // items which then must be removed again immediately.
-        final long diff = System.nanoTime() - lastUpdate - TimeUnit.SECONDS.toNanos(2);
+        final long diff = System.nanoTime() - lastUpdate - INITIALIZATION_DELAY_NANOS;
         if (diff < 0) {
-            executor.schedule(() -> delayedInitialize(executor), -diff, TimeUnit.NANOSECONDS);
+            executor.schedule(() -> delayedInitialize(), -diff, TimeUnit.NANOSECONDS);
         } else {
             executor.shutdown();
+            executor = null;
+
             initialize();
         }
     }
 
     private void initialize() {
-        logger.debug("Enabling channel item provider.");
+        initializeItems();
         initialized = true;
-        // simply call getAll() will create the items and notify all registered listeners automatically
-        getAll();
-        addRegistryChangeListeners();
+    }
+
+    private synchronized void initializeItems() {
+        if (items != null) {
+            return;
+        }
+        items = new ConcurrentHashMap<>();
+        for (ItemChannelLink link : linkRegistry.getAll()) {
+            createItemForLink(link);
+        }
     }
 
     @Deactivate
@@ -322,6 +338,9 @@ public class ChannelItemProvider implements ItemProvider {
 
         @Override
         public void added(Thing element) {
+            if (!initialized) {
+                return;
+            }
             for (Channel channel : element.getChannels()) {
                 for (ItemChannelLink link : linkRegistry.getLinks(channel.getUID())) {
                     createItemForLink(link);
@@ -331,6 +350,9 @@ public class ChannelItemProvider implements ItemProvider {
 
         @Override
         public void removed(Thing element) {
+            if (!initialized) {
+                return;
+            }
             removeItem(element.getUID().toString());
         }
 
@@ -345,12 +367,18 @@ public class ChannelItemProvider implements ItemProvider {
 
         @Override
         public void added(ItemChannelLink element) {
+            if (!initialized) {
+                lastUpdate = System.nanoTime();
+                return;
+            }
             createItemForLink(element);
-            lastUpdate = System.nanoTime();
         }
 
         @Override
         public void removed(ItemChannelLink element) {
+            if (!initialized) {
+                return;
+            }
             removeItem(element.getItemName());
         }
 
@@ -365,6 +393,10 @@ public class ChannelItemProvider implements ItemProvider {
 
         @Override
         public void beforeAdding(Item element) {
+            if (!initialized) {
+                lastUpdate = System.nanoTime();
+                return;
+            }
             // check, if it is our own item
             for (Item item : items.values()) {
                 if (item == element) {
@@ -379,11 +411,13 @@ public class ChannelItemProvider implements ItemProvider {
                 }
                 items.remove(element.getName());
             }
-            lastUpdate = System.nanoTime();
         }
 
         @Override
         public void afterRemoving(Item element) {
+            if (!initialized) {
+                return;
+            }
             // check, if it is our own item
             for (Item item : items.values()) {
                 if (item == element) {
@@ -401,4 +435,5 @@ public class ChannelItemProvider implements ItemProvider {
         }
 
     };
+
 }


### PR DESCRIPTION
_ChannelItemProvider_ supports delayed initialization which waits util no more items and links are added to the ItemRegistry and then initializes the provider. The delayed initialization keeps track of how much time has passed since items were added to the registry in a variable called _lastUpdate_. In the current implementation the _lastUpdate_ variable is used only **before calling the _initialize_ method** and it is changed only by the registry listeners, which are registered **after calling the _initialize_ method**. So when its value starts changing, it will no longer be used. This PR adds another set of registry listeners that only update the _lastUpdate_ variable and are unregistered after the initialization is finished.

Calling the modified method 2 times in a row with parameters _enabled=false_ the first time and _enabled=true_ the second time causes the delayed initialization to run after the component is disabled and leave it in an inconsistent state: with _items_ map set to null and registered registry listeners. The registered listeners then throw NPEs when new Items are added to the registry. A unit test that reproduces the described issue is added. This PR changes the modify method to cancel the delayed initialization.

Signed-off-by: velichko.stoykov <velichko.stoykov@musala.com>