### PR TITLE
use generic type argument

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/DecimalTypeTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.*;
 
 import java.text.DecimalFormatSymbols;
 
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.junit.Test;
 
 /**
@@ -101,14 +100,14 @@ public class DecimalTypeTest {
     public void testConversionToOpenCloseType() {
         assertEquals(OpenClosedType.OPEN, new DecimalType("1.0").as(OpenClosedType.class));
         assertEquals(OpenClosedType.CLOSED, new DecimalType("0.0").as(OpenClosedType.class));
-        assertEquals(UnDefType.UNDEF, new DecimalType("0.5").as(OpenClosedType.class));
+        assertNull(new DecimalType("0.5").as(OpenClosedType.class));
     }
 
     @Test
     public void testConversionToUpDownType() {
         assertEquals(UpDownType.UP, new DecimalType("0.0").as(UpDownType.class));
         assertEquals(UpDownType.DOWN, new DecimalType("1.0").as(UpDownType.class));
-        assertEquals(UnDefType.UNDEF, new DecimalType("0.5").as(OpenClosedType.class));
+        assertNull(new DecimalType("0.5").as(OpenClosedType.class));
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PercentTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PercentTypeTest.java
@@ -12,10 +12,9 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.junit.Test;
 
 /**
@@ -82,14 +81,14 @@ public class PercentTypeTest {
     public void testConversionToOpenCloseType() {
         assertEquals(OpenClosedType.OPEN, new PercentType("100.0").as(OpenClosedType.class));
         assertEquals(OpenClosedType.CLOSED, new PercentType("0.0").as(OpenClosedType.class));
-        assertEquals(UnDefType.UNDEF, new PercentType("50.0").as(OpenClosedType.class));
+        assertNull(new PercentType("50.0").as(OpenClosedType.class));
     }
 
     @Test
     public void testConversionToUpDownType() {
         assertEquals(UpDownType.UP, new PercentType("0.0").as(UpDownType.class));
         assertEquals(UpDownType.DOWN, new PercentType("100.0").as(UpDownType.class));
-        assertEquals(UnDefType.UNDEF, new PercentType("50.0").as(OpenClosedType.class));
+        assertNull(new PercentType("50.0").as(OpenClosedType.class));
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/QuantityTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/QuantityTypeTest.java
@@ -27,7 +27,6 @@ import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.MetricPrefix;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -152,14 +151,14 @@ public class QuantityTypeTest {
     public void testConversionToOpenCloseType() {
         assertEquals(OpenClosedType.OPEN, new QuantityType<>("1.0").as(OpenClosedType.class));
         assertEquals(OpenClosedType.CLOSED, new QuantityType<>("0.0").as(OpenClosedType.class));
-        assertEquals(UnDefType.UNDEF, new QuantityType<>("0.5").as(OpenClosedType.class));
+        assertNull(new QuantityType<>("0.5").as(OpenClosedType.class));
     }
 
     @Test
     public void testConversionToUpDownType() {
         assertEquals(UpDownType.UP, new QuantityType<>("0.0").as(UpDownType.class));
         assertEquals(UpDownType.DOWN, new QuantityType<>("1.0").as(UpDownType.class));
-        assertEquals(UnDefType.UNDEF, new QuantityType<>("0.5").as(OpenClosedType.class));
+        assertNull(new QuantityType<>("0.5").as(OpenClosedType.class));
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -93,7 +93,7 @@ public abstract class GenericItem implements ActiveItem {
     }
 
     @Override
-    public @Nullable State getStateAs(Class<? extends State> typeClass) {
+    public <T extends State> @Nullable T getStateAs(Class<T> typeClass) {
         return state.as(typeClass);
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupFunction.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupFunction.java
@@ -42,7 +42,7 @@ public interface GroupFunction {
      * @param stateClass the type in which the state should be returned
      * @return the calculated group state of the requested type or null, if type is not supported
      */
-    State getStateAs(Set<Item> items, Class<? extends State> stateClass);
+    <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass);
 
     /**
      * Returns the parameters of the function as an array.
@@ -77,10 +77,10 @@ public interface GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 return null;
             }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -302,9 +302,10 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     }
 
     @Override
-    public @Nullable State getStateAs(Class<? extends State> typeClass) {
+    public <T extends State> @Nullable T getStateAs(Class<T> typeClass) {
         // if a group does not have a function it cannot have a state
-        State newState = null;
+        @Nullable
+        T newState = null;
         if (function != null) {
             newState = function.getStateAs(getStateMembers(getMembers()), typeClass);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/Item.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/Item.java
@@ -52,7 +52,7 @@ public interface Item extends Identifiable<String> {
      * @return the current state in the requested type or
      *         null, if state cannot be provided as the requested type
      */
-    public @Nullable State getStateAs(Class<? extends State> typeClass);
+    public <T extends State> @Nullable T getStateAs(Class<T> typeClass);
 
     /**
      * returns the name of the item

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/StringItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/StringItem.java
@@ -69,12 +69,12 @@ public class StringItem extends GenericItem {
     }
 
     @Override
-    public @Nullable State getStateAs(Class<? extends State> typeClass) {
+    public <T extends State> @Nullable T getStateAs(Class<T> typeClass) {
         ArrayList<Class<? extends State>> list = new ArrayList<Class<? extends State>>();
         list.add(typeClass);
         State convertedState = TypeParser.parseState(list, state.toString());
-        if (convertedState != null) {
-            return convertedState;
+        if (typeClass.isInstance(convertedState)) {
+            return typeClass.cast(convertedState);
         } else {
             return super.getStateAs(typeClass);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunction.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/ArithmeticGroupFunction.java
@@ -70,16 +70,16 @@ public interface ArithmeticGroupFunction extends GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 if (stateClass == DecimalType.class) {
                     if (items != null) {
-                        return new DecimalType(items.size() - count(items, activeState));
+                        return stateClass.cast(new DecimalType(items.size() - count(items, activeState)));
                     } else {
-                        return DecimalType.ZERO;
+                        return stateClass.cast(DecimalType.ZERO);
                     }
                 } else {
                     return null;
@@ -139,13 +139,13 @@ public interface ArithmeticGroupFunction extends GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 if (stateClass == DecimalType.class) {
-                    return new DecimalType(count(items, activeState));
+                    return stateClass.cast(new DecimalType(count(items, activeState)));
                 } else {
                     return null;
                 }
@@ -226,7 +226,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
             int count = 0;
             if (items != null) {
                 for (Item item : items) {
-                    DecimalType itemState = (DecimalType) item.getStateAs(DecimalType.class);
+                    DecimalType itemState = item.getStateAs(DecimalType.class);
                     if (itemState != null) {
                         sum = sum.add(itemState.toBigDecimal());
                         count++;
@@ -241,10 +241,10 @@ public interface ArithmeticGroupFunction extends GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 return null;
             }
@@ -269,7 +269,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
             BigDecimal sum = BigDecimal.ZERO;
             if (items != null) {
                 for (Item item : items) {
-                    DecimalType itemState = (DecimalType) item.getStateAs(DecimalType.class);
+                    DecimalType itemState = item.getStateAs(DecimalType.class);
                     if (itemState != null) {
                         sum = sum.add(itemState.toBigDecimal());
                     }
@@ -279,10 +279,10 @@ public interface ArithmeticGroupFunction extends GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 return null;
             }
@@ -307,7 +307,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
             if (items != null && items.size() > 0) {
                 BigDecimal min = null;
                 for (Item item : items) {
-                    DecimalType itemState = (DecimalType) item.getStateAs(DecimalType.class);
+                    DecimalType itemState = item.getStateAs(DecimalType.class);
                     if (itemState != null) {
                         if (min == null || min.compareTo(itemState.toBigDecimal()) > 0) {
                             min = itemState.toBigDecimal();
@@ -322,10 +322,10 @@ public interface ArithmeticGroupFunction extends GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 return null;
             }
@@ -350,7 +350,7 @@ public interface ArithmeticGroupFunction extends GroupFunction {
             if (items != null && items.size() > 0) {
                 BigDecimal max = null;
                 for (Item item : items) {
-                    DecimalType itemState = (DecimalType) item.getStateAs(DecimalType.class);
+                    DecimalType itemState = item.getStateAs(DecimalType.class);
                     if (itemState != null) {
                         if (max == null || max.compareTo(itemState.toBigDecimal()) < 0) {
                             max = itemState.toBigDecimal();
@@ -365,10 +365,10 @@ public interface ArithmeticGroupFunction extends GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 return null;
             }
@@ -414,10 +414,10 @@ public interface ArithmeticGroupFunction extends GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 return null;
             }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -146,35 +146,35 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         return value.longValue();
     }
 
-    protected State defaultConversion(Class<? extends State> target) {
+    protected <T extends State> T defaultConversion(Class<T> target) {
         return State.super.as(target);
     }
 
     @Override
-    public State as(Class<? extends State> target) {
+    public <T extends State> T as(Class<T> target) {
         if (target == OnOffType.class) {
-            return equals(ZERO) ? OnOffType.OFF : OnOffType.ON;
+            return target.cast(equals(ZERO) ? OnOffType.OFF : OnOffType.ON);
         } else if (target == PercentType.class) {
-            return new PercentType(toBigDecimal().multiply(BigDecimal.valueOf(100)));
+            return target.cast(new PercentType(toBigDecimal().multiply(BigDecimal.valueOf(100))));
         } else if (target == UpDownType.class) {
             if (equals(ZERO)) {
-                return UpDownType.UP;
+                return target.cast(UpDownType.UP);
             } else if (toBigDecimal().compareTo(BigDecimal.valueOf(1)) == 0) {
-                return UpDownType.DOWN;
+                return target.cast(UpDownType.DOWN);
             } else {
-                return UnDefType.UNDEF;
+                return target.cast(UnDefType.UNDEF);
             }
         } else if (target == OpenClosedType.class) {
             if (equals(ZERO)) {
-                return OpenClosedType.CLOSED;
+                return target.cast(OpenClosedType.CLOSED);
             } else if (toBigDecimal().compareTo(BigDecimal.valueOf(1)) == 0) {
-                return OpenClosedType.OPEN;
+                return target.cast(OpenClosedType.OPEN);
             } else {
-                return UnDefType.UNDEF;
+                return target.cast(UnDefType.UNDEF);
             }
         } else if (target == HSBType.class) {
-            return new HSBType(DecimalType.ZERO, PercentType.ZERO,
-                    new PercentType(this.toBigDecimal().multiply(BigDecimal.valueOf(100))));
+            return target.cast(new HSBType(DecimalType.ZERO, PercentType.ZERO,
+                    new PercentType(this.toBigDecimal().multiply(BigDecimal.valueOf(100)))));
         } else {
             return defaultConversion(target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -18,7 +18,6 @@ import java.util.IllegalFormatConversionException;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * The decimal type uses a BigDecimal internally and thus can be used for
@@ -162,7 +161,7 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
             } else if (toBigDecimal().compareTo(BigDecimal.valueOf(1)) == 0) {
                 return target.cast(UpDownType.DOWN);
             } else {
-                return target.cast(UnDefType.UNDEF);
+                return null;
             }
         } else if (target == OpenClosedType.class) {
             if (equals(ZERO)) {
@@ -170,7 +169,7 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
             } else if (toBigDecimal().compareTo(BigDecimal.valueOf(1)) == 0) {
                 return target.cast(OpenClosedType.OPEN);
             } else {
-                return target.cast(UnDefType.UNDEF);
+                return null;
             }
         } else if (target == HSBType.class) {
             return target.cast(new HSBType(DecimalType.ZERO, PercentType.ZERO,

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -271,14 +271,15 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
     }
 
     @Override
-    public State as(Class<? extends State> target) {
+    public <T extends State> T as(Class<T> target) {
         if (target == OnOffType.class) {
             // if brightness is not completely off, we consider the state to be on
-            return getBrightness().equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON;
+            return target.cast(getBrightness().equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON);
         } else if (target == DecimalType.class) {
-            return new DecimalType(getBrightness().toBigDecimal().divide(BigDecimal.valueOf(100), 8, RoundingMode.UP));
+            return target.cast(new DecimalType(
+                    getBrightness().toBigDecimal().divide(BigDecimal.valueOf(100), 8, RoundingMode.UP)));
         } else if (target == PercentType.class) {
-            return new PercentType(getBrightness().toBigDecimal());
+            return target.cast(new PercentType(getBrightness().toBigDecimal()));
         } else {
             return defaultConversion(target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
@@ -40,13 +40,13 @@ public enum OnOffType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public State as(Class<? extends State> target) {
+    public <T extends State> T as(Class<T> target) {
         if (target == DecimalType.class) {
-            return this == ON ? new DecimalType(1) : DecimalType.ZERO;
+            return target.cast(this == ON ? new DecimalType(1) : DecimalType.ZERO);
         } else if (target == PercentType.class) {
-            return this == ON ? PercentType.HUNDRED : PercentType.ZERO;
+            return target.cast(this == ON ? PercentType.HUNDRED : PercentType.ZERO);
         } else if (target == HSBType.class) {
-            return this == ON ? HSBType.WHITE : HSBType.BLACK;
+            return target.cast(this == ON ? HSBType.WHITE : HSBType.BLACK);
         } else {
             return State.super.as(target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
@@ -40,11 +40,11 @@ public enum OpenClosedType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public State as(Class<? extends State> target) {
+    public <T extends State> T as(Class<T> target) {
         if (target == DecimalType.class) {
-            return this == OPEN ? new DecimalType(1) : DecimalType.ZERO;
+            return target.cast(this == OPEN ? new DecimalType(1) : DecimalType.ZERO);
         } else if (target == PercentType.class) {
-            return this == OPEN ? PercentType.HUNDRED : PercentType.ZERO;
+            return target.cast(this == OPEN ? PercentType.HUNDRED : PercentType.ZERO);
         } else {
             return State.super.as(target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
@@ -62,31 +62,31 @@ public class PercentType extends DecimalType {
     }
 
     @Override
-    public State as(Class<? extends State> target) {
+    public <T extends State> T as(Class<T> target) {
         if (target == OnOffType.class) {
-            return equals(ZERO) ? OnOffType.OFF : OnOffType.ON;
+            return target.cast(equals(ZERO) ? OnOffType.OFF : OnOffType.ON);
         } else if (target == DecimalType.class) {
-            return new DecimalType(toBigDecimal().divide(BigDecimal.valueOf(100), 8, RoundingMode.UP));
+            return target.cast(new DecimalType(toBigDecimal().divide(BigDecimal.valueOf(100), 8, RoundingMode.UP)));
         } else if (target == UpDownType.class) {
             if (equals(ZERO)) {
-                return UpDownType.UP;
+                return target.cast(UpDownType.UP);
             } else if (equals(HUNDRED)) {
-                return UpDownType.DOWN;
+                return target.cast(UpDownType.DOWN);
             } else {
-                return UnDefType.UNDEF;
+                return target.cast(UnDefType.UNDEF);
             }
         } else if (target == OpenClosedType.class) {
             if (equals(ZERO)) {
-                return OpenClosedType.CLOSED;
+                return target.cast(OpenClosedType.CLOSED);
             } else if (equals(HUNDRED)) {
-                return OpenClosedType.OPEN;
+                return target.cast(OpenClosedType.OPEN);
             } else {
-                return UnDefType.UNDEF;
+                return target.cast(UnDefType.UNDEF);
             }
         } else if (target == HSBType.class) {
-            return new HSBType(DecimalType.ZERO, PercentType.ZERO, this);
+            return target.cast(new HSBType(DecimalType.ZERO, PercentType.ZERO, this));
         } else if (target == QuantityType.class) {
-            return new QuantityType<>(toBigDecimal().doubleValue(), SmartHomeUnits.PERCENT);
+            return target.cast(new QuantityType<>(toBigDecimal().doubleValue(), SmartHomeUnits.PERCENT));
         } else {
             return defaultConversion(target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
@@ -17,7 +17,6 @@ import java.math.RoundingMode;
 
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * The PercentType extends the {@link DecimalType} by putting constraints for its value on top (0-100).
@@ -73,7 +72,7 @@ public class PercentType extends DecimalType {
             } else if (equals(HUNDRED)) {
                 return target.cast(UpDownType.DOWN);
             } else {
-                return target.cast(UnDefType.UNDEF);
+                return null;
             }
         } else if (target == OpenClosedType.class) {
             if (equals(ZERO)) {
@@ -81,7 +80,7 @@ public class PercentType extends DecimalType {
             } else if (equals(HUNDRED)) {
                 return target.cast(OpenClosedType.OPEN);
             } else {
-                return target.cast(UnDefType.UNDEF);
+                return null;
             }
         } else if (target == HSBType.class) {
             return target.cast(new HSBType(DecimalType.ZERO, PercentType.ZERO, this));

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
@@ -31,7 +31,6 @@ import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.types.util.UnitUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -270,7 +269,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
             } else if (toBigDecimal().compareTo(BigDecimal.ONE) == 0) {
                 return target.cast(OnOffType.ON);
             } else {
-                return target.cast(UnDefType.UNDEF);
+                return null;
             }
         } else if (target == UpDownType.class) {
             if (doubleValue() == 0) {
@@ -278,7 +277,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
             } else if (toBigDecimal().compareTo(BigDecimal.ONE) == 0) {
                 return target.cast(UpDownType.DOWN);
             } else {
-                return target.cast(UnDefType.UNDEF);
+                return null;
             }
         } else if (target == OpenClosedType.class) {
             if (doubleValue() == 0) {
@@ -286,7 +285,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
             } else if (toBigDecimal().compareTo(BigDecimal.ONE) == 0) {
                 return target.cast(OpenClosedType.OPEN);
             } else {
-                return target.cast(UnDefType.UNDEF);
+                return null;
             }
         } else if (target == HSBType.class) {
             return target.cast(new HSBType(DecimalType.ZERO, PercentType.ZERO,

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
@@ -261,43 +261,43 @@ public class QuantityType<T extends Quantity<T>> extends Number
     }
 
     @Override
-    public State as(@Nullable Class<? extends @Nullable State> target) {
+    public <U extends State> U as(@Nullable Class<U> target) {
         if (target == OnOffType.class) {
             if (intValue() == 0) {
-                return OnOffType.OFF;
+                return target.cast(OnOffType.OFF);
             } else if (SmartHomeUnits.PERCENT.equals(getUnit())) {
-                return toBigDecimal().compareTo(BigDecimal.ZERO) > 0 ? OnOffType.ON : OnOffType.OFF;
+                return target.cast(toBigDecimal().compareTo(BigDecimal.ZERO) > 0 ? OnOffType.ON : OnOffType.OFF);
             } else if (toBigDecimal().compareTo(BigDecimal.ONE) == 0) {
-                return OnOffType.ON;
+                return target.cast(OnOffType.ON);
             } else {
-                return UnDefType.UNDEF;
+                return target.cast(UnDefType.UNDEF);
             }
         } else if (target == UpDownType.class) {
             if (doubleValue() == 0) {
-                return UpDownType.UP;
+                return target.cast(UpDownType.UP);
             } else if (toBigDecimal().compareTo(BigDecimal.ONE) == 0) {
-                return UpDownType.DOWN;
+                return target.cast(UpDownType.DOWN);
             } else {
-                return UnDefType.UNDEF;
+                return target.cast(UnDefType.UNDEF);
             }
         } else if (target == OpenClosedType.class) {
             if (doubleValue() == 0) {
-                return OpenClosedType.CLOSED;
+                return target.cast(OpenClosedType.CLOSED);
             } else if (toBigDecimal().compareTo(BigDecimal.ONE) == 0) {
-                return OpenClosedType.OPEN;
+                return target.cast(OpenClosedType.OPEN);
             } else {
-                return UnDefType.UNDEF;
+                return target.cast(UnDefType.UNDEF);
             }
         } else if (target == HSBType.class) {
-            return new HSBType(DecimalType.ZERO, PercentType.ZERO,
-                    new PercentType(this.toBigDecimal().multiply(HUNDRED)));
+            return target.cast(new HSBType(DecimalType.ZERO, PercentType.ZERO,
+                    new PercentType(this.toBigDecimal().multiply(HUNDRED))));
         } else if (target == PercentType.class) {
             if (SmartHomeUnits.PERCENT.equals(getUnit())) {
-                return new PercentType(toBigDecimal());
+                return target.cast(new PercentType(toBigDecimal()));
             }
-            return new PercentType(toBigDecimal().multiply(HUNDRED));
+            return target.cast(new PercentType(toBigDecimal().multiply(HUNDRED)));
         } else if (target == DecimalType.class) {
-            return new DecimalType(toBigDecimal());
+            return target.cast(new DecimalType(toBigDecimal()));
         } else {
             return State.super.as(target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityTypeArithmeticGroupFunction.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityTypeArithmeticGroupFunction.java
@@ -42,10 +42,10 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
         }
 
         @Override
-        public State getStateAs(Set<Item> items, Class<? extends State> stateClass) {
+        public <T extends State> T getStateAs(Set<Item> items, Class<T> stateClass) {
             State state = calculate(items);
             if (stateClass.isInstance(state)) {
-                return state;
+                return stateClass.cast(state);
             } else {
                 return null;
             }
@@ -78,7 +78,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
             int count = 0;
             for (Item item : items) {
                 if (item instanceof NumberItem && dimension.equals(((NumberItem) item).getDimension())) {
-                    QuantityType itemState = (QuantityType) item.getStateAs(QuantityType.class);
+                    QuantityType itemState = item.getStateAs(QuantityType.class);
                     if (itemState != null) {
                         if (sum == null) {
                             sum = itemState; // initialise the sum from the first item
@@ -120,7 +120,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
             QuantityType<?> sum = null;
             for (Item item : items) {
                 if (item instanceof NumberItem && dimension.equals(((NumberItem) item).getDimension())) {
-                    QuantityType itemState = (QuantityType) item.getStateAs(QuantityType.class);
+                    QuantityType itemState = item.getStateAs(QuantityType.class);
                     if (itemState != null) {
                         if (sum == null) {
                             sum = itemState; // initialise the sum from the first item
@@ -155,7 +155,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
             QuantityType<?> min = null;
             for (Item item : items) {
                 if (item instanceof NumberItem && dimension.equals(((NumberItem) item).getDimension())) {
-                    QuantityType itemState = (QuantityType) item.getStateAs(QuantityType.class);
+                    QuantityType itemState = item.getStateAs(QuantityType.class);
                     if (itemState != null) {
                         if (min == null
                                 || (min.getUnit().isCompatible(itemState.getUnit()) && min.compareTo(itemState) > 0)) {
@@ -188,7 +188,7 @@ public interface QuantityTypeArithmeticGroupFunction extends GroupFunction {
             QuantityType<?> max = null;
             for (Item item : items) {
                 if (item instanceof NumberItem && dimension.equals(((NumberItem) item).getDimension())) {
-                    QuantityType itemState = (QuantityType) item.getStateAs(QuantityType.class);
+                    QuantityType itemState = item.getStateAs(QuantityType.class);
                     if (itemState != null) {
                         if (max == null
                                 || (max.getUnit().isCompatible(itemState.getUnit()) && max.compareTo(itemState) < 0)) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
@@ -42,11 +42,11 @@ public enum UpDownType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public State as(Class<? extends State> target) {
+    public <T extends State> T as(Class<T> target) {
         if (target == DecimalType.class) {
-            return equals(UP) ? DecimalType.ZERO : new DecimalType(new BigDecimal("1.0"));
+            return target.cast(equals(UP) ? DecimalType.ZERO : new DecimalType(new BigDecimal("1.0")));
         } else if (target == PercentType.class) {
-            return equals(UP) ? PercentType.ZERO : PercentType.HUNDRED;
+            return target.cast(equals(UP) ? PercentType.ZERO : PercentType.HUNDRED);
         } else {
             return State.super.as(target);
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/State.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/State.java
@@ -27,9 +27,9 @@ public interface State extends Type {
      * @return the {@link State}'s value in the given type's representation, or <code>null</code> if the conversion was
      *         not possible
      */
-    default State as(Class<? extends State> target) {
+    default <T extends State> T as(Class<T> target) {
         if (target != null && target.isInstance(this)) {
-            return this;
+            return target.cast(this);
         } else {
             return null;
         }


### PR DESCRIPTION
The "as" and "getStateAs" functions should return an instance of the
given type (or null).
It does not make sense that someone calls e.g.
`item.getStateAs(DecimalType.class)` and needs to cast the return value.
The return value should already use the correct type.