### PR TITLE
Fixed issues found by the Static Code Analysis Tool (few checks)

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/src/main/java/org/eclipse/smarthome/automation/sample/extension/java/internal/WelcomeHomeCommands.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/src/main/java/org/eclipse/smarthome/automation/sample/extension/java/internal/WelcomeHomeCommands.java
@@ -92,7 +92,6 @@ public class WelcomeHomeCommands extends AbstractConsoleCommandExtension {
             activate(params, console);
         } else if (COMMAND_ACTIVATE_L.equalsIgnoreCase(command) || COMMAND_ACTIVATE_L_SHORT.equalsIgnoreCase(command)) {
             activateLights(params, console);
-        } else {
         }
     }
 

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/src/main/java/org/eclipse/smarthome/automation/sample/extension/java/internal/handler/WelcomeHomeActionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/src/main/java/org/eclipse/smarthome/automation/sample/extension/java/internal/handler/WelcomeHomeActionHandler.java
@@ -37,7 +37,6 @@ public class WelcomeHomeActionHandler extends BaseModuleHandler<Action> implemen
     public Map<String, Object> execute(Map<String, Object> context) {
         String device = getDevice(module.getConfiguration());
         String result = getResult(module.getConfiguration());
-        System.out.println("[Automation Java API Demo : " + module.getTypeUID() + "] " + device + ": " + result);
         return null;
     }
 

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/src/main/java/org/eclipse/smarthome/automation/internal/sample/json/internal/handler/SampleActionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/src/main/java/org/eclipse/smarthome/automation/internal/sample/json/internal/handler/SampleActionHandler.java
@@ -46,7 +46,6 @@ public class SampleActionHandler extends BaseModuleHandler<Action> implements Ac
         if (message == null) {
             message = "";
         }
-        System.out.println("[Automation demo] " + module.getTypeUID() + "/" + module.getId() + ": " + message);
         return null;
     }
 

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistry.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/ConfigDescriptionRegistry.java
@@ -268,7 +268,6 @@ public class ConfigDescriptionRegistry {
                     break;
                 }
             }
-
         }
 
         if (found) {

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/service/AbstractWatchServiceTest.java
@@ -230,10 +230,7 @@ public class AbstractWatchServiceTest extends JavaTest {
         try {
             waitForAssert(() -> assertThat(watchService.allFullEvents.size(), is(expected)));
         } catch (AssertionError e) {
-            System.out.println("===");
-            System.out.println("Wrong event count:");
-            watchService.allFullEvents.forEach(event -> System.out.println(event.toString()));
-            System.out.println("===");
+            watchService.allFullEvents.forEach(event -> event.toString());
             throw e;
         }
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/java/org/eclipse/smarthome/core/thing/xml/test/Example.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/java/org/eclipse/smarthome/core/thing/xml/test/Example.java
@@ -42,11 +42,6 @@ public class Example {
         thingList.stream().forEach(it -> {
             if (it instanceof ChannelTypeXmlResult) {
                 ChannelType channelType = ((ChannelTypeXmlResult) it).toChannelType();
-
-                System.out.println(channelType + ", advanced=" + channelType.isAdvanced() + ", itemType="
-                        + channelType.getItemType() + ", label=" + channelType.getLabel() + ", description="
-                        + channelType.getDescription() + ", category=" + channelType.getCategory() + ", tags="
-                        + channelType.getTags() + ", state=" + channelType.getState());
             }
         });
     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/GroupFunctionHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/GroupFunctionHelper.java
@@ -45,7 +45,6 @@ public class GroupFunctionHelper {
      */
     public GroupFunction createGroupFunction(GroupFunctionDTO function, List<State> args,
             @Nullable Class<? extends Quantity<?>> dimension) {
-
         if (dimension != null) {
             return createDimensionGroupFunction(function, args, dimension);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class ItemDTOMapper {
 
-    private final static GroupFunctionHelper GROUP_FUNCTION_HELPER = new GroupFunctionHelper();
+    private static final GroupFunctionHelper GROUP_FUNCTION_HELPER = new GroupFunctionHelper();
 
     /**
      * Maps item DTO into item object.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/ImperialUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/ImperialUnits.java
@@ -86,8 +86,7 @@ public class ImperialUnits extends SmartHomeUnits {
     /**
      * Adds a new unit not mapped to any specified quantity type.
      *
-     * @param unit
-     *            the unit being added.
+     * @param unit the unit being added.
      * @return <code>unit</code>.
      */
     private static <U extends Unit<?>> U addUnit(U unit) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/util/UnitUtils.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/util/UnitUtils.java
@@ -111,11 +111,11 @@ public class UnitUtils {
     }
 
     public static boolean isDifferentMeasurementSystem(Unit<? extends Quantity<?>> thisUnit, Unit<?> thatUnit) {
-        Set<? extends Unit<?>> SI = SIUnits.getInstance().getUnits();
-        Set<? extends Unit<?>> US = ImperialUnits.getInstance().getUnits();
+        Set<? extends Unit<?>> si = SIUnits.getInstance().getUnits();
+        Set<? extends Unit<?>> us = ImperialUnits.getInstance().getUnits();
 
-        boolean differentSystems = (SI.contains(thisUnit) && US.contains(thatUnit)) //
-                || (SI.contains(thatUnit) && US.contains(thisUnit));
+        boolean differentSystems = (si.contains(thisUnit) && us.contains(thatUnit)) //
+                || (si.contains(thatUnit) && us.contains(thisUnit));
 
         if (!differentSystems) {
             if (thisUnit instanceof TransformedUnit

--- a/bundles/io/org.eclipse.smarthome.io.net.test/src/test/java/org/eclipse/smarthome/io/net/http/internal/SecureHttpClientFactoryTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/src/test/java/org/eclipse/smarthome/io/net/http/internal/SecureHttpClientFactoryTest.java
@@ -112,7 +112,6 @@ public class SecureHttpClientFactoryTest {
                         try {
                             ContentResponse response = client.GET(TEST_URL);
                             if (response.getStatus() != 200) {
-                                System.out.println(response.getStatus());
                                 failures.add("Statuscode != 200");
                             }
                         } catch (InterruptedException | ExecutionException | TimeoutException e) {
@@ -160,7 +159,6 @@ public class SecureHttpClientFactoryTest {
                         try {
                             ContentResponse response = client.GET(TEST_URL);
                             if (response.getStatus() != 200) {
-                                System.out.println(response.getStatus());
                                 failures.add("Statuscode != 200");
                             }
                         } catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/SecureHttpClientFactory.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/SecureHttpClientFactory.java
@@ -103,7 +103,6 @@ public class SecureHttpClientFactory implements HttpClientFactory {
             logger.error("error while stopping jetty shared http client", e);
             // nothing else we can do here
         }
-
     }
 
     @Override
@@ -152,7 +151,6 @@ public class SecureHttpClientFactory implements HttpClientFactory {
             logger.warn("ignoring invalid type {} for parameter {}", value.getClass().getName(), parameter);
             return defaultValue;
         }
-
     }
 
     private synchronized void initialize() {
@@ -191,7 +189,6 @@ public class SecureHttpClientFactory implements HttpClientFactory {
             return AccessController.doPrivileged(new PrivilegedExceptionAction<HttpClient>() {
                 @Override
                 public HttpClient run() {
-
                     logger.info("creating httpClient for endpoint {}", endpoint);
                     SslContextFactory sslContextFactory = new SslContextFactory();
                     sslContextFactory.setEndpointIdentificationAlgorithm("HTTPS");

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicColorLightHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicColorLightHandler.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.magic.binding.handler;
 
-import static org.eclipse.smarthome.magic.binding.MagicBindingConstants.CHANNEL_COLOR;
-
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -34,8 +32,9 @@ public class MagicColorLightHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (channelUID.getId().equals(CHANNEL_COLOR)) {
-        }
+        // process the command for the color channel here
+        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_COLOR)) {
+        // }
     }
 
     @Override

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicContactHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicContactHandler.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.magic.binding.handler;
 
-import static org.eclipse.smarthome.magic.binding.MagicBindingConstants.CHANNEL_CONTACT;
-
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -34,8 +32,9 @@ public class MagicContactHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (channelUID.getId().equals(CHANNEL_CONTACT)) {
-        }
+        // process the command for the contact channel here
+        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_CONTACT)) {
+        // }
     }
 
     @Override

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicDimmableLightHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicDimmableLightHandler.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.magic.binding.handler;
 
-import static org.eclipse.smarthome.magic.binding.MagicBindingConstants.CHANNEL_BRIGHTNESS;
-
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -34,8 +32,9 @@ public class MagicDimmableLightHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (channelUID.getId().equals(CHANNEL_BRIGHTNESS)) {
-        }
+        // process the command for the brightness channel here
+        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_BRIGHTNESS)) {
+        // }
     }
 
     @Override

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicLocationThingHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicLocationThingHandler.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.magic.binding.handler;
 
-import static org.eclipse.smarthome.magic.binding.MagicBindingConstants.CHANNEL_LOCATION;
-
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -34,8 +32,9 @@ public class MagicLocationThingHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (channelUID.getId().equals(CHANNEL_LOCATION)) {
-        }
+        // process the command for the location channel here
+        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_LOCATION)) {
+        // }
     }
 
     @Override

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicOnOffLightHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicOnOffLightHandler.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.magic.binding.handler;
 
-import static org.eclipse.smarthome.magic.binding.MagicBindingConstants.CHANNEL_SWITCH;
-
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -34,8 +32,9 @@ public class MagicOnOffLightHandler extends BaseThingHandler {
 
     @Override
     public void handleCommand(ChannelUID channelUID, Command command) {
-        if (channelUID.getId().equals(CHANNEL_SWITCH)) {
-        }
+        // process the command for the switch channel here
+        // if (channelUID.getId().equals(MagicBindingConstants.CHANNEL_SWITCH)) {
+        // }
     }
 
     @Override

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicThermostatThingHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicThermostatThingHandler.java
@@ -40,7 +40,6 @@ public class MagicThermostatThingHandler extends BaseThingHandler {
     public void handleCommand(@NonNull ChannelUID channelUID, @NonNull Command command) {
         if (channelUID.getId().equals(CHANNEL_SET_TEMPERATURE)) {
             if (command instanceof DecimalType || command instanceof QuantityType) {
-
                 String state = command.toFullString() + (command instanceof DecimalType ? " °C" : "");
                 scheduler.schedule(() -> {
                     updateState(CHANNEL_TEMPERATURE, new QuantityType<>(state));

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -418,7 +418,6 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
 
         return quantityState;
-
     }
 
     private String getFormatPattern(String label) {

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/event/EventListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/event/EventListener.java
@@ -65,7 +65,7 @@ public class EventListener {
 
     private int subscriptionID = 15;
     private final int timeout = 500;
-    private final List<String> subscribedEvents = Collections.synchronizedList(new LinkedList<String>());;
+    private final List<String> subscribedEvents = Collections.synchronizedList(new LinkedList<String>());
     private boolean subscribed = false;
 
     // error message

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/StructureManagerImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/StructureManagerImpl.java
@@ -78,7 +78,7 @@ public class StructureManagerImpl implements StructureManager {
     private final Map<Integer, HashMap<Short, List<Device>>> zoneGroupDeviceMap = Collections
             .synchronizedMap(new HashMap<Integer, HashMap<Short, List<Device>>>());
     private final Map<DSID, Device> deviceMap = Collections.synchronizedMap(new HashMap<DSID, Device>());
-    private final Map<DSID, Circuit> circuitMap = Collections.synchronizedMap(new HashMap<DSID, Circuit>());;
+    private final Map<DSID, Circuit> circuitMap = Collections.synchronizedMap(new HashMap<DSID, Circuit>());
     private final Map<String, DSID> dSUIDToDSIDMap = Collections.synchronizedMap(new HashMap<String, DSID>());
 
     private Map<Integer, ZoneGroupsNameAndIDMap> zoneGroupIdNameMap;

--- a/extensions/binding/org.eclipse.smarthome.binding.lirc/src/main/java/org/eclipse/smarthome/binding/lirc/handler/LIRCRemoteHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lirc/src/main/java/org/eclipse/smarthome/binding/lirc/handler/LIRCRemoteHandler.java
@@ -28,7 +28,6 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.RefreshType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,9 +58,8 @@ public class LIRCRemoteHandler extends BaseThingHandler implements LIRCMessageLi
             return;
         }
         if (channelUID.getId().equals(LIRCBindingConstants.CHANNEL_TRANSMIT)) {
-            if (command instanceof RefreshType) {
-                // not supported
-            } else if (command instanceof StringType) {
+            // command instanceof RefreshType is not supported
+            if (command instanceof StringType) {
                 bridgeHandler.transmit(remoteName, command.toString());
             }
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
@@ -612,8 +612,6 @@ public class SonosXMLParser {
                 } else {
                     textField = null;
                 }
-            } else if (qName.equals("logo")) {
-                // logo = attributes.getValue("UUID");
             }
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoCoffeeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoCoffeeHandler.java
@@ -213,9 +213,9 @@ public class WemoCoffeeHandler extends BaseThingHandler implements UpnpIOPartici
                                 e.getMessage());
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR);
                     }
-                } else if (command.equals(OnOffType.OFF)) {
-                    // do nothing, as WeMo Coffee Maker cannot be switched off remotely
                 }
+                // if command.equals(OnOffType.OFF) we do nothing because WeMo Coffee Maker cannot be switched off
+                // remotely
                 updateStatus(ThingStatus.ONLINE);
             }
         }

--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -30,5 +30,5 @@
     <suppress files=".+xml" checks="EshInfXmlValidationCheck" />
     
     <suppress files=".+org.eclipse.smarthome.binding.tradfri.internal.TradfriColor.java" checks="LocalVariableNameCheck"/>
-    <suppress files=".+org.eclipse.smarthome.config.discovery.mdns.internal.MDNSDiscoveryService.java|.+org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService.java" checks="MethodNameCheck"/>
+    <suppress files=".+org.eclipse.smarthome.config.discovery.mdns.internal.MDNSDiscoveryService.java|.+org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService.java|.+org.eclipse.smarthome.io.console.eclipse.internal.ConsoleSupportEclipse.java|.+org.eclipse.smarthome.io.console.rfc147.internal.CommandWrapper.java" checks="MethodNameCheck"/>
 </suppressions>


### PR DESCRIPTION
And suppressed *org.eclipse.smarthome.io.console.eclipse.internal.ConsoleSupportEclipse.java* and *org.eclipse.smarthome.io.console.rfc147.internal.CommandWrapper.java* for MethodNameCheck, because 
they contain methods that start with underscore (custom OSGi console commands)

Signed-off-by: Kristina S. Simova <kssimovaa@gmail.com>