### PR TITLE
Suppress few files for MethodNameCheck in SAT

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -29,4 +29,5 @@
     <suppress files=".+xml" checks="EshInfXmlValidationCheck" />
     
     <suppress files=".+org.eclipse.smarthome.binding.tradfri.internal.TradfriColor.java" checks="LocalVariableNameCheck"/>
+    <suppress files=".+org.eclipse.smarthome.config.discovery.mdns.internal.MDNSDiscoveryService.java|.+org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService.java" checks="MethodNameCheck"/>
 </suppressions>


### PR DESCRIPTION
Suppress *org.eclipse.smarthome.config.discovery.mdns.internal.MDNSDiscoveryService.java* and *org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService.java*, because MethodNameCheck reports methods that are deprecated. 

Signed-off-by: Kristina S. Simova <kssimovaa@gmail.com>