### PR TITLE
fix config description alias handling

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
@@ -15,7 +15,9 @@ Import-Package:
  org.codehaus.groovy.runtime.typehandling,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.test,
+ org.eclipse.smarthome.test.java,
  org.hamcrest;core=split,
  org.junit;version="4.0.0",
  org.mockito,
+ org.mockito.invocation,
  org.mockito.stubbing

--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistryOSGiTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistryOSGiTest.java
@@ -14,6 +14,8 @@ package org.eclipse.smarthome.config.core;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -21,12 +23,10 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 
-import org.eclipse.smarthome.test.OSGiTest;
+import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 
 /**
@@ -34,7 +34,7 @@ import org.mockito.Mock;
  * @author Simon Kaufmann - converted to Java
  *
  */
-public class ConfigDescriptionRegistryOSGiTest extends OSGiTest {
+public class ConfigDescriptionRegistryOSGiTest extends JavaOSGiTest {
 
     private URI URI_DUMMY;
     private URI URI_DUMMY1;
@@ -46,6 +46,8 @@ public class ConfigDescriptionRegistryOSGiTest extends OSGiTest {
     private @Mock ConfigDescriptionProvider configDescriptionProviderMock1;
     private ConfigDescription configDescription2;
     private @Mock ConfigDescriptionProvider configDescriptionProviderMock2;
+    private ConfigDescription configDescriptionAliased;
+    private @Mock ConfigDescriptionProvider configDescriptionProviderAliased;
     private @Mock ConfigDescriptionAliasProvider aliasProvider;
     private @Mock ConfigOptionProvider configOptionsProviderMockAliased;
     private @Mock ConfigOptionProvider configOptionsProviderMock;
@@ -65,40 +67,42 @@ public class ConfigDescriptionRegistryOSGiTest extends OSGiTest {
         pList1.add(param1);
 
         configDescription = new ConfigDescription(URI_DUMMY, pList1);
-        when(configDescriptionProviderMock.getConfigDescriptions(Matchers.any(Locale.class)))
+        when(configDescriptionProviderMock.getConfigDescriptions(any()))
                 .thenReturn(Collections.singleton(configDescription));
-        when(configDescriptionProviderMock.getConfigDescription(Matchers.eq(URI_DUMMY), Matchers.any(Locale.class)))
-                .thenReturn(configDescription);
+        when(configDescriptionProviderMock.getConfigDescription(eq(URI_DUMMY), any())).thenReturn(configDescription);
 
         configDescription1 = new ConfigDescription(URI_DUMMY1);
-        when(configDescriptionProviderMock1.getConfigDescriptions(Matchers.any(Locale.class)))
+        when(configDescriptionProviderMock1.getConfigDescriptions(any()))
                 .thenReturn(Collections.singleton(configDescription1));
-        when(configDescriptionProviderMock1.getConfigDescription(Matchers.eq(URI_DUMMY1), Matchers.any(Locale.class)))
-                .thenReturn(configDescription1);
+        when(configDescriptionProviderMock1.getConfigDescription(eq(URI_DUMMY1), any())).thenReturn(configDescription1);
+
+        configDescriptionAliased = new ConfigDescription(URI_ALIASED, Collections
+                .singletonList(new ConfigDescriptionParameter("instanceId", ConfigDescriptionParameter.Type.INTEGER)));
+        when(configDescriptionProviderAliased.getConfigDescriptions(any()))
+                .thenReturn(Collections.singleton(configDescriptionAliased));
+        when(configDescriptionProviderAliased.getConfigDescription(eq(URI_ALIASED), any()))
+                .thenReturn(configDescriptionAliased);
 
         ConfigDescriptionParameter param2 = new ConfigDescriptionParameter("param2",
                 ConfigDescriptionParameter.Type.INTEGER);
         List<ConfigDescriptionParameter> pList2 = new ArrayList<ConfigDescriptionParameter>();
         pList2.add(param2);
         configDescription2 = new ConfigDescription(URI_DUMMY, pList2);
-        when(configDescriptionProviderMock2.getConfigDescriptions(Matchers.any(Locale.class)))
+        when(configDescriptionProviderMock2.getConfigDescriptions(any()))
                 .thenReturn(Collections.singleton(configDescription2));
-        when(configDescriptionProviderMock2.getConfigDescription(Matchers.eq(URI_DUMMY), Matchers.any(Locale.class)))
-                .thenReturn(configDescription2);
+        when(configDescriptionProviderMock2.getConfigDescription(eq(URI_DUMMY), any())).thenReturn(configDescription2);
 
-        when(aliasProvider.getAlias(Matchers.eq(URI_ALIASED))).thenReturn(URI_DUMMY);
+        when(aliasProvider.getAlias(eq(URI_ALIASED))).thenReturn(URI_DUMMY);
 
-        when(configOptionsProviderMockAliased.getParameterOptions(Matchers.eq(URI_ALIASED), Matchers.anyString(),
-                Matchers.anyString(), Matchers.any(Locale.class)))
-                        .thenReturn(Collections.singletonList(new ParameterOption("Option", "Aliased")));
-        when(configOptionsProviderMockAliased.getParameterOptions(Matchers.eq(URI_DUMMY), Matchers.anyString(),
-                Matchers.anyString(), Matchers.any(Locale.class))).thenReturn(null);
+        when(configOptionsProviderMockAliased.getParameterOptions(eq(URI_ALIASED), anyString(), any(), any()))
+                .thenReturn(Collections.singletonList(new ParameterOption("Option", "Aliased")));
+        when(configOptionsProviderMockAliased.getParameterOptions(eq(URI_DUMMY), anyString(), any(), any()))
+                .thenReturn(null);
 
-        when(configOptionsProviderMock.getParameterOptions(Matchers.eq(URI_DUMMY), Matchers.anyString(),
-                Matchers.anyString(), Matchers.any(Locale.class)))
-                        .thenReturn(Collections.singletonList(new ParameterOption("Option", "Original")));
-        when(configOptionsProviderMock.getParameterOptions(Matchers.eq(URI_ALIASED), Matchers.anyString(),
-                Matchers.anyString(), Matchers.any(Locale.class))).thenReturn(null);
+        when(configOptionsProviderMock.getParameterOptions(eq(URI_DUMMY), anyString(), any(), any()))
+                .thenReturn(Collections.singletonList(new ParameterOption("Option", "Original")));
+        when(configOptionsProviderMock.getParameterOptions(eq(URI_ALIASED), anyString(), any(), any()))
+                .thenReturn(null);
     }
 
     @Test
@@ -177,6 +181,25 @@ public class ConfigDescriptionRegistryOSGiTest extends OSGiTest {
     }
 
     @Test
+    public void testGetConfigDescriptions_aliasedOptionsOriginalWins() throws Exception {
+        assertThat(configDescriptionRegistry.getConfigDescriptions().size(), is(0));
+
+        configDescriptionRegistry.addConfigDescriptionProvider(configDescriptionProviderMock);
+        registerService(aliasProvider);
+        registerService(configOptionsProviderMock);
+        registerService(configOptionsProviderMockAliased);
+
+        ConfigDescription res = configDescriptionRegistry.getConfigDescription(URI_ALIASED);
+        assertThat(res, is(notNullValue()));
+        assertThat(res.getParameters().get(0).getOptions().size(), is(1));
+        assertThat(res.getParameters().get(0).getOptions().get(0).getLabel(), is("Aliased"));
+        assertThat(res.getUID(), is(URI_ALIASED));
+
+        configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderMock);
+        assertThat(configDescriptionRegistry.getConfigDescriptions().size(), is(0));
+    }
+
+    @Test
     public void testGetConfigDescriptions_nonAliasOptions() throws Exception {
         assertThat(configDescriptionRegistry.getConfigDescriptions().size(), is(0));
 
@@ -190,6 +213,28 @@ public class ConfigDescriptionRegistryOSGiTest extends OSGiTest {
         assertThat(res.getParameters().get(0).getOptions().get(0).getLabel(), is("Original"));
         assertThat(res.getUID(), is(URI_ALIASED));
 
+        configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderMock);
+        assertThat(configDescriptionRegistry.getConfigDescriptions().size(), is(0));
+    }
+
+    @Test
+    public void testGetConfigDescriptions_aliasedMixes() throws Exception {
+        assertThat(configDescriptionRegistry.getConfigDescriptions().size(), is(0));
+
+        configDescriptionRegistry.addConfigDescriptionProvider(configDescriptionProviderMock);
+        registerService(aliasProvider);
+
+        ConfigDescription res1 = configDescriptionRegistry.getConfigDescription(URI_ALIASED);
+        assertThat(res1, is(notNullValue()));
+        assertThat(res1.getParameters().size(), is(1));
+
+        configDescriptionRegistry.addConfigDescriptionProvider(configDescriptionProviderAliased);
+
+        ConfigDescription res2 = configDescriptionRegistry.getConfigDescription(URI_ALIASED);
+        assertThat(res2, is(notNullValue()));
+        assertThat(res2.getParameters().size(), is(2));
+
+        configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderAliased);
         configDescriptionRegistry.removeConfigDescriptionProvider(configDescriptionProviderMock);
         assertThat(configDescriptionRegistry.getConfigDescriptions().size(), is(0));
     }


### PR DESCRIPTION
...to first delegate to the alias(es) in order to get set of "default" config
description parameters and then amend it with parameters coming from any
provider for the concrete, requested URI.

fixes #5110
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>