### PR TITLE
[core] Removed access to ItemChannelLinkRegistry from BaseThingHandler

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Dennis Nobel - Initial contribution
  * @author Stefan Bußweiler - Added new thing status info, added new configuration update info
+ * @author Christoph Weitkamp - Moved OSGI ServiceTracker from BaseThingHandler to ThingHandlerCallback
  */
 @NonNullByDefault
 public interface ThingHandlerCallback {
@@ -85,6 +86,7 @@ public interface ThingHandlerCallback {
     /**
      * Informs the framework that a channel has been triggered.
      *
+     * @param thing thing (must not be null)
      * @param channelUID UID of the channel over which has been triggered.
      * @param event Event.
      */
@@ -100,4 +102,11 @@ public interface ThingHandlerCallback {
      */
     ChannelBuilder createChannelBuilder(ChannelUID channelUID, ChannelTypeUID channelTypeUID);
 
+    /**
+     * Returns whether at least one item is linked for the given UID of the channel.
+     *
+     * @param channelUID UID of the channel (must not be null)
+     * @return true if at least one item is linked, false otherwise
+     */
+    boolean isChannelLinked(ChannelUID channelUID);
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -63,6 +63,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.eclipse.smarthome.core.thing.events.ThingEventFactory;
 import org.eclipse.smarthome.core.thing.i18n.ThingStatusInfoI18nLocalizationService;
+import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
@@ -104,6 +105,7 @@ import com.google.common.collect.SetMultimap;
  * @author Kai Kreuzer - Removed usage of itemRegistry and thingLinkRegistry, fixed vetoing mechanism
  * @author Andre Fuechsel - Added the {@link ThingTypeMigrationService} 
  * @author Thomas Höfer - Added localization of thing status info
+ * @author Christoph Weitkamp - Moved OSGI ServiceTracker from BaseThingHandler to ThingHandlerCallback
  */
 @Component(immediate = true, service = { ThingTypeMigrationService.class })
 public class ThingManager implements ThingTracker, ThingTypeMigrationService, ReadyService.ReadyTracker {
@@ -130,6 +132,7 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
 
     private ThingTypeRegistry thingTypeRegistry;
     private ChannelTypeRegistry channelTypeRegistry;
+    private ItemChannelLinkRegistry itemChannelLinkRegistry;
 
     private ThingStatusInfoI18nLocalizationService thingStatusInfoI18nLocalizationService;
 
@@ -266,6 +269,10 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
             return ThingFactoryHelper.createChannelBuilder(channelUID, channelType, configDescriptionRegistry);
         };
 
+        @Override
+        public boolean isChannelLinked(ChannelUID channelUID) {
+            return itemChannelLinkRegistry.getLinks(channelUID).isEmpty();
+        }
     };
 
     private ThingRegistryImpl thingRegistry;
@@ -1049,6 +1056,15 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
 
     protected void unsetChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
         this.channelTypeRegistry = null;
+    }
+
+    @Reference
+    protected void setItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
+        this.itemChannelLinkRegistry = itemChannelLinkRegistry;
+    }
+
+    protected void unsetItemChannelLinkRegistry(ItemChannelLinkRegistry itemChannelLinkRegistry) {
+        this.itemChannelLinkRegistry = null;
     }
 
     @Reference


### PR DESCRIPTION
- Moved `ItemChannelLinkRegistry` from `BaseThingHandler` to `ThingHandlerCallback`

A start for #5182 to make sure my approach goes into the right direction.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>

CC @htreu @sjka wdyt?