### PR TITLE
pom: remove 3rd party repositories and plugin repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,26 +566,4 @@
     </profile>
   </profiles>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>jcenter</id>
-      <url>https://jcenter.bintray.com</url>
-    </pluginRepository>
-  </pluginRepositories>
-
-  <repositories>
-    <repository>
-      <id>jcenter</id>
-      <name>JCenter Repository</name>
-      <url>https://jcenter.bintray.com</url>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
 </project>


### PR DESCRIPTION
If you add a artifact as dependency or as plugin in the Maven build and
this artifact adds repositories this repositories needs also be added to
the current build e.g. to allow the download of transitive dependencies
of the respective artifacts.
So, it is in general a good practice to reduce the used repositories to
that ones that are really necessary (and in the best way, to not use
additionals at all).
The repositories that are removed by that commit has been added by
b0812c2e760d9b25533c55d38c0f14dd1c6cab3f to enable the usage of SAT.
Now we use SAT v0.4.1 that is available on Maven Central, too. There is
no need for that repository anymore and could be removed again.

--

I am currently running a build using an empty local Maven repo to be sure that my assumption is correct.
If not it will be identified by me or later by Travis CI.