### PR TITLE
Paper UI: Fix binding expert configuration

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.configurebinding.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/partials/dialog.configurebinding.html
@@ -3,7 +3,7 @@
 	Configure {{binding.name}} <small>{{binding.id}}</small>
 </h1>
 <div ng-init="form={}">
-	<config-description configuration="configuration" parameters="parameters" />
+	<config-description configuration="configuration" parameters="parameters" expert-mode="expertMode" config-array="configArray"/>
 </div>
 <div ng-show="expertMode" layout="row" layout-align="center">
 	<button class="md-raised md-button" ng-click="addParameter()" aria-label="Add Parameter">Add Parameter</button>


### PR DESCRIPTION
For binding configuration in Paper UI this fixes "Expert Mode".

Signed-off-by: Henning Treu <henning.treu@telekom.de>