### PR TITLE
handle indefinite results in JsonPath transformations

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
@@ -80,4 +80,22 @@ public class JSonPathTransformationServiceTest {
         assertEquals("NULL", transformedResponse);
     }
 
+    @Test
+    public void testIndefinite_filteredToSingle() throws TransformationException {
+        String transformedResponse = processor.transform("$.*[?(@.name=='bob')].id", jsonArray);
+        assertEquals("1", transformedResponse);
+    }
+
+    @Test
+    public void testIndefinite_notFiltered() throws TransformationException {
+        String transformedResponse = processor.transform("$.*.id", jsonArray);
+        assertEquals("NULL", transformedResponse);
+    }
+
+    @Test
+    public void testIndefinite_noMatch() throws TransformationException {
+        String transformedResponse = processor.transform("$.*[?(@.name=='unknown')].id", jsonArray);
+        assertEquals("NULL", transformedResponse);
+    }
+
 }

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -77,7 +77,9 @@ public class JSonPathTransformationService implements TransformationService {
             return list.get(0).toString();
         }
         if (list.size() > 1) {
-            logger.warn("The JsonPath expression yielded more than one result: {}", list);
+            logger.warn(
+                    "JsonPath expressions with more than one result are not allowed, please adapt your selector. Result: {}",
+                    list);
         }
         return UnDefType.NULL.toFullString();
     }


### PR DESCRIPTION
...as JsonPath may return a List if multiple elements matched,
even if they were correctly filtered down to a single element.

fixes #4862
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>