### PR TITLE
print thread info on failed duration assertions in SafeCallerImplTest

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
@@ -18,6 +18,10 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.lang.Thread.State;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -536,16 +540,41 @@ public class SafeCallerImplTest extends JavaTest {
             runnable.run();
         } finally {
             long durationMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-            if (low > -1) {
-                assertTrue(MessageFormat.format("Duration should have been above {0} but was {1}", low, durationMillis),
-                        durationMillis >= low);
-            }
-            if (high > -1) {
-                assertTrue(
-                        MessageFormat.format("Duration should have been below {0} but was {1}", high, durationMillis),
-                        durationMillis < high);
+            try {
+                if (low > -1) {
+                    assertTrue(MessageFormat.format("Duration should have been above {0} but was {1}", low,
+                            durationMillis), durationMillis >= low);
+                }
+                if (high > -1) {
+                    assertTrue(MessageFormat.format("Duration should have been below {0} but was {1}", high,
+                            durationMillis), durationMillis < high);
+                }
+            } catch (AssertionError e) {
+                System.out.println(printThreadDump(name.getMethodName()));
+                throw e;
             }
         }
+    }
+
+    private static String printThreadDump(String threadNamePrefix) {
+        final StringBuilder sb = new StringBuilder();
+        final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        for (ThreadInfo threadInfo : threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds())) {
+            if (!threadInfo.getThreadName().startsWith(threadNamePrefix)) {
+                continue;
+            }
+            sb.append("\"");
+            sb.append(threadInfo.getThreadName());
+            sb.append("\" ");
+            sb.append(State.class.getName());
+            sb.append(": ");
+            sb.append(threadInfo.getThreadState());
+            for (final StackTraceElement stackTraceElement : threadInfo.getStackTrace()) {
+                sb.append("\n    at ");
+                sb.append(stackTraceElement);
+            }
+        }
+        return sb.toString();
     }
 
     private static Object sleep(int duration) {


### PR DESCRIPTION
We have the `SafeCallerImplTest` failing every now and then on some CI servers. I didn't manage yet to reproduce that locally.

With this PR I'd like to gain an insight into what the affected threads are doing at these moments. Hopefully this will help to understand whether really just the CI servers are under such heavy load or if we actually have a "real" problem anywhere.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>