### PR TITLE
Configuration: Move static methods to ConfigUtil. Add documentation.

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/ConfigMapper.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/ConfigMapper.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.config.core.internal;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.eclipse.jdt.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfigMapper {
+    private static final transient Logger logger = LoggerFactory.getLogger(ConfigMapper.class);
+
+    /**
+     * Use this method to automatically map a configuration collection to a Configuration holder object. A common
+     * use-case would be within a service. Usage example:
+     *
+     * <pre>
+     * {@code
+     *   public void modified(Map<String, Object> properties) {
+     *     YourConfig config = ConfigMapper.as(properties, YourConfig.class);
+     *   }
+     * }
+     * </pre>
+     *
+     *
+     * @param properties The configuration map.
+     * @param configurationClass The configuration holder class. An instance of this will be created so make sure that
+     *            a default constructor is available.
+     * @return The configuration holder object. All fields that matched a configuration option are set. If a required
+     *         field is not set, null is returned.
+     */
+    public static <T> @Nullable T as(Map<String, Object> properties, Class<T> configurationClass) {
+        T configuration = null;
+        try {
+            configuration = configurationClass.newInstance();
+        } catch (InstantiationException | IllegalAccessException ex) {
+            return null;
+        }
+
+        List<Field> fields = getAllFields(configurationClass);
+        for (Field field : fields) {
+            // Don't try to write to final fields and ignore transient fields
+            if (Modifier.isFinal(field.getModifiers()) || Modifier.isTransient(field.getModifiers())) {
+                continue;
+            }
+            String fieldName = field.getName();
+            String configKey = fieldName;
+            Class<?> type = field.getType();
+
+            Object value = properties.get(configKey);
+
+            // Consider RequiredField annotations
+            if (value == null) {
+                logger.trace("Skipping field '{}', because config has no entry for {}", fieldName, configKey);
+                continue;
+            }
+
+            // Allows to have List<int>, List<Double>, List<String> etc
+            if (value instanceof Collection) {
+                Collection<?> c = (Collection<?>) value;
+                Class<?> innerClass = (Class<?>) ((ParameterizedType) field.getGenericType())
+                        .getActualTypeArguments()[0];
+                final List<Object> lst = new ArrayList<>(c.size());
+                for (final Object it : c) {
+                    final Object normalized = numberConvert(it, innerClass);
+                    lst.add(normalized);
+                }
+                value = lst;
+            }
+
+            try {
+                value = numberConvert(value, type);
+                logger.trace("Setting value ({}) {} to field '{}' in configuration class {}", type.getSimpleName(),
+                        value, fieldName, configurationClass.getName());
+                FieldUtils.writeField(configuration, fieldName, value, true);
+
+            } catch (Exception ex) {
+                logger.warn("Could not set field value for field '{}': {}", fieldName, ex.getMessage(), ex);
+            }
+        }
+
+        return configuration;
+    }
+
+    /**
+     * Return fields of the given class as well as all super classes.
+     *
+     * @param clazz The class
+     * @return A list of Field objects
+     */
+    private static List<Field> getAllFields(Class<?> clazz) {
+        List<Field> fields = new ArrayList<Field>();
+
+        Class<?> currentClass = clazz;
+        while (currentClass != null) {
+            fields.addAll(Arrays.asList(currentClass.getDeclaredFields()));
+            currentClass = currentClass.getSuperclass();
+        }
+
+        return fields;
+    }
+
+    private static Object numberConvert(Object value, Class<?> type) {
+        Object result = value;
+        // Handle the conversion case of BigDecimal to Float,Double,Long,Integer and the respective
+        // primitive types
+        String typeName = type.getSimpleName();
+        if (value instanceof BigDecimal && !type.equals(BigDecimal.class)) {
+            BigDecimal bdValue = (BigDecimal) value;
+            if (type.equals(Float.class) || typeName.equals("float")) {
+                result = bdValue.floatValue();
+            } else if (type.equals(Double.class) || typeName.equals("double")) {
+                result = bdValue.doubleValue();
+            } else if (type.equals(Long.class) || typeName.equals("long")) {
+                result = bdValue.longValue();
+            } else if (type.equals(Integer.class) || typeName.equals("int")) {
+                result = bdValue.intValue();
+            }
+        } else
+        // Handle the conversion case of String to Float,Double,Long,Integer,BigDecimal and the respective
+        // primitive types
+        if (value instanceof String && !type.equals(String.class)) {
+            String bdValue = (String) value;
+            if (type.equals(Float.class) || typeName.equals("float")) {
+                result = Float.valueOf(bdValue);
+            } else if (type.equals(Double.class) || typeName.equals("double")) {
+                result = Double.valueOf(bdValue);
+            } else if (type.equals(Long.class) || typeName.equals("long")) {
+                result = Long.valueOf(bdValue);
+            } else if (type.equals(BigDecimal.class)) {
+                result = new BigDecimal(bdValue);
+            } else if (type.equals(Integer.class) || typeName.equals("int")) {
+                result = Integer.valueOf(bdValue);
+            }
+        }
+        return result;
+    }
+
+}

--- a/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImplTest.java
+++ b/bundles/test/org.eclipse.smarthome.magic.test/src/test/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImplTest.java
@@ -37,7 +37,7 @@ public class MagicServiceImplTest {
     @Test
     public void shouldProvideConfigOptionsForURIAndParameterName() {
         Collection<ParameterOption> parameterOptions = magicService.getParameterOptions(MagicService.CONFIG_URI,
-                PARAMETER_NAME, null);
+                PARAMETER_NAME, null, null);
 
         assertThat(parameterOptions, hasSize(3));
     }
@@ -45,7 +45,7 @@ public class MagicServiceImplTest {
     @Test
     public void shouldProvidemtpyListForInvalidURI() {
         Collection<ParameterOption> parameterOptions = magicService.getParameterOptions(URI.create("system.audio"),
-                PARAMETER_NAME, null);
+                PARAMETER_NAME, null, null);
 
         assertNull(parameterOptions);
     }
@@ -53,7 +53,7 @@ public class MagicServiceImplTest {
     @Test
     public void shouldProvidemtpyListForInvalidParameterName() {
         Collection<ParameterOption> parameterOptions = magicService.getParameterOptions(MagicService.CONFIG_URI,
-                "some_param_name", null);
+                "some_param_name", null, null);
 
         assertNull(parameterOptions);
     }

--- a/bundles/test/org.eclipse.smarthome.magic/ESH-INF/config/config.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/ESH-INF/config/config.xml
@@ -21,7 +21,7 @@
 			<description>A grouped text parameter.</description>
 			<default>myText</default>
 		</parameter>
-		<parameter name="boolean" type="boolean" groupName="group_normal">
+		<parameter name="bool" type="boolean" groupName="group_normal">
 			<label>Switch</label>
 			<description>A grouped boolean parameter.</description>
 			<default>false</default>

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceConfig.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceConfig.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.magic.binding.internal;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.eclipse.smarthome.magic.binding.MagicService;
+
+/**
+ * Configuration holder object for {@link MagicService}
+ *
+ * @author David Graeff - Initial contribution
+ */
+public class MagicServiceConfig {
+    public String text;
+    public boolean bool;
+    public BigDecimal decimal;
+    public Integer integer;
+
+    public String text_advanced;
+    public boolean boolean_advanced;
+    public BigDecimal decimal_advanced;
+    public Integer integer_advanced;
+
+    public String requiredTextParameter;
+    public String verifiedTextParameter;
+    public String select_limited;
+    public String select_variable;
+
+    public List<String> multiselect_text_limit;
+    public List<BigDecimal> multiselect_integer_limit;
+
+    public BigDecimal select_decimal_limit;
+
+    @Override
+    public String toString() {
+        StringBuffer b = new StringBuffer();
+        for (Field field : this.getClass().getDeclaredFields()) {
+            Object value;
+            try {
+                value = field.get(this);
+            } catch (IllegalArgumentException | IllegalAccessException e) {
+                continue;
+            }
+            if (value != null) {
+                b.append("MagicService config ");
+                b.append(field.getName());
+                b.append(" = ");
+                b.append(value);
+            }
+        }
+        return b.toString();
+    }
+}

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImpl.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicServiceImpl.java
@@ -17,11 +17,17 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Map;
 
 import org.eclipse.smarthome.config.core.ConfigOptionProvider;
+import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.ParameterOption;
 import org.eclipse.smarthome.magic.binding.MagicService;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -31,6 +37,7 @@ import org.osgi.service.component.annotations.Component;
         "service.pid=org.eclipse.smarthome.magic", "service.config.description.uri=test:magic",
         "service.config.label=Magic", "service.config.category=test" })
 public class MagicServiceImpl implements MagicService {
+    private final Logger logger = LoggerFactory.getLogger(MagicServiceImpl.class);
 
     static final String PARAMETER_BACKEND_DECIMAL = "select_decimal_limit";
 
@@ -49,4 +56,14 @@ public class MagicServiceImpl implements MagicService {
         return null;
     }
 
+    @Activate
+    public void activate(Map<String, Object> properties) {
+        modified(properties);
+    }
+
+    @Modified
+    public void modified(Map<String, Object> properties) {
+        MagicServiceConfig config = new Configuration(properties).as(MagicServiceConfig.class);
+        logger.debug(config.toString());
+    }
 }


### PR DESCRIPTION
* getAllFields, as methods moved from Configuration to internal ConfigMapper
* Add String->BigDecimal conversion in ConfigMapper.as
* Add configuration holder object to MagicService of the magic binding to see if the mapping works for all kind of configuration values.
  (Except for the case of bug #5291)

Signed-off-by: David Graeff <david.graeff@web.de>