### PR TITLE
return NULL if PathNotFoundException is thrown

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
@@ -67,7 +67,7 @@ public class JSonPathTransformationServiceTest {
     @Test
     public void testPathMismatchReturnNull() throws TransformationException {
         String transformedResponse = processor.transform("$[5].id", jsonArray);
-        assert(transformedResponse == null);
+        assertEquals("NULL", transformedResponse);
     }
 
     @Test(expected = TransformationException.class)

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
@@ -64,9 +64,10 @@ public class JSonPathTransformationServiceTest {
         processor.transform("$$", jsonArray);
     }
 
-    @Test(expected = TransformationException.class)
+    @Test
     public void testPathMismatchReturnNull() throws TransformationException {
-        processor.transform("$[5].id", jsonArray);
+        String transformedResponse = processor.transform("$[5].id", jsonArray);
+        assert(transformedResponse == null);
     }
 
     @Test(expected = TransformationException.class)

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -65,7 +65,7 @@ public class JSonPathTransformationService implements TransformationService {
                 return transformationResult.toString();
             }
         } catch (PathNotFoundException e) {
-            throw new TransformationException("Invalid path '" + jsonPathExpression + "' in '" + source + "'");
+            return null;
         } catch (InvalidPathException | InvalidJsonException e) {
             throw new TransformationException("An error occurred while transforming JSON expression.", e);
         }

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -52,11 +52,11 @@ public class JSonPathTransformationService implements TransformationService {
             throw new TransformationException("the given parameters 'JSonPath' and 'source' must not be null");
         }
 
-        logger.debug("about to transform '{}' by the function '{}'", source, jsonPathExpression);
+        logger.debug("About to transform '{}' by the function '{}'", source, jsonPathExpression);
 
         try {
             Object transformationResult = JsonPath.read(source, jsonPathExpression);
-            logger.debug("transformation resulted in '{}'", transformationResult);
+            logger.debug("Transformation resulted in '{}'", transformationResult);
             if (transformationResult == null) {
                 return UnDefType.NULL.toFullString();
             } else if (transformationResult instanceof List) {
@@ -65,7 +65,7 @@ public class JSonPathTransformationService implements TransformationService {
                 return transformationResult.toString();
             }
         } catch (PathNotFoundException e) {
-            logger.debug("path not found in JSON string (PathNotFoundException)");
+            logger.debug("Given JSONPath selector expression '" + jsonPathExpression + "' does not match the input string '" + source + "'");
             return UnDefType.NULL.toFullString();
         } catch (InvalidPathException | InvalidJsonException e) {
             throw new TransformationException("An error occurred while transforming JSON expression.", e);

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -65,7 +65,8 @@ public class JSonPathTransformationService implements TransformationService {
                 return transformationResult.toString();
             }
         } catch (PathNotFoundException e) {
-            return null;
+            logger.debug("path not found in JSON string (PathNotFoundException)");
+            return UnDefType.NULL.toFullString();
         } catch (InvalidPathException | InvalidJsonException e) {
             throw new TransformationException("An error occurred while transforming JSON expression.", e);
         }

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -70,7 +70,6 @@ public class JSonPathTransformationService implements TransformationService {
         } catch (InvalidPathException | InvalidJsonException e) {
             throw new TransformationException("An error occurred while transforming JSON expression.", e);
         }
-
     }
 
     private String flattenList(List<?> list) {
@@ -84,5 +83,4 @@ public class JSonPathTransformationService implements TransformationService {
         }
         return UnDefType.NULL.toFullString();
     }
-
 }


### PR DESCRIPTION
reverts a feature or modification from f90852c
discussion also see #4376

works like described in the manual
https://docs.openhab.org/v2.2/addons/transformations/jsonpath/readme.html#example
and it's necessary to parse json which doesn't contain the path
every time you query the json, otherwise the logfile is filled up with the json
stuff
for example, see https://www.dwd.de/DWD/warnungen/warnapp/json/warnings.json

Signed-off-by: Jens Schanz <mail@jensschanz.de>