### PR TITLE
Reload discovery result from storage before emitting event

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
@@ -457,7 +457,9 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
             }
         }
 
-        postEvent(get(result.getThingUID()), type);
+        // in case of EventType added/updated the listeners might have modified the result in the discoveryResultStorage
+        DiscoveryResult resultForEvent = type == EventType.removed ? result : get(result.getThingUID());
+        postEvent(resultForEvent, type);
     }
 
     private void postEvent(DiscoveryResult result, EventType eventType) {

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/PersistentInbox.java
@@ -456,7 +456,8 @@ public final class PersistentInbox implements Inbox, DiscoveryListener, ThingReg
                 logger.error(errorMessage, ex);
             }
         }
-        postEvent(result, type);
+
+        postEvent(get(result.getThingUID()), type);
     }
 
     private void postEvent(DiscoveryResult result, EventType eventType) {


### PR DESCRIPTION
This fixes #4360 by reloading the discovery result from the storage before emitting an event. This guarantees that changes to the result (like setting the flag to IGNORED) are part of the event.

Signed-off-by: Henning Treu <henning.treu@telekom.de>