### PR TITLE
Add new license header style for the XML files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,11 @@
             <mapping>
               <xtend>JAVADOC_STYLE</xtend>
               <mwe2>JAVADOC_STYLE</mwe2>
+              <xml>xml-header-style</xml>
             </mapping>
+            <headerDefinitions>
+              <headerDefinition>src/etc/xml-header-style.xml</headerDefinition>
+            </headerDefinitions>
             <includes>
               <include>src/**/*.java</include>
               <include>src/**/*.groovy</include>

--- a/src/etc/xml-header-style.xml
+++ b/src/etc/xml-header-style.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<additionalHeaders>
+	<xml-header-style>
+		<firstLine><![CDATA[<!--EOL]]></firstLine>
+		<beforeEachLine>&#x9;</beforeEachLine>
+		<endLine><![CDATA[EOL-->]]></endLine>
+		<skipLine><![CDATA[^<\?xml.*>$]]></skipLine>
+		<firstLineDetectionPattern><![CDATA[(\s|\t)*<!--.*$]]></firstLineDetectionPattern>
+		<lastLineDetectionPattern><![CDATA[.*-->(\s|\t)*$]]></lastLineDetectionPattern>
+		<allowBlankLines>true</allowBlankLines>
+		<isMultiline>true</isMultiline>
+	</xml-header-style>
+</additionalHeaders>


### PR DESCRIPTION
@kaikreuzer @maggu2810  As we talked about I added a new header definition file to the maven license plugin configuration, so the header for the XML files will be generated with tabs instead of spaces.