### PR TITLE
Synthetic script encoding

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/src/org/eclipse/smarthome/model/script/runtime/internal/engine/ScriptEngineImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.model.script.runtime.internal.engine;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -118,7 +119,8 @@ public class ScriptEngineImpl implements ScriptEngine, ModelParser {
         XtextResourceSet resourceSet = getResourceSet();
         Resource resource = resourceSet.createResource(computeUnusedUri(resourceSet)); // IS-A XtextResource
         try {
-            resource.load(new StringInputStream(scriptAsString), resourceSet.getLoadOptions());
+            resource.load(new StringInputStream(scriptAsString, StandardCharsets.UTF_8.name()),
+                    resourceSet.getLoadOptions());
         } catch (IOException e) {
             throw new ScriptParsingException(
                     "Unexpected IOException; from close() of a String-based ByteArrayInputStream, no real I/O; how is that possible???",

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/ScriptRuntimeModule.xtend
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/ScriptRuntimeModule.xtend
@@ -35,6 +35,9 @@ import com.google.inject.Binder
 import com.google.inject.name.Names
 import org.eclipse.xtext.xbase.typesystem.computation.ITypeComputer
 import org.eclipse.smarthome.model.script.jvmmodel.ScriptTypeComputer
+import org.eclipse.xtext.parser.IEncodingProvider
+import org.eclipse.smarthome.model.script.internal.ScriptEncodingProvider
+import org.eclipse.xtext.service.DispatchingProvider
 
 /** 
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
@@ -47,6 +50,10 @@ import org.eclipse.smarthome.model.script.jvmmodel.ScriptTypeComputer
     
     def Class<? extends ITypeComputer> bindITypeComputer() {
         return ScriptTypeComputer
+    }
+
+    override configureRuntimeEncodingProvider(Binder binder) {
+        binder.bind(IEncodingProvider).annotatedWith(DispatchingProvider.Runtime).to(ScriptEncodingProvider)
     }
 
     override Class<? extends IExpressionInterpreter> bindIExpressionInterpreter() {

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/internal/ScriptEncodingProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/internal/ScriptEncodingProvider.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.model.script.internal;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.xtext.parser.IEncodingProvider;
+
+/**
+ * {@link IEncodingProvider} implementation for scripts.
+ * <p>
+ * It makes sure that synthetic resources are interpreted as UTF-8 because they will be handed in as strings and turned
+ * into UTF-8 encoded streams by the script engine.
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ */
+public class ScriptEncodingProvider implements IEncodingProvider {
+
+    @Override
+    public String getEncoding(URI uri) {
+        if (uri.toString().startsWith("__synthetic")) {
+            return StandardCharsets.UTF_8.name();
+        }
+        return Charset.defaultCharset().name();
+    }
+
+}


### PR DESCRIPTION
The merge of #5190 made a little funny problem surface when the build is run on a machine which doesn't have UTF-8 set as its default encoding. 

The Xtext based script engine currently uses the default platform encoding when parsing scripts. This somewhat makes sense when scrips are loaded from the file system. So far, so good. 

However, whenever the scripts are passed into the script engine as strings (e.g. from the OSGi console, from rules or from test-cases), they are for sure UTF-8 encoded (as this is that Java strings are). Luckily these strings are made available as "synthetic" resources, i.e. they can be distinguished at runtime. 

This PR adds an encoding provide which uses this knowledge to force Xtext into using UTF-8 for such resources.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>