### PR TITLE
add nullness annotations for i18n interfaces and impl

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core/pom.xml
@@ -20,4 +20,22 @@
     <bundle.namespace>org.eclipse.smarthome.core</bundle.namespace>
   </properties>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.openhab.tools.sat</groupId>
+          <artifactId>sat-plugin</artifactId>
+          <version>${sat.version}</version>
+          <executions>
+            <execution>
+              <id>sat-all</id>
+              <phase>none</phase>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/LocaleProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/LocaleProvider.java
@@ -14,11 +14,14 @@ package org.eclipse.smarthome.core.i18n;
 
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * The interface describe a provider for a locale.
  *
  * @author Markus Rathgeb - Initial contribution and API
  */
+@NonNullByDefault
 public interface LocaleProvider {
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/LocationProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/LocationProvider.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.i18n;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.types.PointType;
 
 /**
@@ -19,6 +21,7 @@ import org.eclipse.smarthome.core.library.types.PointType;
  *
  * @author Stefan Triller - Initial contribution and API
  */
+@NonNullByDefault
 public interface LocationProvider {
 
     /**
@@ -26,6 +29,7 @@ public interface LocationProvider {
      *
      * @return location of the current installation or null if the location is not set
      */
+    @Nullable
     PointType getLocation();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TimeZoneProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TimeZoneProvider.java
@@ -14,11 +14,14 @@ package org.eclipse.smarthome.core.i18n;
 
 import java.time.ZoneId;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * This interface describes a provider for time zone.
  *
  * @author Erdoan Hadzhiyusein - Initial contribution and API
  */
+@NonNullByDefault
 public interface TimeZoneProvider {
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TranslationProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TranslationProvider.java
@@ -65,6 +65,6 @@ public interface TranslationProvider {
      */
     @Nullable
     String getText(@Nullable Bundle bundle, @Nullable String key, @Nullable String defaultText, @Nullable Locale locale,
-            Object @Nullable... arguments);
+            @Nullable Object @Nullable... arguments);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TranslationProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/i18n/TranslationProvider.java
@@ -14,6 +14,8 @@ package org.eclipse.smarthome.core.i18n;
 
 import java.util.Locale;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.Bundle;
 
 /**
@@ -26,6 +28,7 @@ import org.osgi.framework.Bundle;
  * @author Michael Grammling - Initial Contribution
  * @author Thomas Höfer - Added getText operation with arguments
  */
+@NonNullByDefault
 public interface TranslationProvider {
 
     /**
@@ -41,7 +44,9 @@ public interface TranslationProvider {
      * @param locale the locale (language) to be used (could be null)
      * @return the translated text or the default text (could be null or empty)
      */
-    String getText(Bundle bundle, String key, String defaultText, Locale locale);
+    @Nullable
+    String getText(@Nullable Bundle bundle, @Nullable String key, @Nullable String defaultText,
+            @Nullable Locale locale);
 
     /**
      * Returns a translation for the specified key in the specified locale (language) by only
@@ -58,6 +63,8 @@ public interface TranslationProvider {
      * @param arguments the arguments to be injected into the translation (could be null)
      * @return the translated text or the default text (could be null or empty)
      */
-    String getText(Bundle bundle, String key, String defaultText, Locale locale, Object... arguments);
+    @Nullable
+    String getText(@Nullable Bundle bundle, @Nullable String key, @Nullable String defaultText, @Nullable Locale locale,
+            Object @Nullable... arguments);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
@@ -20,6 +20,7 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.TimeZone;
 
@@ -34,7 +35,8 @@ import javax.measure.quantity.Temperature;
 import javax.measure.spi.SystemOfUnits;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.i18n.LocaleProvider;
 import org.eclipse.smarthome.core.i18n.LocationProvider;
 import org.eclipse.smarthome.core.i18n.TimeZoneProvider;
@@ -75,6 +77,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 
+@NonNullByDefault
 @Component(immediate = true, configurationPid = "org.eclipse.smarthome.core.i18nprovider", property = {
         "service.pid=org.eclipse.smarthome.core.i18nprovider", "service.config.description.uri:String=system:i18n",
         "service.config.label:String=Regional Settings", "service.config.category:String=system" })
@@ -88,22 +91,22 @@ public class I18nProviderImpl
     static final String SCRIPT = "script";
     static final String REGION = "region";
     static final String VARIANT = "variant";
-    private Locale locale;
+    private @Nullable Locale locale;
 
     // TranslationProvider
-    private ResourceBundleTracker resourceBundleTracker;
+    private @NonNullByDefault({}) ResourceBundleTracker resourceBundleTracker;
 
     // LocationProvider
     static final String LOCATION = "location";
-    private PointType location;
+    private @Nullable PointType location;
 
     // TimeZoneProvider
     static final String TIMEZONE = "timezone";
-    private ZoneId timeZone;
+    private @Nullable ZoneId timeZone;
 
     // UnitProvider
     private static final String MEASUREMENT_SYSTEM = "measurementSystem";
-    private SystemOfUnits measurementSystem;
+    private @Nullable SystemOfUnits measurementSystem;
     private final Map<Class<? extends Quantity<?>>, Map<SystemOfUnits, Unit<? extends Quantity<?>>>> dimensionMap = new HashMap<>();
 
     @Activate
@@ -137,30 +140,40 @@ public class I18nProviderImpl
         setMeasurementSystem(measurementSystem);
     }
 
-    private void setMeasurementSystem(String measurementSystem) {
+    private void setMeasurementSystem(@Nullable String measurementSystem) {
         SystemOfUnits oldMeasurementSystem = this.measurementSystem;
 
-        String ms = StringUtils.isBlank(measurementSystem) ? "" : measurementSystem;
+        final String ms;
+        if (measurementSystem == null || measurementSystem.isEmpty()) {
+            ms = "";
+        } else {
+            ms = measurementSystem;
+        }
+
+        final SystemOfUnits newMeasurementSystem;
         switch (ms) {
             case "SI":
-                this.measurementSystem = SIUnits.getInstance();
+                newMeasurementSystem = SIUnits.getInstance();
                 break;
             case "US":
-                this.measurementSystem = ImperialUnits.getInstance();
+                newMeasurementSystem = ImperialUnits.getInstance();
                 break;
             default:
                 logger.debug("Error setting measurement system for value '{}'.", measurementSystem);
-                this.measurementSystem = null;
+                newMeasurementSystem = null;
+                break;
         }
+        this.measurementSystem = newMeasurementSystem;
 
-        if (oldMeasurementSystem != null && this.measurementSystem == null) {
+        if (oldMeasurementSystem != null && newMeasurementSystem == null) {
             logger.info("Measurement system is not set, falling back to locale based system.");
-        } else if (this.measurementSystem != null && !this.measurementSystem.equals(oldMeasurementSystem)) {
-            logger.info("Measurement system set to '{}'.", this.measurementSystem.getName());
+        } else if (newMeasurementSystem != null && !newMeasurementSystem.equals(oldMeasurementSystem)) {
+            logger.info("Measurement system set to '{}'.", newMeasurementSystem.getName());
         }
     }
 
-    private void setLocale(String language, String script, String region, String variant) {
+    private void setLocale(@Nullable String language, @Nullable String script, @Nullable String region,
+            @Nullable String variant) {
         Locale oldLocale = this.locale;
         if (StringUtils.isEmpty(language)) {
             // at least the language must be defined otherwise the system default locale is used
@@ -200,36 +213,40 @@ public class I18nProviderImpl
             logger.warn("Variant ({}) is invalid. Skip it.", variant, ex);
             return;
         }
+        final Locale newLocale = builder.build();
+        locale = newLocale;
 
-        locale = builder.build();
-
-        if (!this.locale.equals(oldLocale)) {
-            logger.info("Locale set to '{}'.", this.locale);
+        if (!newLocale.equals(oldLocale)) {
+            logger.info("Locale set to '{}'.", newLocale);
         }
     }
 
-    private String toStringOrNull(Object value) {
+    private @Nullable String toStringOrNull(@Nullable Object value) {
         return value == null ? null : value.toString();
     }
 
-    private void setLocation(final String location) {
+    private void setLocation(final @Nullable String location) {
         PointType oldLocation = this.location;
-        if (location != null) {
+        PointType newLocation;
+        if (location == null || location.isEmpty()) {
+            newLocation = null;
+        } else {
             try {
-                this.location = PointType.valueOf(location);
+                newLocation = PointType.valueOf(location);
             } catch (IllegalArgumentException e) {
+                newLocation = oldLocation;
                 // preserve old location or null if none was set before
                 logger.warn("Could not set new location: {}, keeping old one, error message: {}", location,
                         e.getMessage());
             }
-            if (this.location != null && !this.location.equals(oldLocation)) {
-                logger.info("Location set to '{}'.", this.location);
-            }
         }
-
+        if (!Objects.equals(newLocation, oldLocation)) {
+            this.location = newLocation;
+            logger.info("Location set to '{}'.", newLocation);
+        }
     }
 
-    private void setTimeZone(final String zoneId) {
+    private void setTimeZone(final @Nullable String zoneId) {
         ZoneId oldTimeZone = this.timeZone;
         if (StringUtils.isBlank(zoneId)) {
             timeZone = null;
@@ -251,20 +268,22 @@ public class I18nProviderImpl
     }
 
     @Override
-    public PointType getLocation() {
+    public @Nullable PointType getLocation() {
         return location;
     }
 
     @Override
     public ZoneId getTimeZone() {
+        final ZoneId timeZone = this.timeZone;
         if (timeZone == null) {
             return TimeZone.getDefault().toZoneId();
         }
-        return this.timeZone;
+        return timeZone;
     }
 
     @Override
     public Locale getLocale() {
+        final Locale locale = this.locale;
         if (locale == null) {
             return Locale.getDefault();
         }
@@ -272,7 +291,8 @@ public class I18nProviderImpl
     }
 
     @Override
-    public String getText(Bundle bundle, String key, String defaultText, Locale locale) {
+    public @Nullable String getText(@Nullable Bundle bundle, @Nullable String key, @Nullable String defaultText,
+            @Nullable Locale locale) {
         LanguageResourceBundleManager languageResource = this.resourceBundleTracker.getLanguageResource(bundle);
 
         if (languageResource != null) {
@@ -286,7 +306,8 @@ public class I18nProviderImpl
     }
 
     @Override
-    public String getText(Bundle bundle, String key, String defaultText, Locale locale, Object... arguments) {
+    public @Nullable String getText(@Nullable Bundle bundle, @Nullable String key, @Nullable String defaultText,
+            @Nullable Locale locale, Object @Nullable... arguments) {
         String text = getText(bundle, key, defaultText, locale);
 
         if (text != null) {
@@ -298,18 +319,17 @@ public class I18nProviderImpl
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends @NonNull Quantity<T>> Unit<T> getUnit(Class<T> dimension) {
+    public <T extends Quantity<T>> @Nullable Unit<T> getUnit(@Nullable Class<T> dimension) {
         Map<SystemOfUnits, Unit<? extends Quantity<?>>> map = dimensionMap.get(dimension);
-
-        if (map != null) {
-            return (Unit<T>) map.get(getMeasurementSystem());
+        if (map == null) {
+            return null;
         }
-
-        return null;
+        return (Unit<T>) map.get(getMeasurementSystem());
     }
 
     @Override
     public SystemOfUnits getMeasurementSystem() {
+        final SystemOfUnits measurementSystem = this.measurementSystem;
         if (measurementSystem != null) {
             return measurementSystem;
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
@@ -307,7 +307,7 @@ public class I18nProviderImpl
 
     @Override
     public @Nullable String getText(@Nullable Bundle bundle, @Nullable String key, @Nullable String defaultText,
-            @Nullable Locale locale, Object @Nullable... arguments) {
+            @Nullable Locale locale, @Nullable Object @Nullable... arguments) {
         String text = getText(bundle, key, defaultText, locale);
 
         if (text != null) {

--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -4,3 +4,5 @@ checkstyle.headerCheck.values=2014,2018
 checkstyle.bundleVendorCheck.allowedValues=Eclipse.org/SmartHome
 checkstyle.pomXmlCheck.currentVersionRegex=^0\.10\.0
 checkstyle.requiredFilesCheck.files=build.properties,pom.xml,META-INF/MANIFEST.MF
+checkstyle.beforeExecutionExclusionFileFilter.fileNamePattern=.+org.eclipse.smarthome.core.internal.i18n.I18nProviderImpl\.java$|.+org.eclipse.smarthome.core.i18n.TranslationProvider\.java$
+


### PR DESCRIPTION
I added WIP, because there are some question / preconditions that must be fixed:

---

First one question about the `getText` method of the `TranslationProvider`, more precise about the `arguments` argument.
The JavaDoc states:
```JavaDoc
@param arguments the arguments to be injected into the translation (could be null)
```
What do we expect / allow for the value of `arguments`:
1. it can be null and if present its entries can be nullable, too (so a `@Nullable Object @Nullable []`)
1. it can be null but if present its entries must be non-null (so a `@NonNull Object @Nullable []`)
1. itself must be non-null but can contain nullable entries (so a `@Nullable Object @NonNull []`)
1. itself must be non-null and it entries must be non-null (so a `@NonNull Object @NonNull []`)

From the reading of the JavaDoc I would expect 1 or 2.

---

It seems there is a "bug" in SAT. It breaks on annotated optional arguments (openhab/static-code-analysis#276).

I added the exclusion that will be used by SAT in a new release.
Until SAT has released a new version and that one is used by ESH, I added a work around to disable that for the respective bundle.

---

The current implementation of `private void setLocation(final @Nullable String location)` keeps the old location if the `location` is set to `null`. That differs from the other `set` functions that unset the explicit value.
I changed that implementation now, as I have assumed this has not been done differently for this attribute by intention.
If it has been done by intention please comment or better, comment in every case.