### PR TITLE
Tradfri: Show IP address in label of discovered gateway

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryParticipant.java
@@ -12,12 +12,8 @@
  */
 package org.eclipse.smarthome.binding.tradfri.internal.discovery;
 
-import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.GATEWAY_CONFIG_HOST;
-import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.GATEWAY_CONFIG_PORT;
-import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.GATEWAY_TYPE_UID;
-import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_FIRMWARE_VERSION;
-import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
-import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_VENDOR;
+import static org.eclipse.smarthome.binding.tradfri.TradfriBindingConstants.*;
+import static org.eclipse.smarthome.core.thing.Thing.*;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,7 +47,7 @@ public class TradfriDiscoveryParticipant implements MDNSDiscoveryParticipant {
      * RegEx patter to match the gateway name announced by mDNS
      * Possible values:
      * gw:001122334455, gw-001122334455, gw:00-11-22-33-44-55, gw-001122334455ServiceName
-     * 
+     *
      */
     private final Pattern GATEWAY_NAME_REGEX_PATTERN = Pattern.compile("(gw[:-]{1}([a-f0-9]{2}[-]?){6}){1}");
 
@@ -80,18 +76,21 @@ public class TradfriDiscoveryParticipant implements MDNSDiscoveryParticipant {
     public DiscoveryResult createResult(ServiceInfo service) {
         ThingUID thingUID = getThingUID(service);
         if (thingUID != null) {
-            if (service.getHostAddresses() != null && service.getHostAddresses().length > 0 && !service.getHostAddresses()[0].isEmpty()) {
+            if (service.getHostAddresses() != null && service.getHostAddresses().length > 0
+                    && !service.getHostAddresses()[0].isEmpty()) {
                 logger.debug("Discovered Tradfri gateway: {}", service);
+                String ipAddress = service.getHostAddresses()[0];
                 Map<String, Object> properties = new HashMap<>(4);
                 properties.put(PROPERTY_VENDOR, "IKEA of Sweden");
-                properties.put(GATEWAY_CONFIG_HOST, service.getHostAddresses()[0]);
+                properties.put(GATEWAY_CONFIG_HOST, ipAddress);
                 properties.put(GATEWAY_CONFIG_PORT, service.getPort());
                 properties.put(PROPERTY_SERIAL_NUMBER, service.getName());
                 String fwVersion = service.getPropertyString("version");
                 if (fwVersion != null) {
                     properties.put(PROPERTY_FIRMWARE_VERSION, fwVersion);
                 }
-                return DiscoveryResultBuilder.create(thingUID).withProperties(properties).withLabel("TRÅDFRI Gateway")
+                return DiscoveryResultBuilder.create(thingUID).withProperties(properties)
+                        .withLabel("TRÅDFRI Gateway (" + ipAddress + ")")
                         .withRepresentationProperty(GATEWAY_CONFIG_HOST).build();
             } else {
                 logger.warn("Discovered Tradfri gateway doesn't have an IP address: {}", service);


### PR DESCRIPTION
Analog to the [hue binding](https://github.com/eclipse/smarthome/blob/master/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java#L94) it is nice to see the IP address in the discovery result, especially if one has more than one gateway in the network.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>