### PR TITLE
Fix isChannelLinked logic

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -274,7 +274,7 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
 
         @Override
         public boolean isChannelLinked(ChannelUID channelUID) {
-            return itemChannelLinkRegistry.getLinks(channelUID).isEmpty();
+            return !itemChannelLinkRegistry.getLinks(channelUID).isEmpty();
         }
     };
 


### PR DESCRIPTION
PR #5244 moved the ItemChannelLinkRegistry from the BaseThingHandler to
the ThingHandlerCallback but inverted its logic. This PR fixes the logic
again.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>