### PR TITLE
Support installation of Voice extensions from the IoT Marketplace.

### DIFF
--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/src/test/java/org/eclipse/smarthome/extensionservice/marketplace/internal/MarketplaceExtensionServiceTest.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/src/test/java/org/eclipse/smarthome/extensionservice/marketplace/internal/MarketplaceExtensionServiceTest.java
@@ -59,6 +59,22 @@ public class MarketplaceExtensionServiceTest {
     }
 
     @Test
+    public void shouldParseUiExtensionIdFromValidURI() throws Exception {
+        String url = BASE_PATH + "?mpc_install=3414678";
+        String extensionId = marketplaceService.getExtensionId(new URI(url));
+
+        assertThat(extensionId, is("market:ui-3414678"));
+    }
+
+    @Test
+    public void shouldParseVoiceExtensionIdFromValidURI() throws Exception {
+        String url = BASE_PATH + "?mpc_install=396962433";
+        String extensionId = marketplaceService.getExtensionId(new URI(url));
+
+        assertThat(extensionId, is("market:voice-396962433"));
+    }
+
+    @Test
     public void shouldParseExtensionIdFromValidURIWithMultipleQueryParams() throws Exception {
         String url = BASE_PATH + "?p1&p2=foo&mpc_install=3305842&p3=bar";
         String extensionId = marketplaceService.getExtensionId(new URI(url));
@@ -94,6 +110,8 @@ public class MarketplaceExtensionServiceTest {
         List<Node> nodes = new ArrayList<>(2);
         nodes.add(createBindingNode());
         nodes.add(createRuleNode());
+        nodes.add(createUiNode());
+        nodes.add(createVoiceNode());
         return nodes;
     }
 
@@ -109,6 +127,20 @@ public class MarketplaceExtensionServiceTest {
         Node node = new Node();
         node.id = "3305842";
         node.packagetypes = "binding";
+        return node;
+    }
+
+    private Node createUiNode() {
+        Node node = new Node();
+        node.id = "3414678";
+        node.packagetypes = "ui";
+        return node;
+    }
+
+    private Node createVoiceNode() {
+        Node node = new Node();
+        node.id = "396962433";
+        node.packagetypes = "voice";
         return node;
     }
 

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/src/test/java/org/eclipse/smarthome/extensionservice/marketplace/internal/MarketplaceExtensionServiceTest.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/src/test/java/org/eclipse/smarthome/extensionservice/marketplace/internal/MarketplaceExtensionServiceTest.java
@@ -59,14 +59,6 @@ public class MarketplaceExtensionServiceTest {
     }
 
     @Test
-    public void shouldParseUiExtensionIdFromValidURI() throws Exception {
-        String url = BASE_PATH + "?mpc_install=3414678";
-        String extensionId = marketplaceService.getExtensionId(new URI(url));
-
-        assertThat(extensionId, is("market:ui-3414678"));
-    }
-
-    @Test
     public void shouldParseVoiceExtensionIdFromValidURI() throws Exception {
         String url = BASE_PATH + "?mpc_install=396962433";
         String extensionId = marketplaceService.getExtensionId(new URI(url));
@@ -110,7 +102,6 @@ public class MarketplaceExtensionServiceTest {
         List<Node> nodes = new ArrayList<>(2);
         nodes.add(createBindingNode());
         nodes.add(createRuleNode());
-        nodes.add(createUiNode());
         nodes.add(createVoiceNode());
         return nodes;
     }
@@ -127,13 +118,6 @@ public class MarketplaceExtensionServiceTest {
         Node node = new Node();
         node.id = "3305842";
         node.packagetypes = "binding";
-        return node;
-    }
-
-    private Node createUiNode() {
-        Node node = new Node();
-        node.id = "3414678";
-        node.packagetypes = "ui";
         return node;
     }
 

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/ESH-INF/config/config.xml
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/ESH-INF/config/config.xml
@@ -16,6 +16,16 @@
 			<description>Whether to make rule templates from the marketplace available or not.</description>
 			<default>true</default>
 		</parameter>
+	        <parameter name="ui" type="boolean" required="false">
+			<label>Include UI Extensions</label>
+			<description>Whether to make UI extensions from the marketplace available or not.</description>
+			<default>true</default>
+		</parameter>
+	        <parameter name="voice" type="boolean" required="false">
+			<label>Include Voice Extensions</label>
+			<description>Whether to make voice extensions from the marketplace available or not.</description>
+			<default>true</default>
+		</parameter>
 		<parameter name="maturity" type="integer" required="false">
 			<label>Maturity Level</label>
 			<description>Only show entries that have a certain maturity.</description>

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/ESH-INF/config/config.xml
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/ESH-INF/config/config.xml
@@ -16,11 +16,6 @@
 			<description>Whether to make rule templates from the marketplace available or not.</description>
 			<default>true</default>
 		</parameter>
-	        <parameter name="ui" type="boolean" required="false">
-			<label>Include UI Extensions</label>
-			<description>Whether to make UI extensions from the marketplace available or not.</description>
-			<default>true</default>
-		</parameter>
 	        <parameter name="voice" type="boolean" required="false">
 			<label>Include Voice Extensions</label>
 			<description>Whether to make voice extensions from the marketplace available or not.</description>

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/MarketplaceExtension.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/MarketplaceExtension.java
@@ -28,6 +28,8 @@ public class MarketplaceExtension extends Extension {
     // extension types from marketplace
     public static final String EXT_TYPE_RULE_TEMPLATE = "ruletemplate";
     public static final String EXT_TYPE_BINDING = "binding";
+    public static final String EXT_TYPE_UI = "ui";
+    public static final String EXT_TYPE_VOICE = "voice";
 
     // extension package formats from marketplace
     public static final String EXT_FORMAT_BUNDLE = "bundle";

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/MarketplaceExtension.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/MarketplaceExtension.java
@@ -28,7 +28,6 @@ public class MarketplaceExtension extends Extension {
     // extension types from marketplace
     public static final String EXT_TYPE_RULE_TEMPLATE = "ruletemplate";
     public static final String EXT_TYPE_BINDING = "binding";
-    public static final String EXT_TYPE_UI = "ui";
     public static final String EXT_TYPE_VOICE = "voice";
 
     // extension package formats from marketplace

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/internal/BundleExtensionHandler.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/internal/BundleExtensionHandler.java
@@ -57,7 +57,6 @@ public class BundleExtensionHandler implements MarketplaceExtensionHandler {
     // extension types supported by this handler
     private static final List<String> SUPPORTED_EXT_TYPES = Arrays.asList(
         MarketplaceExtension.EXT_TYPE_BINDING,
-        MarketplaceExtension.EXT_TYPE_UI,
         MarketplaceExtension.EXT_TYPE_VOICE);
 
     private final Logger logger = LoggerFactory.getLogger(BundleExtensionHandler.class);

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/internal/BundleExtensionHandler.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/internal/BundleExtensionHandler.java
@@ -16,7 +16,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -35,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A {@link MarketplaceExtensionHandler} implementation, which handles bindings as jar files (OSGi bundles) and installs
+ * A {@link MarketplaceExtensionHandler} implementation, which handles extensions as jar files (specifically, OSGi bundles) and installs
  * them through the standard OSGi bundle installation mechanism.
  * The information, which installed bundle corresponds to which extension is written to a file in the bundle's data
  * store. It is therefore wiped together with the bundles upon an OSGi "clean".
@@ -45,38 +47,46 @@ import org.slf4j.LoggerFactory;
  *
  */
 @Component(immediate = true)
-public class BindingExtensionHandler implements MarketplaceExtensionHandler {
-
+public class BundleExtensionHandler implements MarketplaceExtensionHandler {
+    // this is for backwards compatibility; if we don't see BUNDLE_FILE but
+    // we do see this, we migrate its contents to BUNDLE_FILE
     private static final String BINDING_FILE = "installedBindingsMap.csv";
 
-    private final Logger logger = LoggerFactory.getLogger(BindingExtensionHandler.class);
+    private static final String BUNDLE_FILE = "installedBundlesMap.csv";
 
-    private Map<String, Long> installedBindings;
+    // extension types supported by this handler
+    private static final List<String> SUPPORTED_EXT_TYPES = Arrays.asList(
+        MarketplaceExtension.EXT_TYPE_BINDING,
+        MarketplaceExtension.EXT_TYPE_UI,
+        MarketplaceExtension.EXT_TYPE_VOICE);
+
+    private final Logger logger = LoggerFactory.getLogger(BundleExtensionHandler.class);
+
+    private Map<String, Long> installedBundles;
 
     private BundleContext bundleContext;
 
     @Activate
     protected void activate(BundleContext bundleContext, Map<String, Object> config) {
         this.bundleContext = bundleContext;
-        installedBindings = loadInstalledBindingsMap();
+        installedBundles = loadInstalledBundlesMap();
     }
 
     @Deactivate
     protected void deactivate() {
-        this.installedBindings = null;
+        this.installedBundles = null;
         this.bundleContext = null;
     }
 
     @Override
     public boolean supports(MarketplaceExtension ext) {
-        // we support only bindings as pure OSGi bundles
-        return ext.getType().equals(MarketplaceExtension.EXT_TYPE_BINDING)
-                && ext.getPackageFormat().equals(MarketplaceExtension.EXT_FORMAT_BUNDLE);
+        // we support only certain extension types, and only as pure OSGi bundles
+        return SUPPORTED_EXT_TYPES.contains(ext.getType()) && ext.getPackageFormat().equals(MarketplaceExtension.EXT_FORMAT_BUNDLE);
     }
 
     @Override
     public boolean isInstalled(MarketplaceExtension ext) {
-        return installedBindings.containsKey(ext.getId());
+        return installedBundles.containsKey(ext.getId());
     }
 
     @Override
@@ -89,32 +99,32 @@ public class BindingExtensionHandler implements MarketplaceExtensionHandler {
             } catch (BundleException e) {
                 logger.warn("Installed bundle, but failed to start it: {}", e.getMessage());
             }
-            installedBindings.put(ext.getId(), bundle.getBundleId());
-            persistInstalledBindingsMap(installedBindings);
+            installedBundles.put(ext.getId(), bundle.getBundleId());
+            persistInstalledBundlesMap(installedBundles);
         } catch (BundleException e) {
-            logger.debug("Failed to install binding from marketplace.", e);
-            throw new MarketplaceHandlerException("Binding cannot be installed: " + e.getMessage());
+            logger.debug("Failed to install bundle from marketplace.", e);
+            throw new MarketplaceHandlerException("Bundle cannot be installed: " + e.getMessage());
         }
     }
 
     @Override
     public void uninstall(MarketplaceExtension ext) throws MarketplaceHandlerException {
-        Long id = installedBindings.get(ext.getId());
+        Long id = installedBundles.get(ext.getId());
         if (id != null) {
             Bundle bundle = bundleContext.getBundle(id);
             if (bundle != null) {
                 try {
                     bundle.stop();
                     bundle.uninstall();
-                    installedBindings.remove(ext.getId());
-                    persistInstalledBindingsMap(installedBindings);
+                    installedBundles.remove(ext.getId());
+                    persistInstalledBundlesMap(installedBundles);
                 } catch (BundleException e) {
-                    throw new MarketplaceHandlerException("Failed deinstalling binding: " + e.getMessage());
+                    throw new MarketplaceHandlerException("Failed deinstalling bundle: " + e.getMessage());
                 }
             } else {
                 // we do not have such a bundle, so let's remove it from our internal map
-                installedBindings.remove(ext.getId());
-                persistInstalledBindingsMap(installedBindings);
+                installedBundles.remove(ext.getId());
+                persistInstalledBundlesMap(installedBundles);
                 throw new MarketplaceHandlerException("Id not known.");
             }
         } else {
@@ -122,37 +132,46 @@ public class BindingExtensionHandler implements MarketplaceExtensionHandler {
         }
     }
 
-    private Map<String, Long> loadInstalledBindingsMap() {
-        File dataFile = bundleContext.getDataFile(BINDING_FILE);
+    private Map<String, Long> loadInstalledBundlesMap() {
+        File dataFile = bundleContext.getDataFile(BUNDLE_FILE);
         if (dataFile != null && dataFile.exists()) {
-            try (FileReader reader = new FileReader(dataFile)) {
-                LineIterator lineIterator = IOUtils.lineIterator(reader);
-                Map<String, Long> map = new HashMap<>();
-                while (lineIterator.hasNext()) {
-                    String line = lineIterator.nextLine();
-                    String[] parts = line.split(";");
-                    if (parts.length == 2) {
-                        try {
-                            map.put(parts[0], Long.valueOf(parts[1]));
-                        } catch (NumberFormatException e) {
-                            logger.debug("Cannot parse '{}' as a number in file {} - ignoring it.", parts[1],
-                                    dataFile.getName());
-                        }
-                    } else {
-                        logger.debug("Invalid line in file {} - ignoring it:\n{}", dataFile.getName(), line);
-                    }
-                }
-                return map;
-            } catch (IOException e) {
-                logger.debug("File '{}' for installed bindings does not exist.", dataFile.getName());
-                // ignore and just return an empty map
-            }
+            return loadInstalledBundlesFile(dataFile);
+        }
+        File obsoleteFile = bundleContext.getDataFile(BINDING_FILE);
+        if (obsoleteFile != null & obsoleteFile.exists()) {
+            return loadInstalledBundlesFile(obsoleteFile);
         }
         return new HashMap<>();
     }
 
-    private synchronized void persistInstalledBindingsMap(Map<String, Long> map) {
-        File dataFile = bundleContext.getDataFile(BINDING_FILE);
+    private Map<String, Long> loadInstalledBundlesFile(File dataFile) {
+        try (FileReader reader = new FileReader(dataFile)) {
+            LineIterator lineIterator = IOUtils.lineIterator(reader);
+            Map<String, Long> map = new HashMap<>();
+            while (lineIterator.hasNext()) {
+                String line = lineIterator.nextLine();
+                String[] parts = line.split(";");
+                if (parts.length == 2) {
+                    try {
+                        map.put(parts[0], Long.valueOf(parts[1]));
+                    } catch (NumberFormatException e) {
+                        logger.debug("Cannot parse '{}' as a number in file {} - ignoring it.", parts[1],
+                            dataFile.getName());
+                    }
+                } else {
+                    logger.debug("Invalid line in file {} - ignoring it:\n{}", dataFile.getName(), line);
+                }
+            }
+            return map;
+        } catch (IOException e) {
+            logger.debug("File '{}' for installed bundles does not exist.", dataFile.getName());
+            // ignore and just return an empty map
+        }
+        return new HashMap<>();
+    }
+
+    private synchronized void persistInstalledBundlesMap(Map<String, Long> map) {
+        File dataFile = bundleContext.getDataFile(BUNDLE_FILE);
         if (dataFile != null) {
             try (FileWriter writer = new FileWriter(dataFile)) {
                 for (Entry<String, Long> entry : map.entrySet()) {
@@ -162,7 +181,7 @@ public class BindingExtensionHandler implements MarketplaceExtensionHandler {
                 logger.warn("Failed writing file '{}': {}", dataFile.getName(), e.getMessage());
             }
         } else {
-            logger.debug("System does not support bundle data files -> not persisting installed binding info");
+            logger.debug("System does not support bundle data files -> not persisting installed bundle info");
         }
     }
 

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/internal/MarketplaceExtensionService.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/internal/MarketplaceExtensionService.java
@@ -68,7 +68,6 @@ public class MarketplaceExtensionService implements ExtensionService {
     private enum PackageType {
         BINDING("binding", MarketplaceExtension.EXT_TYPE_BINDING, "bindings", "Bindings"),
         RULE_TEMPLATE("rule_template", MarketplaceExtension.EXT_TYPE_RULE_TEMPLATE, "ruletemplates", "Rule Templates"),
-        UI("ui", MarketplaceExtension.EXT_TYPE_UI, "ui", "UI"),
         VOICE("voice", MarketplaceExtension.EXT_TYPE_VOICE, "voice", "Voice");
 
         /**

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/internal/MarketplaceExtensionService.java
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/src/main/java/org/eclipse/smarthome/extensionservice/marketplace/internal/MarketplaceExtensionService.java
@@ -15,6 +15,7 @@ package org.eclipse.smarthome.extensionservice.marketplace.internal;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -61,10 +62,42 @@ import org.slf4j.LoggerFactory;
         ConfigurableService.SERVICE_PROPERTY_LABEL + "=Marketplace" //
 })
 public class MarketplaceExtensionService implements ExtensionService {
+    /**
+     * Enumeration of supported extension package types plus associated attributes.
+     */
+    private enum PackageType {
+        BINDING("binding", MarketplaceExtension.EXT_TYPE_BINDING, "bindings", "Bindings"),
+        RULE_TEMPLATE("rule_template", MarketplaceExtension.EXT_TYPE_RULE_TEMPLATE, "ruletemplates", "Rule Templates"),
+        UI("ui", MarketplaceExtension.EXT_TYPE_UI, "ui", "UI"),
+        VOICE("voice", MarketplaceExtension.EXT_TYPE_VOICE, "voice", "Voice");
 
-    // constants used in marketplace nodes
-    private static final String MP_PACKAGETYPE_BINDING = "binding";
-    private static final String MP_PACKAGETYPE_RULE_TEMPLATE = "rule_template";
+        /**
+         * Constant used in marketplace nodes.
+         */
+        final String typeName;
+
+        /**
+         * MarketplaceExtension.EXT_TYPE_ symbolic name.
+         */
+        final String extType;
+
+        /**
+         * Key used in config file for setting visibility property.
+         */
+        final String configKey;
+
+        /**
+         * Label to display on Paper UI tab.
+         */
+        final String label;
+
+        private PackageType(String typeName, String extType, String configKey, String label) {
+            this.typeName = typeName;
+            this.extType = extType;
+            this.configKey = configKey;
+            this.label = label;
+        }
+    }
 
     private static final String MARKETPLACE_HOST = "marketplace.eclipse.org";
     private static final Pattern EXTENSION_ID_PATTERN = Pattern.compile(".*?mpc_install=([^&]+?)(&.*)?");
@@ -79,8 +112,9 @@ public class MarketplaceExtensionService implements ExtensionService {
                                                                                           // some
     // invalid elements
 
-    private boolean includeBindings = true;
-    private boolean includeRuleTemplates = true;
+    // configured package type inclusion settings, keyed by package typeName
+    private Map<String, Boolean> packageTypeInclusions = new HashMap<>();
+
     private int maturityLevel = 1;
     private final Set<MarketplaceExtensionHandler> extensionHandlers = new HashSet<>();
 
@@ -98,13 +132,11 @@ public class MarketplaceExtensionService implements ExtensionService {
 
     @Modified
     protected void modified(Map<String, Object> config) {
-        Object bindingCfg = config.get("bindings");
-        if (bindingCfg != null) {
-            this.includeBindings = bindingCfg.toString().equals(Boolean.TRUE.toString());
-        }
-        Object ruleTemplateCfg = config.get("ruletemplates");
-        if (ruleTemplateCfg != null) {
-            this.includeRuleTemplates = ruleTemplateCfg.toString().equals(Boolean.TRUE.toString());
+        for (PackageType packageType : PackageType.values()) {
+            Object inclusionCfg = config.get(packageType.configKey);
+            if (inclusionCfg != null) {
+                packageTypeInclusions.put(packageType.typeName, inclusionCfg.toString().equals(Boolean.TRUE.toString()));
+            }
         }
         Object cfgMaturityLevel = config.get("maturity");
         if (cfgMaturityLevel != null) {
@@ -147,10 +179,7 @@ public class MarketplaceExtensionService implements ExtensionService {
             if (toMaturityLevel(node.status) < this.maturityLevel) {
                 continue;
             }
-            if (!includeBindings && node.packagetypes.equals(MP_PACKAGETYPE_BINDING)) {
-                continue;
-            }
-            if (!includeRuleTemplates && node.packagetypes.equals(MP_PACKAGETYPE_RULE_TEMPLATE)) {
+            if (!packageTypeInclusions.getOrDefault(node.packagetypes, true)) {
                 continue;
             }
 
@@ -185,17 +214,14 @@ public class MarketplaceExtensionService implements ExtensionService {
             logger.debug("Ignoring node {} due to invalid content.", node.id);
             return null;
         }
-        if (MP_PACKAGETYPE_BINDING.equals(node.packagetypes)) {
-            MarketplaceExtension ext = new MarketplaceExtension(extId, MarketplaceExtension.EXT_TYPE_BINDING, name,
+        for (PackageType packageType : PackageType.values()) {
+            if (packageType.typeName.equals(node.packagetypes)) {
+                MarketplaceExtension ext = new MarketplaceExtension(extId, packageType.extType, name,
                     version, node.supporturl, false, desc, null, node.image, node.updateurl, node.packageformat);
-            return ext;
-        } else if (MP_PACKAGETYPE_RULE_TEMPLATE.equals(node.packagetypes)) {
-            MarketplaceExtension ext = new MarketplaceExtension(extId, MarketplaceExtension.EXT_TYPE_RULE_TEMPLATE,
-                    name, version, node.supporturl, false, desc, null, node.image, node.updateurl, node.packageformat);
-            return ext;
-        } else {
-            return null;
+                return ext;
+            }
         }
+        return null;
     }
 
     @Override
@@ -212,19 +238,13 @@ public class MarketplaceExtensionService implements ExtensionService {
     public List<ExtensionType> getTypes(Locale locale) {
         ArrayList<ExtensionType> types = new ArrayList<>(2);
         List<Extension> exts = getExtensions(locale);
-        if (includeBindings) {
-            for (Extension ext : exts) {
-                if (ext.getType().equals(MarketplaceExtension.EXT_TYPE_BINDING)) {
-                    types.add(new ExtensionType(MarketplaceExtension.EXT_TYPE_BINDING, "Bindings"));
-                    break;
-                }
-            }
-        }
-        if (includeRuleTemplates) {
-            for (Extension ext : exts) {
-                if (ext.getType().equals(MarketplaceExtension.EXT_TYPE_RULE_TEMPLATE)) {
-                    types.add(new ExtensionType(MarketplaceExtension.EXT_TYPE_RULE_TEMPLATE, "Rule Templates"));
-                    break;
+        for (PackageType packageType : PackageType.values()) {
+            if (packageTypeInclusions.getOrDefault(packageType.typeName, true)) {
+                for (Extension ext : exts) {
+                    if (ext.getType().equals(packageType.extType)) {
+                        types.add(new ExtensionType(packageType.extType, packageType.label));
+                        break;
+                    }
                 }
             }
         }
@@ -305,18 +325,15 @@ public class MarketplaceExtensionService implements ExtensionService {
 
     private String getExtensionId(Node node) {
         StringBuilder sb = new StringBuilder(MarketplaceExtension.EXT_PREFIX);
-        switch (node.packagetypes) {
-            case MP_PACKAGETYPE_RULE_TEMPLATE:
-                sb.append(MarketplaceExtension.EXT_TYPE_RULE_TEMPLATE).append("-");
-                break;
-            case MP_PACKAGETYPE_BINDING:
-                sb.append(MarketplaceExtension.EXT_TYPE_BINDING).append("-");
-                break;
-            default:
-                return null;
+        boolean found = false;
+        for (PackageType packageType : PackageType.values()) {
+            if (packageType.typeName.equals(node.packagetypes)) {
+                sb.append(packageType.extType).append("-");
+                sb.append(node.id.replaceAll("[^a-zA-Z0-9_]", ""));
+                return sb.toString();
+            }
         }
-        sb.append(node.id.replaceAll("[^a-zA-Z0-9_]", ""));
-        return sb.toString();
+        return null;
     }
 
     private int toMaturityLevel(String maturity) {


### PR DESCRIPTION
This PR is for the discussion in 

https://community.openhab.org/t/moving-beyond-bindings-in-the-iot-addon-marketplace/42194

I tried to make the code a bit more data-driven (via enum PackageType) to make it easier to keep adding more extension types.  For the moment, I only added Voice and UI, but I can add the others (actions, persistence, transformations) if desired.

I renamed BindingExtensionHandler to BundleExtensionHandler for generality.  I also arranged for migration of the old installedBindingsMap.csv to the new installedBundlesMap.csv.  This might be unnecessary since I think this file gets discarded during an upgrade anyway, but it seems like the safest thing to do.

I tested by enabling plugin org.eclipse.smarthome.extensionservice.marketplace in my Eclipse workspace configuration.  For UI, I was able to test https://marketplace.eclipse.org/content/gauge-widget-habpanel.  With this change, it now shows up in the UI tab under extensions in the Paper UI, and I was able to successfully install+uninstall it.

For Voice, I am not able to do full testing since the Marketplace server does not currently allow for this package type when publishing an addon.  So I'll need someone's help to make that happen.

Bug: https://github.com/eclipse/smarthome/issues/3320

Signed-off-by: John Sichi <jsichi@gmail.com>