### PR TITLE
Added pmd suppressions file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -533,6 +533,7 @@
                 </execution>
               </executions>
               <configuration>
+                <pmdFilter>${basedirRoot}/tools/static-code-analysis/pmd/suppressions.properties</pmdFilter>
                 <checkstyleProperties>${basedirRoot}/tools/static-code-analysis/checkstyle/ruleset.properties</checkstyleProperties>
                 <checkstyleFilter>${basedirRoot}/tools/static-code-analysis/checkstyle/suppressions.xml</checkstyleFilter>
                 <findbugsExclude>${basedirRoot}/tools/static-code-analysis/findbugs/suppressions.xml</findbugsExclude>

--- a/tools/static-code-analysis/pmd/suppressions.properties
+++ b/tools/static-code-analysis/pmd/suppressions.properties
@@ -1,0 +1,5 @@
+org.eclipse.smarthome.automation.sample.moduletype.demo.internal.handlers.ConsolePrintAction=SystemPrintln
+org.eclipse.smarthome.io.console.karaf.internal.OSGiConsole=SystemPrintln
+org.eclipse.smarthome.io.console.rfc147.internal.CommandWrapper=SystemPrintln
+org.eclipse.smarthome.io.console.rfc147.internal.OSGiConsole=SystemPrintln
+org.eclipse.smarthome.core.internal.events.ThreadedEventHandler=EmptyIfStmt


### PR DESCRIPTION
Added a PMD suppression file location property in the pom file to suppress:

- *org.eclipse.smarthome.core.internal.events.ThreadedEventHandler.java* for EmptyIfStmt PMD check, because the empty if branch is left this way intentionally and cannot be removed.
- *org.eclipse.smarthome.automation.sample.moduletype.demo.internal.handlers.ConsolePrintAction.java*, *org.eclipse.smarthome.io.console.karaf.internal.OSGiConsole.java*, *org.eclipse.smarthome.io.console.rfc147.internal.CommandWrapper.java* and *org.eclipse.smarthome.io.console.rfc147.internal.OSGiConsole.java* for SystemPrintln PMD check (custom consoles).

Signed-off-by: Kristina S. Simova <kssimovaa@gmail.com>