### PR TITLE
Optimize thing update handling

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/org/eclipse/smarthome/model/thing/tests/GenericThingProviderTest.groovy
@@ -16,6 +16,7 @@ import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.*
 import static org.junit.matchers.JUnitMatchers.*
 
+import org.eclipse.smarthome.core.events.Event
 import org.eclipse.smarthome.core.events.EventSubscriber
 import org.eclipse.smarthome.core.thing.Bridge
 import org.eclipse.smarthome.core.thing.Channel
@@ -499,8 +500,11 @@ class GenericThingProviderTest extends OSGiTest {
         assertThat thingRegistry.getAll().size(), is(2)
 
         waitForAssert {
-            assertThat receivedEvents.size(), is(equalTo(2))
-            receivedEvents.each { assertThat it, isA(ThingUpdatedEvent) }
+            assertEquals(1, receivedEvents.size());
+            Event event = receivedEvents.get(0);
+            assertEquals(ThingUpdatedEvent.class, event.getClass());
+            ThingUpdatedEvent thingUpdatedEvent = (ThingUpdatedEvent) event;
+            assertEquals("hue:LCT001:myBridge:bulb1", thingUpdatedEvent.getThing().UID.toString());
         }
 
     }

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
@@ -599,8 +599,10 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
         newThings.forEach [ newThing |
             val oldThing = oldThings.findFirst[it.UID == newThing.UID]
             if (oldThing != null) {
-                logger.debug("Updating thing '{}' from model '{}'.", newThing.UID, modelName);
-                notifyListenersAboutUpdatedElement(oldThing, newThing)
+                if (!ThingHelper.equals(oldThing, newThing)) {
+                    logger.debug("Updating thing '{}' from model '{}'.", newThing.UID, modelName);
+                    notifyListenersAboutUpdatedElement(oldThing, newThing)
+                }
             } else {
                 logger.debug("Adding thing '{}' from model '{}'.", newThing.UID, modelName);
                 thingsMap.get(modelName).add(newThing)

--- a/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.thing/src/org/eclipse/smarthome/model/thing/internal/GenericThingProvider.xtend
@@ -112,15 +112,15 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
 
     def private void createThingsFromModel(String modelName) {
         logger.debug("Read things from model '{}'", modelName);
-        if (thingsMap.get(modelName) == null) {
+        if (thingsMap.get(modelName) === null) {
             thingsMap.put(modelName, newArrayList)
         }
-        if (modelRepository != null) {
+        if (modelRepository !== null) {
             val model = modelRepository.getModel(modelName) as ThingModel
             model?.things?.map[
                 // Get the ThingHandlerFactories
                 val ThingUID thingUID = constructThingUID
-                if (thingUID != null) {
+                if (thingUID !== null) {
                     val thingTypeUID = constructThingTypeUID(thingUID)
                     return thingHandlerFactories.findFirst[
                         supportsThingType(thingTypeUID)
@@ -131,7 +131,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                 }
             ]?.filter[
                 // Drop it if there is no ThingHandlerFactory yet which can handle it 
-                it != null
+                it !== null
             ]?.toSet?.forEach[
                 // Execute for each unique ThingHandlerFactory
                 createThingsFromModelForThingHandlerFactory(modelName, it)
@@ -140,10 +140,10 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
     }
     
     def private ThingUID constructThingUID(ModelThing modelThing) {
-        if (modelThing.id != null) {
+        if (modelThing.id !== null) {
             return new ThingUID(modelThing.id)
         } else {
-            if (modelThing.bridgeUID != null) {
+            if (modelThing.bridgeUID !== null) {
                 val bindingId = new ThingUID(modelThing.bridgeUID).bindingId
                 return new ThingUID(bindingId, modelThing.thingTypeId, modelThing.thingId)
             } else {
@@ -154,7 +154,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
     }
     
     def private ThingTypeUID constructThingTypeUID(ModelThing modelThing, ThingUID thingUID) {
-        if (modelThing.thingTypeId != null) {
+        if (modelThing.thingTypeId !== null) {
             return new ThingTypeUID(thingUID.bindingId, modelThing.thingTypeId)
         } else {
             return new ThingTypeUID(thingUID.bindingId, thingUID.thingTypeId)
@@ -164,16 +164,16 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
     def private void createThing(ModelThing modelThing, Bridge parentBridge, Collection<Thing> thingList,
         ThingHandlerFactory thingHandlerFactory) {
         val ThingUID thingUID = getThingUID(modelThing, parentBridge?.UID)
-        if (thingUID == null) {
+        if (thingUID === null) {
             // ignore the Thing because its definition is broken
             return
         }
         val thingTypeUID = modelThing.constructThingTypeUID(thingUID)
         var ThingUID bridgeUID = null
-        if (parentBridge != null) {
+        if (parentBridge !== null) {
             bridgeUID = parentBridge.UID
         } else {
-            if (modelThing.bridgeUID != null && !modelThing.bridgeUID.empty) {
+            if (modelThing.bridgeUID !== null && !modelThing.bridgeUID.empty) {
                 bridgeUID = new ThingUID(modelThing.bridgeUID)
             }
         }
@@ -194,7 +194,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
 
         val thingType = thingTypeUID.thingType
 
-        val label = if (modelThing.label != null) modelThing.label else thingType?.label
+        val label = if (modelThing.label !== null) modelThing.label else thingType?.label
         
         val location = modelThing.location
 
@@ -219,7 +219,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
         var thing = thingBuilder.build
 
         // ask the ThingHandlerFactories for a thing
-        if (thingFromHandler != null) {
+        if (thingFromHandler !== null) {
 
             // If a thingHandlerFactory could create a thing, merge the content of the modelThing to it
             thingFromHandler.merge(thing)
@@ -249,7 +249,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
 
     def private Thing getThingFromThingHandlerFactories(ThingTypeUID thingTypeUID, String label,
         Configuration configuration, ThingUID thingUID, ThingUID bridgeUID, ThingHandlerFactory specific) {
-        if (specific != null && specific.supportsThingType(thingTypeUID)) {
+        if (specific !== null && specific.supportsThingType(thingTypeUID)) {
             logger.trace("Creating thing from specific ThingHandlerFactory {} for thingType {}", specific, thingTypeUID)
             return getThingFromThingHandlerFactory(thingTypeUID, label, configuration, thingUID, bridgeUID, specific)
         }
@@ -266,7 +266,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
     def private getThingFromThingHandlerFactory(ThingTypeUID thingTypeUID, String label, Configuration configuration,
         ThingUID thingUID, ThingUID bridgeUID, ThingHandlerFactory thingHandlerFactory) {
         val thing = thingHandlerFactory.createThing(thingTypeUID, configuration, thingUID, bridgeUID)
-        if (thing == null) {
+        if (thing === null) {
             // Apparently the HandlerFactory's eyes were bigger than its stomach...
             // Possible cause: Asynchronous loading of the XML files
             // Add the data to the queue in order to retry it later
@@ -274,7 +274,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                 "ThingHandlerFactory '{}' claimed it can handle '{}' type but actually did not. Queued for later refresh.",
                 thingHandlerFactory.class.simpleName, thingTypeUID.asString)
             queue.add(new QueueContent(thingTypeUID, label, configuration, thingUID, bridgeUID, thingHandlerFactory))
-            if (lazyRetryThread == null || !lazyRetryThread.alive) {
+            if (lazyRetryThread === null || !lazyRetryThread.alive) {
                 lazyRetryThread = new Thread(lazyRetryRunnable)
                 lazyRetryThread.start
             }
@@ -336,13 +336,13 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                 var String itemType
                 var label = it.label
                 val configuration = createConfiguration
-                if (it.channelType != null) {
+                if (it.channelType !== null) {
                     channelTypeUID = new ChannelTypeUID(thingUID.bindingId, it.channelType)
                     val resolvedChannelType = channelTypeUID.channelType
-                    if (resolvedChannelType != null) {
+                    if (resolvedChannelType !== null) {
                         itemType = resolvedChannelType.itemType
                         parsedKind = resolvedChannelType.kind
-                        if (label == null) {
+                        if (label === null) {
                             label = resolvedChannelType.label
                         }
                         applyDefaultConfiguration(configuration, resolvedChannelType)
@@ -352,7 +352,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                 } else {
                     itemType = it.type
                     
-                    val kind = if (it.channelKind == null) "State" else it.channelKind                 
+                    val kind = if (it.channelKind === null) "State" else it.channelKind                 
                     parsedKind = ChannelKind.parse(kind)
                 }
                 
@@ -367,7 +367,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
         channelDefinitions.forEach [
             if (addedChannelIds.add(id)) {
                 val channelType = it.channelTypeUID.channelType
-                if (channelType != null) {
+                if (channelType !== null) {
                     channels +=
                         ChannelBuilder.create(new ChannelUID(thingTypeUID, thingUID, id), channelType.itemType).
                             withType(it.channelTypeUID).build
@@ -382,15 +382,15 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
     }
     
     def private applyDefaultConfiguration(Configuration configuration, ChannelType channelType) {
-        if (configDescriptionRegistry != null && configuration != null) {
-            if (channelType.configDescriptionURI != null) {
+        if (configDescriptionRegistry !== null && configuration !== null) {
+            if (channelType.configDescriptionURI !== null) {
                 val configDescription = configDescriptionRegistry.getConfigDescription(channelType.configDescriptionURI)
-                if (configDescription != null) {
+                if (configDescription !== null) {
                     configDescription.parameters.filter[
-                        ^default != null && configuration.get(name) == null
+                        ^default !== null && configuration.get(name) === null
                     ].forEach[
                         val value = getDefaultValueAsCorrectType(type, ^default)
-                        if (value != null) {
+                        if (value !== null) {
                             configuration.put(name, value);
                         }
                     ]
@@ -456,7 +456,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                 case org.eclipse.smarthome.model.core.EventType.MODIFIED: {
                     val oldThings = thingsMap.get(modelName) ?: newArrayList
                     val model = modelRepository.getModel(modelName) as ThingModel
-                    if (model != null) {
+                    if (model !== null) {
                         val newThingUIDs = model.allThingUIDs
                         val removedThings = oldThings.filter[!newThingUIDs.contains(it.UID)]
                         removedThings.forEach [
@@ -492,7 +492,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
     }    
     
     def private ThingUID getThingUID(ModelThing modelThing, ThingUID parentUID) {
-        if (parentUID != null && modelThing.id == null) {
+        if (parentUID !== null && modelThing.id === null) {
             val thingTypeUID = new ThingTypeUID(parentUID.bindingId, modelThing.thingTypeId)
             return new ThingUID(thingTypeUID, modelThing.thingId, parentUID.parentPath)
         } else {
@@ -588,9 +588,9 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
         }
         val oldThings = thingsMap.get(modelName).clone
         val newThings = newArrayList()
-        if (modelRepository != null) {
+        if (modelRepository !== null) {
             val model = modelRepository.getModel(modelName) as ThingModel
-            if (model != null) {
+            if (model !== null) {
                 model.things.forEach [
                     createThing(null, newThings, factory)
                 ]
@@ -598,7 +598,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
         }
         newThings.forEach [ newThing |
             val oldThing = oldThings.findFirst[it.UID == newThing.UID]
-            if (oldThing != null) {
+            if (oldThing !== null) {
                 if (!ThingHelper.equals(oldThing, newThing)) {
                     logger.debug("Updating thing '{}' from model '{}'.", newThing.UID, modelName);
                     notifyListenersAboutUpdatedElement(oldThing, newThing)
@@ -621,7 +621,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                         logger.trace("Searching thingHandlerFactory for thingType: {}", qc.thingTypeUID)
                         val thing = qc.thingHandlerFactory.createThing(qc.thingTypeUID, qc.configuration, qc.thingUID,
                             qc.bridgeUID)
-                        if (thing != null) {
+                        if (thing !== null) {
                             queue.remove(qc)
                             logger.debug("Successfully loaded '{}' during retry", qc.thingUID)
                             newThings.add(thing)
@@ -633,7 +633,7 @@ class GenericThingProvider extends AbstractProvider<Thing> implements ThingProvi
                                 !thingsMap.get(mName).filter[it.UID == newThing.UID].empty
                             ]
                             val oldThing = thingsMap.get(modelName).findFirst[it.UID == newThing.UID]
-                            if (oldThing != null) {
+                            if (oldThing !== null) {
                                 newThing.merge(oldThing)
                                 thingsMap.get(modelName).remove(oldThing)
                                 thingsMap.get(modelName).add(newThing)


### PR DESCRIPTION
only update things if they really changed, like it is done in the lazyRetryRunnable. This caused superfluous ThingUpdatedEvents when restarting a binding.

And while being there anyway I also fixed a bazillion of warnings by using the triple-operators for `null` comparisons. 

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>