### PR TITLE
ignore point2point interfaces for local interface search

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -117,7 +117,7 @@ public class NetUtil implements NetworkAddressService {
             final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             while (interfaces.hasMoreElements()) {
                 final NetworkInterface current = interfaces.nextElement();
-                if (!current.isUp() || current.isLoopback() || current.isVirtual()) {
+                if (!current.isUp() || current.isLoopback() || current.isVirtual() || current.isPointToPoint()) {
                     continue;
                 }
                 final Enumeration<InetAddress> addresses = current.getInetAddresses();
@@ -146,7 +146,7 @@ public class NetUtil implements NetworkAddressService {
             final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             while (interfaces.hasMoreElements()) {
                 final NetworkInterface current = interfaces.nextElement();
-                if (!current.isUp() || current.isLoopback() || current.isVirtual()) {
+                if (!current.isUp() || current.isLoopback() || current.isVirtual() || current.isPointToPoint()) {
                     continue;
                 }
                 final Enumeration<InetAddress> addresses = current.getInetAddresses();
@@ -399,7 +399,7 @@ public class NetUtil implements NetworkAddressService {
             final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
             while (interfaces.hasMoreElements()) {
                 final NetworkInterface current = interfaces.nextElement();
-                if (!current.isUp() || current.isLoopback() || current.isVirtual()) {
+                if (!current.isUp() || current.isLoopback() || current.isVirtual() || current.isPointToPoint()) {
                     continue;
                 }
 


### PR DESCRIPTION
PointToPoint interfaces are used to connect to the internet or to some other remote network. The ip address of these interface is used to connect from the remote network to this system. So this is not a local address and should not be in the list of local ip addresses, because

    it cannot be used to connect to other local devices and systems
    in case of an internet connection this is the public address. Opening a server socket on the public address is a serious security risk.
