### PR TITLE
Suppress org.eclipse.smarthome.binding.tradfri.internal.TradfriColor.java for LocalVariableNameCheck in SAT

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -24,4 +24,6 @@
     <suppress files="build.properties" checks="AboutHtmlCheck" />
 
     <suppress files=".+org.eclipse.smarthome.ui.paper.+" checks="OutsideOfLibExternalLibrariesCheck|ManifestExternalLibrariesCheck|BuildPropertiesExternalLibrariesCheck" />
+    
+    <suppress files=".+org.eclipse.smarthome.binding.tradfri.internal.TradfriColor.java" checks="LocalVariableNameCheck"/>
 </suppressions>


### PR DESCRIPTION
Suppress org.eclipse.smarthome.binding.tradfri.internal.TradfriColor.java for LocalVariableNameCheck so that the Static Analysis Tool won't check the local variable's names, as they are specific and changing them will make the code hard to read.

Signed-off-by: Kristina S. Simova <kssimovaa@gmail.com>