### PR TITLE
change javax.naming.ConfigurationException to org.osgi.service.cm.Con…

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnectionTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnectionTest.java
@@ -19,13 +19,12 @@ import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
 
-import javax.naming.ConfigurationException;
-
 import org.eclipse.paho.client.mqttv3.IMqttActionListener;
 import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.smarthome.io.transport.mqtt.reconnect.AbstractReconnectStrategy;
 import org.eclipse.smarthome.io.transport.mqtt.reconnect.PeriodicReconnectStrategy;
 import org.junit.Test;
+import org.osgi.service.cm.ConfigurationException;
 
 /**
  * Tests the MqttBrokerConnection class

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttServiceTests.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/src/test/java/org/eclipse/smarthome/io/transport/mqtt/MqttServiceTests.java
@@ -16,10 +16,9 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import javax.naming.ConfigurationException;
-
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.osgi.service.cm.ConfigurationException;
 
 /**
  * Tests the MqttService class

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttBrokerConnection.java
@@ -18,8 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.naming.ConfigurationException;
-
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -38,6 +36,7 @@ import org.eclipse.smarthome.io.transport.mqtt.reconnect.AbstractReconnectStrate
 import org.eclipse.smarthome.io.transport.mqtt.reconnect.PeriodicReconnectStrategy;
 import org.eclipse.smarthome.io.transport.mqtt.sslcontext.AcceptAllCertificatesSSLContext;
 import org.eclipse.smarthome.io.transport.mqtt.sslcontext.SSLContextProvider;
+import org.osgi.service.cm.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/MqttService.java
@@ -18,13 +18,12 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.naming.ConfigurationException;
-
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.transport.mqtt.internal.MqttBrokerConnectionServiceInstance;
 import org.osgi.framework.Constants;
+import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -136,7 +135,7 @@ public class MqttService {
                 connection = new MqttBrokerConnection(host, config.port, config.secure, config.clientID);
                 brokerConnections.put(brokerID, connection);
             } else {
-                throw new ConfigurationException("You need to provide a hostname/IP!");
+                throw new ConfigurationException("host", "You need to provide a hostname/IP!");
             }
         }
 

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnectionServiceInstance.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/internal/MqttBrokerConnectionServiceInstance.java
@@ -14,8 +14,6 @@ package org.eclipse.smarthome.io.transport.mqtt.internal;
 
 import java.util.Map;
 
-import javax.naming.ConfigurationException;
-
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -25,6 +23,7 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnectionConfig;
 import org.eclipse.smarthome.io.transport.mqtt.MqttException;
 import org.eclipse.smarthome.io.transport.mqtt.MqttService;
+import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/reconnect/PeriodicReconnectStrategy.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/reconnect/PeriodicReconnectStrategy.java
@@ -17,11 +17,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import javax.naming.ConfigurationException;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.transport.mqtt.MqttException;
+import org.osgi.service.cm.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/sslcontext/AcceptAllCertificatesSSLContext.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/sslcontext/AcceptAllCertificatesSSLContext.java
@@ -16,11 +16,11 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 
-import javax.naming.ConfigurationException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import org.osgi.service.cm.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class AcceptAllCertificatesSSLContext implements SSLContextProvider {
             return sslContext;
         } catch (KeyManagementException | NoSuchAlgorithmException e) {
             logger.warn("SSL configuration failed", e);
-            throw new ConfigurationException(e.getMessage());
+            throw new ConfigurationException("ssl", e.getMessage());
         }
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/sslcontext/SSLContextProvider.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/src/main/java/org/eclipse/smarthome/io/transport/mqtt/sslcontext/SSLContextProvider.java
@@ -12,10 +12,10 @@
  */
 package org.eclipse.smarthome.io.transport.mqtt.sslcontext;
 
-import javax.naming.ConfigurationException;
 import javax.net.ssl.SSLContext;
 
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
+import org.osgi.service.cm.ConfigurationException;
 
 /**
  * Implement this and provide a {@link SSLContext} instance to be used by the {@link MqttBrokerConnection} for secure


### PR DESCRIPTION
Change mqtt binding not to rely on javax.naming. 
Fixes #5325 

Change javax.naming.ConfigurationException to org.osgi.service.cm.ConfigurationException in mqtt binding

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>