### PR TITLE
suppres PMD warning 'AvoidCatchingThrowable' for some classes

### DIFF
--- a/tools/static-code-analysis/pmd/suppressions.properties
+++ b/tools/static-code-analysis/pmd/suppressions.properties
@@ -10,4 +10,10 @@ org.eclipse.smarthome.core.thing.internal.ChannelItemProvider=CompareObjectsWith
 org.eclipse.smarthome.core.thing.internal.ThingManager=CompareObjectsWithEquals
 org.eclipse.smarthome.core.internal.common.SafeCallManagerImpl=CompareObjectsWithEquals
 org.eclipse.smarthome.core.internal.events.ThreadedEventHandler=CompareObjectsWithEquals
+org.eclipse.smarthome.binding.hue.handler.HueBridgeHandler=AvoidCatchingThrowable
+org.eclipse.smarthome.core.common.registry.AbstractRegistry=AvoidCatchingThrowable
+org.eclipse.smarthome.model.script.interpreter.ScriptInterpreter=AvoidCatchingThrowable
+org.eclipse.smarthome.ui.internal.proxy.ProxyServletService=AvoidCatchingThrowable
+org.eclipse.smarthome.automation.core.internal.RuleEngineImpl=AvoidCatchingThrowable
+org.eclipse.smarthome.automation.internal.core.provider.AutomationResourceBundlesEventQueue=AvoidCatchingThrowable
 


### PR DESCRIPTION
[This PMD check](https://pmd.github.io/pmd-5.8.1/pmd-java/rules/java/strictexception.html#AvoidCatchingThrowable) that is used in the [static analysis tool](https://github.com/openhab/static-code-analysis) triggers warning whenever `Throwable` errors are caught in the code.

After using git blame I found that in all of these cases there is a specific reason to use throwable.

In [HueBridgeHandler](https://github.com/eclipse/smarthome/blob/master/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java#L160) the code handles catching Throwable and catching Exception differently.
The `ScriptInterpreter.java` class is generated by xtend and in [AbstractRegistry](https://github.com/eclipse/smarthome/commit/38ac359dce) and in [ProxyServletService](https://github.com/eclipse/smarthome/commit/a0e98012a1) Exception was changed to Throwable for a specific reason.


However, there are 3 more classes in which `catch (Throwable t)` is used: 
RuleEngine, AutomationResourceBundleEventQueue and ScriptImpl.

@danchom, I saw that you are the author of the [RuleEngine](https://github.com/eclipse/smarthome/commit/3d2b6e6453#diff-d496a3945090abb3b9b346c925d42370R946) class. I was wondering if there is a specific reason why `catch Throwable` is preferred over `catch Exception` [here](https://github.com/eclipse/smarthome/commit/3d2b6e6453#diff-d496a3945090abb3b9b346c925d42370R946)?

@adimova, I saw that you are the author of the [AutomationResourceBundlesEventQueue](https://github.com/eclipse/smarthome/commit/3d2b6e6453#diff-2f5febc89267b77022ae6c5890218c5bR138) class. I was wondering if there is any specific reason why `catch Throwable` is preferred over `catch Exception` [here](https://github.com/eclipse/smarthome/commit/3d2b6e6453#diff-2f5febc89267b77022ae6c5890218c5bR138)?

@kaikreuzer, I saw that you are the author of the [ScriptImpl](https://github.com/eclipse/smarthome/commit/108712ea468ed465fdad086718d2f39d9e69751e#diff-001dc55913ce2f7df07e2af1b0582670R66) class. I was wondering if there is any specific reason why `catch Throwable` is preferred over `catch Exception` [here](https://github.com/eclipse/smarthome/commit/108712ea468ed465fdad086718d2f39d9e69751e#diff-001dc55913ce2f7df07e2af1b0582670R66)?

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>