### PR TITLE
Re-export Byte-Buddy and Objenesis from test bundle

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
@@ -7,11 +7,11 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.io.net
 Import-Package: 
- net.bytebuddy.dynamic.loading,
  org.eclipse.jdt.annotation;resolution:=optional,
+ org.eclipse.smarthome.test,
+ org.eclipse.smarthome.test.java,
  org.hamcrest;core=split,
  org.hamcrest.core,
  org.junit;version="4.0.0",
  org.mockito,
- org.mockito.stubbing,
- org.objenesis
+ org.mockito.stubbing

--- a/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
@@ -38,3 +38,6 @@ Import-Package: com.google.common.collect,
  org.osgi.service.component.runtime,
  org.osgi.service.component.runtime.dto,
  org.slf4j
+Require-Bundle: net.bytebuddy.byte-buddy;bundle-version="1.7.0";visibility:=reexport,
+ net.bytebuddy.byte-buddy-agent;bundle-version="1.7.0";visibility:=reexport,
+ org.objenesis;bundle-version="2.6.0";visibility:=reexport


### PR DESCRIPTION
...in order to have them in the classpath when running
plain JUnit tests with Mockito directly in the IDE.

That's actually a piece which was missing in #5056.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>