### PR TITLE
Config parameter: limitToOptions Sync code with documentation

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigDescriptionParameterBuilderTest.groovy
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/groovy/org/eclipse/smarthome/config/core/test/ConfigDescriptionParameterBuilderTest.groovy
@@ -145,7 +145,7 @@ class ConfigDescriptionParameterBuilderTest {
         assertFalse param.isReadOnly()
         assertFalse param.isMultiple()
         assertFalse param.isAdvanced()
-        assertFalse param.getLimitToOptions()
+        assertTrue param.getLimitToOptions()
         def param2 = new ConfigDescriptionParameter("Dummy", Type.BOOLEAN, null, null,
                 null, null, null, null, null, null,
                 null, null, null, null,
@@ -155,7 +155,7 @@ class ConfigDescriptionParameterBuilderTest {
         assertFalse param2.isReadOnly()
         assertFalse param2.isMultiple()
         assertFalse param2.isAdvanced()
-        assertFalse param2.getLimitToOptions()
+        assertTrue param2.getLimitToOptions()
         assertTrue param2.getFilterCriteria().isEmpty()
         assertTrue param2.getOptions().isEmpty()
     }

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameter.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionParameter.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.smarthome.config.core;
 
-import com.google.gson.annotations.SerializedName;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,6 +20,8 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
+import com.google.gson.annotations.SerializedName;
 
 /**
  * The {@link ConfigDescriptionParameter} class contains the description of a
@@ -95,7 +96,7 @@ public class ConfigDescriptionParameter {
     private List<ParameterOption> options = new ArrayList<ParameterOption>();
     private List<FilterCriteria> filterCriteria = new ArrayList<FilterCriteria>();
 
-    private boolean limitToOptions = false;
+    private boolean limitToOptions = true;
     private boolean advanced = false;
     private boolean verify = false;
 


### PR DESCRIPTION
Fixes #2844

Since limitToOptions = false is currently broken anyway, see #4014 I think we can now sync the code with the documentation to at least starting to fix all related issues (see also #3556).

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>