### PR TITLE
PersistenceModelManager: Make initialisation code paths consistent

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/internal/PersistenceModelManager.java
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/src/org/eclipse/smarthome/model/persistence/internal/PersistenceModelManager.java
@@ -56,21 +56,19 @@ public class PersistenceModelManager implements ModelRepositoryChangeListener {
     public PersistenceModelManager() {
     }
 
-    protected void activate() {
-        modelRepository.addModelRepositoryChangeListener(this);
-        for (String modelName : modelRepository.getAllModelNamesOfType("persist")) {
-            String serviceName = modelName.substring(0, modelName.length() - ".persist".length());
-            manager.startEventHandling(serviceName);
-        }
-    }
+	protected void activate() {
+		modelRepository.addModelRepositoryChangeListener(this);
+		for (String modelName : modelRepository.getAllModelNamesOfType("persist")) {
+			addModel(modelName);
+		}
+	}
 
-    protected void deactivate() {
-        modelRepository.removeModelRepositoryChangeListener(this);
-        for (String modelName : modelRepository.getAllModelNamesOfType("persist")) {
-            String serviceName = modelName.substring(0, modelName.length() - ".persist".length());
-            manager.stopEventHandling(serviceName);
-        }
-    }
+	protected void deactivate() {
+		modelRepository.removeModelRepositoryChangeListener(this);
+		for (String modelName : modelRepository.getAllModelNamesOfType("persist")) {
+			removeModel(modelName);
+		}
+	}
 
     protected void setModelRepository(ModelRepository modelRepository) {
         this.modelRepository = modelRepository;
@@ -91,22 +89,34 @@ public class PersistenceModelManager implements ModelRepositoryChangeListener {
     @Override
     public void modelChanged(String modelName, EventType type) {
         if (modelName.endsWith(".persist")) {
-            final String dbId = modelName.substring(0, modelName.length() - ".persist".length());
             if (type == EventType.REMOVED || type == EventType.MODIFIED) {
-                manager.removeConfig(dbId);
+                removeModel(modelName);
             }
-
             if (type == EventType.ADDED || type == EventType.MODIFIED) {
-                final PersistenceModel model = (PersistenceModel) modelRepository.getModel(modelName);
-                if (model != null) {
-                    manager.addConfig(dbId, new PersistenceServiceConfiguration(mapConfigs(model.getConfigs()),
-                            mapStrategies(model.getDefaults()), mapStrategies(model.getStrategies())));
-                }
+                addModel(modelName);
             }
         }
     }
 
-    private List<SimpleItemConfiguration> mapConfigs(List<PersistenceConfiguration> configs) {
+	private void addModel(String modelName) {
+		final PersistenceModel model = (PersistenceModel) modelRepository.getModel(modelName);
+		if (model != null) {
+		    String serviceName = serviceName(modelName);
+			manager.addConfig(serviceName, new PersistenceServiceConfiguration(mapConfigs(model.getConfigs()),
+		            mapStrategies(model.getDefaults()), mapStrategies(model.getStrategies())));
+		}
+	}
+
+	private void removeModel(String modelName) {
+		String serviceName = serviceName(modelName);
+		manager.removeConfig(serviceName);
+	}
+
+    private String serviceName(String modelName) {
+		return modelName.substring(0, modelName.length() - ".persist".length());
+	}
+
+	private List<SimpleItemConfiguration> mapConfigs(List<PersistenceConfiguration> configs) {
         final List<SimpleItemConfiguration> lst = new LinkedList<>();
         for (final PersistenceConfiguration config : configs) {
             lst.add(mapConfig(config));


### PR DESCRIPTION
NOTE: This PR includes and depends on the changes in PR #5054.

When PersistenceModelManager#activate is called, the ModelRepository is
present, but we cannot be sure whether it has loaded the persistence models
yet.

a) If it has not, PersistenceModelManager registers itself as a change
listener, then when a model is loaded ModelRepository calls
PersistenceModelManager#modelChanged which extracts its configuration and
calls PersistenceManager#addConfig with that, which in turn calls
PersistenceManager#startEventHandling.

b) If it has, PersistenceModelManager registers itself as a change
listener, but since the models are already loaded #modelChanged does not
get called.  Instead PersistenceModelManager loops over the models and
calls PersistenceManager#startEventHandling for each, but it never extracts
any configuration from the models, and since PersistenceManager is now
missing the configuration it does not actually set up any event handling
jobs.

In short, case b) is broken.

This change extracts methods for the behaviour that _should_ occur, namely
adding or removing the extracted configuration of each model to/from the
PersistenceManager (and _not_ calling
itself in #addConfig/#removeConfig), and calls these on both initialisation
and deinitialisation paths, ensuring that PersistenceManager knows the
configuration of each configured PersistenceService so it can actually
handle events.