### PR TITLE
Obey mandatory channel configs before initializing thing handlers

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -23,10 +23,19 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.ConfigDescription;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
+import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
+import org.eclipse.smarthome.config.core.ConfigDescriptionProvider;
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.common.SafeCaller;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.service.ReadyMarker;
@@ -36,8 +45,10 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
@@ -46,20 +57,22 @@ import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelKind;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder;
-import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
+import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.ComponentContext;
 
 /**
  *
@@ -73,16 +86,22 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     private ReadyService readyService;
     private ItemChannelLinkRegistry itemChannelLinkRegistry;
 
+    private final String CONFIG_PARAM_NAME = "test";
+    private final ChannelTypeUID CHANNEL_TYPE_UID = new ChannelTypeUID("binding", "channel");
     private final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding:type");
     private final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "id");
     private final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, "channel");
-    private final ChannelTypeUID CHANNEL_TYPE_UID = new ChannelTypeUID("binding", "channel");
     private Thing THING;
+    private URI CONFIG_DESCRIPTION_THING;
+    private URI CONFIG_DESCRIPTION_CHANNEL;
 
     @Before
     public void setUp() throws Exception {
-        THING = ThingBuilder.create(THING_TYPE_UID, THING_UID)
-                .withChannels(Collections.singletonList(ChannelBuilder.create(CHANNEL_UID, "Switch").build())).build();
+        CONFIG_DESCRIPTION_THING = new URI("test:test");
+        CONFIG_DESCRIPTION_CHANNEL = new URI("test:channel");
+        THING = ThingBuilder.create(THING_TYPE_UID, THING_UID).withChannels(Collections.singletonList( //
+                ChannelBuilder.create(CHANNEL_UID, "Switch").withType(CHANNEL_TYPE_UID).build() //
+        )).build();
         registerVolatileStorageService();
 
         configureAutoLinking(false);
@@ -131,36 +150,28 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         registerThingTypeProvider();
         AtomicReference<ThingHandlerCallback> thc = new AtomicReference<>();
         AtomicReference<Boolean> initializeRunning = new AtomicReference<>(false);
-        ThingHandlerFactory thingHandlerFactory = new BaseThingHandlerFactory() {
-            @Override
-            public boolean supportsThingType(@NonNull ThingTypeUID thingTypeUID) {
-                return true;
-            }
+        registerThingHandlerFactory(THING_TYPE_UID, thing -> {
+            ThingHandler mockHandler = mock(ThingHandler.class);
+            doAnswer(a -> {
+                thc.set((ThingHandlerCallback) a.getArguments()[0]);
+                return null;
+            }).when(mockHandler).setCallback(ArgumentMatchers.isA(ThingHandlerCallback.class));
+            doAnswer(a -> {
+                initializeRunning.set(true);
 
-            @Override
-            protected @Nullable ThingHandler createHandler(@NonNull Thing thing) {
-                ThingHandler mockHandler = mock(ThingHandler.class);
-                doAnswer(a -> {
-                    thc.set((ThingHandlerCallback) a.getArguments()[0]);
-                    return null;
-                }).when(mockHandler).setCallback(any(ThingHandlerCallback.class));
-                doAnswer(a -> {
-                    initializeRunning.set(true);
+                // call thingUpdated() from within initialize()
+                thc.get().thingUpdated(THING);
 
-                    // call thingUpdated() from within initialize()
-                    thc.get().thingUpdated(THING);
+                // hang on a little to provoke a potential dead-lock
+                Thread.sleep(1000);
 
-                    // hang on a little to provoke a potential dead-lock
-                    Thread.sleep(1000);
+                initializeRunning.set(false);
+                return null;
+            }).when(mockHandler).initialize();
+            when(mockHandler.getThing()).thenReturn(THING);
+            return mockHandler;
+        });
 
-                    initializeRunning.set(false);
-                    return null;
-                }).when(mockHandler).initialize();
-                when(mockHandler.getThing()).thenReturn(THING);
-                return mockHandler;
-            }
-        };
-        registerService(thingHandlerFactory, ThingHandlerFactory.class.getName());
         new Thread((Runnable) () -> managedThingProvider.add(THING)).start();
 
         waitForAssert(() -> {
@@ -213,18 +224,79 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         assertThat(channel.getDefaultTags().iterator().next(), is("Test Tag"));
     }
 
+    @Test
+    public void testInitializeOnlyIfInitializable() throws Exception {
+        registerThingTypeProvider();
+        registerChannelTypeProvider();
+        registerThingHandlerFactory(THING_TYPE_UID, thing -> new BaseThingHandler(thing) {
+            @Override
+            public void handleCommand(@NonNull ChannelUID channelUID, @NonNull Command command) {
+            }
+        });
+
+        ConfigDescriptionProvider mockConfigDescriptionProvider = mock(ConfigDescriptionProvider.class);
+        List<ConfigDescriptionParameter> parameters = Collections.singletonList( //
+                ConfigDescriptionParameterBuilder.create(CONFIG_PARAM_NAME, Type.TEXT).withRequired(true).build() //
+        );
+        registerService(mockConfigDescriptionProvider, ConfigDescriptionProvider.class.getName());
+
+        // verify a missing mandatory thing config prevents it from getting initialized
+        when(mockConfigDescriptionProvider.getConfigDescription(eq(CONFIG_DESCRIPTION_THING), any()))
+                .thenReturn(new ConfigDescription(CONFIG_DESCRIPTION_THING, parameters));
+        assertThingStatus(Collections.emptyMap(), Collections.emptyMap(), ThingStatus.UNINITIALIZED,
+                ThingStatusDetail.HANDLER_CONFIGURATION_PENDING);
+
+        // verify a missing mandatory channel config prevents it from getting initialized
+        when(mockConfigDescriptionProvider.getConfigDescription(eq(CONFIG_DESCRIPTION_CHANNEL), any()))
+                .thenReturn(new ConfigDescription(CONFIG_DESCRIPTION_CHANNEL, parameters));
+        assertThingStatus(Collections.singletonMap(CONFIG_PARAM_NAME, "value"), Collections.emptyMap(),
+                ThingStatus.UNINITIALIZED, ThingStatusDetail.HANDLER_CONFIGURATION_PENDING);
+
+        // verify a satisfied config does not prevent it from getting initialized anymore
+        assertThingStatus(Collections.singletonMap(CONFIG_PARAM_NAME, "value"),
+                Collections.singletonMap(CONFIG_PARAM_NAME, "value"), ThingStatus.ONLINE, ThingStatusDetail.NONE);
+    }
+
+    private void assertThingStatus(Map<String, Object> propsThing, Map<String, Object> propsChannel, ThingStatus status,
+            ThingStatusDetail statusDetail) {
+        Configuration configThing = new Configuration(propsThing);
+        Configuration configChannel = new Configuration(propsChannel);
+
+        Thing thing = ThingBuilder.create(THING_TYPE_UID, THING_UID).withChannels(Collections.singletonList( //
+                ChannelBuilder.create(CHANNEL_UID, "Switch").withType(CHANNEL_TYPE_UID).withConfiguration(configChannel)
+                        .build() //
+        )).withConfiguration(configThing).build();
+
+        managedThingProvider.add(thing);
+
+        waitForAssert(() -> {
+            assertEquals(status, thing.getStatus());
+            assertEquals(statusDetail, thing.getStatusInfo().getStatusDetail());
+        });
+
+        managedThingProvider.remove(thing.getUID());
+    }
+
+    private void registerThingHandlerFactory(ThingTypeUID thingTypeUID,
+            Function<Thing, ThingHandler> thingHandlerProducer) {
+        ComponentContext context = mock(ComponentContext.class);
+        when(context.getBundleContext()).thenReturn(bundleContext);
+
+        TestThingHandlerFactory mockThingHandlerFactory = new TestThingHandlerFactory(thingTypeUID,
+                thingHandlerProducer);
+        mockThingHandlerFactory.activate(context);
+        registerService(mockThingHandlerFactory, ThingHandlerFactory.class.getName());
+    }
+
     private void registerThingTypeProvider() throws Exception {
-        URI configDescriptionUri = new URI("test:test");
-        ThingType thingType = ThingTypeBuilder.instance(new ThingTypeUID("binding", "type"), "label")
-                .withConfigDescriptionURI(configDescriptionUri).build();
+        ThingType thingType = ThingTypeBuilder.instance(THING_TYPE_UID, "label")
+                .withConfigDescriptionURI(CONFIG_DESCRIPTION_THING)
+                .withChannelDefinitions(Collections.singletonList(new ChannelDefinition("channel", CHANNEL_TYPE_UID)))
+                .build();
 
         ThingTypeProvider mockThingTypeProvider = mock(ThingTypeProvider.class);
-        when(mockThingTypeProvider.getThingType(any(ThingTypeUID.class), any())).thenReturn(thingType);
+        when(mockThingTypeProvider.getThingType(eq(THING_TYPE_UID), any())).thenReturn(thingType);
         registerService(mockThingTypeProvider);
-
-        ThingTypeRegistry mockThingTypeRegistry = mock(ThingTypeRegistry.class);
-        when(mockThingTypeRegistry.getThingType(any(ThingTypeUID.class))).thenReturn(thingType);
-        registerService(mockThingTypeRegistry);
     }
 
     private void registerChannelTypeProvider() throws Exception {
@@ -239,7 +311,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
 
     private void configureAutoLinking(Boolean on) throws IOException {
         ConfigurationAdmin configAdmin = getService(ConfigurationAdmin.class);
-        Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.links", null);
+        org.osgi.service.cm.Configuration config = configAdmin.getConfiguration("org.eclipse.smarthome.links", null);
         Dictionary<String, Object> properties = config.getProperties();
         if (properties == null) {
             properties = new Hashtable<>();
@@ -247,5 +319,31 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         properties.put("autoLinks", on.toString());
         config.update(properties);
     }
+
+    private static class TestThingHandlerFactory extends BaseThingHandlerFactory {
+
+        private final ThingTypeUID thingTypeUID;
+        private final Function<Thing, ThingHandler> thingHandlerProducer;
+
+        public TestThingHandlerFactory(ThingTypeUID thingTypeUID, Function<Thing, ThingHandler> thingHandlerProducer) {
+            this.thingTypeUID = thingTypeUID;
+            this.thingHandlerProducer = thingHandlerProducer;
+        }
+
+        @Override
+        public void activate(ComponentContext context) {
+            super.activate(context);
+        }
+
+        @Override
+        public boolean supportsThingType(@NonNull ThingTypeUID thingTypeUID) {
+            return this.thingTypeUID.equals(thingTypeUID);
+        }
+
+        @Override
+        protected @Nullable ThingHandler createHandler(@NonNull Thing thing) {
+            return thingHandlerProducer.apply(thing);
+        }
+    };
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -614,11 +614,12 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
     /**
      * Determines if all 'required' configuration parameters are available in the configuration
      *
-     * @param prototype
-     * @param targetUID
-     * @param configDescriptionURIFunction
-     * @param configuration
-     * @return
+     * @param prototype the "prototype", i.e. thing type or channel type
+     * @param targetUID the UID of the thing or channel entity
+     * @param configDescriptionURIFunction a function to determine the the config description UID for the given
+     *            prototype
+     * @param configuration the current configuration
+     * @return true if all required configuration parameters are given, false otherwise
      */
     private <T extends Identifiable<?>> boolean isComplete(T prototype, UID targetUID,
             Function<T, URI> configDescriptionURIFunction, Configuration configuration) {
@@ -635,12 +636,11 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
         }
 
         List<String> requiredParameters = getRequiredParameters(description);
-        Map<String, Object> properties = configuration.getProperties();
+        Set<String> propertyKeys = configuration.getProperties().keySet();
         if (logger.isDebugEnabled()) {
-            logger.debug("Configuration of '{}' needs {}, has {}.", targetUID, requiredParameters,
-                    configuration.getProperties().keySet());
+            logger.debug("Configuration of '{}' needs {}, has {}.", targetUID, requiredParameters, propertyKeys);
         }
-        return properties.keySet().containsAll(requiredParameters);
+        return propertyKeys.containsAll(requiredParameters);
     }
 
     private ConfigDescription resolve(URI configDescriptionURI, Locale locale) {


### PR DESCRIPTION
If things have missing mandatory configuration parameters, then the `ThingManager` does not initialize handlers but sets the thing status to `UNINITIALIZED/HANDLER_CONFIGURATION_PENDING` instead. 

This PR now amends the mechanism to also look for missing mandatory **channel** configuration parameters.

fixes #5170
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>