### PR TITLE
Added null annotations to transformation services

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.transform.test/.classpath
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/test/java"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/org.eclipse.smarthome.core.transform"/>
+	<classpathentry kind="output" path="target/test-classes"/>
+</classpath>

--- a/bundles/core/org.eclipse.smarthome.core.transform.test/.project
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.smarthome.core.transform.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/bundles/core/org.eclipse.smarthome.core.transform.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/META-INF/MANIFEST.MF
@@ -1,0 +1,19 @@
+Manifest-Version: 1.0
+Bundle-ClassPath: .
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Core Transform Tests
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-SymbolicName: org.eclipse.smarthome.core.transform.test
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.10.0.qualifier
+Fragment-Host: org.eclipse.smarthome.core.transform
+Import-Package: 
+ org.eclipse.jdt.annotation;resolution:=optional,
+ org.eclipse.smarthome.test,
+ org.eclipse.smarthome.test.java,
+ org.hamcrest;core=split,
+ org.junit,
+ org.junit.rules,
+ org.junit.runner,
+ org.junit.runners,
+ org.osgi.service.cm

--- a/bundles/core/org.eclipse.smarthome.core.transform.test/NOTICE
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/NOTICE
@@ -1,0 +1,19 @@
+This content is produced and maintained by the Eclipse SmartHome project.
+
+* Project home: https://eclipse.org/smarthome/
+
+== Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0/.
+
+== Source Code
+
+https://github.com/eclipse/smarthome
+
+== Copyright Holders
+
+See the NOTICE file distributed with the source code at
+https://github.com/eclipse/smarthome/blob/master/NOTICE
+for detailed information regarding copyright ownership.

--- a/bundles/core/org.eclipse.smarthome.core.transform.test/build.properties
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/build.properties
@@ -1,0 +1,5 @@
+source.. = src/test/java/
+output.. = target/test-classes/
+bin.includes = META-INF/,\
+               .,\
+               NOTICE

--- a/bundles/core/org.eclipse.smarthome.core.transform.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>core</artifactId>
+    <groupId>org.eclipse.smarthome.bundles</groupId>
+    <version>0.10.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.eclipse.smarthome.core</groupId>
+  <artifactId>org.eclipse.smarthome.core.transform.test</artifactId>
+
+  <packaging>eclipse-test-plugin</packaging>
+
+  <name>Eclipse SmartHome Core Transform Test</name>
+
+  <properties>
+    <bundle.symbolicName>org.eclipse.smarthome.core.transform.test</bundle.symbolicName>
+    <bundle.namespace>org.eclipse.smarthome.core.transform.test</bundle.namespace>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>target-platform-configuration</artifactId>
+        <configuration>
+          <dependency-resolution>
+            <extraRequirements>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.ds</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.event</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core.thing</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core.transform</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.equinox.cm</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+              <requirement>
+                <type>eclipse-plugin</type>
+                <id>org.eclipse.smarthome.core</id>
+                <versionRange>0.0.0</versionRange>
+              </requirement>
+            </extraRequirements>
+          </dependency-resolution>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${tycho-groupid}</groupId>
+        <artifactId>tycho-surefire-plugin</artifactId>
+        <configuration>
+          <bundleStartLevel>
+            <bundle>
+              <id>org.eclipse.equinox.ds</id>
+              <level>1</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core.transform</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core.thing</id>
+              <level>4</level>
+              <autoStart>true</autoStart>
+            </bundle>
+
+            <bundle>
+              <id>org.eclipse.equinox.event</id>
+              <level>2</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.equinox.cm</id>
+              <level>2</level>
+              <autoStart>true</autoStart>
+            </bundle>
+            <bundle>
+              <id>org.eclipse.smarthome.core</id>
+              <level>3</level>
+              <autoStart>true</autoStart>
+            </bundle>
+          </bundleStartLevel>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/bundles/core/org.eclipse.smarthome.core.transform.test/src/test/java/org/eclipse/smarthome/core/transform/actions/TransformationTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/src/test/java/org/eclipse/smarthome/core/transform/actions/TransformationTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.transform.actions;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.smarthome.core.transform.TransformationException;
+import org.junit.Test;
+
+public class TransformationTest {
+
+    @Test
+    public void testTransform() {
+        String result = Transformation.transform("UnknownTransformation", "function", "test");
+        assertEquals("test", result);
+    }
+
+    @Test
+    public void testTransformRaw() {
+        try {
+            Transformation.transformRaw("UnknownTransformation", "function", "test");
+        } catch (TransformationException e) {
+            assertEquals("No transformation service 'UnknownTransformation' could be found.", e.getMessage());
+        }
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public abstract class AbstractFileTransformationService<T> implements TransformationService {
 
-    @NonNullByDefault({})
+    @Nullable
     private WatchService watchService = null;
 
     protected final Map<String, T> cachedFiles = new ConcurrentHashMap<>();

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
@@ -120,7 +120,7 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
      * @throws TransformationException
      */
     @Override
-    public String transform(String filename, String source) throws TransformationException {
+    public @Nullable String transform(String filename, String source) throws TransformationException {
         if (filename == null || source == null) {
             throw new TransformationException("the given parameters 'filename' and 'source' must not be null");
         }

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/AbstractFileTransformationService.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.FilenameUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.i18n.LocaleProvider;
 import org.osgi.framework.BundleContext;
@@ -49,8 +51,10 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - File caching mechanism
  * @author Markus Rathgeb - Add locale provider support
  */
+@NonNullByDefault
 public abstract class AbstractFileTransformationService<T> implements TransformationService {
 
+    @NonNullByDefault({})
     private WatchService watchService = null;
 
     protected final Map<String, T> cachedFiles = new ConcurrentHashMap<>();
@@ -58,7 +62,9 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
 
     private final Logger logger = LoggerFactory.getLogger(AbstractFileTransformationService.class);
 
+    @NonNullByDefault({})
     private LocaleProvider localeProvider;
+    @NonNullByDefault({})
     private ServiceTracker<LocaleProvider, LocaleProvider> localeProviderTracker;
 
     private class LocaleProviderServiceTrackerCustomizer
@@ -71,17 +77,17 @@ public abstract class AbstractFileTransformationService<T> implements Transforma
         }
 
         @Override
-        public LocaleProvider addingService(ServiceReference<LocaleProvider> reference) {
+        public LocaleProvider addingService(@Nullable ServiceReference<LocaleProvider> reference) {
             localeProvider = context.getService(reference);
             return localeProvider;
         }
 
         @Override
-        public void modifiedService(ServiceReference<LocaleProvider> reference, LocaleProvider service) {
+        public void modifiedService(@Nullable ServiceReference<LocaleProvider> reference, LocaleProvider service) {
         }
 
         @Override
-        public void removedService(ServiceReference<LocaleProvider> reference, LocaleProvider service) {
+        public void removedService(@Nullable ServiceReference<LocaleProvider> reference, LocaleProvider service) {
             localeProvider = null;
         }
 

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationException.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationException.java
@@ -12,12 +12,15 @@
  */
 package org.eclipse.smarthome.core.transform;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * A TransformationException is thrown when any step of a transformation went
  * wrong. The originating exception should be attached to increase traceability.
  *
  * @author Thomas.Eichstaedt-Engelen
  */
+@NonNullByDefault
 public class TransformationException extends Exception {
 
     /** generated serial Version UID */

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationHelper.java
@@ -82,10 +82,10 @@ public class TransformationHelper {
      * @param context a valid bundle context, required for accessing the services
      * @param stateDescPattern the pattern that contains the transformation instructions
      * @param state the state to be formatted before being passed into the transformation function
-     * @return the result of the transformation
+     * @return the result of the transformation. If no transformation was done, <code>null</code> is returned
      * @throws TransformationException if transformation service is not available or the transformation failed
      */
-    public static String transform(BundleContext context, String stateDescPattern, String state)
+    public static @Nullable String transform(BundleContext context, String stateDescPattern, String state)
             throws TransformationException {
         Matcher matcher = EXTRACT_TRANSFORMFUNCTION_PATTERN.matcher(stateDescPattern);
         if (matcher.find()) {

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationHelper.java
@@ -51,6 +51,7 @@ public class TransformationHelper {
      * Queries the OSGi service registry for a service that provides a transformation service of
      * a given transformation type (e.g. REGEX, XSLT, etc.)
      *
+     * @param context the bundle context which can be null
      * @param transformationType the desired transformation type
      * @return a service instance or null, if none could be found
      */

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationHelper.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationHelper.java
@@ -17,6 +17,8 @@ import java.util.IllegalFormatException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
@@ -27,6 +29,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public class TransformationHelper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TransformationHelper.class);
@@ -51,7 +54,8 @@ public class TransformationHelper {
      * @param transformationType the desired transformation type
      * @return a service instance or null, if none could be found
      */
-    public static TransformationService getTransformationService(BundleContext context, String transformationType) {
+    public static @Nullable TransformationService getTransformationService(@Nullable BundleContext context,
+            String transformationType) {
         if (context != null) {
             String filter = "(smarthome.transform=" + transformationType + ")";
             try {

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationService.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.core.transform;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * A TransformationProcessor transforms a given input and returns the transformed
@@ -47,6 +48,7 @@ public interface TransformationService {
      *         transformation couldn't be completed for any reason.
      * @throws TransformationException if any error occurs
      */
+    @Nullable
     String transform(String function, String source) throws TransformationException;
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationService.java
@@ -37,15 +37,13 @@ public interface TransformationService {
 
     /**
      * Transforms the input <code>source</code> by means of the given <code>function</code> and returns the transformed
-     * output. If the transformation couldn't be completed
-     * for any reason, one should return the unchanged <code>source</code>. This
-     * method should never return <code>null</code>. In case of any error an {@link TransformationException} should be
-     * thrown.
+     * output. The transformation may return <code>null</code> to express its operation resulted in a <code>null</code>
+     * output. In case of any error an {@link TransformationException} should be thrown.
      *
      * @param function the function to be used to transform the input
      * @param source the input to be transformed
-     * @return the transformed result or the unchanged <code>source</code> if the
-     *         transformation couldn't be completed for any reason.
+     * @return the transformed result or <code>null</code> if the
+     *         transformation's output is <code>null</code>.
      * @throws TransformationException if any error occurs
      */
     @Nullable

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/TransformationService.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.transform;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * A TransformationProcessor transforms a given input and returns the transformed
  * result. Transformations could make sense in various situations, for example:
@@ -27,9 +29,9 @@ package org.eclipse.smarthome.core.transform;
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public interface TransformationService {
-    
-    
+
     public static final String TRANSFORM_FOLDER_NAME = "transform";
 
     /**
@@ -38,7 +40,7 @@ public interface TransformationService {
      * for any reason, one should return the unchanged <code>source</code>. This
      * method should never return <code>null</code>. In case of any error an {@link TransformationException} should be
      * thrown.
-     * 
+     *
      * @param function the function to be used to transform the input
      * @param source the input to be transformed
      * @return the transformed result or the unchanged <code>source</code> if the

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
@@ -45,6 +45,9 @@ public class Transformation {
         if (service != null) {
             try {
                 result = service.transform(function, value);
+                if (result == null) {
+                    result = value;
+                }
             } catch (TransformationException e) {
                 logger.error("Error executing the transformation '{}': {}", type, e.getMessage());
                 result = value;

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
@@ -45,9 +45,6 @@ public class Transformation {
         if (service != null) {
             try {
                 result = service.transform(function, value);
-                if (result == null) {
-                    result = value;
-                }
             } catch (TransformationException e) {
                 logger.error("Error executing the transformation '{}': {}", type, e.getMessage());
                 result = value;

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
@@ -35,17 +35,10 @@ public class Transformation {
         String result;
         TransformationService service = TransformationHelper
                 .getTransformationService(TransformationActivator.getContext(), type);
-        Logger logger = LoggerFactory.getLogger(Transformation.class);
         if (service != null) {
-            try {
-                result = service.transform(function, value);
-            } catch (TransformationException e) {
-                logger.error("Error executing the transformation '{}': {}", type, e.getMessage());
-                result = value;
-            }
+            result = service.transform(function, value);
         } else {
-            logger.warn("No transformation service '{}' could be found.", type);
-            result = value;
+            throw new TransformationException("No transformation service '" + type + "' could be found.");
         }
         return result;
     }

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
@@ -58,7 +58,7 @@ public class Transformation {
         try {
             result = trans(type, function, value);
         } catch (TransformationException e) {
-            logger.error("Error executing the transformation '{}': {}", type, e.getMessage());
+            logger.debug("Error executing the transformation '{}': {}", type, e.getMessage());
             result = value;
         }
         return result;

--- a/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
+++ b/bundles/core/org.eclipse.smarthome.core.transform/src/main/java/org/eclipse/smarthome/core/transform/actions/Transformation.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.transform.actions;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationHelper;
 import org.eclipse.smarthome.core.transform.TransformationService;
@@ -26,18 +28,10 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public class Transformation {
 
-    /**
-     * Applies a transformation of a given type with some function to a value.
-     *
-     * @param type the transformation type, e.g. REGEX or MAP
-     * @param function the function to call, this value depends on the transformation type
-     * @param value the value to apply the transformation to
-     * @return the transformed value or the original one, if there was no service registered for the
-     *         given type or a transformation exception occurred.
-     */
-    public static String transform(String type, String function, String value) {
+    private static @Nullable String trans(String type, String function, String value) throws TransformationException {
         String result;
         TransformationService service = TransformationHelper
                 .getTransformationService(TransformationActivator.getContext(), type);
@@ -54,6 +48,42 @@ public class Transformation {
             result = value;
         }
         return result;
+    }
+
+    /**
+     * Applies a transformation of a given type with some function to a value.
+     *
+     * @param type the transformation type, e.g. REGEX or MAP
+     * @param function the function to call, this value depends on the transformation type
+     * @param value the value to apply the transformation to
+     * @return the transformed value or the original one, if there was no service registered for the
+     *         given type or a transformation exception occurred.
+     */
+    public static @Nullable String transform(String type, String function, String value) {
+        Logger logger = LoggerFactory.getLogger(Transformation.class);
+        String result;
+        try {
+            result = trans(type, function, value);
+        } catch (TransformationException e) {
+            logger.error("Error executing the transformation '{}': {}", type, e.getMessage());
+            result = value;
+        }
+        return result;
+    }
+
+    /**
+     * Applies a transformation of a given type with some function to a value.
+     *
+     * @param type the transformation type, e.g. REGEX or MAP
+     * @param function the function to call, this value depends on the transformation type
+     * @param value the value to apply the transformation to
+     * @return the transformed value
+     * @throws TransformationException, if there was no service registered for the
+     *             given type or a transformation exception occurred
+     */
+    public static @Nullable String transformRaw(String type, String function, String value)
+            throws TransformationException {
+        return trans(type, function, value);
     }
 
 }

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -29,6 +29,7 @@
     <module>org.eclipse.smarthome.core.persistence</module>
     <module>org.eclipse.smarthome.core.scheduler</module>
     <module>org.eclipse.smarthome.core.transform</module>
+    <module>org.eclipse.smarthome.core.transform.test</module>
     <module>org.eclipse.smarthome.core.binding.xml</module>
     <module>org.eclipse.smarthome.core.binding.xml.test</module>
     <module>org.eclipse.smarthome.core.thing.xml</module>

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -497,8 +497,13 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                         .getTransformationService(UIActivator.getContext(), type);
                 if (transformation != null) {
                     try {
-                        ret = label.substring(0, label.indexOf("[") + 1) + transformation.transform(pattern, value)
-                                + "]";
+                        String transformationResult = transformation.transform(pattern, value);
+                        if (transformationResult != null) {
+                            ret = label.substring(0, label.indexOf("[") + 1) + transformationResult + "]";
+                        } else {
+                            logger.warn("transformation of type {} did not return a valid result", type);
+                            ret = label.substring(0, label.indexOf("[") + 1) + value + "]";
+                        }
                     } catch (TransformationException e) {
                         logger.error("transformation throws exception [transformation={}, value={}]", transformation,
                                 value, e);

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -502,7 +502,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
                             ret = label.substring(0, label.indexOf("[") + 1) + transformationResult + "]";
                         } else {
                             logger.warn("transformation of type {} did not return a valid result", type);
-                            ret = label.substring(0, label.indexOf("[") + 1) + value + "]";
+                            ret = label.substring(0, label.indexOf("[") + 1) + UnDefType.NULL + "]";
                         }
                     } catch (TransformationException e) {
                         logger.error("transformation throws exception [transformation={}, value={}]", transformation,

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/src/main/java/org/eclipse/smarthome/transform/exec/internal/ExecTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/src/main/java/org/eclipse/smarthome/transform/exec/internal/ExecTransformationService.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.transform.exec.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
 import org.eclipse.smarthome.io.net.exec.ExecUtil;
@@ -40,7 +41,7 @@ public class ExecTransformationService implements TransformationService {
      *            the input to transform
      */
     @Override
-    public String transform(String commandLine, String source) throws TransformationException {
+    public @Nullable String transform(String commandLine, String source) throws TransformationException {
         if (commandLine == null || source == null) {
             throw new TransformationException("the given parameters 'commandLine' and 'source' must not be null");
         }

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/src/main/java/org/eclipse/smarthome/transform/exec/internal/ExecTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/src/main/java/org/eclipse/smarthome/transform/exec/internal/ExecTransformationService.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.transform.exec.internal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
 import org.eclipse.smarthome.io.net.exec.ExecUtil;
@@ -24,6 +25,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Pauli Anttila
  */
+@NonNullByDefault
 public class ExecTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(ExecTransformationService.class);

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
@@ -24,6 +24,7 @@ import javax.script.ScriptException;
 
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
@@ -53,7 +54,7 @@ public class JavaScriptTransformationService implements TransformationService {
      *            the input to transform
      */
     @Override
-    public String transform(String filename, String source) throws TransformationException {
+    public @Nullable String transform(String filename, String source) throws TransformationException {
         Logger logger = LoggerFactory.getLogger(JavaScriptTransformationService.class);
         if (filename == null || source == null) {
             throw new TransformationException("the given parameters 'filename' and 'source' must not be null");

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
@@ -23,6 +23,7 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
@@ -32,9 +33,10 @@ import org.slf4j.LoggerFactory;
 /**
  * The implementation of {@link TransformationService} which transforms the
  * input by Java Script.
- * 
+ *
  * @author Pauli Anttila
  */
+@NonNullByDefault
 public class JavaScriptTransformationService implements TransformationService {
 
     /**
@@ -42,7 +44,7 @@ public class JavaScriptTransformationService implements TransformationService {
      * transformation rule to be read from a file which is stored under the
      * 'configurations/transform' folder. To organize the various
      * transformations one should use subfolders.
-     * 
+     *
      * @param filename
      *            the name of the file which contains the Java script
      *            transformation rule. Transformation service inject input

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/src/test/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationServiceTest.java
@@ -77,7 +77,7 @@ public class JSonPathTransformationServiceTest {
     @Test
     public void testNullValue() throws TransformationException {
         String transformedResponse = processor.transform("$[0].empty", jsonArray);
-        assertEquals("NULL", transformedResponse);
+        assertEquals(null, transformedResponse);
     }
 
     @Test

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/README.md
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/README.md
@@ -52,7 +52,6 @@ Now the resulting Number can also be used in the label to [change the color](htt
 
 ## Differences to standard JsonPath
 
-Returns `null` if the JsonPath expression could not be found.
 Compared to standard JSON the transformation it returns evaluated values when a single alement is retrieved from the query.
 Means it does not return a valid JSON `[ 23.2 ]` but `23.2`, `[ "Outside" ]` but `Outside`.
 This makes it possible to use it in labels or output channel of things and get Numbers or Strings instead of JSON arrays.

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.transform.jsonpath.internal;
 
 import java.util.List;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -33,6 +34,7 @@ import com.jayway.jsonpath.PathNotFoundException;
  * @author Sebastian Janzen
  *
  */
+@NonNullByDefault
 public class JSonPathTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(JSonPathTransformationService.class);

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -15,6 +15,7 @@ package org.eclipse.smarthome.transform.jsonpath.internal;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -48,7 +49,7 @@ public class JSonPathTransformationService implements TransformationService {
      *             which is encapsulated in a {@link TransformationException}.
      */
     @Override
-    public String transform(String jsonPathExpression, String source) throws TransformationException {
+    public @Nullable String transform(String jsonPathExpression, String source) throws TransformationException {
         if (jsonPathExpression == null || source == null) {
             throw new TransformationException("the given parameters 'JSonPath' and 'source' must not be null");
         }

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/JSonPathTransformationService.java
@@ -60,7 +60,7 @@ public class JSonPathTransformationService implements TransformationService {
             Object transformationResult = JsonPath.read(source, jsonPathExpression);
             logger.debug("transformation resulted in '{}'", transformationResult);
             if (transformationResult == null) {
-                return UnDefType.NULL.toFullString();
+                return null;
             } else if (transformationResult instanceof List) {
                 return flattenList((List<?>) transformationResult);
             } else {

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
@@ -11,6 +11,5 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.transform,
- org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
@@ -11,5 +11,6 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.transform,
+ org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
@@ -15,20 +15,23 @@ package org.eclipse.smarthome.transform.regex.internal;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
+import org.eclipse.smarthome.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * <p>
  * The implementation of {@link TransformationService} which transforms the input by Regular Expressions.
- * 
+ *
  * <p>
  * <b>Note:</b> the given Regular Expression must contain exactly one group!
  *
  * @author Thomas.Eichstaedt-Engelen
  */
+@NonNullByDefault
 public class RegExTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(RegExTransformationService.class);
@@ -66,7 +69,7 @@ public class RegExTransformationService implements TransformationService {
             logger.debug(
                     "the given regex '^{}$' doesn't match the given content '{}' -> couldn't compute transformation",
                     regExpression, source);
-            return null;
+            return UnDefType.NULL.toFullString();
         }
         matcher.reset();
 
@@ -87,7 +90,11 @@ public class RegExTransformationService implements TransformationService {
             }
         }
 
-        return result;
+        if (result != null) {
+            return result;
+        } else {
+            return UnDefType.NULL.toFullString();
+        }
     }
 
 }

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
@@ -69,7 +69,8 @@ public class RegExTransformationService implements TransformationService {
             logger.debug(
                     "the given regex '^{}$' doesn't match the given content '{}' -> couldn't compute transformation",
                     regExpression, source);
-            return UnDefType.NULL.toFullString();
+            throw new TransformationException("the given regex '^" + regExpression
+                    + "$' doesn't match the given content '" + source + "' -> couldn't compute transformation");
         }
         matcher.reset();
 

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/RegExTransformationService.java
@@ -16,9 +16,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
-import org.eclipse.smarthome.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +39,7 @@ public class RegExTransformationService implements TransformationService {
     private static final Pattern SUBSTR_PATTERN = Pattern.compile("^s/(.*?[^\\\\])/(.*?[^\\\\])/(.*)$");
 
     @Override
-    public String transform(String regExpression, String source) throws TransformationException {
+    public @Nullable String transform(String regExpression, String source) throws TransformationException {
         if (regExpression == null || source == null) {
             throw new TransformationException("the given parameters 'regex' and 'source' must not be null");
         }
@@ -69,8 +69,7 @@ public class RegExTransformationService implements TransformationService {
             logger.debug(
                     "the given regex '^{}$' doesn't match the given content '{}' -> couldn't compute transformation",
                     regExpression, source);
-            throw new TransformationException("the given regex '^" + regExpression
-                    + "$' doesn't match the given content '" + source + "' -> couldn't compute transformation");
+            return null;
         }
         matcher.reset();
 
@@ -91,11 +90,7 @@ public class RegExTransformationService implements TransformationService {
             }
         }
 
-        if (result != null) {
-            return result;
-        } else {
-            return UnDefType.NULL.toFullString();
-        }
+        return result;
     }
 
 }

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationService.java
@@ -22,6 +22,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
 import org.slf4j.Logger;
@@ -41,7 +42,7 @@ public class XPathTransformationService implements TransformationService {
     private final Logger logger = LoggerFactory.getLogger(XPathTransformationService.class);
 
     @Override
-    public String transform(String xpathExpression, String source) throws TransformationException {
+    public @Nullable String transform(String xpathExpression, String source) throws TransformationException {
         if (xpathExpression == null || source == null) {
             throw new TransformationException("the given parameters 'xpath' and 'source' must not be null");
         }

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/XPathTransformationService.java
@@ -21,6 +21,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ import org.xml.sax.InputSource;
  *
  * @author Thomas.Eichstaedt-Engelen
  */
+@NonNullByDefault
 public class XPathTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(XPathTransformationService.class);

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
@@ -23,6 +23,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
@@ -54,7 +55,7 @@ public class XsltTransformationService implements TransformationService {
      *            the input to transform
      */
     @Override
-    public String transform(String filename, String source) throws TransformationException {
+    public @Nullable String transform(String filename, String source) throws TransformationException {
         if (filename == null || source == null) {
             throw new TransformationException("the given parameters 'filename' and 'source' must not be null");
         }

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/XsltTransformationService.java
@@ -22,6 +22,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
@@ -34,6 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Thomas.Eichstaedt-Engelen
  */
+@NonNullByDefault
 public class XsltTransformationService implements TransformationService {
 
     private final Logger logger = LoggerFactory.getLogger(XsltTransformationService.class);


### PR DESCRIPTION
While adding the annotations I noticed an inconsistency in the
RegExTransformationService. It validated the transformation contract
because it returned null. Now it returns UnDefType.NULL.toFullString()
just like the JSonPathTransformationService.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>