### PR TITLE
Fix QuantityType parsing for exponential numbers with units

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/QuantityTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/QuantityTypeTest.java
@@ -70,6 +70,7 @@ public class QuantityTypeTest {
         new QuantityType<>("3 µs");
         new QuantityType<>("3km/h");
         new QuantityType<>("1084 hPa");
+        new QuantityType<>("0E-22 m");
         QuantityType.valueOf("2m");
     }
 
@@ -222,6 +223,18 @@ public class QuantityTypeTest {
     @Test(expected = ArithmeticException.class)
     public void testDivide_Zero() {
         new QuantityType<>("4 m").divide(QuantityType.ZERO);
+    }
+
+    @Test
+    public void testExponentials() {
+        QuantityType<Length> exponential = new QuantityType<>("10E-2 m");
+        assertEquals(exponential, new QuantityType<>("10 cm"));
+
+        exponential = new QuantityType<>("10E+3 m");
+        assertEquals(exponential, new QuantityType<>("10 km"));
+
+        exponential = new QuantityType<>("10E3 m");
+        assertEquals(exponential, new QuantityType<>("10 km"));
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
@@ -25,6 +25,7 @@ import javax.measure.Unit;
 import javax.measure.UnitConverter;
 import javax.measure.quantity.Dimensionless;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
@@ -74,7 +75,8 @@ public class QuantityType<T extends Quantity<T>> extends Number
         String[] constituents = value.split(UNIT_PATTERN);
 
         // getQuantity needs a space between numeric value and unit
-        String formatted = String.join(" ", constituents);
+        constituents = (String[]) ArrayUtils.add(constituents, constituents.length - 1, " ");
+        String formatted = String.join("", constituents);
         quantity = (Quantity<T>) Quantities.getQuantity(formatted);
     }
 


### PR DESCRIPTION
Fixes #5247.

Signed-off-by: Henning Treu <henning.treu@telekom.de>