### PR TITLE
corrected null annotations

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterGroup.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterGroup.java
@@ -47,8 +47,8 @@ public class ConfigDescriptionParameterGroup {
      * @param label the human readable group label
      * @param description a description that can be provided to the user
      */
-    public ConfigDescriptionParameterGroup(String name, @Nullable String context, Boolean advanced, String label,
-            String description) {
+    public ConfigDescriptionParameterGroup(String name, @Nullable String context, Boolean advanced,
+            @Nullable String label, @Nullable String description) {
         this.name = name;
         this.context = context;
         this.advanced = advanced;

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterGroup.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameterGroup.java
@@ -34,8 +34,8 @@ public class ConfigDescriptionParameterGroup {
     private final String name;
     private final @Nullable String context;
     private final boolean advanced;
-    private final String label;
-    private final String description;
+    private final @Nullable String label;
+    private final @Nullable String description;
 
     /**
      * Create a Parameter Group. A group is used by the user interface to display groups
@@ -88,6 +88,7 @@ public class ConfigDescriptionParameterGroup {
      *
      * @return group label as a string
      */
+    @Nullable
     public String getLabel() {
         return label;
     }
@@ -97,6 +98,7 @@ public class ConfigDescriptionParameterGroup {
      *
      * @return group description as a string
      */
+    @Nullable
     public String getDescription() {
         return description;
     }
@@ -104,6 +106,7 @@ public class ConfigDescriptionParameterGroup {
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + " [groupId=\"" + name + "\", context=\"" + context + "\", advanced=\""
-                + advanced + "\", label=\"" + label + "\", description=\"" + description + "\"]";
+                + advanced + "\"" + (label != null ? ", label=\"" + label + "\"" : "")
+                + (description != null ? ", description=\"" + description + "\"" : "") + "]";
     }
 }


### PR DESCRIPTION
I think #4884 introduced a bug here, which I discovered [here](https://github.com/openhab/openhab2-addons/pull/3140/files#diff-f717f341604676be676a8725bea23b99R306) - according to our schema, both label and description are optional and thus can be null. Our XML parser even feeds them in as null (but there isn't any error or warning in the IDE, since we have disabled pretty much all warnings...), so that this went unnoticed.

related to #4884

Signed-off-by: Kai Kreuzer <kai@openhab.org>