### PR TITLE
Fix Event handling in BasicUI

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.basic/web-src/smarthome.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/web-src/smarthome.js
@@ -2228,9 +2228,9 @@
 	document.addEventListener("DOMContentLoaded", function() {
 		smarthome.UI = new UI(document);
 		smarthome.UI.layoutChangeProxy = new VisibilityChangeProxy(100, 50);
+		smarthome.eventMapper = new EventMapper();
 		smarthome.UI.initControls();
 		smarthome.changeListener = new ChangeListener();
-		smarthome.eventMapper = new EventMapper();
 
 		window.addEventListener("beforeunload", function() {
 			smarthome.changeListener.suppressErrors();


### PR DESCRIPTION
Seems like PR #5109 initialized its new EventHandler after the controls.
But apparently the controls need this new handler and thus it has to be
initialized before them.

Fixes #5348

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>