### PR TITLE
switch to manually maintained REST API version

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/beans/RootBean.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/beans/RootBean.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public class RootBean {
 
-    public final String version = "1.0";
+    public final String version = "1";
 
     public final List<Links> links = new ArrayList<Links>();
 

--- a/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/beans/RootBean.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest/src/main/java/org/eclipse/smarthome/io/rest/internal/resources/beans/RootBean.java
@@ -15,18 +15,16 @@ package org.eclipse.smarthome.io.rest.internal.resources.beans;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.smarthome.io.rest.internal.RESTActivator;
-
 /**
  * This is a java bean that is used to define the root entry
  * page of the REST interface.
- * 
+ *
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
 public class RootBean {
 
-    public final String version = RESTActivator.getContext().getBundle().getVersion().toString();
+    public final String version = "1.0";
 
     public final List<Links> links = new ArrayList<Links>();
 


### PR DESCRIPTION
We have so far used the bundle version of the io.rest bundle as a version that we expose through the REST API.
The primary use case is to allow REST clients to figure out, which version they are talking to, i.e. whether certain features are already available or not.

Unfortunately, there is a problem with this this approach: Our different builds result in different kinds of version syntax, e.g. 0.10.0, 0.10.0.201802051234, 0.10.0.b1 or 0.10.0.RC1.
If client comes across those versions, it has the problem that it has no clue how to order them. Is 0.10.0.b1 newer or older than 0.10.0.201802051234? There is no way to figure this out. (Note: this is exactly the situation for openHAB 2.2.0 release, which includes 0.10.0.b1).

Imho, the only satisfying solution for this is to manually maintain the REST API version. We should increase the minor version whenever we add new features to the REST API and increase the major version, whenever we break some existing feature on it.

My suggestion is to start with 1.0 as this is bigger than any previous 0.x.0 version.

@sjka & @maggu2810, wdyt, does this make sense?

/cc @lolodomo & @mueller-ma

Signed-off-by: Kai Kreuzer <kai@openhab.org>