### PR TITLE
Add guava avoidance remark to coding guidelines

### DIFF
--- a/docs/documentation/development/guidelines.md
+++ b/docs/documentation/development/guidelines.md
@@ -63,7 +63,7 @@ Test classes do not have to be annotated.
 1. A few common utility libraries are available that every Eclipse SmartHome based solution has to provide and which can be used throughout the code (and which are made available in the target platform):
  - Apache Commons IO (v2.2)
  - Apache Commons Lang (v2.6)
- - Google Guava (v10.0.1)
+ - ~~Google Guava (v10.0.1)~~ (historically allowed, to be avoided in new contributions)
 
 ## D. Runtime Behavior
 


### PR DESCRIPTION
In the realm of #4743 and #2801 et al. it makes sense to
not accept any new contributions adding unecessary usages
of guava again, therefore the documentation is updated
accordingly.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>