### PR TITLE
Renamed methods and local variables reported by the Static Code Analysis Tool

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.provider.file/src/main/java/org/eclipse/smarthome/automation/internal/provider/file/WatchServiceUtil.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.provider.file/src/main/java/org/eclipse/smarthome/automation/internal/provider/file/WatchServiceUtil.java
@@ -25,7 +25,7 @@ import java.util.Map;
 @SuppressWarnings("rawtypes")
 public class WatchServiceUtil {
 
-    static Map<AbstractFileProvider, Map<String, AutomationWatchService>> WATCH_SERVICES = new HashMap<AbstractFileProvider, Map<String, AutomationWatchService>>();
+    private static final Map<AbstractFileProvider, Map<String, AutomationWatchService>> WATCH_SERVICES = new HashMap<AbstractFileProvider, Map<String, AutomationWatchService>>();
 
     public static void initializeWatchService(String watchingDir, AbstractFileProvider provider) {
         AutomationWatchService aws = null;

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/AbstractResourceBundleProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/AbstractResourceBundleProvider.java
@@ -82,7 +82,7 @@ public abstract class AbstractResourceBundleProvider<E> {
      * This static field provides a root directory for automation object resources in the bundle resources.
      * It is common for all resources - {@link ModuleType}s, {@link RuleTemplate}s and {@link Rule}s.
      */
-    protected static String PATH = "ESH-INF/automation";
+    protected static final String ROOT_DIRECTORY = "ESH-INF/automation";
 
     /**
      * This field holds a reference to the service instance for internationalization support within the platform.

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/AutomationResourceBundlesTracker.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/AutomationResourceBundlesTracker.java
@@ -281,7 +281,7 @@ public class AutomationResourceBundlesTracker implements BundleTrackerCustomizer
      *         resources, <tt>false</tt> otherwise.
      */
     private boolean isAnAutomationProvider(Bundle bundle) {
-        return bundle.getEntryPaths(AbstractResourceBundleProvider.PATH) != null;
+        return bundle.getEntryPaths(AbstractResourceBundleProvider.ROOT_DIRECTORY) != null;
     }
 
 }

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/ModuleTypeResourceBundleProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/ModuleTypeResourceBundleProvider.java
@@ -44,7 +44,7 @@ import org.osgi.framework.Bundle;
  * bundle resources. It extends functionality of {@link AbstractResourceBundleProvider} by specifying:
  * <ul>
  * <li>the path to resources, corresponding to the {@link ModuleType}s - root directory
- * {@link AbstractResourceBundleProvider#PATH} with sub-directory "moduletypes".
+ * {@link AbstractResourceBundleProvider#ROOT_DIRECTORY} with sub-directory "moduletypes".
  * <li>type of the {@link Parser}s, corresponding to the {@link ModuleType}s - {@link Parser#PARSER_MODULE_TYPE}
  * <li>specific functionality for loading the {@link ModuleType}s
  * <li>tracking the managing service of the {@link ModuleType}s.
@@ -65,7 +65,7 @@ public class ModuleTypeResourceBundleProvider extends AbstractResourceBundleProv
      */
     public ModuleTypeResourceBundleProvider() {
         listeners = new LinkedList<ProviderChangeListener<ModuleType>>();
-        path = PATH + "/moduletypes/";
+        path = ROOT_DIRECTORY + "/moduletypes/";
     }
 
     @Override

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/RuleResourceBundleImporter.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/RuleResourceBundleImporter.java
@@ -30,7 +30,7 @@ import org.osgi.framework.Bundle;
  * bundle resources. It extends functionality of {@link AbstractResourceBundleProvider} by specifying:
  * <ul>
  * <li>the path to resources, corresponding to the {@link Rule}s - root directory
- * {@link AbstractResourceBundleProvider#PATH} with sub-directory "rules".
+ * {@link AbstractResourceBundleProvider#ROOT_DIRECTORY} with sub-directory "rules".
  * <li>type of the {@link Parser}s, corresponding to the {@link Rule}s - {@link Parser#PARSER_RULE}
  * <li>specific functionality for loading the {@link Rule}s
  * <li>tracking the managing service of the {@link Rule}s.
@@ -54,7 +54,7 @@ public class RuleResourceBundleImporter extends AbstractResourceBundleProvider<R
      * @param registry the managing service of the {@link Rule}s.
      */
     public RuleResourceBundleImporter() {
-        path = PATH + "/rules/";
+        path = ROOT_DIRECTORY + "/rules/";
     }
 
     protected void setManagedRuleProvider(ManagedRuleProvider mProvider) {

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/TemplateResourceBundleProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/src/main/java/org/eclipse/smarthome/automation/internal/core/provider/TemplateResourceBundleProvider.java
@@ -38,7 +38,7 @@ import org.osgi.framework.Bundle;
  * bundle resources. It extends functionality of {@link AbstractResourceBundleProvider} by specifying:
  * <ul>
  * <li>the path to resources, corresponding to the {@link RuleTemplates}s - root directory
- * {@link AbstractResourceBundleProvider#PATH} with sub-directory "templates".
+ * {@link AbstractResourceBundleProvider#ROOT_DIRECTORY} with sub-directory "templates".
  * <li>type of the {@link Parser}s, corresponding to the {@link RuleTemplates}s - {@link Parser#PARSER_TEMPLATE}
  * <li>specific functionality for loading the {@link RuleTemplates}s
  * <li>tracking the managing service of the {@link ModuleType}s.
@@ -60,7 +60,7 @@ public class TemplateResourceBundleProvider extends AbstractResourceBundleProvid
      */
     public TemplateResourceBundleProvider() {
         listeners = new LinkedList<ProviderChangeListener<RuleTemplate>>();
-        path = PATH + "/templates/";
+        path = ROOT_DIRECTORY + "/templates/";
     }
 
     @Override

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/src/main/java/org/eclipse/smarthome/automation/sample/extension/java/internal/type/AirConditionerTriggerType.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/src/main/java/org/eclipse/smarthome/automation/sample/extension/java/internal/type/AirConditionerTriggerType.java
@@ -27,7 +27,7 @@ import org.eclipse.smarthome.automation.type.TriggerType;
  */
 public class AirConditionerTriggerType extends TriggerType {
 
-    public static String UID = "AirConditionerTrigger";
+    public static final String UID = "AirConditionerTrigger";
 
     public static TriggerType initialize() {
         List<Output> output = new ArrayList<Output>();

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioFormat.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioFormat.java
@@ -24,20 +24,20 @@ import java.util.Set;
 public class AudioFormat {
 
     // generic mp3 format without any further constraints
-    public static AudioFormat MP3 = new AudioFormat(AudioFormat.CONTAINER_NONE, AudioFormat.CODEC_MP3, null, null, null,
-            null);
-
-    // generic wav format without any further constraints
-    public static AudioFormat WAV = new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED, null,
-            null, null, null);
-
-    // generic OGG format without any further constraints
-    public static AudioFormat OGG = new AudioFormat(AudioFormat.CONTAINER_OGG, AudioFormat.CODEC_VORBIS, null, null,
+    public static final AudioFormat MP3 = new AudioFormat(AudioFormat.CONTAINER_NONE, AudioFormat.CODEC_MP3, null, null,
             null, null);
 
+    // generic wav format without any further constraints
+    public static final AudioFormat WAV = new AudioFormat(AudioFormat.CONTAINER_WAVE, AudioFormat.CODEC_PCM_SIGNED,
+            null, null, null, null);
+
+    // generic OGG format without any further constraints
+    public static final AudioFormat OGG = new AudioFormat(AudioFormat.CONTAINER_OGG, AudioFormat.CODEC_VORBIS, null,
+            null, null, null);
+
     // generic AAC format without any further constraints
-    public static AudioFormat AAC = new AudioFormat(AudioFormat.CONTAINER_NONE, AudioFormat.CODEC_AAC, null, null, null,
-            null);
+    public static final AudioFormat AAC = new AudioFormat(AudioFormat.CONTAINER_NONE, AudioFormat.CODEC_AAC, null, null,
+            null, null);
 
     /**
      * {@link AudioCodec} encoded data without any container header or footer,

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusDetail.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusDetail.java
@@ -37,9 +37,9 @@ public enum ThingStatusDetail {
      */
     GONE;
 
-    public static OnlineStatus ONLINE = new OnlineStatus();
+    public static final OnlineStatus ONLINE = new OnlineStatus();
 
-    public static OfflineStatus OFFLINE = new OfflineStatus();
+    public static final OfflineStatus OFFLINE = new OfflineStatus();
 
     public static final class OnlineStatus {
         private OnlineStatus() {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/ProgressCallbackImpl.java
@@ -37,7 +37,7 @@ import org.osgi.framework.FrameworkUtil;
  */
 final class ProgressCallbackImpl implements ProgressCallback {
 
-    private static String UPDATE_CANCELED_MESSAGE_KEY = "update-canceled";
+    private static final String UPDATE_CANCELED_MESSAGE_KEY = "update-canceled";
 
     /**
      * Handler instance is needed to retrieve the error messages from the correct bundle.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/ImperialUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/ImperialUnits.java
@@ -38,7 +38,7 @@ import tec.uom.se.unit.Units;
 @NonNullByDefault
 public class ImperialUnits extends SmartHomeUnits {
 
-    private static ImperialUnits INSTANCE = new ImperialUnits();
+    private static final ImperialUnits INSTANCE = new ImperialUnits();
 
     private ImperialUnits() {
         // avoid external instantiation

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SIUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SIUnits.java
@@ -36,7 +36,7 @@ import tec.uom.se.unit.Units;
 @NonNullByDefault
 public class SIUnits extends SmartHomeUnits {
 
-    private static SIUnits INSTANCE = new SIUnits();
+    private static final SIUnits INSTANCE = new SIUnits();
 
     private SIUnits() {
         // avoid external instantiation

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
@@ -66,7 +66,7 @@ import tec.uom.se.unit.Units;
 @NonNullByDefault
 public class SmartHomeUnits extends AbstractSystemOfUnits {
 
-    private static SmartHomeUnits INSTANCE = new SmartHomeUnits();
+    private static final SmartHomeUnits INSTANCE = new SmartHomeUnits();
 
     protected SmartHomeUnits() {
         // avoid external instantiation

--- a/bundles/storage/org.eclipse.smarthome.storage.json.test/src/main/java/org/eclipse/smarthome/storage/json/internal/JSonStorageTest.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.json.test/src/main/java/org/eclipse/smarthome/storage/json/internal/JSonStorageTest.java
@@ -55,7 +55,7 @@ public class JSonStorageTest extends JavaTest {
     }
 
     @Test
-    public void allInsertedNumbersAreLoadedAsBigDecimal_fromCache() {
+    public void allInsertedNumbersAreLoadedAsBigDecimalFromCache() {
         objectStorage.put("DummyObject", new DummyObject());
         DummyObject dummy = objectStorage.get("DummyObject");
 
@@ -70,7 +70,7 @@ public class JSonStorageTest extends JavaTest {
     }
 
     @Test
-    public void allInsertedNumbersAreLoadedAsBigDecimal_fromDisk() {
+    public void allInsertedNumbersAreLoadedAsBigDecimalFromDisk() {
         objectStorage.put("DummyObject", new DummyObject());
         persistAndReadAgain();
         DummyObject dummy = objectStorage.get("DummyObject");
@@ -86,7 +86,7 @@ public class JSonStorageTest extends JavaTest {
     }
 
     @Test
-    public void testIntegerScale_fromCache() {
+    public void testIntegerScaleFromCache() {
         objectStorage.put("DummyObject", new DummyObject());
         DummyObject dummy = objectStorage.get("DummyObject");
 
@@ -98,7 +98,7 @@ public class JSonStorageTest extends JavaTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testIntegerScale_fromDisk() {
+    public void testIntegerScaleFromDisk() {
         objectStorage.put("DummyObject", new DummyObject());
         persistAndReadAgain();
         DummyObject dummy = objectStorage.get("DummyObject");

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicDelayedOnlineHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicDelayedOnlineHandler.java
@@ -31,7 +31,7 @@ import org.eclipse.smarthome.core.types.Command;
 @NonNullByDefault
 public class MagicDelayedOnlineHandler extends BaseThingHandler {
 
-    public static int DELAY = 15;
+    private static final int DELAY = 15;
 
     public MagicDelayedOnlineHandler(Thing thing) {
         super(thing);

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/CircuitHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/CircuitHandler.java
@@ -59,7 +59,7 @@ public class CircuitHandler extends BaseThingHandler implements DeviceStatusList
     /**
      * Contains all supported thing types of this handler, will be filled by DsDeviceThingTypeProvider.
      */
-    public static Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<ThingTypeUID>();
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<ThingTypeUID>();
 
     private String dSID;
     private Circuit circuit;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
@@ -83,10 +83,10 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
     /**
      * Contains all supported thing types of this handler, will be filled by DsDeviceThingTypeProvider.
      */
-    public static Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<ThingTypeUID>();
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<ThingTypeUID>();
 
-    public static String TWO_STAGE_SWITCH_IDENTICATOR = "2";
-    public static String THREE_STAGE_SWITCH_IDENTICATOR = "3";
+    public static final String TWO_STAGE_SWITCH_IDENTICATOR = "2";
+    public static final String THREE_STAGE_SWITCH_IDENTICATOR = "3";
 
     private String dSID;
     private Device device;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/ZoneTemperatureControlHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/ZoneTemperatureControlHandler.java
@@ -72,7 +72,7 @@ public class ZoneTemperatureControlHandler extends BaseThingHandler implements T
     /**
      * Contains all supported thing types of this handler
      */
-    public static Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
             Arrays.asList(DigitalSTROMBindingConstants.THING_TYPE_ZONE_TEMERATURE_CONTROL));
 
     private final Logger logger = LoggerFactory.getLogger(ZoneTemperatureControlHandler.class);

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/DeviceDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/DeviceDiscoveryService.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.binding.digitalstrom.DigitalSTROMBindingConstants;
 import org.eclipse.smarthome.binding.digitalstrom.handler.BridgeHandler;
+import org.eclipse.smarthome.binding.digitalstrom.handler.DeviceHandler;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.Circuit;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.Device;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.GeneralDeviceInformation;
@@ -39,7 +40,8 @@ import org.slf4j.LoggerFactory;
 /**
  * The {@link DeviceDiscoveryService} discovers all digitalSTROM-Devices, of one supported device-color-type. The
  * device-color-type has to be given to the {@link #DeviceDiscoveryService(BridgeHandler, ThingTypeUID)} as
- * {@link ThingTypeUID}. The supported {@link ThingTypeUID} can be found at {@link DeviceHandler#SUPPORTED_THING_TYPES}.
+ * {@link ThingTypeUID}. The supported {@link ThingTypeUID} can be found at
+ * {@link DeviceHandler#SUPPORTED_THING_TYPES}.
  *
  * @author Michael Ochel - Initial contribution
  * @author Matthias Siegele - Initial contribution

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceparameters/DeviceConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceparameters/DeviceConfig.java
@@ -26,7 +26,7 @@ public interface DeviceConfig {
      *
      * @return configuration class
      */
-    int getClass_();
+    int getConfigurationClass();
 
     /**
      * Returns the digitalSTROM-Device configuration index.

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceparameters/impl/JSONDeviceConfigImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceparameters/impl/JSONDeviceConfigImpl.java
@@ -48,7 +48,7 @@ public class JSONDeviceConfigImpl implements DeviceConfig {
     }
 
     @Override
-    public int getClass_() {
+    public int getConfigurationClass() {
         return class_;
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosXMLParser.java
@@ -45,7 +45,7 @@ public class SonosXMLParser {
 
     static final Logger LOGGER = LoggerFactory.getLogger(SonosXMLParser.class);
 
-    private static MessageFormat METADATA_FORMAT = new MessageFormat(
+    private static final MessageFormat METADATA_FORMAT = new MessageFormat(
             "<DIDL-Lite xmlns:dc=\"http://purl.org/dc/elements/1.1/\" "
                     + "xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\" "
                     + "xmlns:r=\"urn:schemas-rinconnetworks-com:metadata-1-0/\" "

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/json/WeatherUndergroundJsonCurrent.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/json/WeatherUndergroundJsonCurrent.java
@@ -528,7 +528,7 @@ public class WeatherUndergroundJsonCurrent {
             return state;
         }
 
-        public String getState_name() {
+        public String getStateName() {
             return state_name;
         }
 
@@ -536,7 +536,7 @@ public class WeatherUndergroundJsonCurrent {
             return country;
         }
 
-        public String getCountry_iso3166() {
+        public String getCountryIso3166() {
             return country_iso3166;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/json/WeatherUndergroundJsonLocation.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/json/WeatherUndergroundJsonLocation.java
@@ -54,11 +54,11 @@ public class WeatherUndergroundJsonLocation {
         return country;
     }
 
-    public String getCountry_iso3166() {
+    public String getCountryIso3166() {
         return country_iso3166;
     }
 
-    public String getCountry_name() {
+    public String getCountryName() {
         return country_name;
     }
 
@@ -70,11 +70,11 @@ public class WeatherUndergroundJsonLocation {
         return city;
     }
 
-    public String getTz_short() {
+    public String getTzShort() {
         return tz_short;
     }
 
-    public String getTz_long() {
+    public String getTzLong() {
         return tz_long;
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/handler/test/WemoLightHandlerOSGiTest.groovy
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/src/main/groovy/org/eclipse/smarthome/binding/wemo/handler/test/WemoLightHandlerOSGiTest.groovy
@@ -49,8 +49,6 @@ class WemoLightHandlerOSGiTest extends GenericWemoLightOSGiTest {
         setUpServices()
         servlet = new WemoLightHttpServlet(SERVICE_ID, SERVICE_NUMBER);
         registerServlet(SERVLET_URL, servlet);
-        // The default timeout is 15 seconds, for this test 1 second timeout is enough
-        WemoLightHandler.DEFAULT_REFRESH_INITIAL_DELAY = 1
     }
 
     @After

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/handler/WemoLightHandler.java
@@ -81,7 +81,7 @@ public class WemoLightHandler extends BaseThingHandler implements UpnpIOParticip
     /**
      * The default refresh initial delay in Seconds.
      */
-    private static int DEFAULT_REFRESH_INITIAL_DELAY = 15;
+    private static final int DEFAULT_REFRESH_INITIAL_DELAY = 15;
 
     private ScheduledFuture<?> refreshJob;
 

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/src/main/java/org/eclipse/smarthome/ui/iconset/classic/internal/ClassicIconProvider.java
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/src/main/java/org/eclipse/smarthome/ui/iconset/classic/internal/ClassicIconProvider.java
@@ -37,7 +37,7 @@ public class ClassicIconProvider extends AbstractResourceIconProvider implements
 
     private final Logger logger = LoggerFactory.getLogger(ClassicIconProvider.class);
 
-    static String ICONSET_ID = "classic";
+    static final String ICONSET_ID = "classic";
 
     @Override
     public Set<IconSet> getIconSets(Locale locale) {
@@ -53,7 +53,7 @@ public class ClassicIconProvider extends AbstractResourceIconProvider implements
 
     @Override
     protected InputStream getResource(String iconSetId, String resourceName) {
-        if (ICONSET_ID.equals(iconSetId)) {
+        if (ClassicIconProvider.ICONSET_ID.equals(iconSetId)) {
             URL iconResource = context.getBundle().getEntry("icons/" + resourceName);
             try {
                 return iconResource.openStream();
@@ -68,7 +68,7 @@ public class ClassicIconProvider extends AbstractResourceIconProvider implements
 
     @Override
     protected boolean hasResource(String iconSetId, String resourceName) {
-        if (ICONSET_ID.equals(iconSetId)) {
+        if (ClassicIconProvider.ICONSET_ID.equals(iconSetId)) {
             URL iconResource = context.getBundle().getEntry("icons/" + resourceName);
             return iconResource != null;
         } else {

--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -30,5 +30,5 @@
     <suppress files=".+xml" checks="EshInfXmlValidationCheck" />
     
     <suppress files=".+org.eclipse.smarthome.binding.tradfri.internal.TradfriColor.java" checks="LocalVariableNameCheck"/>
-    <suppress files=".+org.eclipse.smarthome.config.discovery.mdns.internal.MDNSDiscoveryService.java|.+org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService.java|.+org.eclipse.smarthome.io.console.eclipse.internal.ConsoleSupportEclipse.java|.+org.eclipse.smarthome.io.console.rfc147.internal.CommandWrapper.java" checks="MethodNameCheck"/>
+    <suppress files=".+org.eclipse.smarthome.config.discovery.mdns.internal.MDNSDiscoveryService.java|.+org.eclipse.smarthome.config.discovery.upnp.internal.UpnpDiscoveryService.java|.+org.eclipse.smarthome.io.console.eclipse.internal.ConsoleSupportEclipse.java|.+org.eclipse.smarthome.io.console.rfc147.internal.CommandWrapper.java|.+org.eclipse.smarthome.binding.astro.internal.calc.MoonCalc.java|.+org.eclipse.smarthome.core.library.unit.MetricPrefix.java" checks="MethodNameCheck"/>
 </suppressions>


### PR DESCRIPTION
Renamed methods and local variables reported by the Static Code Analysis Tool and suppressed *org.eclipse.smarthome.binding.astro.internal.calc.MoonCalc.java*, *org.eclipse.smarthome.core.library.unit.MetricPrefix.java* for MethodNameCheck, as they contain specific methods with calculations and renaming them will make the code hard to read.

Signed-off-by: Kristina S. Simova <kssimovaa@gmail.com>