### PR TITLE
Wait for callback to be called

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -335,7 +335,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         });
 
         // childHandlerInitialized(...) must be called
-        assertEquals(0, childHandlerInitializedSemaphore.availablePermits());
+        waitForAssert(() -> assertEquals(0, childHandlerInitializedSemaphore.availablePermits()));
 
         // thingUpdated(...) is not called
         assertEquals(1, thingUpdatedSemapthore.availablePermits());
@@ -411,7 +411,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         });
 
         // childHandlerInitialized(...) must be called
-        assertEquals(0, childHandlerInitializedSemaphore.availablePermits());
+        waitForAssert(() -> assertEquals(0, childHandlerInitializedSemaphore.availablePermits()));
 
         // thingUpdated(...) is not called
         assertEquals(1, thingUpdatedSemapthore.availablePermits());


### PR DESCRIPTION
The handler synchronization is run asynchronously, so between the thing being actually set to ONLINE and the corresponding callbacks (i.d. childHandlerInitialized()) being called, many things can happen...

https://github.com/eclipse/smarthome/blob/3d01f359cbdbdeb3b7458c5d16787b1433a9d723/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java#L174-L184

fixes #5248
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>