### PR TITLE
Paper UI: On item changed filter cached items

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -33,7 +33,11 @@ var paths = {
         './web-src/index.html'
     ],
     concat: [{
-        'src': './web-src/js/**/services*.js',
+        'src': [
+            './web-src/js/**/services*.js',
+            './web-src/js/repositories/repositories-module.js',
+            './web-src/js/repositories/repositories-services.js'
+            ],
         'name': 'services.js'
     }, {
         'src': [
@@ -244,6 +248,8 @@ gulp.task('inject', ['build'], function () {
                      './web-src/js/setup/controller*.js',
                      './web-src/js/**/directive*.js',
                      './web-src/js/**/service*.js',
+                     './web-src/js/repositories/repositories-module.js',
+                     './web-src/js/repositories/repositories-services.js',
                      './web-src/js/filters/*',
                      './web-src/js/extensions.js',
                      './web-src/js/controller*.js',

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/tests/setup.test.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/tests/setup.test.js
@@ -293,18 +293,21 @@ describe('module PaperUI.controllers.setup', function() {
             rootScope = $rootScope;
             $httpBackend = $injector.get('$httpBackend');
             mdDialog = $injector.get('$mdDialog');
-            thingTypeRepository = $injector.get('thingTypeRepository');
-            thingTypeRepository.singleElements = {
-                'A:B' : {
+            
+            var thingType = {
                     UID : 'A:B',
                     label : 'LABEL'
-                }
             }
+            
+            thingTypeService = $injector.get('thingTypeService');
+            spyOn(thingTypeService, 'getByUid').and.callFake(function(parameter, callback) {
+                callback(thingType);
+            })
+
+            thingTypeRepository = $injector.get('thingTypeRepository');
             spyOn(thingTypeRepository, 'getOne').and.callThrough();
-            rootScope.data.thingTypes = [ {
-                UID : 'A:B',
-                label : 'LABEL'
-            } ];
+            rootScope.data.thingTypes = [ thingType ];
+            
             approveInboxEntryDialogController = $controller('ApproveInboxEntryDialogController', {
                 '$scope' : scope,
                 'discoveryResult' : {
@@ -312,6 +315,7 @@ describe('module PaperUI.controllers.setup', function() {
                     thingTypeUID : 'A:B'
                 }
             });
+            
             discoveryService = $injector.get('discoveryService');
         }));
         it('should require ApproveInboxEntryDialogController', function() {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/controllers.js
@@ -89,15 +89,15 @@ angular.module('PaperUI.controllers', [ 'PaperUI.constants' ])//
 
         console.log('Item ' + itemName + ' updated: ' + state);
 
-        itemRepository.getAll(function(items) {
-            angular.forEach(items, function(item) {
-                if (item.name === itemName) {
-                    changeState(item);
-                }
+        itemRepository.filter(function condition(item) {
+            return item.name === itemName;
+        }, function callback(items) {
+            items.forEach(function(item) {
+                changeState(item);
             });
-        }, false);
+        });
 
-        var changeState = function(item) {
+        function changeState(item) {
             var updateState = true;
             if (item.name === itemName) {
                 // ignore ON and OFF update for Dimmer
@@ -127,9 +127,11 @@ angular.module('PaperUI.controllers', [ 'PaperUI.constants' ])//
 
                 updateState = updateState && item.state !== state;
                 if (updateState) {
-                    console.log('Updating ' + itemName + ' to ' + state)
-                    item.state = state;
-                    item.stateText = util.getItemStateText(item);
+                    $scope.$apply(function() {
+                        item.state = state;
+                        item.stateText = util.getItemStateText(item);
+                    });
+                    console.log('Updating ' + itemName + ' to ' + item.stateText)
                 } else {
                     console.log('Ignoring state ' + state + ' for ' + itemName)
                 }

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-module.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-module.js
@@ -37,7 +37,7 @@
 
         function getAll(callback, refresh) {
             if (typeof callback === 'boolean') {
-                refresh = true;
+                refresh = callback;
                 callback = null;
             }
             var deferred = $q.defer();

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-module.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-module.js
@@ -6,7 +6,7 @@
 
     function Repository() {
         return {
-            Repository : RepositoryImpl
+            create : RepositoryImpl
         }
     }
 

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-module.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-module.js
@@ -1,0 +1,172 @@
+;
+(function() {
+    'use strict';
+
+    angular.module('PaperUI.services.repositories', [ 'PaperUI.services.rest' ]).factory('Repository', Repository);
+
+    function Repository() {
+        return {
+            Repository : RepositoryImpl
+        }
+    }
+
+    function RepositoryImpl($q, $rootScope, remoteService, dataType, staticData, getOneFunction, idParameterName, elmentId) {
+        var self = this;
+
+        this.cacheEnabled = true;
+        this.dirty = false;
+        this.initialFetch = false;
+        this.staticData = staticData
+        this.singleElements = getOneFunction ? {} : null;
+
+        return {
+            add : add,
+            remove : remove,
+            update : update,
+            getAll : getAll,
+            getOne : getOne,
+            find : find,
+            filter : filter,
+            findByIndex : findByIndex,
+            setDirty : setDirty
+        };
+
+        function setDirty() {
+            self.dirty = true;
+        }
+
+        function getAll(callback, refresh) {
+            if (typeof callback === 'boolean') {
+                refresh = true;
+                callback = null;
+            }
+            var deferred = $q.defer();
+            deferred.promise.then(function(res) {
+                if (callback && res !== 'No update') {
+                    return callback(res);
+                } else {
+                    return;
+                }
+            }, function(res) {
+                return;
+            }, function(res) {
+                if (callback) {
+                    return callback(res);
+                } else {
+                    return;
+                }
+            });
+            if (self.cacheEnabled && self.staticData && self.initialFetch && !refresh && !self.dirty) {
+                deferred.resolve($rootScope.data[dataType]);
+            } else {
+                remoteService.getAll(function(data) {
+                    if ((!self.cacheEnabled || (data.length != $rootScope.data[dataType].length) || self.dirty || refresh)) {
+                        self.initialFetch = true;
+                        $rootScope.data[dataType] = data;
+                        self.dirty = false;
+                        deferred.resolve(data);
+                    } else {
+                        // set initial data
+                        if (!self.initialFetch) {
+                            self.initialFetch = true;
+                            $rootScope.data[dataType] = data;
+                            self.dirty = false;
+                        }
+                        deferred.resolve('No update');
+                    }
+                });
+                if (self.cacheEnabled && self.initialFetch) {
+                    deferred.notify($rootScope.data[dataType]);
+                }
+            }
+            return deferred.promise;
+        }
+
+        function getOne(condition, callback, refresh) {
+            var element = find(condition);
+            if (element != null && !self.dirty && !refresh) {
+                resolveSingleElement(callback, element)
+            } else {
+                getAll(null, true).then(function(res) {
+                    if (callback) {
+                        resolveSingleElement(callback, find(condition));
+                        return;
+                    } else {
+                        return;
+                    }
+                }, function(res) {
+                    callback(null);
+                    return;
+                }, function(res) {
+                    return;
+                });
+            }
+        }
+
+        function resolveSingleElement(callback, element) {
+            if (!element) {
+                callback(undefined);
+            } else if (getOneFunction && self.singleElements[element.UID]) {
+                callback(self.singleElements[element.UID]);
+            } else if (getOneFunction) {
+                var parameter = {};
+                parameter[idParameterName] = element[elmentId];
+                getOneFunction(parameter, function(singleElement) {
+                    self.singleElements[element.UID] = singleElement;
+                    callback(singleElement)
+                })
+            } else {
+                callback(element);
+            }
+        }
+
+        function find(condition) {
+            for (var i = 0; i < $rootScope.data[dataType].length; i++) {
+                var element = $rootScope.data[dataType][i];
+                if (condition(element)) {
+                    return element;
+                }
+            }
+            return null;
+        }
+
+        function findByIndex(condition) {
+            for (var i = 0; i < $rootScope.data[dataType].length; i++) {
+                var element = $rootScope.data[dataType][i];
+                if (condition(element)) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        function add(element) {
+            $rootScope.data[dataType].push(element);
+        }
+
+        function remove(element, index) {
+            if (typeof (index) === 'undefined' && $rootScope.data[dataType].indexOf(element) !== -1) {
+                $rootScope.data[dataType].splice($rootScope.data[dataType].indexOf(element), 1);
+            } else if (typeof (index) !== 'undefined' && index !== -1) {
+                $rootScope.data[dataType].splice(index, 1);
+            }
+        }
+
+        function update(element) {
+            var index = $rootScope.data[dataType].indexOf(element);
+            $rootScope.data[dataType][index] = element;
+        }
+
+        function filter(condition, callback) {
+            var result = [];
+            $rootScope.data[dataType].forEach(function(element) {
+                if (condition(element)) {
+                    result.push(element);
+                }
+            });
+
+            callback(result);
+        }
+    }
+
+})();

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-services.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-services.js
@@ -1,15 +1,15 @@
 angular.module('PaperUI.services.repositories')//
 .factory('bindingRepository', function(Repository, $q, $rootScope, bindingService) {
     $rootScope.data.bindings = [];
-    return new Repository.Repository($q, $rootScope, bindingService, 'bindings', true);
+    return new Repository.create($q, $rootScope, bindingService, 'bindings', true);
 }).factory('thingTypeRepository', function(Repository, $q, $rootScope, thingTypeService) {
     $rootScope.data.thingTypes = [];
-    return new Repository.Repository($q, $rootScope, thingTypeService, 'thingTypes', true, thingTypeService.getByUid, 'thingTypeUID', 'UID');
+    return new Repository.create($q, $rootScope, thingTypeService, 'thingTypes', true, thingTypeService.getByUid, 'thingTypeUID', 'UID');
 }).factory('channelTypeRepository', function(Repository, $q, $rootScope, channelTypeService) {
     $rootScope.data.channelTypes = [];
-    return new Repository.Repository($q, $rootScope, channelTypeService, 'channelTypes', true);
+    return new Repository.create($q, $rootScope, channelTypeService, 'channelTypes', true);
 }).factory('discoveryResultRepository', function(Repository, $q, $rootScope, inboxService, eventService) {
-    var repository = new Repository.Repository($q, $rootScope, inboxService, 'discoveryResults')
+    var repository = new Repository.create($q, $rootScope, inboxService, 'discoveryResults')
     $rootScope.data.discoveryResults = [];
     eventService.onEvent('smarthome/inbox/*', function(topic, discoveryResult) {
         var index = repository.findByIndex(function(result) {
@@ -29,7 +29,7 @@ angular.module('PaperUI.services.repositories')//
     });
     return repository;
 }).factory('thingRepository', function(Repository, $q, $rootScope, thingService, eventService) {
-    var repository = new Repository.Repository($q, $rootScope, thingService, 'things')
+    var repository = new Repository.create($q, $rootScope, thingService, 'things')
     $rootScope.data.things = [];
 
     var itemNameToThingUID = function(itemName) {
@@ -131,7 +131,7 @@ angular.module('PaperUI.services.repositories')//
 
     return repository;
 }).factory('itemRepository', function(Repository, $q, $rootScope, itemService, eventService) {
-    var repository = new Repository.Repository($q, $rootScope, itemService, 'items')
+    var repository = new Repository.create($q, $rootScope, itemService, 'items')
     $rootScope.data.items = [];
     eventService.onEvent('smarthome/items/*/updated', function(topic, itemUpdate) {
         if (topic.split('/').length > 2) {
@@ -175,7 +175,7 @@ angular.module('PaperUI.services.repositories')//
     });
     return repository;
 }).factory('ruleRepository', function(Repository, $q, $rootScope, ruleService, eventService) {
-    var repository = new Repository.Repository($q, $rootScope, ruleService, 'rules', true)
+    var repository = new Repository.create($q, $rootScope, ruleService, 'rules', true)
     $rootScope.data.rules = [];
 
     eventService.onEvent('smarthome/rules/*/updated', function(topic, ruleUpdate) {
@@ -227,7 +227,7 @@ angular.module('PaperUI.services.repositories')//
 
     return repository;
 }).factory('templateRepository', function(Repository, $q, $rootScope, templateService) {
-    var repository = new Repository.Repository($q, $rootScope, templateService, 'templates')
+    var repository = new Repository.create($q, $rootScope, templateService, 'templates')
     $rootScope.data.templates = [];
     return repository;
 });

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.repositories.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.repositories.js
@@ -1,16 +1,28 @@
-var Repository = function($q, $rootScope, remoteService, dataType, staticData, getOneFunction, idParameterName, elmentId) {
+function Repository($q, $rootScope, remoteService, dataType, staticData, getOneFunction, idParameterName, elmentId) {
     var self = this;
 
     this.cacheEnabled = true;
     this.dirty = false;
     this.initialFetch = false;
     this.staticData = staticData
-    this.setDirty = function() {
+    this.singleElements = getOneFunction ? {} : null;
+
+    return {
+        add : add,
+        remove : remove,
+        update : update,
+        getAll : getAll,
+        getOne : getOne,
+        find : find,
+        findByIndex : findByIndex,
+        setDirty : setDirty
+    };
+
+    function setDirty() {
         self.dirty = true;
     }
 
-    this.singleElements = getOneFunction ? {} : null;
-    this.getAll = function(callback, refresh) {
+    function getAll(callback, refresh) {
         if (typeof callback === 'boolean') {
             refresh = true;
             callback = null;
@@ -55,15 +67,16 @@ var Repository = function($q, $rootScope, remoteService, dataType, staticData, g
             }
         }
         return deferred.promise;
-    };
-    this.getOne = function(condition, callback, refresh) {
-        var element = self.find(condition);
-        if (element != null && !this.dirty && !refresh) {
-            self.resolveSingleElement(callback, element)
+    }
+
+    function getOne(condition, callback, refresh) {
+        var element = find(condition);
+        if (element != null && !self.dirty && !refresh) {
+            resolveSingleElement(callback, element)
         } else {
-            self.getAll(null, true).then(function(res) {
+            getAll(null, true).then(function(res) {
                 if (callback) {
-                    self.resolveSingleElement(callback, self.find(condition));
+                    resolveSingleElement(callback, find(condition));
                     return;
                 } else {
                     return;
@@ -75,9 +88,9 @@ var Repository = function($q, $rootScope, remoteService, dataType, staticData, g
                 return;
             });
         }
-    };
+    }
 
-    this.resolveSingleElement = function(callback, element) {
+    function resolveSingleElement(callback, element) {
         if (!element) {
             callback(undefined);
         } else if (getOneFunction && self.singleElements[element.UID]) {
@@ -94,7 +107,7 @@ var Repository = function($q, $rootScope, remoteService, dataType, staticData, g
         }
     }
 
-    this.find = function(condition) {
+    function find(condition) {
         for (var i = 0; i < $rootScope.data[dataType].length; i++) {
             var element = $rootScope.data[dataType][i];
             if (condition(element)) {
@@ -102,8 +115,9 @@ var Repository = function($q, $rootScope, remoteService, dataType, staticData, g
             }
         }
         return null;
-    };
-    this.findByIndex = function(condition) {
+    }
+
+    function findByIndex(condition) {
         for (var i = 0; i < $rootScope.data[dataType].length; i++) {
             var element = $rootScope.data[dataType][i];
             if (condition(element)) {
@@ -111,21 +125,24 @@ var Repository = function($q, $rootScope, remoteService, dataType, staticData, g
             }
         }
         return -1;
-    };
-    this.add = function(element) {
+    }
+
+    function add(element) {
         $rootScope.data[dataType].push(element);
-    };
-    this.remove = function(element, index) {
+    }
+
+    function remove(element, index) {
         if (typeof (index) === 'undefined' && $rootScope.data[dataType].indexOf(element) !== -1) {
             $rootScope.data[dataType].splice($rootScope.data[dataType].indexOf(element), 1);
         } else if (typeof (index) !== 'undefined' && index !== -1) {
             $rootScope.data[dataType].splice(index, 1);
         }
-    };
-    this.update = function(element) {
+    }
+
+    function update(element) {
         var index = $rootScope.data[dataType].indexOf(element);
         $rootScope.data[dataType][index] = element;
-    };
+    }
 }
 
 angular.module('PaperUI.services.repositories', [ 'PaperUI.services.rest' ]).factory('bindingRepository', function($q, $rootScope, bindingService) {


### PR DESCRIPTION
Fixes #5232.

On item changes events filter items in the front end repository instead reloading the whole list.

Also:
* Refactor front end repositories to depend on abstract repository factory.
* Refactor repositories to be angularjs components.