### PR TITLE
Corrected NTP test failures

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
@@ -115,6 +115,13 @@ public class DateTimeType implements PrimitiveType, State, Command {
         return zonedDateTime;
     }
 
+    /*
+     * Returns the zonedDateTime object for a given time zone
+     */
+    public ZonedDateTime getZonedDateTimeAtZone(ZoneId zone) {
+        return zonedDateTime.withZoneSameInstant(zone);
+    }
+
     public static DateTimeType valueOf(String value) {
         return new DateTimeType(value);
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/src/test/java/org/eclipse/smarthome/binding/ntp/test/NtpOSGiTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/src/test/java/org/eclipse/smarthome/binding/ntp/test/NtpOSGiTest.java
@@ -14,7 +14,7 @@ package org.eclipse.smarthome.binding.ntp.test;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.time.ZoneId;
@@ -217,7 +217,8 @@ public class NtpOSGiTest extends JavaOSGiTest {
         String testItemState = getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME).toString();
         assertFormat(testItemState, DateTimeType.DATE_PATTERN_WITH_TZ_AND_MS);
         ZonedDateTime timeZoneFromItemRegistry = ((DateTimeType) getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME))
-                .getZonedDateTime();
+                .getZonedDateTimeAtZone(ZoneId.of(TEST_TIME_ZONE_ID));
+        ;
         ZoneOffset expectedOffset;
         if (timeZoneFromItemRegistry.getZone().getRules().isDaylightSavings(timeZoneFromItemRegistry.toInstant())) {
             expectedOffset = ZoneOffset.of("-07:00");
@@ -235,7 +236,7 @@ public class NtpOSGiTest extends JavaOSGiTest {
         configuration.put(NtpBindingConstants.PROPERTY_TIMEZONE, TEST_TIME_ZONE_ID);
         initialize(configuration, NtpBindingConstants.CHANNEL_DATE_TIME, ACCEPTED_ITEM_TYPE_DATE_TIME, null, null);
         ZonedDateTime timeZoneIdFromItemRegistry = ((DateTimeType) getItemState(ACCEPTED_ITEM_TYPE_DATE_TIME))
-                .getZonedDateTime();
+                .getZonedDateTimeAtZone(ZoneId.of(TEST_TIME_ZONE_ID));
         ZoneOffset testZoneId;
         if (timeZoneIdFromItemRegistry.getZone().getRules().isDaylightSavings(timeZoneIdFromItemRegistry.toInstant())) {
             testZoneId = ZoneOffset.of("-07:00");


### PR DESCRIPTION
#5224

Extended the DateTimeType API with a method that returns the zonedDateTime instance for a given time zone. The test failures are because of time zone change in LA (test zone) and the .isDaylightSavingTime() for System Zone (which is Europe/Bucharest).

Signed-off-by: Erdoan Hadzhiyusein <3rdoan@gmail.com>