### PR TITLE
Paper UI: add API for custom image tile load function

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/openlayers-esh.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/openlayers-esh.json
@@ -1,6 +1,7 @@
 {
   "exports": [
     "ol.Collection#extend",
+    "ol.ImageTile#getImage",
     "ol.Map",
     "ol.Map#addLayer",
     "ol.Map#getView",


### PR DESCRIPTION
Add OpenLayers ImageTile#getImage API to the custom OpenLayers build. This is needed to provide a custom ImageTile load function.

Signed-off-by: Henning Treu <henning.treu@telekom.de>