### PR TITLE
remove javax.xml.bind import

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
@@ -15,7 +15,6 @@ Import-Package:
  com.google.gson,
  javax.jmdns,
  javax.net.ssl,
- javax.xml.bind,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverconnection/impl/HttpTransportImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverconnection/impl/HttpTransportImpl.java
@@ -30,6 +30,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -38,7 +39,6 @@ import javax.net.ssl.SSLSession;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import javax.xml.bind.DatatypeConverter;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -532,7 +532,7 @@ public class HttpTransportImpl implements HttpTransport {
 
             byte[] by = ((X509Certificate) cert[0]).getEncoded();
             if (by.length != 0) {
-                return BEGIN_CERT + DatatypeConverter.printBase64Binary(by) + END_CERT;
+                return BEGIN_CERT + Base64.getEncoder().encodeToString(by) + END_CERT;
             }
         } catch (MalformedURLException e) {
             if (!informConnectionManager(ConnectionManager.MALFORMED_URL_EXCEPTION)) {


### PR DESCRIPTION

As issue #5327 states, javax.xml.bind is not in Java8's compact profile 2. 

This PR replaces the `javax.xml.bind.DatatypeConverter`  with `java.util.Base64`, which is in the compact1 profile.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>