### PR TITLE
Intern UID segment strings

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/UID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/UID.java
@@ -69,6 +69,7 @@ public abstract class UID {
         for (int i = 0; i < segments.length; i++) {
             String segment = segments[i];
             validateSegment(segment, i, segments.length);
+            segments[i] = segment.intern();
         }
         this.segments = segments;
     }


### PR DESCRIPTION
...in order to avoid cluttering the heap with hundreds identical strings. Especially binding and thing type IDs are repeated all over the place.

UID derived classes are often held in maps within the framework and therefore actually are quite persistent in the heap. A quick analysis showed that something in the range of a little over 100K heap space could be saved just by that.

To me this looks like significant enough to consider, especially as [since Java 7 interned strings are stored in the heap](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6962931) (as opposed to the PermGen space where they were before).

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>