### PR TITLE
Paper UI: clean package.json & ignore build artifact

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/.gitignore
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/.gitignore
@@ -6,3 +6,4 @@ web-src/bower_components/
 web/
 web-src/index.html
 PaperUI-tests.xml
+package-lock.json

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
@@ -6,8 +6,8 @@
     "install": "node node_modules/openlayers/tasks/build.js openlayers-esh.json node_modules/openlayers/ol-esh.js",
     "start": "gulp serve --development",
     "build": "gulp default",
-    "test" : "gulp test",
-    "dev"  : "gulp serve --development --noMinify"
+    "test": "gulp test",
+    "dev": "gulp serve --development --noMinify"
   },
   "dependencies": {
     "angular": "1.4.8",


### PR DESCRIPTION
During maven build of Paper UI npm reformatted package.json. Also, the pure informative build artifact `package-lock.json` is now git ignored.