### PR TITLE
Simple Magic Firmware Update ThingType

### DIFF
--- a/bundles/test/org.eclipse.smarthome.magic/ESH-INF/thing/thing-types.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/ESH-INF/thing/thing-types.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="magic" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<thing:thing-descriptions bindingId="magic"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
@@ -100,5 +101,30 @@
 		<channels>
 			<channel id="number" typeId="number" />
 		</channels>
+	</thing-type>
+
+	<thing-type id="firmware-update">
+		<label>Magic Firmware Updatable Thing</label>
+		<description>A thing which allows updating its firmware</description>
+
+		<properties>
+			<property name="firmwareVersion">0.1.0</property>
+		</properties>
+
+		<config-description uri="thing-type:magic:update-config">
+			<parameter name="updateModel" type="text" required="true">
+				<required>true</required>
+				<options>
+					<option value="Alohomora">Alohomora</option>
+					<option value="Colloportus">Colloportus</option>
+					<option value="Lumos">Lumos</option>
+					<option value="Nox">Nox</option>
+				</options>
+				<label>Model ID</label>
+				<description>The model of the magic firmware update thing</description>
+				<default>Not specified</default>
+			</parameter>
+		</config-description>
+
 	</thing-type>
 </thing:thing-descriptions>

--- a/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
@@ -26,12 +26,15 @@ Import-Package:
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
  org.eclipse.smarthome.core.thing.binding.builder,
+ org.eclipse.smarthome.core.thing.binding.firmware,
+ org.eclipse.smarthome.core.thing.firmware,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.magic.binding,
  org.eclipse.smarthome.magic.binding.handler,
  org.eclipse.smarthome.magic.service,
  org.osgi.framework,
+ org.osgi.service.component,
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/bundles/test/org.eclipse.smarthome.magic/README.md
+++ b/bundles/test/org.eclipse.smarthome.magic/README.md
@@ -4,7 +4,6 @@ The Magic Bundle is a virtual device bundle which provides different Things, Cha
 
 Future plans:
 
-* Firmware update support
 * Simulate communication errors
 * Provide REST API to update thing status from _outside_
 * Provide REST API to temporarily create new Channels/Things
@@ -14,6 +13,13 @@ Future plans:
 * Magic Light - On/Off
 * Magic Light - Dimmable
 * Magic Light - Color
+* Magic Sensor - Door/Window Contact
+* Magic Location
+* Magic Configurable Thing
+* Magic Thermostat
+* Magic Delayed Online Thing - goes online after some time
+* Magic Firmware Updatable Thing - can be firmware updated, depending on the model
+
 
 ## Discovery
 
@@ -34,6 +40,11 @@ Available channels:
 * switch - the on/off toggle maps to a Switch item.
 * brightness - the brightness value maps to a Dimmer item.
 * color - the color maps to a Color item.
+* alert - the alert function of the color light.
+* contact - the contact of the door/window contact.
+* location - the location of the magic location.
+* temperature - the temperature of the magic thermostat.
+* number - the delay in seconds for the delayed thing to go online.
 
 ## Full Example
 

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/MagicBindingConstants.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/MagicBindingConstants.java
@@ -24,7 +24,7 @@ public class MagicBindingConstants {
 
     public static final String BINDING_ID = "magic";
 
-    // List all Thing Type UIDs, related to the Hue Binding
+    // List all Thing Type UIDs, related to the Magic Binding
 
     // generic thing types
     public static final ThingTypeUID THING_TYPE_EXTENSIBLE_THING = new ThingTypeUID(BINDING_ID, "extensible-thing");
@@ -36,6 +36,7 @@ public class MagicBindingConstants {
     public static final ThingTypeUID THING_TYPE_DELAYED_THING = new ThingTypeUID(BINDING_ID, "delayed-thing");
     public static final ThingTypeUID THING_TYPE_LOCATION = new ThingTypeUID(BINDING_ID, "location-thing");
     public static final ThingTypeUID THING_TYPE_THERMOSTAT = new ThingTypeUID(BINDING_ID, "thermostat");
+    public static final ThingTypeUID THING_TYPE_FIRMWARE_UPDATE = new ThingTypeUID(BINDING_ID, "firmware-update");
 
     // List all channels
     public static final String CHANNEL_SWITCH = "switch";
@@ -46,4 +47,11 @@ public class MagicBindingConstants {
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_SET_TEMPERATURE = "set-temperature";
 
+    // Firmware update needed models
+    public static final String UPDATE_MODEL_PROPERTY = "updateModel";
+
+    public static final String MODEL_ALOHOMORA = "Alohomora";
+    public static final String MODEL_COLLOPORTUS = "Colloportus";
+    public static final String MODEL_LUMOS = "Lumos";
+    public static final String MODEL_NOX = "Nox";
 }

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicConfigurableThingHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicConfigurableThingHandler.java
@@ -24,7 +24,7 @@ import org.eclipse.smarthome.core.types.Command;
 /**
  * Handler for thing with a configuration parameter
  *
- * @author Stefan Triller
+ * @author Stefan Triller - Initial contribution
  *
  */
 @NonNullByDefault

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicFirmwareUpdateThingHandler.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/handler/MagicFirmwareUpdateThingHandler.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.magic.binding.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.thing.binding.firmware.Firmware;
+import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler;
+import org.eclipse.smarthome.core.thing.binding.firmware.ProgressCallback;
+import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.magic.binding.MagicBindingConstants;
+
+/**
+ * Handler for firmware updatable magic things. Defines full progress sequence and simulates firmware update with small
+ * delays between the steps.
+ *
+ * @author Dimitar Ivanov - Initial contribution
+ *
+ */
+@NonNullByDefault
+public class MagicFirmwareUpdateThingHandler extends BaseThingHandler implements FirmwareUpdateHandler {
+
+    private static final int STEP_DELAY = 100;
+
+    public MagicFirmwareUpdateThingHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        // Nothing to do
+    }
+
+    @Override
+    public void initialize() {
+        String updateModel = (String) getThing().getConfiguration().get(MagicBindingConstants.UPDATE_MODEL_PROPERTY);
+        switch (updateModel) {
+            case MagicBindingConstants.MODEL_ALOHOMORA:
+            case MagicBindingConstants.MODEL_COLLOPORTUS:
+            case MagicBindingConstants.MODEL_LUMOS:
+            case MagicBindingConstants.MODEL_NOX:
+                getThing().setProperty(Thing.PROPERTY_MODEL_ID, updateModel);
+        }
+
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void updateFirmware(Firmware firmware, ProgressCallback progressCallback) {
+        progressCallback.defineSequence(ProgressStep.DOWNLOADING, ProgressStep.TRANSFERRING, ProgressStep.UPDATING,
+                ProgressStep.REBOOTING, ProgressStep.WAITING);
+
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.FIRMWARE_UPDATING, "Firmware is updating");
+
+        progressCallback.next();
+        for (int percent = 1; percent < 100; percent++) {
+            try {
+                Thread.sleep(STEP_DELAY);
+            } catch (InterruptedException e) {
+                progressCallback.failed("Magic firmware update progress callback interrupted while sleeping", e);
+            }
+            progressCallback.update(percent);
+            if (percent % 20 == 0) {
+                progressCallback.next();
+            }
+        }
+
+        getThing().setProperty(Thing.PROPERTY_FIRMWARE_VERSION, firmware.getVersion());
+
+        progressCallback.success();
+
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void cancel() {
+        // not needed for now
+    }
+
+    @Override
+    public boolean isUpdateExecutable() {
+        return true;
+    }
+}

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
@@ -27,6 +27,7 @@ import org.eclipse.smarthome.magic.binding.handler.MagicContactHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicDelayedOnlineHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicDimmableLightHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicExtensibleThingHandler;
+import org.eclipse.smarthome.magic.binding.handler.MagicFirmwareUpdateThingHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicLocationThingHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicOnOffLightHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicThermostatThingHandler;
@@ -45,7 +46,8 @@ public class MagicHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.newHashSet(THING_TYPE_EXTENSIBLE_THING,
             THING_TYPE_ON_OFF_LIGHT, THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_COLOR_LIGHT, THING_TYPE_CONTACT_SENSOR,
-            THING_TYPE_CONFIG_THING, THING_TYPE_DELAYED_THING, THING_TYPE_LOCATION, THING_TYPE_THERMOSTAT);
+            THING_TYPE_CONFIG_THING, THING_TYPE_DELAYED_THING, THING_TYPE_LOCATION, THING_TYPE_THERMOSTAT,
+            THING_TYPE_FIRMWARE_UPDATE);
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -82,6 +84,9 @@ public class MagicHandlerFactory extends BaseThingHandlerFactory {
         }
         if (thingTypeUID.equals(THING_TYPE_THERMOSTAT)) {
             return new MagicThermostatThingHandler(thing);
+        }
+        if (thingTypeUID.equals(THING_TYPE_FIRMWARE_UPDATE)) {
+            return new MagicFirmwareUpdateThingHandler(thing);
         }
 
         return null;

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/firmware/MagicFirmwareProvider.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/firmware/MagicFirmwareProvider.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.magic.binding.internal.firmware;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.firmware.Firmware;
+import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareBuilder;
+import org.eclipse.smarthome.core.thing.firmware.FirmwareProvider;
+import org.eclipse.smarthome.magic.binding.MagicBindingConstants;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Provides firmware for the magic thing type for firmware update.
+ *
+ * @author Dimitar Ivanov - Initial contribution
+ */
+@Component(service = FirmwareProvider.class)
+public class MagicFirmwareProvider implements FirmwareProvider {
+
+    //@formatter:off
+    private final Set<Firmware> magicFirmwares = Stream
+            // General firmware versions for the thing type
+            .of(createFirmware(null, "0.1.0", false),
+                createFirmware(null, "1.0.0", false),
+             // Model restricted firmware versions
+                createFirmware(MagicBindingConstants.MODEL_ALOHOMORA, "1.0.1", true),
+                createFirmware(MagicBindingConstants.MODEL_ALOHOMORA, "1.1.0", true),
+                createFirmware(MagicBindingConstants.MODEL_COLLOPORTUS, "1.0.1", true),
+                createFirmware(MagicBindingConstants.MODEL_COLLOPORTUS, "1.2.0", true),
+                createFirmware(MagicBindingConstants.MODEL_LUMOS, "2.3.1", true),
+                createFirmware(MagicBindingConstants.MODEL_LUMOS, "2.5.0", true)
+                ).collect(Collectors.toSet());
+    //@formatter:on
+
+    @Override
+    public Firmware getFirmware(Thing thing, String version) {
+        return getFirmware(thing, version, null);
+    }
+
+    @SuppressWarnings("null")
+    @Override
+    public Firmware getFirmware(Thing thing, String version, Locale locale) {
+        return getFirmwares(thing, locale).stream().filter(firmware -> firmware.getVersion().equals(version))
+                .findFirst().get();
+    }
+
+    @Override
+    public Set<Firmware> getFirmwares(Thing thing) {
+        return getFirmwares(thing, null);
+    }
+
+    @Override
+    public Set<Firmware> getFirmwares(Thing thing, Locale locale) {
+        return magicFirmwares.stream().filter(firmware -> firmware.isSuitableFor(thing)).collect(Collectors.toSet());
+    }
+
+    private static Firmware createFirmware(final String model, final String version, boolean modelRestricted) {
+        Firmware firmware = FirmwareBuilder.create(MagicBindingConstants.THING_TYPE_FIRMWARE_UPDATE, version)
+                .withModel(model).withModelRestricted(modelRestricted).build();
+        return firmware;
+    }
+}


### PR DESCRIPTION
Related to #4964. The following changes are introduced:
- Used to test the refactoring in PR #5343 and is now rebased, because #5343 is merged;
- Added simple magic firmware update thing type
- The model of the magic firmware update thing can be configured during pairing 
- Implemented simple firmware provider which provides several hardcoded firmware for different models;
- Updated the README.MD file to some of the previous changes + the new ones.

Signed-off-by: Dimitar Ivanov <dstivanov@gmail.com>