### PR TITLE
Fixed CompareObjectsWithEquals issues found by PMD

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/util/GenericUnmarshaller.java
+++ b/bundles/config/org.eclipse.smarthome.config.xml/src/main/java/org/eclipse/smarthome/config/xml/util/GenericUnmarshaller.java
@@ -52,7 +52,7 @@ public abstract class GenericUnmarshaller<T> implements Converter {
     @SuppressWarnings("rawtypes")
     @Override
     public final boolean canConvert(Class paramClass) {
-        return (clazz == paramClass);
+        return (clazz.equals(paramClass));
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/text/AbstractRuleBasedInterpreter.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice/src/main/java/org/eclipse/smarthome/core/voice/text/AbstractRuleBasedInterpreter.java
@@ -842,7 +842,7 @@ public abstract class AbstractRuleBasedInterpreter implements HumanLanguageInter
 
     @Override
     public String getGrammar(Locale locale, String format) {
-        if (format != JSGF) {
+        if (!JSGF.equals(format)) {
             return null;
         }
         JSGFGenerator generator = new JSGFGenerator(ResourceBundle.getBundle(LANGUAGE_SUPPORT, locale));

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
@@ -718,7 +718,7 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
         logger.debug("load channel: typeID={}, itemType={}",
                 DsChannelTypeProvider.getOutputChannelTypeID(device.getFunctionalColorGroup(), device.getOutputMode()),
                 DsChannelTypeProvider.getItemType(channelTypeID));
-        if (channelTypeID != null && (currentChannel == null || currentChannel != channelTypeID)) {
+        if (channelTypeID != null && (currentChannel == null || !currentChannel.equals(channelTypeID))) {
             loadOutputChannel(new ChannelTypeUID(BINDING_ID, channelTypeID),
                     DsChannelTypeProvider.getItemType(channelTypeID));
         }

--- a/tools/static-code-analysis/pmd/suppressions.properties
+++ b/tools/static-code-analysis/pmd/suppressions.properties
@@ -5,3 +5,9 @@ org.eclipse.smarthome.io.console.rfc147.internal.OSGiConsole=SystemPrintln
 org.eclipse.smarthome.core.internal.events.ThreadedEventHandler=EmptyIfStmt
 org.eclipse.smarthome.model.core.internal.ModelRepositoryImpl=AvoidCatchingNPE
 org.eclipse.smarthome.io.net.http.internal.SecureHttpClientFactory=AvoidThrowingRawExceptionTypes
+org.eclipse.smarthome.automation.core.internal.RuleRegistryImpl=CompareObjectsWithEquals
+org.eclipse.smarthome.core.thing.internal.ChannelItemProvider=CompareObjectsWithEquals
+org.eclipse.smarthome.core.thing.internal.ThingManager=CompareObjectsWithEquals
+org.eclipse.smarthome.core.internal.common.SafeCallManagerImpl=CompareObjectsWithEquals
+org.eclipse.smarthome.core.internal.events.ThreadedEventHandler=CompareObjectsWithEquals
+


### PR DESCRIPTION
Fixed [CompareObjectsWithEquals ](https://pmd.github.io/pmd-5.8.1/pmd-java/rules/java/design.html#CompareObjectsWithEquals)issues found by PMD.

I noticed that refactoring from `==` to `equals` breaks existing tests in **org.eclipse.smarthome.automation.core.internal.RuleRegistryImpl** and
**org.eclipse.smarthome.core.thing.internal.ChannelItemProvider** so I assume using `==` there is intentional.