### PR TITLE
remove package-import of javax.naming in mqtt.transport

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
@@ -13,7 +13,6 @@ Export-Package:
  org.eclipse.smarthome.io.transport.mqtt.reconnect,
  org.eclipse.smarthome.io.transport.mqtt.sslcontext
 Import-Package: 
- javax.naming,
  javax.net,
  javax.net.ssl,
  org.apache.commons.lang,
@@ -27,8 +26,8 @@ Import-Package:
  org.eclipse.smarthome.io.transport.mqtt,
  org.eclipse.smarthome.io.transport.mqtt.reconnect,
  org.eclipse.smarthome.io.transport.mqtt.sslcontext,
+ org.osgi.framework,
  org.osgi.service.cm,
  org.osgi.service.component,
- org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml


### PR DESCRIPTION
...which #5330 forgot to remove.

fixes #5325
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>