### PR TITLE
QuantityType: Fix rule execution & product unit conversion

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
@@ -111,9 +111,11 @@ public class NumberItem extends GenericItem {
 
         // QuantityType update, check unit and convert if necessary:
         if (state instanceof QuantityType) {
-            Unit<?> unit = getUnit();
-            if (unit != null && !((QuantityType<?>) state).getUnit().getSystemUnit().equals(unit.getSystemUnit())) {
-                QuantityType<?> convertedState = ((QuantityType<?>) state).toUnit(unit);
+            Unit<?> itemUnit = getUnit();
+            Unit<?> stateUnit = ((QuantityType<?>) state).getUnit();
+            if (itemUnit != null && (!stateUnit.getSystemUnit().equals(itemUnit.getSystemUnit())
+                    || UnitUtils.isDifferentMeasurementSystem(itemUnit, stateUnit))) {
+                QuantityType<?> convertedState = ((QuantityType<?>) state).toUnit(itemUnit);
                 if (convertedState != null) {
                     super.setState(convertedState);
                     return;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/util/UnitUtils.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/util/UnitUtils.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.types.util;
 
+import static java.util.stream.Collectors.toSet;
+
 import java.util.Set;
 
 import javax.measure.Quantity;
@@ -127,6 +129,15 @@ public class UnitUtils {
                     && isMetricConversion(((TransformedUnit<?>) thatUnit).getConverter())) {
                 return isDifferentMeasurementSystem(thisUnit, ((TransformedUnit<?>) thatUnit).getParentUnit());
             }
+        }
+
+        // Compare the unit symbols. For product units (e.g. 1km / 1h) the equality is not given in the Sets above.
+        if (!differentSystems) {
+            Set<String> siSymbols = SI.stream().map(Unit::getSymbol).collect(toSet());
+            Set<String> usSymbols = US.stream().map(Unit::getSymbol).collect(toSet());
+
+            differentSystems = (siSymbols.contains(thisUnit.getSymbol()) && usSymbols.contains(thatUnit.getSymbol())) //
+                    || (siSymbols.contains(thatUnit.getSymbol()) && usSymbols.contains(thisUnit.getSymbol()));
         }
 
         return differentSystems;

--- a/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/RulesRuntimeModule.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.rule/src/org/eclipse/smarthome/model/rule/RulesRuntimeModule.xtend
@@ -16,8 +16,11 @@ package
  */
 org.eclipse.smarthome.model.rule
 
+import com.google.inject.Binder
+import com.google.inject.name.Names
 import org.eclipse.smarthome.model.rule.scoping.RulesImplicitlyImportedTypes
 import org.eclipse.smarthome.model.script.interpreter.ScriptInterpreter
+import org.eclipse.smarthome.model.script.jvmmodel.ScriptTypeComputer
 import org.eclipse.smarthome.model.script.scoping.ActionClassLoader
 import org.eclipse.smarthome.model.script.scoping.ScriptImportSectionNamespaceScopeProvider
 import org.eclipse.smarthome.model.script.scoping.StateAndCommandProvider
@@ -32,14 +35,18 @@ import org.eclipse.xtext.scoping.IScopeProvider
 import org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider
 import org.eclipse.xtext.xbase.interpreter.IExpressionInterpreter
 import org.eclipse.xtext.xbase.scoping.batch.ImplicitlyImportedFeatures
-import com.google.inject.Binder
-import com.google.inject.name.Names
+import org.eclipse.xtext.xbase.typesystem.computation.ITypeComputer
 
 /** 
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
  * @author Oliver Libutzki - Initial contribution
  */
-@SuppressWarnings("restriction") class RulesRuntimeModule extends org.eclipse.smarthome.model.rule.AbstractRulesRuntimeModule {
+@SuppressWarnings("restriction") class RulesRuntimeModule extends AbstractRulesRuntimeModule {
+
+    def Class<? extends ITypeComputer> bindITypeComputer() {
+        return ScriptTypeComputer
+    }
+
     def Class<? extends ImplicitlyImportedFeatures> bindImplicitlyImportedTypes() {
         return RulesImplicitlyImportedTypes
     }

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/lib/NumberExtensionsTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/lib/NumberExtensionsTest.java
@@ -164,7 +164,7 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorLessEqualsThan_Type_Quantity() {
-        assertFalse(NumberExtensions.operator_lessEqualsThan((Type) Q_LENGTH_1m, Q_LENGTH_1m));
+        assertTrue(NumberExtensions.operator_lessEqualsThan((Type) Q_LENGTH_1m, Q_LENGTH_1m));
     }
 
     @Test
@@ -185,8 +185,7 @@ public class NumberExtensionsTest {
 
     @Test
     public void operatorGreaterEqualsThan_Type_Quantity() {
-        assertFalse(
-                NumberExtensions.operator_greaterEqualsThan((Type) Q_LENGTH_1m, new QuantityType<Length>("100 cm")));
+        assertTrue(NumberExtensions.operator_greaterEqualsThan((Type) Q_LENGTH_1m, new QuantityType<Length>("100 cm")));
     }
 
     @Test

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/lib/NumberExtensions.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/lib/NumberExtensions.java
@@ -175,6 +175,9 @@ public class NumberExtensions {
     // Comparison operators between ESH types and numbers
 
     public static boolean operator_equals(Type type, Number x) {
+        if (type instanceof QuantityType && x instanceof QuantityType) {
+            return operator_equals((QuantityType) type, (QuantityType) x);
+        }
         if (type != null && type instanceof DecimalType && x != null) {
             return ((DecimalType) type).toBigDecimal().compareTo(numberToBigDecimal(x)) == 0;
         } else {
@@ -183,6 +186,9 @@ public class NumberExtensions {
     }
 
     public static boolean operator_notEquals(Type type, Number x) {
+        if (type instanceof QuantityType && x instanceof QuantityType) {
+            return operator_notEquals((QuantityType) type, (QuantityType) x);
+        }
         if (type != null && type instanceof DecimalType && x != null) {
             return ((DecimalType) type).toBigDecimal().compareTo(numberToBigDecimal(x)) != 0;
         } else {
@@ -192,6 +198,9 @@ public class NumberExtensions {
     }
 
     public static boolean operator_greaterThan(Type type, Number x) {
+        if (type instanceof QuantityType && x instanceof QuantityType) {
+            return operator_greaterThan((QuantityType) type, (QuantityType) x);
+        }
         if (type != null && type instanceof DecimalType && x != null) {
             return ((DecimalType) type).toBigDecimal().compareTo(numberToBigDecimal(x)) > 0;
         } else {
@@ -200,6 +209,9 @@ public class NumberExtensions {
     }
 
     public static boolean operator_greaterEqualsThan(Type type, Number x) {
+        if (type instanceof QuantityType && x instanceof QuantityType) {
+            return operator_greaterEqualsThan((QuantityType) type, (QuantityType) x);
+        }
         if (type != null && type instanceof DecimalType && x != null) {
             return ((DecimalType) type).toBigDecimal().compareTo(numberToBigDecimal(x)) >= 0;
         } else {
@@ -208,6 +220,9 @@ public class NumberExtensions {
     }
 
     public static boolean operator_lessThan(Type type, Number x) {
+        if (type instanceof QuantityType && x instanceof QuantityType) {
+            return operator_lessThan((QuantityType) type, (QuantityType) x);
+        }
         if (type != null && type instanceof DecimalType && x != null) {
             return ((DecimalType) type).toBigDecimal().compareTo(numberToBigDecimal(x)) < 0;
         } else {
@@ -216,6 +231,9 @@ public class NumberExtensions {
     }
 
     public static boolean operator_lessEqualsThan(Type type, Number x) {
+        if (type instanceof QuantityType && x instanceof QuantityType) {
+            return operator_lessEqualsThan((QuantityType) type, (QuantityType) x);
+        }
         if (type != null && type instanceof DecimalType && x != null) {
             return ((DecimalType) type).toBigDecimal().compareTo(numberToBigDecimal(x)) <= 0;
         } else {


### PR DESCRIPTION
Two fixes which occurred during demo preparation:
* Fix QuantityType rule execution by adding the type computer to the RulesRuntimeModule and forward comparison operators.
* Compare unit symbols for product units to convert calculated units to the desired item unit.

Signed-off-by: Henning Treu <henning.treu@telekom.de>