### PR TITLE
Fix 'use System.arraycopy' warnings generated by Static Code Analysis…

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/parser/ParsingException.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/parser/ParsingException.java
@@ -67,10 +67,8 @@ public class ParsingException extends Exception {
         StackTraceElement[] st = new StackTraceElement[size];
         for (int n = 0; n < exceptions.size(); n++) {
             StackTraceElement[] ste = exceptions.get(n).getStackTrace();
-            for (int i = 0; i < ste.length; i++) {
-                st[index] = ste[i];
-                index++;
-            }
+            System.arraycopy(ste, 0, st, index, ste.length);
+            index += ste.length;
         }
         return st;
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingUID.java
@@ -94,9 +94,7 @@ public class ThingUID extends UID {
         String[] result = new String[3 + bridgeIds.length];
         result[0] = bindingId;
         result[1] = thingTypeId;
-        for (int i = 0; i < bridgeIds.length; i++) {
-            result[i + 2] = bridgeIds[i];
-        }
+        System.arraycopy(bridgeIds, 0, result, 2, bridgeIds.length);
         result[result.length - 1] = id;
         return result;
     }


### PR DESCRIPTION
As suggested by the **AvoidArrayLoops** in [pmd](http://pmd.sourceforge.net/pmd-5.0.0/rules/java/optimizations.html), copying data between two arrays is changed to be done with System.arraycopy method.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>