### PR TITLE
Add null annotations to core.library.unit

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/ImperialUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/ImperialUnits.java
@@ -21,6 +21,8 @@ import javax.measure.quantity.Speed;
 import javax.measure.quantity.Temperature;
 import javax.measure.spi.SystemOfUnits;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 import tec.uom.se.format.SimpleUnitFormat;
 import tec.uom.se.function.AddConverter;
 import tec.uom.se.function.RationalConverter;
@@ -33,6 +35,7 @@ import tec.uom.se.unit.Units;
  * @author Henning Treu - initial contribution
  *
  */
+@NonNullByDefault
 public class ImperialUnits extends SmartHomeUnits {
 
     private static ImperialUnits INSTANCE = new ImperialUnits();

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/MetricPrefix.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/MetricPrefix.java
@@ -15,6 +15,8 @@ package org.eclipse.smarthome.core.library.unit;
 import javax.measure.Quantity;
 import javax.measure.Unit;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The metric prefixes used to derive units by specific powers of 10. This delegates to the enum instances of
  * {@link tec.uom.se.unit.MetricPrefix}.
@@ -22,6 +24,7 @@ import javax.measure.Unit;
  * @author Henning Treu - initial contribution and API
  *
  */
+@NonNullByDefault
 public class MetricPrefix {
 
     public static <T extends Quantity<T>> Unit<T> YOTTA(Unit<T> unit) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SIUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SIUnits.java
@@ -22,6 +22,8 @@ import javax.measure.quantity.Temperature;
 import javax.measure.quantity.Volume;
 import javax.measure.spi.SystemOfUnits;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 import tec.uom.se.unit.Units;
 
 /**
@@ -31,6 +33,7 @@ import tec.uom.se.unit.Units;
  * @author Henning Treu - initial contribution
  *
  */
+@NonNullByDefault
 public class SIUnits extends SmartHomeUnits {
 
     private static SIUnits INSTANCE = new SIUnits();

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
@@ -43,6 +43,7 @@ import javax.measure.quantity.Temperature;
 import javax.measure.quantity.Time;
 import javax.measure.quantity.Volume;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.dimension.Intensity;
 
 import tec.uom.se.AbstractSystemOfUnits;
@@ -62,6 +63,7 @@ import tec.uom.se.unit.Units;
  * @author Henning Treu - initial contribution
  *
  */
+@NonNullByDefault
 public class SmartHomeUnits extends AbstractSystemOfUnits {
 
     private static SmartHomeUnits INSTANCE = new SmartHomeUnits();


### PR DESCRIPTION
This fixes a lot of warnings when using UoM with the Nest Binding (https://github.com/openhab/openhab2-addons/pull/3150) such as:

```
Null type safety (type annotations): The expression of type 'Unit<Temperature>' needs unchecked conversion to conform to '@NonNull Unit<Temperature>'
[WARNING] /home/wouter/git/openhab/openhab2-addons/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/handler/NestThermostatHandlerTest.java:[261] 
	handleCommand(CHANNEL_MIN_SET_POINT, new QuantityType<>(23.75, CELSIUS));
	                                                               ^^^^^^^
Null type safety (type annotations): The expression of type 'Unit<Temperature>' needs unchecked conversion to conform to '@NonNull Unit<Temperature>'
[WARNING] /home/wouter/git/openhab/openhab2-addons/addons/binding/org.openhab.binding.nest.test/src/test/java/org/openhab/binding/nest/handler/NestThermostatHandlerTest.java:[264] 
	handleCommand(CHANNEL_MIN_SET_POINT, new QuantityType<>(70, FAHRENHEIT));
	                                                            ^^^^^^^^^^
```
