### PR TITLE
PersistenceManager: Use service name consistently

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/internal/PersistenceModelManager.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/internal/PersistenceModelManager.java
@@ -67,7 +67,8 @@ public class PersistenceModelManager implements ModelRepositoryChangeListener {
     protected void deactivate() {
         modelRepository.removeModelRepositoryChangeListener(this);
         for (String modelName : modelRepository.getAllModelNamesOfType("persist")) {
-            manager.stopEventHandling(modelName);
+            String serviceName = modelName.substring(0, modelName.length() - ".persist".length());
+            manager.stopEventHandling(serviceName);
         }
     }
 


### PR DESCRIPTION
PersistenceManagerImpl uses the service name to identify a persistence
service in some methods but the model name (which is usually the service
name plus the suffix ".persist") in others.  And in some cases different
code paths use either of them and assume that they're identical.

As an example, #startEventHandling accepts the service name and calls
uses it as a key for the persistenceJobs Map. #stopEventHandling accepts
the model name and calls #removeTimers with it, which again uses it as a
key for persistenceJobs.
And since both names are Strings, the compiler does not recognise the error.

This change modifies PersistenceManagerImpl to always refer to the
service name and drops all references to model names.
It does not modify the PersistenceManager interface since it already
refers to all of these parameters as database ids.
It also fixes PersistenceModelManager to pass the service name instead
of the model name to its PersistenceManager.