### PR TITLE
WIP: Add properties to config description

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.xml/config-description-1.0.0.xsd
+++ b/bundles/config/org.eclipse.smarthome.config.xml/config-description-1.0.0.xsd
@@ -56,6 +56,7 @@
             <xs:element name="verify" type="xs:boolean" minOccurs="0" />
 			<xs:element name="multipleLimit" type="xs:integer" minOccurs="0" />
             <xs:element name="unitLabel" type="xs:string" minOccurs="0" />
+            <xs:element name="properties" type="config-description:properties" minOccurs="0"/>
 		</xs:all>
 		<xs:attribute name="name" type="xs:string" use="required" />
 		<xs:attribute name="type" type="config-description:parameterType"
@@ -169,5 +170,19 @@
 		<xs:attribute name="uri"
 			type="config-description:uriRestrictionPattern" use="required" />
 	</xs:complexType>
-
+	
+	<xs:complexType name="properties">
+		<xs:sequence>
+            <xs:element name="property" type="config-description:property" minOccurs="1" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+	
+	<xs:complexType name="property">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+                <xs:attribute name="name" type="xs:string" use="required" />
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	
 </xs:schema>


### PR DESCRIPTION
I would like to propose to add properties to config parameters. This is to support some level of parameterisation of configuration.

As a concrete example, in the zwave binding, in order to describe a parameter, I need to use the parameter name to embed some data -:

```
      <parameter name="config_17_1" type="integer" groupName="configuration">
      </parameter>
```

This embeds a parameter number and a size into the name - ie parameter 17, 1 byte. I don't really like this, but there's currently no alternative. I should add that in some instances, a lot more data is added to this name so this is a simple example, and I can have this sort of thing ```config_17_4_0000FF00_wo```.

My proposal is to add properties, so instead of the above, we would have -:
```
      <parameter name="config" type="integer" groupName="configuration">
        <properties>
          <property name="parameter">17</property>
          <property name="length">1</property>
        </properties>
      </parameter>
```

I'm about to start doing the same sort of thing in the ZigBee binding, and I would prefer not to if we can agree on something along the lines proposed here.

This PR just adds the XSD to present the proposal - it would be extended if agreed.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>