### PR TITLE
Fix DST bug in Scheduler

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/CronExpression.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/scheduler/CronExpression.java
@@ -176,7 +176,7 @@ public final class CronExpression extends AbstractExpression<CronExpressionPart>
      * @throws ParseException if the string expression cannot be parsed into a valid <code>CronExpression</code>.
      */
     public CronExpression(final String expression, final Date startTime, final TimeZone zone) throws ParseException {
-        super(expression, " \t", startTime, zone, 0, 2);
+        super(expression, " \t", startTime, zone, 0, 3);
     }
 
     @Override


### PR DESCRIPTION
While searching for possible future execution candidates there is a
problem if a change from standard time to daylight saving time occurs.

This time jump forward leads to a duplicate of a date. For example in
Europe, Germany SUN 2018 Mar 25 3:00:00 exists TWICE because the time was
shifted from 2am to 3am.

While pruning the execution candidates we only kept the next 2 whereas the
first usually is the current time, which leaves the 2nd candidate to be
the final one. If the time change occurs we only have 2 same dates which
both are the current time and thus both are discarded.

With this PR I have changed the implementation to keep 3 candidates, so
there will be a future execution date left.

Fixes #5294
Fixes #3185

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>