### PR TITLE
add pmd suppressions file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -533,6 +533,7 @@
                 </execution>
               </executions>
               <configuration>
+                <pmdFilter>${basedirRoot}/tools/static-code-analysis/pmd/suppressions.properties</pmdFilter>
                 <checkstyleProperties>${basedirRoot}/tools/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
                 <checkstyleFilter>${basedirRoot}/tools/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
                 <findbugsExclude>${basedirRoot}/tools/static-code-analysis/findbugs/suppressions.xml</findbugsExclude>

--- a/tools/static-code-analysis/pmd/suppressions.properties
+++ b/tools/static-code-analysis/pmd/suppressions.properties
@@ -1,0 +1,1 @@
+org.eclipse.smarthome.binding.hue.internal.HueBridge=DoNotThrowExceptionInFinally


### PR DESCRIPTION
Added a PMD suppression file location property in the pom file.

Currently org.eclipse.smarthome.binding.hue.internal.HueBridge throws exception in a finally block and thus violates the DoNotThrowExceptionInFinally PMD check. This check is now ignored for this class.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>