### PR TITLE
Add placeholders for years in ESH header check pattern

### DIFF
--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -1,5 +1,6 @@
 checkstyle.aboutHtmlCheck.url=https://eclipse.org/legal/epl/about.html
-checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) \\d\\d\\d\\d,\\d\\d\\d\\d Contributors to the Eclipse Foundation$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information regarding copyright ownership.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
+checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0},{1} Contributors to the Eclipse Foundation$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information regarding copyright ownership.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
+checkstyle.headerCheck.values=2014,2018
 checkstyle.bundleVendorCheck.allowedValues=Eclipse.org/SmartHome
 checkstyle.pomXmlCheck.currentVersionRegex=^0\.10\.0
 checkstyle.requiredFilesCheck.files=build.properties,pom.xml,META-INF/MANIFEST.MF


### PR DESCRIPTION
See https://github.com/eclipse/smarthome/pull/5095

Signed-off-by: svilenvul <svilen.valkanov@musala.com>