### PR TITLE
[5198] prevent Responses to be interpreted as xml

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/RuleResource.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/RuleResource.java
@@ -171,7 +171,7 @@ public class RuleResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @PUT
@@ -190,7 +190,7 @@ public class RuleResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @GET
@@ -229,7 +229,7 @@ public class RuleResource implements RESTResource {
         } else {
             rule.setConfiguration(new Configuration(config));
             ruleRegistry.update(rule);
-            return Response.ok().build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).build();
         }
     }
 
@@ -249,7 +249,7 @@ public class RuleResource implements RESTResource {
         } else {
             ruleRegistry.setEnabled(ruleUID, !"false".equalsIgnoreCase(enabled));
             // ruleRegistry.update(rule);
-            return Response.ok().build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).build();
         }
     }
 
@@ -268,7 +268,7 @@ public class RuleResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         } else {
             ruleRegistry.runNow(ruleUID);
-            return Response.ok().build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).build();
         }
     }
 
@@ -399,7 +399,7 @@ public class RuleResource implements RESTResource {
                 configuration.put(param, ConfigUtil.normalizeType(value));
                 module.setConfiguration(configuration);
                 ruleRegistry.update(rule);
-                return Response.ok().build();
+                return Response.ok(null, MediaType.APPLICATION_JSON).build();
             }
         }
         return Response.status(Status.NOT_FOUND).build();

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/RuleResource.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/RuleResource.java
@@ -171,7 +171,7 @@ public class RuleResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @PUT
@@ -190,7 +190,7 @@ public class RuleResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @GET
@@ -229,7 +229,7 @@ public class RuleResource implements RESTResource {
         } else {
             rule.setConfiguration(new Configuration(config));
             ruleRegistry.update(rule);
-            return Response.ok(null, MediaType.APPLICATION_JSON).build();
+            return Response.ok(null, MediaType.TEXT_PLAIN).build();
         }
     }
 
@@ -249,7 +249,7 @@ public class RuleResource implements RESTResource {
         } else {
             ruleRegistry.setEnabled(ruleUID, !"false".equalsIgnoreCase(enabled));
             // ruleRegistry.update(rule);
-            return Response.ok(null, MediaType.APPLICATION_JSON).build();
+            return Response.ok(null, MediaType.TEXT_PLAIN).build();
         }
     }
 
@@ -268,7 +268,7 @@ public class RuleResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         } else {
             ruleRegistry.runNow(ruleUID);
-            return Response.ok(null, MediaType.APPLICATION_JSON).build();
+            return Response.ok(null, MediaType.TEXT_PLAIN).build();
         }
     }
 
@@ -399,7 +399,7 @@ public class RuleResource implements RESTResource {
                 configuration.put(param, ConfigUtil.normalizeType(value));
                 module.setConfiguration(configuration);
                 ruleRegistry.update(rule);
-                return Response.ok(null, MediaType.APPLICATION_JSON).build();
+                return Response.ok(null, MediaType.TEXT_PLAIN).build();
             }
         }
         return Response.status(Status.NOT_FOUND).build();

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/discovery/InboxResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/discovery/InboxResource.java
@@ -108,7 +108,7 @@ public class InboxResource implements RESTResource {
             return JSONResponse.createErrorResponse(Status.CONFLICT, "No binding found that can create the thing");
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @DELETE
@@ -118,7 +118,7 @@ public class InboxResource implements RESTResource {
             @ApiResponse(code = 404, message = "Discovery result not found in the inbox.") })
     public Response delete(@PathParam("thingUID") @ApiParam(value = "thingUID", required = true) String thingUID) {
         if (inbox.remove(new ThingUID(thingUID))) {
-            return Response.ok().build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).build();
         } else {
             return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Thing not found in inbox");
         }
@@ -139,7 +139,7 @@ public class InboxResource implements RESTResource {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response ignore(@PathParam("thingUID") @ApiParam(value = "thingUID", required = true) String thingUID) {
         inbox.setFlag(new ThingUID(thingUID), DiscoveryResultFlag.IGNORED);
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @POST
@@ -148,7 +148,7 @@ public class InboxResource implements RESTResource {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response unignore(@PathParam("thingUID") @ApiParam(value = "thingUID", required = true) String thingUID) {
         inbox.setFlag(new ThingUID(thingUID), DiscoveryResultFlag.NEW);
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @Override

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/discovery/InboxResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/discovery/InboxResource.java
@@ -108,7 +108,7 @@ public class InboxResource implements RESTResource {
             return JSONResponse.createErrorResponse(Status.CONFLICT, "No binding found that can create the thing");
         }
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @DELETE
@@ -118,7 +118,7 @@ public class InboxResource implements RESTResource {
             @ApiResponse(code = 404, message = "Discovery result not found in the inbox.") })
     public Response delete(@PathParam("thingUID") @ApiParam(value = "thingUID", required = true) String thingUID) {
         if (inbox.remove(new ThingUID(thingUID))) {
-            return Response.ok(null, MediaType.APPLICATION_JSON).build();
+            return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } else {
             return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Thing not found in inbox");
         }
@@ -139,7 +139,7 @@ public class InboxResource implements RESTResource {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response ignore(@PathParam("thingUID") @ApiParam(value = "thingUID", required = true) String thingUID) {
         inbox.setFlag(new ThingUID(thingUID), DiscoveryResultFlag.IGNORED);
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @POST
@@ -148,7 +148,7 @@ public class InboxResource implements RESTResource {
     @ApiResponses(value = { @ApiResponse(code = 200, message = "OK") })
     public Response unignore(@PathParam("thingUID") @ApiParam(value = "thingUID", required = true) String thingUID) {
         inbox.setFlag(new ThingUID(thingUID), DiscoveryResultFlag.NEW);
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @Override

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/extensions/ExtensionResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/extensions/ExtensionResource.java
@@ -160,7 +160,7 @@ public class ExtensionResource implements RESTResource {
                 postFailureEvent(extensionId, e.getMessage());
             }
         });
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @POST
@@ -179,7 +179,7 @@ public class ExtensionResource implements RESTResource {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, "The given URL is malformed or not valid.");
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @POST
@@ -196,7 +196,7 @@ public class ExtensionResource implements RESTResource {
                 postFailureEvent(extensionId, e.getMessage());
             }
         });
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     private void postFailureEvent(String extensionId, String msg) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/extensions/ExtensionResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/extensions/ExtensionResource.java
@@ -160,7 +160,7 @@ public class ExtensionResource implements RESTResource {
                 postFailureEvent(extensionId, e.getMessage());
             }
         });
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @POST
@@ -179,7 +179,7 @@ public class ExtensionResource implements RESTResource {
             return JSONResponse.createErrorResponse(Status.BAD_REQUEST, "The given URL is malformed or not valid.");
         }
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @POST
@@ -196,7 +196,7 @@ public class ExtensionResource implements RESTResource {
                 postFailureEvent(extensionId, e.getMessage());
             }
         });
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     private void postFailureEvent(String extensionId, String msg) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
@@ -371,7 +371,7 @@ public class ItemResource implements RESTResource {
             genericMemberItem.addGroupName(groupItem.getName());
             managedItemProvider.update(genericMemberItem);
 
-            return Response.ok(null, MediaType.APPLICATION_JSON).build();
+            return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (ItemNotFoundException e) {
             return Response.status(Status.NOT_FOUND).build();
         }
@@ -409,7 +409,7 @@ public class ItemResource implements RESTResource {
             genericMemberItem.removeGroupName(groupItem.getName());
             managedItemProvider.update(genericMemberItem);
 
-            return Response.ok(null, MediaType.APPLICATION_JSON).build();
+            return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } catch (ItemNotFoundException e) {
             return Response.status(Status.NOT_FOUND).build();
         }
@@ -427,7 +427,7 @@ public class ItemResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @PUT
@@ -453,7 +453,7 @@ public class ItemResource implements RESTResource {
         ((ActiveItem) item).addTag(tag);
         managedItemProvider.update(item);
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @DELETE
@@ -479,7 +479,7 @@ public class ItemResource implements RESTResource {
         ((ActiveItem) item).removeTag(tag);
         managedItemProvider.update(item);
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     /**

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
@@ -371,7 +371,7 @@ public class ItemResource implements RESTResource {
             genericMemberItem.addGroupName(groupItem.getName());
             managedItemProvider.update(genericMemberItem);
 
-            return Response.ok().build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).build();
         } catch (ItemNotFoundException e) {
             return Response.status(Status.NOT_FOUND).build();
         }
@@ -409,7 +409,7 @@ public class ItemResource implements RESTResource {
             genericMemberItem.removeGroupName(groupItem.getName());
             managedItemProvider.update(genericMemberItem);
 
-            return Response.ok().build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).build();
         } catch (ItemNotFoundException e) {
             return Response.status(Status.NOT_FOUND).build();
         }
@@ -427,7 +427,7 @@ public class ItemResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @PUT
@@ -453,7 +453,7 @@ public class ItemResource implements RESTResource {
         ((ActiveItem) item).addTag(tag);
         managedItemProvider.update(item);
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @DELETE
@@ -479,7 +479,7 @@ public class ItemResource implements RESTResource {
         ((ActiveItem) item).removeTag(tag);
         managedItemProvider.update(item);
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     /**

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -116,7 +116,7 @@ public class ItemChannelLinkResource implements RESTResource {
         } else {
             itemChannelLinkRegistry.update(link);
         }
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     @DELETE
@@ -136,7 +136,7 @@ public class ItemChannelLinkResource implements RESTResource {
         ItemChannelLink result = itemChannelLinkRegistry
                 .remove(AbstractLink.getIDFor(itemName, new ChannelUID(channelUid)));
         if (result != null) {
-            return Response.ok().build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).build();
         } else {
             return JSONResponse.createErrorResponse(Status.METHOD_NOT_ALLOWED, "Channel is read-only.");
         }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/link/ItemChannelLinkResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/link/ItemChannelLinkResource.java
@@ -116,7 +116,7 @@ public class ItemChannelLinkResource implements RESTResource {
         } else {
             itemChannelLinkRegistry.update(link);
         }
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     @DELETE
@@ -136,7 +136,7 @@ public class ItemChannelLinkResource implements RESTResource {
         ItemChannelLink result = itemChannelLinkRegistry
                 .remove(AbstractLink.getIDFor(itemName, new ChannelUID(channelUid)));
         if (result != null) {
-            return Response.ok(null, MediaType.APPLICATION_JSON).build();
+            return Response.ok(null, MediaType.TEXT_PLAIN).build();
         } else {
             return JSONResponse.createErrorResponse(Status.METHOD_NOT_ALLOWED, "Channel is read-only.");
         }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
@@ -308,7 +308,7 @@ public class ThingResource implements RESTResource {
             }
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     /**
@@ -452,7 +452,7 @@ public class ThingResource implements RESTResource {
 
         ThingStatusInfo thingStatusInfo = thingStatusInfoI18nLocalizationService.getLocalizedThingStatusInfo(thing,
                 LocaleUtil.getLocale(language));
-        return Response.ok().entity(thingStatusInfo).build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).entity(thingStatusInfo).build();
     }
 
     @GET
@@ -475,9 +475,9 @@ public class ThingResource implements RESTResource {
 
         ConfigStatusInfo info = configStatusService.getConfigStatus(thingUID, LocaleUtil.getLocale(language));
         if (info != null) {
-            return Response.ok().entity(info.getConfigStatusMessages()).build();
+            return Response.ok(null, MediaType.APPLICATION_JSON).entity(info.getConfigStatusMessages()).build();
         }
-        return Response.ok().entity(Collections.EMPTY_SET).build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).entity(Collections.EMPTY_SET).build();
     }
 
     @PUT
@@ -522,7 +522,7 @@ public class ThingResource implements RESTResource {
             return Response.status(Status.NO_CONTENT).build();
         }
 
-        return Response.ok().entity(buildFirmwareStatusDTO(info)).build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).entity(buildFirmwareStatusDTO(info)).build();
     }
 
     private FirmwareStatusDTO getThingFirmwareStatus(ThingUID thingUID) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
@@ -308,7 +308,7 @@ public class ThingResource implements RESTResource {
             }
         }
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     /**
@@ -452,7 +452,7 @@ public class ThingResource implements RESTResource {
 
         ThingStatusInfo thingStatusInfo = thingStatusInfoI18nLocalizationService.getLocalizedThingStatusInfo(thing,
                 LocaleUtil.getLocale(language));
-        return Response.ok(null, MediaType.APPLICATION_JSON).entity(thingStatusInfo).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).entity(thingStatusInfo).build();
     }
 
     @GET
@@ -475,9 +475,9 @@ public class ThingResource implements RESTResource {
 
         ConfigStatusInfo info = configStatusService.getConfigStatus(thingUID, LocaleUtil.getLocale(language));
         if (info != null) {
-            return Response.ok(null, MediaType.APPLICATION_JSON).entity(info.getConfigStatusMessages()).build();
+            return Response.ok(null, MediaType.TEXT_PLAIN).entity(info.getConfigStatusMessages()).build();
         }
-        return Response.ok(null, MediaType.APPLICATION_JSON).entity(Collections.EMPTY_SET).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).entity(Collections.EMPTY_SET).build();
     }
 
     @PUT
@@ -522,7 +522,7 @@ public class ThingResource implements RESTResource {
             return Response.status(Status.NO_CONTENT).build();
         }
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).entity(buildFirmwareStatusDTO(info)).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).entity(buildFirmwareStatusDTO(info)).build();
     }
 
     private FirmwareStatusDTO getThingFirmwareStatus(ThingUID thingUID) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingTypeResource.java
@@ -180,7 +180,7 @@ public class ThingTypeResource implements RESTResource {
         }
 
         Stream<FirmwareDTO> firmwareStream = firmwares.stream().map(this::convertToFirmwareDTO);
-        return Response.ok(null, MediaType.APPLICATION_JSON).entity(new Stream2JSONInputStream(firmwareStream)).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).entity(new Stream2JSONInputStream(firmwareStream)).build();
     }
 
     private ThingTypeDTO convertToThingTypeDTO(ThingType thingType, Locale locale) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingTypeResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingTypeResource.java
@@ -180,7 +180,7 @@ public class ThingTypeResource implements RESTResource {
         }
 
         Stream<FirmwareDTO> firmwareStream = firmwares.stream().map(this::convertToFirmwareDTO);
-        return Response.ok().entity(new Stream2JSONInputStream(firmwareStream)).build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).entity(new Stream2JSONInputStream(firmwareStream)).build();
     }
 
     private ThingTypeDTO convertToThingTypeDTO(ThingType thingType, Locale locale) {

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
@@ -132,7 +132,7 @@ public class LogHandler implements RESTResource {
             LOG_BUFFER.pollLast(); // Remove last element of Deque
         }
 
-        return Response.ok().build();
+        return Response.ok(null, MediaType.APPLICATION_JSON).build();
     }
 
     /**

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/src/main/java/org/eclipse/smarthome/io/rest/log/internal/LogHandler.java
@@ -132,7 +132,7 @@ public class LogHandler implements RESTResource {
             LOG_BUFFER.pollLast(); // Remove last element of Deque
         }
 
-        return Response.ok(null, MediaType.APPLICATION_JSON).build();
+        return Response.ok(null, MediaType.TEXT_PLAIN).build();
     }
 
     /**

--- a/bundles/io/org.eclipse.smarthome.io.rest.voice/src/main/java/org/eclipse/smarthome/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.voice/src/main/java/org/eclipse/smarthome/io/rest/voice/internal/VoiceResource.java
@@ -121,7 +121,7 @@ public class VoiceResource implements RESTResource {
         if (hli != null) {
             try {
                 hli.interpret(locale, text);
-                return Response.ok(null, MediaType.APPLICATION_JSON).build();
+                return Response.ok(null, MediaType.TEXT_PLAIN).build();
             } catch (InterpretationException e) {
                 return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());
             }
@@ -144,7 +144,7 @@ public class VoiceResource implements RESTResource {
         if (hli != null) {
             try {
                 hli.interpret(locale, text);
-                return Response.ok(null, MediaType.APPLICATION_JSON).build();
+                return Response.ok(null, MediaType.TEXT_PLAIN).build();
             } catch (InterpretationException e) {
                 return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());
             }

--- a/bundles/io/org.eclipse.smarthome.io.rest.voice/src/main/java/org/eclipse/smarthome/io/rest/voice/internal/VoiceResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.voice/src/main/java/org/eclipse/smarthome/io/rest/voice/internal/VoiceResource.java
@@ -121,7 +121,7 @@ public class VoiceResource implements RESTResource {
         if (hli != null) {
             try {
                 hli.interpret(locale, text);
-                return Response.ok().build();
+                return Response.ok(null, MediaType.APPLICATION_JSON).build();
             } catch (InterpretationException e) {
                 return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());
             }
@@ -144,7 +144,7 @@ public class VoiceResource implements RESTResource {
         if (hli != null) {
             try {
                 hli.interpret(locale, text);
-                return Response.ok().build();
+                return Response.ok(null, MediaType.APPLICATION_JSON).build();
             } catch (InterpretationException e) {
                 return JSONResponse.createErrorResponse(Status.BAD_REQUEST, e.getMessage());
             }


### PR DESCRIPTION
The ResponseBuilder "guesses" the best mimetype for the Response by
interpreting the accept headers from the Request. When the client
sets no preferation and xml is valid, the response will be interpreted
as xml. If FF doesn't find the xml root element in this case, which happens
when the Response is empty, a console error is printed out.

Bug: https://github.com/eclipse/smarthome/issues/5198
Signed-off-by: Marcel Walwei <maw.albrecht.jung@gmail.com>