### PR TITLE
deprecated the Channel constructors

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
@@ -32,7 +32,6 @@ import org.eclipse.smarthome.core.events.EventFilter
 import org.eclipse.smarthome.core.events.EventSubscriber
 import org.eclipse.smarthome.core.i18n.TranslationProvider
 import org.eclipse.smarthome.core.thing.Bridge
-import org.eclipse.smarthome.core.thing.Channel
 import org.eclipse.smarthome.core.thing.ChannelUID
 import org.eclipse.smarthome.core.thing.ManagedThingProvider
 import org.eclipse.smarthome.core.thing.Thing
@@ -42,6 +41,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
 import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder
 import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder
@@ -366,7 +366,7 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
         public void initialize() {
             ThingBuilder thingBuilder = editThing()
             thingBuilder.withChannels([
-                new Channel(new ChannelUID("bindingId:type:thingId:1"), "String")
+                ChannelBuilder.create(new ChannelUID("bindingId:type:thingId:1"), "String").build()
             ])
             updateThing(thingBuilder.build())
             updateStatus(ThingStatus.ONLINE)

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ThingBuilderTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/ThingBuilderTest.groovy
@@ -15,10 +15,10 @@ package org.eclipse.smarthome.core.thing.binding
 import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 
-import org.eclipse.smarthome.core.thing.Channel
 import org.eclipse.smarthome.core.thing.ChannelUID
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
 import org.junit.Test
 
@@ -30,8 +30,8 @@ class ThingBuilderTest {
     @Test(expected=IllegalArgumentException)
     void 'assert that no duplicate channels can be added individually'() {
         ThingBuilder thingBuilder = ThingBuilder.create(THING_TYPE_UID, THING_UID)
-        thingBuilder.withChannel(new Channel(new ChannelUID(THING_UID, "channel1"), ""))
-        thingBuilder.withChannel(new Channel(new ChannelUID(THING_UID, "channel1"), ""))
+        thingBuilder.withChannel(ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build())
+        thingBuilder.withChannel(ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build())
     }
 
     @Test(expected=IllegalArgumentException)
@@ -39,8 +39,8 @@ class ThingBuilderTest {
         ThingBuilder thingBuilder = ThingBuilder.create(THING_TYPE_UID, THING_UID)
         thingBuilder.withChannels(
                 [
-                    new Channel(new ChannelUID(THING_UID, "channel1"), ""),
-                    new Channel(new ChannelUID(THING_UID, "channel1"), "")
+                    ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(),
+                    ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build()
                 ])
     }
 
@@ -48,8 +48,8 @@ class ThingBuilderTest {
     void 'assert that no duplicate channels can be added as varargs'() {
         ThingBuilder thingBuilder = ThingBuilder.create(THING_TYPE_UID, THING_UID)
         thingBuilder.withChannels(
-                new Channel(new ChannelUID(THING_UID, "channel1"), ""),
-                new Channel(new ChannelUID(THING_UID, "channel1"), "")
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(),
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build()
                 )
     }
 
@@ -57,8 +57,8 @@ class ThingBuilderTest {
     void 'assert that channel can be removed'() {
         ThingBuilder thingBuilder = ThingBuilder.create(THING_TYPE_UID, THING_UID)
         thingBuilder.withChannels(
-                new Channel(new ChannelUID(THING_UID, "channel1"), ""),
-                new Channel(new ChannelUID(THING_UID, "channel2"), "")
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(),
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel2"), "").build()
                 )
         thingBuilder.withoutChannel(new ChannelUID(THING_UID, "channel1"))
         assertThat thingBuilder.build().getChannels().size(), is(equalTo(1))
@@ -69,8 +69,8 @@ class ThingBuilderTest {
     void 'assert that removing a missing channel fails silently'() {
         ThingBuilder thingBuilder = ThingBuilder.create(THING_TYPE_UID, THING_UID)
         thingBuilder.withChannels(
-                new Channel(new ChannelUID(THING_UID, "channel1"), ""),
-                new Channel(new ChannelUID(THING_UID, "channel2"), "")
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(),
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel2"), "").build()
                 )
         thingBuilder.withoutChannel(new ChannelUID(THING_UID, "channel3"))
         assertThat thingBuilder.build().getChannels().size(), is(equalTo(2))

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiTest.groovy
@@ -40,7 +40,6 @@ import org.eclipse.smarthome.core.library.types.StringType
 import org.eclipse.smarthome.core.service.ReadyMarker
 import org.eclipse.smarthome.core.service.ReadyService
 import org.eclipse.smarthome.core.thing.Bridge
-import org.eclipse.smarthome.core.thing.Channel
 import org.eclipse.smarthome.core.thing.ChannelUID
 import org.eclipse.smarthome.core.thing.ManagedThingProvider
 import org.eclipse.smarthome.core.thing.Thing
@@ -58,6 +57,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider
 import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder
 import org.eclipse.smarthome.core.thing.events.ThingEventFactory
@@ -111,8 +111,7 @@ class ThingManagerOSGiTest extends OSGiTest {
         def channelTypeUID = new ChannelTypeUID("binding:channelType")
 
         THING = ThingBuilder.create(THING_UID).withChannels([
-            new Channel(CHANNEL_UID, channelTypeUID, "Switch", ChannelKind.STATE,
-            null, Collections.emptySet(), null, null, null)
+            ChannelBuilder.create(CHANNEL_UID, "Switch").withKind(ChannelKind.STATE).withType(channelTypeUID).build()
         ]).build()
         registerVolatileStorageService()
 
@@ -274,7 +273,7 @@ class ThingManagerOSGiTest extends OSGiTest {
         registerThingTypeProvider()
 
         Thing thing2 = ThingBuilder.create(THING_UID).withChannels([
-            new Channel(CHANNEL_UID, "Switch")
+            ChannelBuilder.create(CHANNEL_UID, "Switch").build()
         ]).build()
 
         boolean raceCondition = false
@@ -777,7 +776,7 @@ class ThingManagerOSGiTest extends OSGiTest {
         receivedEvent = null
         itemUpdateEvent = null
         def thing = ThingBuilder.create(THING_UID).withChannels([
-            new Channel(CHANNEL_UID, "Switch")
+            ChannelBuilder.create(CHANNEL_UID, "Switch").build()
         ]).build()
         managedThingProvider.update(thing)
 

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/util/ThingHelperTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/util/ThingHelperTest.groovy
@@ -17,78 +17,84 @@ import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
 import org.eclipse.smarthome.config.core.Configuration
-import org.eclipse.smarthome.core.thing.Channel
 import org.eclipse.smarthome.core.thing.ChannelUID
 import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
 import org.junit.Test
 
 class ThingHelperTest {
 
-	@Test
-	void 'Two technical equal Thing instances are detected as "equal"'() {
-		Thing thingA = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
-				.withChannels(new Channel(new ChannelUID("binding:type:thingId:channel1"), "itemType"),
-				new Channel(new ChannelUID("binding:type:thingId:channel2"), "itemType"))
-				.withConfiguration(new Configuration())
-				.build()
-		thingA.getConfiguration().put("prop1", "value1")
-		thingA.getConfiguration().put("prop2", "value2")
+    @Test
+    void 'Two technical equal Thing instances are detected as "equal"'() {
+        Thing thingA = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withChannels(
+                ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel1"), "itemType").build(),
+                ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel2"), "itemType").build()
+                )
+                .withConfiguration(new Configuration())
+                .build()
+        thingA.getConfiguration().put("prop1", "value1")
+        thingA.getConfiguration().put("prop2", "value2")
 
-		assertTrue ThingHelper.equals(thingA, thingA)
+        assertTrue ThingHelper.equals(thingA, thingA)
 
-		Thing thingB = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
-				.withChannels(new Channel(new ChannelUID("binding:type:thingId:channel2"), "itemType"),
-				new Channel(new ChannelUID("binding:type:thingId:channel1"), "itemType"))
-				.withConfiguration(new Configuration())
-				.build()
-		thingB.getConfiguration().put("prop2", "value2")
-		thingB.getConfiguration().put("prop1", "value1")
+        Thing thingB = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withChannels(
+                ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel2"), "itemType").build(),
+                ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel1"), "itemType").build()
+                )
+                .withConfiguration(new Configuration())
+                .build()
+        thingB.getConfiguration().put("prop2", "value2")
+        thingB.getConfiguration().put("prop1", "value1")
 
-		assertTrue ThingHelper.equals(thingA, thingB)
-	}
+        assertTrue ThingHelper.equals(thingA, thingB)
+    }
 
-	@Test
-	void 'Two things are different after properties were modified'() {
-		Thing thingA = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
-				.withChannels(new Channel(new ChannelUID("binding:type:thingId:channel1"), "itemType"),
-				new Channel(new ChannelUID("binding:type:thingId:channel2"), "itemType"))
-				.withConfiguration(new Configuration())
-				.build()
-		thingA.getConfiguration().put("prop1", "value1")
+    @Test
+    void 'Two things are different after properties were modified'() {
+        Thing thingA = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withChannels(
+                ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel1"), "itemType").build(),
+                ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel2"), "itemType").build()
+                )
+                .withConfiguration(new Configuration())
+                .build()
+        thingA.getConfiguration().put("prop1", "value1")
 
-		Thing thingB = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
-				.withChannels(new Channel(new ChannelUID("binding:type:thingId:channel2"), "itemType"),
-				new Channel(new ChannelUID("binding:type:thingId:channel1"), "itemType"))
-				.withConfiguration(new Configuration())
-				.build()
-		thingB.getConfiguration().put("prop1", "value1")
+        Thing thingB = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withChannels(
+                ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel2"), "itemType").build(),
+                ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel1"), "itemType").build()
+                )
+                .withConfiguration(new Configuration())
+                .build()
+        thingB.getConfiguration().put("prop1", "value1")
 
-		assertTrue ThingHelper.equals(thingA, thingB)
+        assertTrue ThingHelper.equals(thingA, thingB)
 
-		thingB.getConfiguration().put("prop3", "value3")
+        thingB.getConfiguration().put("prop3", "value3")
 
-		assertFalse ThingHelper.equals(thingA, thingB)
-	}
+        assertFalse ThingHelper.equals(thingA, thingB)
+    }
 
-	@Test
-	void 'Two things are different after channels were modified'() {
-		Thing thingA = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
-				.withConfiguration(new Configuration()).build()
+    @Test
+    void 'Two things are different after channels were modified'() {
+        Thing thingA = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withConfiguration(new Configuration()).build()
 
-		Thing thingB = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
-				.withConfiguration(new Configuration()).build()
+        Thing thingB = ThingBuilder.create(new ThingUID(new ThingTypeUID("binding:type"), "thingId"))
+                .withConfiguration(new Configuration()).build()
 
-		assertTrue ThingHelper.equals(thingA, thingB)
+        assertTrue ThingHelper.equals(thingA, thingB)
 
-		thingB.setChannels([
-			new Channel(new ChannelUID("binding:type:thingId:channel3"), "itemType3")
-		])
+        thingB.setChannels([ChannelBuilder.create(new ChannelUID("binding:type:thingId:channel3"), "itemType3").build()])
 
-		assertFalse ThingHelper.equals(thingA, thingB)
-	}
+        assertFalse ThingHelper.equals(thingA, thingB)
+    }
 
 
     @Test
@@ -127,10 +133,13 @@ class ThingHelperTest {
         ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "test")
 
         Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withChannels(
-                new Channel(new ChannelUID(THING_UID, "channel1"), ""),
-                new Channel(new ChannelUID(THING_UID, "channel2"), "")
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel1"), "").build(),
+                ChannelBuilder.create(new ChannelUID(THING_UID, "channel2"), "").build()
                 ).build();
 
-        ThingHelper.addChannelsToThing(thing, [new Channel(new ChannelUID(THING_UID, "channel2"), ""), new Channel(new ChannelUID(THING_UID, "channel3"), "")])
+        ThingHelper.addChannelsToThing(thing, [
+            ChannelBuilder.create(new ChannelUID(THING_UID, "channel2"), "").build(),
+            ChannelBuilder.create(new ChannelUID(THING_UID, "channel3"), "").build()
+        ])
     }
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelItemProviderTest.java
@@ -27,9 +27,9 @@ import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemFactory;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.library.items.NumberItem;
-import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.junit.Before;
@@ -79,7 +79,8 @@ public class ChannelItemProviderTest {
         props.put("initialDelay", "false");
         provider.activate(props);
 
-        when(thingRegistry.getChannel(same(CHANNEL_UID))).thenReturn(new Channel(CHANNEL_UID, "Number"));
+        when(thingRegistry.getChannel(same(CHANNEL_UID)))
+                .thenReturn(ChannelBuilder.create(CHANNEL_UID, "Number").build());
         when(itemFactory.createItem("Number", ITEM_NAME)).thenReturn(ITEM);
         when(localeProvider.getLocale()).thenReturn(Locale.ENGLISH);
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -30,7 +30,6 @@ import org.eclipse.smarthome.core.common.SafeCaller;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.service.ReadyMarker;
 import org.eclipse.smarthome.core.service.ReadyService;
-import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -42,6 +41,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.ThingType;
@@ -76,7 +76,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     @Before
     public void setUp() throws Exception {
         THING = ThingBuilder.create(THING_TYPE_UID, THING_UID)
-                .withChannels(Collections.singletonList(new Channel(CHANNEL_UID, "Switch"))).build();
+                .withChannels(Collections.singletonList(ChannelBuilder.create(CHANNEL_UID, "Switch").build())).build();
         registerVolatileStorageService();
 
         configureAutoLinking(false);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelKind;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 
@@ -69,6 +70,10 @@ public class Channel {
         this.properties = Collections.unmodifiableMap(new HashMap<String, String>(0));
     }
 
+    /**
+     * @deprecated - use {@link ChannelBuilder} instead
+     */
+    @Deprecated
     public Channel(ChannelUID uid, String acceptedItemType) {
         this.uid = uid;
         this.acceptedItemType = acceptedItemType;
@@ -77,19 +82,35 @@ public class Channel {
         this.properties = Collections.unmodifiableMap(new HashMap<String, String>(0));
     }
 
+    /**
+     * @deprecated - use {@link ChannelBuilder} instead
+     */
+    @Deprecated
     public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration) {
         this(uid, null, acceptedItemType, ChannelKind.STATE, configuration, new HashSet<String>(0), null, null, null);
     }
 
+    /**
+     * @deprecated - use {@link ChannelBuilder} instead
+     */
+    @Deprecated
     public Channel(ChannelUID uid, String acceptedItemType, Set<String> defaultTags) {
         this(uid, null, acceptedItemType, ChannelKind.STATE, null, defaultTags, null, null, null);
     }
 
+    /**
+     * @deprecated - use {@link ChannelBuilder} instead
+     */
+    @Deprecated
     public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags,
             Map<String, String> properties) {
         this(uid, null, acceptedItemType, ChannelKind.STATE, null, defaultTags, properties, null, null);
     }
 
+    /**
+     * @deprecated - use ChannelBuilder instead
+     */
+    @Deprecated
     public Channel(ChannelUID uid, @Nullable ChannelTypeUID channelTypeUID, @Nullable String acceptedItemType,
             ChannelKind kind, @Nullable Configuration configuration, Set<String> defaultTags,
             @Nullable Map<String, String> properties, @Nullable String label, @Nullable String description) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/thing/EnrichThingDTOMapperTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/thing/EnrichThingDTOMapperTest.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.firmware.dto.FirmwareStatusDTO;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
@@ -109,8 +110,8 @@ public class EnrichThingDTOMapperTest {
     private List<Channel> mockChannels() {
         List<Channel> channels = new ArrayList<>();
 
-        channels.add(new Channel(new ChannelUID(THING_TYPE_UID + ":" + UID + ":1"), ITEM_TYPE));
-        channels.add(new Channel(new ChannelUID(THING_TYPE_UID + ":" + UID + ":2"), ITEM_TYPE));
+        channels.add(ChannelBuilder.create(new ChannelUID(THING_TYPE_UID + ":" + UID + ":1"), ITEM_TYPE).build());
+        channels.add(ChannelBuilder.create(new ChannelUID(THING_TYPE_UID + ":" + UID + ":2"), ITEM_TYPE).build());
 
         return channels;
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.astro.test/src/test/groovy/org/eclipse/smarthome/binding/astro/handler/test/AstroCommandTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro.test/src/test/groovy/org/eclipse/smarthome/binding/astro/handler/test/AstroCommandTest.groovy
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID
 import org.eclipse.smarthome.core.thing.Thing
 import org.eclipse.smarthome.core.thing.ThingUID
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder
 import org.eclipse.smarthome.core.types.RefreshType
 import org.eclipse.smarthome.core.types.State
 import org.junit.Test
@@ -44,25 +45,25 @@ class AstroCommandTest {
     public void 'refresh command updates the state of the channels'(){
         ThingUID thingUID = new ThingUID(AstroBindingConstants.THING_TYPE_SUN, TEST_SUN_THING_ID)
         ChannelUID channelUID = new ChannelUID(thingUID,DEFAULT_TEST_CHANNEL_ID)
-        Channel channel = new Channel(channelUID, DEFAULT_IMEM_TYPE)
-        
+        Channel channel = ChannelBuilder.create(channelUID, DEFAULT_IMEM_TYPE).build()
+
         Configuration thingConfiguration = new Configuration()
         thingConfiguration.put(GEOLOCATION_PROPERTY, GEOLOCATION_VALUE)
         thingConfiguration.put(INTERVAL_PROPERTY, INTERVAL_DEFAULT_VALUE)
-        
+
         Thing thing = mock(Thing.class)
         when(thing.getConfiguration()).thenReturn(thingConfiguration)
         when(thing.getUID()).thenReturn(thingUID)
         when(thing.getChannel(DEFAULT_TEST_CHANNEL_ID)).thenReturn(channel)
-        
+
         ThingHandlerCallback callback = mock(ThingHandlerCallback.class)
         AstroThingHandler sunHandler = Mockito.spy(new SunHandler(thing))
-        
+
         // Required from the AstroThingHandler to send the status update
         Mockito.doReturn(new Sun()).when(sunHandler).getPlanet()
         Mockito.doReturn(true).when(sunHandler).isLinked(any(String.class))
         sunHandler.setCallback(callback);
-        
+
         sunHandler.handleCommand(channelUID, RefreshType.REFRESH)
         verify(callback, times(1)).stateUpdated(eq(channelUID), any(State.class))
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/src/test/java/org/eclipse/smarthome/binding/fsinternetradio/test/FSInternetRadioHandlerJavaTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/src/test/java/org/eclipse/smarthome/binding/fsinternetradio/test/FSInternetRadioHandlerJavaTest.java
@@ -52,6 +52,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -792,7 +793,7 @@ public class FSInternetRadioHandlerJavaTest extends JavaTest {
     private Channel createChannel(ThingUID thingUID, String channelID, String acceptedItemType) {
         ChannelUID channelUID = new ChannelUID(thingUID, channelID);
 
-        Channel radioChannel = new Channel(channelUID, acceptedItemType);
+        Channel radioChannel = ChannelBuilder.create(channelUID, acceptedItemType).build();
         channels.add(radioChannel);
         return radioChannel;
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/src/test/java/org/eclipse/smarthome/binding/ntp/test/NtpOSGiTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/src/test/java/org/eclipse/smarthome/binding/ntp/test/NtpOSGiTest.java
@@ -21,7 +21,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -50,6 +49,7 @@ import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ManagedItemChannelLinkProvider;
@@ -410,8 +410,8 @@ public class NtpOSGiTest extends JavaOSGiTest {
         ThingUID ntpUid = new ThingUID(NtpBindingConstants.THING_TYPE_NTP, TEST_THING_ID);
 
         ChannelUID channelUID = new ChannelUID(ntpUid, channelID);
-        Channel channel = new Channel(channelUID, channelTypeUID, acceptedItemType, ChannelKind.STATE,
-                channelConfiguration, Collections.emptySet(), null, "label", null);
+        Channel channel = ChannelBuilder.create(channelUID, acceptedItemType).withType(channelTypeUID)
+                .withConfiguration(channelConfiguration).withLabel("label").withKind(ChannelKind.STATE).build();
 
         ntpThing = ThingBuilder.create(NtpBindingConstants.THING_TYPE_NTP, ntpUid).withConfiguration(configuration)
                 .withChannel(channel).build();

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoLightOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoLightOSGiTest.groovy
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
 import org.eclipse.smarthome.core.thing.binding.ThingHandler
 import org.eclipse.smarthome.core.thing.binding.builder.BridgeBuilder
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
 import org.eclipse.smarthome.core.thing.type.ChannelKind
 import org.eclipse.smarthome.io.transport.upnp.UpnpIOParticipant
@@ -84,9 +85,7 @@ class GenericWemoLightOSGiTest extends GenericWemoOSGiTest {
         ThingUID thingUID = new ThingUID(thingTypeUID, TEST_THING_ID);
 
         ChannelUID channelUID = new ChannelUID(thingUID, channelID)
-        Channel channel = new Channel(channelUID, DEFAULT_CHANNEL_TYPE_UID, itemAcceptedType, ChannelKind.STATE,
-                null, Collections.emptySet(), null, "label", null);
-
+        Channel channel = ChannelBuilder.create(channelUID, itemAcceptedType).withType(DEFAULT_CHANNEL_TYPE_UID).withKind(ChannelKind.STATE).withLabel("label").build();
         ThingUID bridgeUID = new ThingUID(BRIDGE_TYPE_UID, WEMO_BRIDGE_ID);
 
         thing = ThingBuilder.create(thingTypeUID, thingUID)

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/test/GenericWemoOSGiTest.groovy
@@ -43,6 +43,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID
 import org.eclipse.smarthome.core.thing.ThingUID
 import org.eclipse.smarthome.core.thing.binding.ThingHandler
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory
+import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink
 import org.eclipse.smarthome.core.thing.link.ManagedItemChannelLinkProvider
@@ -177,8 +178,7 @@ public abstract class GenericWemoOSGiTest extends OSGiTest {
         ThingUID thingUID = new ThingUID(thingTypeUID, TEST_THING_ID);
 
         ChannelUID channelUID = new ChannelUID(thingUID, channelID)
-        Channel channel = new Channel(channelUID, DEFAULT_CHANNEL_TYPE_UID, itemAcceptedType, ChannelKind.STATE,
-                null, Collections.emptySet(), null, "label", null);
+        Channel channel = ChannelBuilder.create(channelUID, itemAcceptedType).withType(DEFAULT_CHANNEL_TYPE_UID).withKind(ChannelKind.STATE).withLabel("label").build();
 
         thing = ThingBuilder.create(thingTypeUID, thingUID)
                 .withConfiguration(configuration)


### PR DESCRIPTION
...in order to point people to using the builder.

Also, cleaned up all the tests which were still using the constructors.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>