### PR TITLE
[LIFX] Fix Beam product ID and update supported products in documentation

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/README.md
@@ -17,15 +17,21 @@ The following table lists the thing types of the supported LIFX devices:
 | LIFX A19                     | colorlight   |
 | LIFX BR30                    | colorlight   |
 | LIFX Downlight               | colorlight   |
+| LIFX GU10                    | colorlight   |
+| LIFX Mini Color              | colorlight   |
+| LIFX Tile                    | colorlight   |
 |                              |              |
 | LIFX+ A19                    | colorirlight |
 | LIFX+ BR30                   | colorirlight |
 |                              |              |
+| LIFX Beam                    | colormzlight |
 | LIFX Z                       | colormzlight |
 |                              |              |
 | White 800 (Low Voltage)      | whitelight   |
 | White 800 (High Voltage)     | whitelight   |
 | White 900 BR30 (Low Voltage) | whitelight   |
+| LIFX Mini Day and Dusk       | whitelight   |
+| LIFX Mini White              | whitelight   |
 
 The thing type determines the capability of a device and with that the possible ways of interacting with it. The following matrix lists the capabilities (channels) for each type:
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Products.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Products.java
@@ -39,6 +39,7 @@ public enum Products {
     LZ_2(1, 32, "LIFX Z 2", true, false, true, false),
     LDL_1(1, 36, "LIFX Downlight", true, false, false, false),
     LDL_2(1, 37, "LIFX Downlight", true, false, false, false),
+    LB(1, 38, "LIFX Beam", true, false, true, false),
     LA19_2(1, 43, "LIFX A19", true, false, false, false),
     LBR30_2(1, 44, "LIFX BR30", true, false, false, false),
     LPA19_2(1, 45, "LIFX+ A19", true, true, false, false),
@@ -48,7 +49,6 @@ public enum Products {
     LMW(1, 51, "LIFX Mini White", false, false, false, false),
     LGU10(1, 52, "LIFX GU10", true, false, false, false),
     LT(1, 55, "LIFX Tile", true, false, false, true),
-    LB(1, 56, "LIFX Beam", true, false, true, false),
     LMC(1, 59, "LIFX Mini Color", true, false, false, false),
     LMDD_2(1, 60, "LIFX Mini Day and Dusk", false, false, false, false),
     LMW_2(1, 61, "LIFX Mini White", false, false, false, false);


### PR DESCRIPTION
*  LIFX corrected the Beam product ID (see https://github.com/LIFX/products/commit/f90a6f05b79c0bb0dd97d6b16449b465ac74497e)
* Adds missing supported products to the binding documentation
