### PR TITLE
made discovery scheduler non-static

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.mdns/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.mdns/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryService.java
@@ -104,7 +104,7 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
 
     @Override
     protected void startScan() {
-        SCHEDULER.schedule(new Runnable() {
+        scheduler.schedule(new Runnable() {
             @Override
             public void run() {
                 scan();

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
@@ -57,8 +57,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
 
     private final Logger logger = LoggerFactory.getLogger(AbstractDiscoveryService.class);
 
-    protected static final ScheduledExecutorService SCHEDULER = ThreadPoolManager
-            .getScheduledPool(DISCOVERY_THREADPOOL_NAME);
+    protected final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(DISCOVERY_THREADPOOL_NAME);
 
     private final Set<DiscoveryListener> discoveryListeners = new CopyOnWriteArraySet<>();
     protected @Nullable ScanListener scanListener = null;
@@ -201,7 +200,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
                     }
                 };
 
-                scheduledStop = SCHEDULER.schedule(runnable, getScanTimeout(), TimeUnit.SECONDS);
+                scheduledStop = scheduler.schedule(runnable, getScanTimeout(), TimeUnit.SECONDS);
             }
             this.timestampOfLastScan = new Date().getTime();
 

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/discovery/AstroDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/discovery/AstroDiscoveryService.java
@@ -95,7 +95,7 @@ public class AstroDiscoveryService extends AbstractDiscoveryService {
     @Override
     protected void startBackgroundDiscovery() {
         if (astroDiscoveryJob == null) {
-            astroDiscoveryJob = SCHEDULER.scheduleWithFixedDelay(() -> {
+            astroDiscoveryJob = scheduler.scheduleWithFixedDelay(() -> {
                 PointType currentLocation = locationProvider.getLocation();
                 if (!Objects.equals(currentLocation, previousLocation)) {
                     logger.debug("Location has been changed from {} to {}: Creating new discovery results",

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/BridgeDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/BridgeDiscoveryService.java
@@ -104,6 +104,6 @@ public class BridgeDiscoveryService extends AbstractDiscoveryService {
 
     @Override
     protected void startScan() {
-        SCHEDULER.execute(resultCreater);
+        scheduler.execute(resultCreater);
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
@@ -72,7 +72,7 @@ public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
 
     @Override
     protected void startScan() {
-        SCHEDULER.schedule(new Runnable() {
+        scheduler.schedule(new Runnable() {
             @Override
             public void run() {
                 discoverHueBridges();

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
@@ -144,7 +144,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
 
         ScheduledFuture<?> localDiscoveryJob = discoveryJob;
         if (localDiscoveryJob == null || localDiscoveryJob.isCancelled()) {
-            discoveryJob = SCHEDULER.scheduleWithFixedDelay(this::doScan, 0, REFRESH_INTERVAL, TimeUnit.SECONDS);
+            discoveryJob = scheduler.scheduleWithFixedDelay(this::doScan, 0, REFRESH_INTERVAL, TimeUnit.SECONDS);
         }
     }
 
@@ -191,7 +191,7 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
                 selector = localSelector;
 
                 broadcastKey = openBroadcastChannel(localSelector, LOG_ID, BROADCAST_PORT);
-                networkJob = SCHEDULER.schedule(this::receiveAndHandlePackets, 0, TimeUnit.MILLISECONDS);
+                networkJob = scheduler.schedule(this::receiveAndHandlePackets, 0, TimeUnit.MILLISECONDS);
 
                 LifxSelectorContext selectorContext = new LifxSelectorContext(localSelector, sourceId,
                         sequenceNumberSupplier, LOG_ID, broadcastKey);

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/discovery/NtpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/discovery/NtpDiscovery.java
@@ -55,7 +55,7 @@ public class NtpDiscovery extends AbstractDiscoveryService {
 
     @Override
     protected void startBackgroundDiscovery() {
-        SCHEDULER.schedule(() -> {
+        scheduler.schedule(() -> {
             discoverNtp();
         }, 1, TimeUnit.SECONDS);
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/discovery/WeatherUndergroundDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/discovery/WeatherUndergroundDiscoveryService.java
@@ -88,7 +88,7 @@ public class WeatherUndergroundDiscoveryService extends AbstractDiscoveryService
     @Override
     protected void startBackgroundDiscovery() {
         if (discoveryJob == null) {
-            discoveryJob = SCHEDULER.scheduleWithFixedDelay(() -> {
+            discoveryJob = scheduler.scheduleWithFixedDelay(() -> {
                 PointType currentLocation = locationProvider.getLocation();
                 if (!Objects.equals(currentLocation, previousLocation)) {
                     logger.debug("Location has been changed from {} to {}: Creating new discovery results",

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/discovery/WemoLinkDiscoveryService.java
@@ -239,8 +239,8 @@ public class WemoLinkDiscoveryService extends AbstractDiscoveryService implement
         logger.trace("Start WeMo device background discovery");
 
         if (scanningJob == null || scanningJob.isCancelled()) {
-            this.scanningJob = AbstractDiscoveryService.SCHEDULER.scheduleWithFixedDelay(this.scanningRunnable,
-                    INITIAL_DELAY, SCAN_INTERVAL, TimeUnit.SECONDS);
+            this.scanningJob = scheduler.scheduleWithFixedDelay(this.scanningRunnable, INITIAL_DELAY, SCAN_INTERVAL,
+                    TimeUnit.SECONDS);
         } else {
             logger.trace("scanningJob active");
         }


### PR DESCRIPTION
https://github.com/eclipse/smarthome/pull/5200 caused an API breaking change by renaming the protected field `scheduler` to `SCHEDULER` - almost all bindings are using this field and thus won't compile anymore.

With regard to [this comment](https://github.com/eclipse/smarthome/pull/5200#issuecomment-372103324), I actually wonder why it has to be static - I do not see any good reason for it and thus suggest to change it. While this is still a potentially breaking change, it should at least be source compatible to all bindings that do not expect it to be static (and I actually couldn't find such a binding, so it should be a very small impact).

Signed-off-by: Kai Kreuzer <kai@openhab.org>