### PR TITLE
Update README.md

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.astro/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/README.md
@@ -171,13 +171,13 @@ astro:sun:home [ geolocation="52.5200066,13.4049540,100", interval=60 ] {
 Items:
 
 ```
-DateTime Sunrise_Time       "Sunrise [%1$tH:%1$tM]"  { channel="astro:sun:home:rise#start" }
-DateTime Sunset_Time        "Sunset [%1$tH:%1$tM]"   { channel="astro:sun:home:set#start" }
-Number   Azimuth            "Azimuth"                { channel="astro:sun:home:position#azimuth" }
-Number   Elevation          "Elevation"              { channel="astro:sun:home:position#elevation" }
-String   MoonPhase          "MoonPhase"              { channel="astro:moon:home:phase#name" }
-Number   Total_Radiation    "Radiation"              { channel="astro:sun:home:radiation#total" }
-Number   Diffuse_Radiation  "Diffuse Radiation"      { channel="astro:sun:home:radiation#diffuse" }
+DateTime Sunrise_Time       "Sunrise [%1$tH:%1$tM]"                  { channel="astro:sun:home:rise#start" }
+DateTime Sunset_Time        "Sunset [%1$tH:%1$tM]"                   { channel="astro:sun:home:set#start" }
+Number   Azimuth            "Azimuth"                                { channel="astro:sun:home:position#azimuth" }
+Number   Elevation          "Elevation"                              { channel="astro:sun:home:position#elevation" }
+String   MoonPhase          "MoonPhase"                              { channel="astro:moon:home:phase#name" }
+Number   Total_Radiation    "Radiation [%.2f W/m\u00B2]"             { channel="astro:sun:home:radiation#total" }
+Number   Diffuse_Radiation  "Diffuse Radiation [%.2f W/m\u00B2]"     { channel="astro:sun:home:radiation#diffuse" }
 ```
 
 Events:


### PR DESCRIPTION
I added the dimensions [W/m2] to the radiation channels in the item example area, as asked in https://github.com/eclipse/smarthome/issues/4913, and I arranged the other lines to have all the "channel text" in the same column.

Signed-off-by: Marco Foletto <ocram.ottelof@gmail.com>