### PR TITLE
[audio] Fixed stop currently playing streams

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.media/src/main/java/org/eclipse/smarthome/automation/module/media/internal/MediaActionTypeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.media/src/main/java/org/eclipse/smarthome/automation/module/media/internal/MediaActionTypeProvider.java
@@ -132,7 +132,7 @@ public class MediaActionTypeProvider implements ModuleTypeProvider {
 
         for (String sinkId : audioManager.getSinkIds()) {
             AudioSink sink = audioManager.getSink(sinkId);
-            options.add(new ParameterOption(sinkId, sink.getLabel(null)));
+            options.add(new ParameterOption(sinkId, sink.getLabel(locale)));
         }
         return options;
     }

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioManagerTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioManagerTest.groovy
@@ -37,16 +37,19 @@ public class AudioManagerTest extends AudioOSGiTest {
     }
 
     @Test
-    public void 'null streams are not processed'(){
+    public void 'null streams are processed'(){
         registerSink()
 
         audioManager.play(null, audioSinkFake.getId())
 
-        waitForAssert({    
-            assertThat "null stream was processed",    
+        waitForAssert({
+            assertThat "The 'null' stream was not processed",
                     audioSinkFake.isStreamProcessed,
-                    is(false)  
+                    is(true)
         })
+        assertThat "The currently playing stream was not stopped",
+                audioSinkFake.isStreamStopped,
+                is(true)
     }
 
     @Test
@@ -293,6 +296,9 @@ public class AudioManagerTest extends AudioOSGiTest {
                     audioSinkFake.audioFormat,
                     is(nullValue())
         })
+        assertThat "The currently playing stream was stopped",
+                audioSinkFake.isStreamStopped,
+                is(false)
 
         switch(playType){
             case PlayType.STREAM:
@@ -318,7 +324,7 @@ public class AudioManagerTest extends AudioOSGiTest {
     }
 
     /**
-     * 
+     *
      * @param param - either default source or default sink
      */
     private void assertAddedParameterOption(String param){

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioManagerTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioManagerTest.groovy
@@ -36,10 +36,17 @@ public class AudioManagerTest extends AudioOSGiTest {
         assertProcessedStream(audioStream, PlayType.STREAM)
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void 'null streams are not processed'(){
         registerSink()
+
         audioManager.play(null, audioSinkFake.getId())
+
+        waitForAssert({    
+            assertThat "null stream was processed",    
+                    audioSinkFake.isStreamProcessed,
+                    is(false)  
+        })
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/fake/AudioSinkFake.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/fake/AudioSinkFake.groovy
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.core.audio.test.fake
 
-import java.util.Collections;
-import java.util.Set
 import java.util.stream.Collectors
 import java.util.stream.Stream
 
@@ -21,9 +19,9 @@ import org.eclipse.smarthome.core.audio.AudioFormat
 import org.eclipse.smarthome.core.audio.AudioSink
 import org.eclipse.smarthome.core.audio.AudioStream
 import org.eclipse.smarthome.core.audio.FixedLengthAudioStream
+import org.eclipse.smarthome.core.audio.URLAudioStream
 import org.eclipse.smarthome.core.audio.UnsupportedAudioFormatException
 import org.eclipse.smarthome.core.audio.UnsupportedAudioStreamException
-import org.eclipse.smarthome.core.audio.URLAudioStream
 import org.eclipse.smarthome.core.library.types.PercentType
 
 /**
@@ -38,6 +36,7 @@ public class AudioSinkFake implements AudioSink {
     public AudioStream audioStream
     public AudioFormat audioFormat
     public boolean isStreamProcessed = false
+    public boolean isStreamStopped = false
     public PercentType volume
     public boolean isIOExceptionExpected = false
     public boolean isUnsupportedAudioFormatExceptionExpected = false
@@ -66,7 +65,11 @@ public class AudioSinkFake implements AudioSink {
             throw new UnsupportedAudioStreamException("Expected audio stream exception", null)
         }
         this.audioStream = audioStream
-        audioFormat =  audioStream.getFormat()
+        if( audioStream != null ) {
+            audioFormat = audioStream.getFormat()
+        } else {
+            isStreamStopped = true
+        }
         isStreamProcessed = true
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioManager.java
@@ -37,26 +37,26 @@ public interface AudioManager {
     /**
      * Plays the passed audio stream using the default audio sink.
      *
-     * @param audioStream The audio stream to play
+     * @param audioStream The audio stream to play or null if streaming should be stopped
      */
-    void play(AudioStream audioStream);
+    void play(@Nullable AudioStream audioStream);
 
     /**
      * Plays the passed audio stream on the given sink.
      *
-     * @param audioStream The audio stream to play
+     * @param audioStream The audio stream to play or null if streaming should be stopped
      * @param sinkId The id of the audio sink to use or null for the default
      */
-    void play(AudioStream audioStream, @Nullable String sinkId);
+    void play(@Nullable AudioStream audioStream, @Nullable String sinkId);
 
     /**
      * Plays the passed audio stream on the given sink.
      *
-     * @param audioStream The audio stream to play
+     * @param audioStream The audio stream to play or null if streaming should be stopped
      * @param sinkId The id of the audio sink to use or null for the default
      * @param volume The volume to be used or null if the default notification volume should be used
      */
-    void play(AudioStream audioStream, @Nullable String sinkId, @Nullable PercentType volume);
+    void play(@Nullable AudioStream audioStream, @Nullable String sinkId, @Nullable PercentType volume);
 
     /**
      * Plays an audio file from the "sounds" folder using the default audio sink.

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioSink.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioSink.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Set;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.PercentType;
 
 /**
@@ -27,6 +29,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  * @author Christoph Weitkamp - Added getSupportedStreams() and UnsupportedAudioStreamException
  * 
  */
+@NonNullByDefault
 public interface AudioSink {
 
     /**
@@ -42,6 +45,7 @@ public interface AudioSink {
      * @param locale the locale to provide the label for
      * @return a localized string to be used in UIs
      */
+    @Nullable
     public String getLabel(Locale locale);
 
     /**
@@ -51,14 +55,16 @@ public interface AudioSink {
      * is thrown.
      *
      * If the passed {@link AudioStream} has a {@link AudioFormat} not supported by this instance,
-     * an {@link UnsupportedAudioFormatException} is thrown. In case the audioStream is null, this should be interpreted
-     * as a request to end any currently playing stream.
+     * an {@link UnsupportedAudioFormatException} is thrown.
+     *
+     * In case the audioStream is null, this should be interpreted as a request to end any currently playing stream.
      *
      * @param audioStream the audio stream to play or null to keep quiet
      * @throws UnsupportedAudioFormatException If audioStream format is not supported
      * @throws UnsupportedAudioStreamException If audioStream is not supported
      */
-    void process(AudioStream audioStream) throws UnsupportedAudioFormatException, UnsupportedAudioStreamException;
+    void process(@Nullable AudioStream audioStream)
+            throws UnsupportedAudioFormatException, UnsupportedAudioStreamException;
 
     /**
      * Gets a set containing all supported audio formats

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioManagerImpl.java
@@ -96,11 +96,10 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
         play(audioStream, sinkId, null);
     }
 
+    @Override
     public void play(AudioStream audioStream, String sinkId, PercentType volume) {
-        Objects.requireNonNull(audioStream, "Audio stream cannot be played as it is null.");
-
         AudioSink sink = getSink(sinkId);
-        if (sink != null && sink.getSupportedStreams().stream().anyMatch(clazz -> clazz.isInstance(audioStream))) {
+        if (sink != null) {
             // get current volume
             PercentType oldVolume = getVolume(sinkId);
             // set notification sound volume
@@ -113,14 +112,10 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
                 logger.warn("Error playing '{}': {}", audioStream, e.getMessage(), e);
             } finally {
                 // restore volume
-                if (oldVolume != null) {
-                    setVolume(oldVolume, sinkId);
-                }
+                setVolume(oldVolume, sinkId);
             }
         } else {
-            logger.warn(
-                    "Failed playing audio stream '{}' as no audio sink was found or audio sink doesn't support the stream.",
-                    audioStream);
+            logger.warn("Failed playing audio stream '{}' as no audio sink was found.", audioStream);
         }
     }
 
@@ -154,11 +149,10 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
         stream(url, null);
     }
 
-
     @Override
     public void stream(String url, String sinkId) throws AudioException {
         AudioStream audioStream = url != null ? new URLAudioStream(url) : null;
-        play(audioStream, sinkId);
+        play(audioStream, sinkId, null);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.voice.test/src/test/java/org/eclipse/smarthome/core/voice/internal/SinkStub.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice.test/src/test/java/org/eclipse/smarthome/core/voice/internal/SinkStub.java
@@ -37,6 +37,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
 public class SinkStub implements AudioSink {
 
     private boolean isStreamProcessed;
+    private PercentType volume;
     private static final Set<AudioFormat> SUPPORTED_AUDIO_FORMATS = Collections
             .unmodifiableSet(Stream.of(AudioFormat.MP3, AudioFormat.WAV).collect(Collectors.toSet()));
     private static final Set<Class<? extends AudioStream>> SUPPORTED_AUDIO_STREAMS = Collections
@@ -72,12 +73,13 @@ public class SinkStub implements AudioSink {
     @Override
     public PercentType getVolume() throws IOException {
         // this method will no be used in the tests
-        return null;
+        return volume;
     }
 
     @Override
     public void setVolume(PercentType volume) throws IOException {
         // this method will not be used in the tests
+        this.volume = volume;
     }
 
     public boolean isStreamProcessed() {

--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/internal/VoiceManagerImpl.java
@@ -208,9 +208,7 @@ public class VoiceManagerImpl implements VoiceManager, ConfigOptionProvider {
                             logger.warn("Error saying '{}': {}", text, e.getMessage(), e);
                         } finally {
                             // restore volume
-                            if (oldVolume != null) {
-                                audioManager.setVolume(oldVolume, sinkId);
-                            }
+                            audioManager.setVolume(oldVolume, sinkId);
                         }
                     } else {
                         logger.warn("Failed playing audio stream '{}' as audio sink doesn't support it.", audioStream);


### PR DESCRIPTION
- Added `@Nullable` for `play(audioStream, ...)` methods in `AudioManager` API
- Added annotations for `AudioSink` API
- Removed  redundant `ǹull` checks

This fix reverts a regression introduced with #4963 . It wasn't possible to stop currently playing stream anymore.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>