### PR TITLE
Proxy service: add a timeout setting

### DIFF
--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/proxy/ProxyServletService.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/proxy/ProxyServletService.java
@@ -73,6 +73,7 @@ public class ProxyServletService extends HttpServlet {
     public static final String PROXY_ALIAS = "proxy";
 
     private static final String CONFIG_MAX_THREADS = "maxThreads";
+    private static final String CONFIG_TIMEOUT = "timeout";
     private static final int DEFAULT_MAX_THREADS = 8;
     public static final String ATTR_URI = ProxyServletService.class.getName() + ".URI";
     public static final String ATTR_SERVLET_EXCEPTION = ProxyServletService.class.getName() + ".ProxyServletException";
@@ -146,6 +147,11 @@ public class ProxyServletService extends HttpServlet {
         if (props.get(CONFIG_MAX_THREADS) == null) {
             props.put(CONFIG_MAX_THREADS,
                     String.valueOf(Math.max(DEFAULT_MAX_THREADS, Runtime.getRuntime().availableProcessors())));
+        }
+
+        // By default disable the timeout for the Jetty proxy server
+        if (props.get(CONFIG_TIMEOUT) == null) {
+            props.put(CONFIG_TIMEOUT, String.valueOf(0));
         }
 
         return props;


### PR DESCRIPTION
Default value is set to 0 which disables the timeout.
Disabling the timeout avoids stopping the video playback after the timeout.

Fixes #4873

Signed-off-by: Laurent Garnier <lg.hc@free.fr>