### PR TITLE
return NULL if PathNotFoundException is thrown

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -65,7 +65,7 @@ public class JSonPathTransformationService implements TransformationService {
                 return transformationResult.toString();
             }
         } catch (PathNotFoundException e) {
-            throw new TransformationException("Invalid path '" + jsonPathExpression + "' in '" + source + "'");
+		return null;
         } catch (InvalidPathException | InvalidJsonException e) {
             throw new TransformationException("An error occurred while transforming JSON expression.", e);
         }


### PR DESCRIPTION
reverts a feature from f90852c
discussion also see #4376

works like described in the manual
https://docs.openhab.org/v2.2/addons/transformations/jsonpath/readme.html#example
and it's necessary to parse json which doesn't contain the path
every time you query the json, otherwise the logfile is filled up with the json
stuff
for example, see https://www.dwd.de/DWD/warnungen/warnapp/json/warnings.json