### PR TITLE
fix ThingManagerOSGiJavaTest

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -323,6 +323,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         managedThingProvider.add(thing);
         waitForAssert(() -> {
             assertEquals(ThingStatus.UNINITIALIZED, thing.getStatus());
+            assertEquals(ThingStatusDetail.HANDLER_INITIALIZING_ERROR, thing.getStatusInfo().getStatusDetail());
         });
 
         assertEquals(1, childHandlerInitializedSemaphore.availablePermits());
@@ -398,6 +399,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         managedThingProvider.add(thing);
         waitForAssert(() -> {
             assertEquals(ThingStatus.UNINITIALIZED, thing.getStatus());
+            assertEquals(ThingStatusDetail.HANDLER_INITIALIZING_ERROR, thing.getStatusInfo().getStatusDetail());
         });
 
         assertEquals(1, childHandlerInitializedSemaphore.availablePermits());


### PR DESCRIPTION
...as in testChildHandlerInitialized_replacedUnitializedThing sometimes the
test execution was faster than the framework realizing the handler failed.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>