### PR TITLE
rework the code in HueBridge to not throw exceptions in a finally block

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
@@ -687,12 +687,11 @@ public class HueBridge {
         try {
             scheduleCommand = null;
             callback.onScheduleCommand(this);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             // Command will automatically fail to return a result because of deferred execution
-        } finally {
-            if (scheduleCommand != null && Util.stringSize(scheduleCommand.getBody()) > 90) {
-                throw new InvalidCommandException("Commmand body is larger than 90 bytes");
-            }
+        }
+        if (scheduleCommand != null && Util.stringSize(scheduleCommand.getBody()) > 90) {
+            throw new InvalidCommandException("Commmand body is larger than 90 bytes");
         }
 
         // Restore HTTP client


### PR DESCRIPTION
As suggested [in this comment](https://github.com/eclipse/smarthome/pull/5133#issuecomment-368064619), I refactored the code instead of adding PMD check suppressions. I created another PR since the name of the branch in #5133 could be misleading.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>