### PR TITLE
Remove interface inference

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/internal/DiscoveryServiceRegistryImpl.java
@@ -473,7 +473,7 @@ public final class DiscoveryServiceRegistryImpl implements DiscoveryServiceRegis
     private void addDiscoveryServiceActivated(final DiscoveryService discoveryService) {
         discoveryService.addDiscoveryListener(this);
         if (discoveryService instanceof ExtendedDiscoveryService) {
-            safeCaller.create((ExtendedDiscoveryService) discoveryService).build()
+            safeCaller.create((ExtendedDiscoveryService) discoveryService, ExtendedDiscoveryService.class).build()
                     .setDiscoveryServiceCallback(discoveryServiceCallback);
         }
         this.discoveryServices.add(discoveryService);

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
@@ -14,7 +14,7 @@ package org.eclipse.smarthome.core.internal.common;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -119,7 +119,7 @@ public class SafeCallerImplTest extends JavaTest {
     @Test
     public void testInterfaceDetection() throws Exception {
         ITarget target = new Target();
-        String result = safeCaller.create(target).build().method();
+        String result = safeCaller.create(target, ITarget.class).build().method();
         assertThat(result, is("Hello"));
     }
 
@@ -128,7 +128,7 @@ public class SafeCallerImplTest extends JavaTest {
         Runnable mock = mock(Runnable.class);
         doThrow(RuntimeException.class).when(mock).run();
 
-        safeCaller.create(mock).onException(mockErrorHandler).build().run();
+        safeCaller.create(mock, Runnable.class).onException(mockErrorHandler).build().run();
         waitForAssert(() -> {
             verify(mockErrorHandler).accept(isA(Throwable.class));
         });
@@ -139,7 +139,7 @@ public class SafeCallerImplTest extends JavaTest {
         Runnable mock = mock(Runnable.class);
         doAnswer(a -> sleep(BLOCK)).when(mock).run();
 
-        safeCaller.create(mock).withTimeout(TIMEOUT).onTimeout(mockTimeoutHandler).build().run();
+        safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).onTimeout(mockTimeoutHandler).build().run();
         waitForAssert(() -> {
             verify(mockTimeoutHandler).run();
         });
@@ -162,13 +162,13 @@ public class SafeCallerImplTest extends JavaTest {
 
         spawn(() -> {
             assertDurationBetween(TIMEOUT - GRACE, BLOCK - GRACE, () -> {
-                safeCaller.create(mock).withTimeout(TIMEOUT).build().run();
+                safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).build().run();
             });
         });
         sleep(GRACE); // give it a chance to start
         spawn(() -> {
             assertDurationBetween(TIMEOUT - GRACE, BLOCK - GRACE, () -> {
-                safeCaller.create(mock).withTimeout(TIMEOUT).build().run();
+                safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).build().run();
             });
         });
         waitForAssert(() -> {
@@ -183,10 +183,10 @@ public class SafeCallerImplTest extends JavaTest {
         configureSingleThread();
 
         assertDurationBetween(TIMEOUT - GRACE, BLOCK - GRACE, () -> {
-            safeCaller.create(mock).withTimeout(TIMEOUT).build().run();
+            safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).build().run();
         });
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock).withTimeout(TIMEOUT).build().run();
+            safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).build().run();
         });
         assertDurationBetween(TIMEOUT - GRACE, BLOCK + GRACE, () -> {
             waitForAssert(() -> {
@@ -203,13 +203,13 @@ public class SafeCallerImplTest extends JavaTest {
 
         spawn(() -> {
             assertDurationBetween(TIMEOUT - GRACE, BLOCK - GRACE, () -> {
-                safeCaller.create(mock).withTimeout(TIMEOUT).build().run();
+                safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).build().run();
             });
         });
         sleep(GRACE); // give it a chance to start
         spawn(() -> {
             assertDurationBelow(GRACE, () -> {
-                safeCaller.create(mock).withTimeout(TIMEOUT).build().run();
+                safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).build().run();
             });
         });
         assertDurationBetween(BLOCK - 2 * GRACE, BLOCK + TIMEOUT + GRACE, () -> {
@@ -225,10 +225,10 @@ public class SafeCallerImplTest extends JavaTest {
         doAnswer(a -> sleep(TIMEOUT)).when(mock).run();
 
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock).withTimeout(TIMEOUT).withAsync().build().run();
+            safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).withAsync().build().run();
         });
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock).withTimeout(TIMEOUT).withAsync().build().run();
+            safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).withAsync().build().run();
         });
         waitForAssert(() -> {
             verify(mock, times(2)).run();
@@ -242,10 +242,10 @@ public class SafeCallerImplTest extends JavaTest {
         configureSingleThread();
 
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock).withTimeout(TIMEOUT).withAsync().build().run();
+            safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).withAsync().build().run();
         });
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock).withTimeout(TIMEOUT).withAsync().build().run();
+            safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).withAsync().build().run();
         });
         waitForAssert(() -> {
             verify(mock, times(2)).run();
@@ -259,10 +259,10 @@ public class SafeCallerImplTest extends JavaTest {
         Runnable mock2 = mock(Runnable.class);
 
         assertDurationBetween(TIMEOUT - GRACE, BLOCK - GRACE, () -> {
-            safeCaller.create(mock1).withTimeout(TIMEOUT).withIdentifier("id").build().run();
+            safeCaller.create(mock1, Runnable.class).withTimeout(TIMEOUT).withIdentifier("id").build().run();
         });
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock2).withTimeout(TIMEOUT).withIdentifier("id").build().run();
+            safeCaller.create(mock2, Runnable.class).withTimeout(TIMEOUT).withIdentifier("id").build().run();
         });
     }
 
@@ -274,10 +274,10 @@ public class SafeCallerImplTest extends JavaTest {
         doAnswer(a -> sleep(BLOCK)).when(mock2).run();
 
         assertDurationBetween(TIMEOUT - GRACE, BLOCK - GRACE, () -> {
-            safeCaller.create(mock1).withTimeout(TIMEOUT).withIdentifier(new Object()).build().run();
+            safeCaller.create(mock1, Runnable.class).withTimeout(TIMEOUT).withIdentifier(new Object()).build().run();
         });
         assertDurationBetween(TIMEOUT - GRACE, BLOCK - GRACE, () -> {
-            safeCaller.create(mock2).withTimeout(TIMEOUT).withIdentifier(new Object()).build().run();
+            safeCaller.create(mock2, Runnable.class).withTimeout(TIMEOUT).withIdentifier(new Object()).build().run();
         });
     }
 
@@ -287,7 +287,8 @@ public class SafeCallerImplTest extends JavaTest {
         doAnswer(a -> sleep(BLOCK)).when(mock).run();
 
         assertDurationAbove(BLOCK - GRACE, () -> {
-            safeCaller.create(mock).withTimeout(BLOCK + GRACE * 2).onTimeout(mockTimeoutHandler).build().run();
+            safeCaller.create(mock, Runnable.class).withTimeout(BLOCK + GRACE * 2).onTimeout(mockTimeoutHandler).build()
+                    .run();
         });
         verifyNoMoreInteractions(mockTimeoutHandler);
     }
@@ -347,18 +348,18 @@ public class SafeCallerImplTest extends JavaTest {
     public void testLambdas() throws Exception {
         ITarget thingHandler = new Target();
 
-        safeCaller.create((Callable<Void>) () -> {
+        safeCaller.create(() -> {
             thingHandler.method();
             return null;
-        }).build().call();
+        }, Callable.class).build().call();
 
-        safeCaller.create((Runnable) () -> {
+        safeCaller.create(() -> {
             thingHandler.method();
-        }).build().run();
+        }, Runnable.class).build().run();
 
         String res = safeCaller.create((Function<String, String>) name -> {
             return "Hello " + name + "!";
-        }).build().apply("World");
+        }, Function.class).build().apply("World");
         assertThat(res, is("Hello World!"));
     }
 
@@ -367,7 +368,7 @@ public class SafeCallerImplTest extends JavaTest {
         Runnable mock1 = mock(Runnable.class);
         doAnswer(a -> sleep(BLOCK)).when(mock1).run();
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock1).withTimeout(TIMEOUT).withAsync().build().run();
+            safeCaller.create(mock1, Runnable.class).withTimeout(TIMEOUT).withAsync().build().run();
         });
         waitForAssert(() -> verify(mock1, times(1)).run());
     }
@@ -379,7 +380,7 @@ public class SafeCallerImplTest extends JavaTest {
         doAnswer(a -> sleep(BLOCK)).when(mock1).run();
 
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock1).withTimeout(TIMEOUT).withAsync().withIdentifier(identifier)
+            safeCaller.create(mock1, Runnable.class).withTimeout(TIMEOUT).withAsync().withIdentifier(identifier)
                     .onTimeout(mockTimeoutHandler).onException(mockErrorHandler).build().run();
         });
         waitForAssert(() -> verify(mock1, times(1)).run());
@@ -394,7 +395,7 @@ public class SafeCallerImplTest extends JavaTest {
         doThrow(RuntimeException.class).when(mock1).run();
 
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock1).withTimeout(TIMEOUT).withAsync().withIdentifier(identifier)
+            safeCaller.create(mock1, Runnable.class).withTimeout(TIMEOUT).withAsync().withIdentifier(identifier)
                     .onTimeout(mockTimeoutHandler).onException(mockErrorHandler).build().run();
         });
         waitForAssert(() -> verify(mock1, times(1)).run());
@@ -411,8 +412,10 @@ public class SafeCallerImplTest extends JavaTest {
         doAnswer(a -> sleep(BLOCK)).when(mock2).run();
 
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock1).withTimeout(TIMEOUT).withAsync().withIdentifier(new Object()).build().run();
-            safeCaller.create(mock2).withTimeout(TIMEOUT).withAsync().withIdentifier(new Object()).build().run();
+            safeCaller.create(mock1, Runnable.class).withTimeout(TIMEOUT).withAsync().withIdentifier(new Object())
+                    .build().run();
+            safeCaller.create(mock2, Runnable.class).withTimeout(TIMEOUT).withAsync().withIdentifier(new Object())
+                    .build().run();
         });
         waitForAssert(() -> verify(mock1, times(1)).run());
         waitForAssert(() -> verify(mock2, times(1)).run());
@@ -427,8 +430,8 @@ public class SafeCallerImplTest extends JavaTest {
         doAnswer(a -> sleep(BLOCK)).when(mock2).run();
 
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock1).withTimeout(TIMEOUT).withAsync().build().run();
-            safeCaller.create(mock2).withTimeout(TIMEOUT).withAsync().build().run();
+            safeCaller.create(mock1, Runnable.class).withTimeout(TIMEOUT).withAsync().build().run();
+            safeCaller.create(mock2, Runnable.class).withTimeout(TIMEOUT).withAsync().build().run();
         });
         waitForAssert(() -> verify(mock1, times(1)).run());
         waitForAssert(() -> verify(mock2, times(1)).run());
@@ -444,8 +447,10 @@ public class SafeCallerImplTest extends JavaTest {
         doAnswer(a -> sleep(BLOCK)).when(mock2).run();
 
         assertDurationBelow(GRACE, () -> {
-            safeCaller.create(mock1).withAsync().withIdentifier(identifier).withTimeout(BLOCK + TIMEOUT).build().run();
-            safeCaller.create(mock2).withAsync().withIdentifier(identifier).withTimeout(BLOCK + TIMEOUT).build().run();
+            safeCaller.create(mock1, Runnable.class).withAsync().withIdentifier(identifier).withTimeout(BLOCK + TIMEOUT)
+                    .build().run();
+            safeCaller.create(mock2, Runnable.class).withAsync().withIdentifier(identifier).withTimeout(BLOCK + TIMEOUT)
+                    .build().run();
         });
         waitForAssert(() -> verify(mock1, times(1)).run());
         waitForAssert(() -> verify(mock2, times(1)).run());
@@ -459,7 +464,7 @@ public class SafeCallerImplTest extends JavaTest {
 
         for (int i = 0; i < THREAD_POOL_SIZE; i++) {
             assertDurationBelow(GRACE, () -> {
-                safeCaller.create(mock).withTimeout(TIMEOUT).withAsync().build().run();
+                safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).withAsync().build().run();
             });
         }
 
@@ -477,7 +482,8 @@ public class SafeCallerImplTest extends JavaTest {
 
         for (int i = 0; i < THREAD_POOL_SIZE * 2; i++) {
             assertDurationBelow(GRACE, () -> {
-                safeCaller.create(mock).withTimeout(TIMEOUT).withIdentifier(new Object()).withAsync().build().run();
+                safeCaller.create(mock, Runnable.class).withTimeout(TIMEOUT).withIdentifier(new Object()).withAsync()
+                        .build().run();
             });
         }
         assertDurationBetween(BLOCK - GRACE, BLOCK + TIMEOUT + GRACE, () -> {
@@ -513,7 +519,7 @@ public class SafeCallerImplTest extends JavaTest {
     @Test
     public void testDuplicateInterface() {
         ITarget target = new DerivedTarget();
-        safeCaller.create(target).build().method();
+        safeCaller.create(target, ITarget.class).build().method();
     }
 
     private void assertDurationBelow(long high, Runnable runnable) {

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
@@ -357,7 +357,7 @@ public class SafeCallerImplTest extends JavaTest {
             thingHandler.method();
         }, Runnable.class).build().run();
 
-        String res = safeCaller.create((Function<String, String>) name -> {
+        Object res = safeCaller.create((Function<String, String>) name -> {
             return "Hello " + name + "!";
         }, Function.class).build().apply("World");
         assertThat(res, is("Hello World!"));

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
@@ -65,7 +65,7 @@ import com.google.common.collect.ImmutableSet;
  * central instance to start a firmware update.
  *
  * @author Thomas Höfer - Initial contribution
- * @authot Dimitar Ivanov - update and cancel operations are run with different safe caller identifiers in order to
+ * @author Dimitar Ivanov - update and cancel operations are run with different safe caller identifiers in order to
  *         execute asynchronously
  */
 @Component(immediate = true, service = { EventSubscriber.class, FirmwareUpdateService.class })

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateService.java
@@ -12,10 +12,7 @@
  */
 package org.eclipse.smarthome.core.thing.firmware;
 
-import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.createUnknownInfo;
-import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.createUpToDateInfo;
-import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.createUpdateAvailableInfo;
-import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.createUpdateExecutableInfo;
+import static org.eclipse.smarthome.core.thing.firmware.FirmwareStatusInfo.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -68,7 +65,8 @@ import com.google.common.collect.ImmutableSet;
  * central instance to start a firmware update.
  *
  * @author Thomas Höfer - Initial contribution
- * @authot Dimitar Ivanov - update and cancel operations are run with different safe caller identifiers in order to execute asynchronously
+ * @authot Dimitar Ivanov - update and cancel operations are run with different safe caller identifiers in order to
+ *         execute asynchronously
  */
 @Component(immediate = true, service = { EventSubscriber.class, FirmwareUpdateService.class })
 public final class FirmwareUpdateService implements EventSubscriber {
@@ -234,16 +232,17 @@ public final class FirmwareUpdateService implements EventSubscriber {
 
         logger.debug("Starting firmware update for thing with UID {} and firmware with UID {}", thingUID, firmwareUID);
 
-        safeCaller.create(firmwareUpdateHandler).withTimeout(timeout).withAsync().onTimeout(() -> {
-            logger.error("Timeout occurred for firmware update of thing with UID {} and firmware with UID {}.",
-                    thingUID, firmwareUID);
-            progressCallback.failedInternal("timeout-error");
-        }).onException(e -> {
-            logger.error(
-                    "Unexpected exception occurred for firmware update of thing with UID {} and firmware with UID {}.",
-                    thingUID, firmwareUID, e.getCause());
-            progressCallback.failedInternal("unexpected-handler-error");
-        }).build().updateFirmware(firmware, progressCallback);
+        safeCaller.create(firmwareUpdateHandler, FirmwareUpdateHandler.class).withTimeout(timeout).withAsync()
+                .onTimeout(() -> {
+                    logger.error("Timeout occurred for firmware update of thing with UID {} and firmware with UID {}.",
+                            thingUID, firmwareUID);
+                    progressCallback.failedInternal("timeout-error");
+                }).onException(e -> {
+                    logger.error(
+                            "Unexpected exception occurred for firmware update of thing with UID {} and firmware with UID {}.",
+                            thingUID, firmwareUID, e.getCause());
+                    progressCallback.failedInternal("unexpected-handler-error");
+                }).build().updateFirmware(firmware, progressCallback);
     }
 
     /**
@@ -262,14 +261,15 @@ public final class FirmwareUpdateService implements EventSubscriber {
         final ProgressCallbackImpl progressCallback = getProgressCallback(thingUID);
 
         logger.debug("Cancelling firmware update for thing with UID {}.", thingUID);
-        safeCaller.create(firmwareUpdateHandler).withTimeout(timeout).withAsync().onTimeout(() -> {
-            logger.error("Timeout occurred while cancelling firmware update of thing with UID {}.", thingUID);
-            progressCallback.failedInternal("timeout-error-during-cancel");
-        }).onException(e -> {
-            logger.error("Unexpected exception occurred while cancelling firmware update of thing with UID {}.",
-                    thingUID, e.getCause());
-            progressCallback.failedInternal("unexpected-handler-error-during-cancel");
-        }).withIdentifier(new Object()).build().cancel();
+        safeCaller.create(firmwareUpdateHandler, FirmwareUpdateHandler.class).withTimeout(timeout).withAsync()
+                .onTimeout(() -> {
+                    logger.error("Timeout occurred while cancelling firmware update of thing with UID {}.", thingUID);
+                    progressCallback.failedInternal("timeout-error-during-cancel");
+                }).onException(e -> {
+                    logger.error("Unexpected exception occurred while cancelling firmware update of thing with UID {}.",
+                            thingUID, e.getCause());
+                    progressCallback.failedInternal("unexpected-handler-error-during-cancel");
+                }).withIdentifier(new Object()).build().cancel();
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
@@ -250,8 +250,9 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
                 if (handler != null) {
                     Profile profile = getProfile(link, item, thing);
                     if (profile instanceof StateProfile) {
-                        safeCaller.create(((StateProfile) profile)).withAsync().withIdentifier(thing)
-                                .withTimeout(THINGHANDLER_EVENT_TIMEOUT).build().onCommandFromItem(command);
+                        safeCaller.create(((StateProfile) profile), StateProfile.class).withAsync()
+                                .withIdentifier(thing).withTimeout(THINGHANDLER_EVENT_TIMEOUT).build()
+                                .onCommandFromItem(command);
                     }
                 }
             }
@@ -280,7 +281,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
                 ThingHandler handler = thing.getHandler();
                 if (handler != null) {
                     Profile profile = getProfile(link, item, thing);
-                    safeCaller.create(profile).withAsync().withIdentifier(handler)
+                    safeCaller.create(profile, Profile.class).withAsync().withIdentifier(handler)
                             .withTimeout(THINGHANDLER_EVENT_TIMEOUT).build().onStateUpdateFromItem(newState);
                 }
             }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileCallbackImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/ProfileCallbackImpl.java
@@ -65,8 +65,8 @@ public class ProfileCallbackImpl implements ProfileCallback {
                 if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                     logger.debug("Delegating command '{}' for item '{}' to handler for channel '{}'", command,
                             link.getItemName(), link.getLinkedUID());
-                    safeCaller.create(handler).withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT)
-                            .onTimeout(() -> {
+                    safeCaller.create(handler, ThingHandler.class)
+                            .withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT).onTimeout(() -> {
                                 logger.warn("Handler for thing '{}' takes more than {}ms for handling a command",
                                         handler.getThing().getUID(), CommunicationManager.THINGHANDLER_EVENT_TIMEOUT);
                             }).build().handleCommand(link.getLinkedUID(), command);
@@ -97,8 +97,8 @@ public class ProfileCallbackImpl implements ProfileCallback {
                 if (ThingHandlerHelper.isHandlerInitialized(thing)) {
                     logger.debug("Delegating update '{}' for item '{}' to handler for channel '{}'", state,
                             link.getItemName(), link.getLinkedUID());
-                    safeCaller.create(handler).withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT)
-                            .onTimeout(() -> {
+                    safeCaller.create(handler, ThingHandler.class)
+                            .withTimeout(CommunicationManager.THINGHANDLER_EVENT_TIMEOUT).onTimeout(() -> {
                                 logger.warn("Handler for thing '{}' takes more than {}ms for handling an update",
                                         handler.getThing().getUID(), CommunicationManager.THINGHANDLER_EVENT_TIMEOUT);
                             }).build().handleUpdate(link.getLinkedUID(), state);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeCaller.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeCaller.java
@@ -39,17 +39,6 @@ public interface SafeCaller {
      * @param interfaceType the interface which defines the relevant methods
      * @return a safe call builder instance.
      */
-    <T> SafeCallerBuilder<T> create(T target, Class<T> interfaceType);
-
-    /**
-     * Create a safe call builder for the given object.
-     *
-     * It's a short variant of {@link #create(Object, Class)} where the interface(s) are inferred automatically. It work
-     * only if the static type of {@code target} is an interface.
-     *
-     * @param target the object on which calls should be protected by the safe caller
-     * @return a safe call builder instance.
-     */
-    <T> SafeCallerBuilder<T> create(T target);
+    <T extends I, I> SafeCallerBuilder<T> create(T target, Class<I> interfaceType);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeCaller.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/SafeCaller.java
@@ -39,6 +39,6 @@ public interface SafeCaller {
      * @param interfaceType the interface which defines the relevant methods
      * @return a safe call builder instance.
      */
-    <T extends I, I> SafeCallerBuilder<T> create(T target, Class<I> interfaceType);
+    <T> SafeCallerBuilder<T> create(T target, Class<T> interfaceType);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerImpl.java
@@ -12,10 +12,7 @@
  */
 package org.eclipse.smarthome.core.internal.common;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -74,27 +71,12 @@ public class SafeCallerImpl implements SafeCaller {
     }
 
     @Override
-    public <T> SafeCallerBuilder<T> create(T target, Class<T> interfaceType) {
+    public <T extends I, I> SafeCallerBuilder<T> create(T target, Class<I> interfaceType) {
         return new SafeCallerBuilderImpl<T>(target, new Class<?>[] { interfaceType }, manager);
-    }
-
-    @Override
-    public <T> SafeCallerBuilder<T> create(T target) {
-        return new SafeCallerBuilderImpl<T>(target, getAllInterfaces(target), manager);
     }
 
     protected ExecutorService getScheduler() {
         return ThreadPoolManager.getPool(SAFE_CALL_POOL_NAME);
-    }
-
-    private static <T> Class<?>[] getAllInterfaces(T target) {
-        Set<Class<?>> ret = new HashSet<>();
-        Class<?> clazz = target.getClass();
-        while (clazz != null) {
-            ret.addAll(Arrays.asList(clazz.getInterfaces()));
-            clazz = clazz.getSuperclass();
-        }
-        return ret.toArray(new Class<?>[ret.size()]);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/common/SafeCallerImpl.java
@@ -71,7 +71,7 @@ public class SafeCallerImpl implements SafeCaller {
     }
 
     @Override
-    public <T extends I, I> SafeCallerBuilder<T> create(T target, Class<I> interfaceType) {
+    public <T> SafeCallerBuilder<T> create(T target, Class<T> interfaceType) {
         return new SafeCallerBuilderImpl<T>(target, new Class<?>[] { interfaceType }, manager);
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/EventHandler.java
@@ -132,7 +132,7 @@ public class EventHandler {
         for (final EventSubscriber eventSubscriber : eventSubscribers) {
             EventFilter filter = eventSubscriber.getEventFilter();
             if (filter == null || filter.apply(event)) {
-                safeCaller.create(eventSubscriber).withAsync().onTimeout(() -> {
+                safeCaller.create(eventSubscriber, EventSubscriber.class).withAsync().onTimeout(() -> {
                     logger.warn("Dispatching event to subscriber '{}' takes more than {}ms.",
                             eventSubscriber.toString(), SafeCaller.DEFAULT_TIMEOUT);
                 }).onException(e -> {


### PR DESCRIPTION
As seen e.g. in https://github.com/openhab/org.openhab.binding.zigbee/issues/47#issuecomment-364414903, the `SafeCaller.create(Class)` method which infers the target interface has proven itself to be quite dangerous. Especially with target objects which are not in the framework's control (which is the main use-case for the SafeCaller), not all interfaces might be reachable from the current class loader. Hence I think it would be best to completely drop it. It was convenient, but not such a great improvement to start catching such exceptions and jumping through further hoops to make it possible.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>