### PR TITLE
Added documentation for audio & voice to menu

### DIFF
--- a/docs/_includes/documentation-menu.html
+++ b/docs/_includes/documentation-menu.html
@@ -51,6 +51,7 @@
 					<li><a href="{{docu}}/features/icons.html">Overview</a></li>
 					<li><a href="{{docu}}/features/ui/iconset/classic/readme.html">Classic Icon Set</a></li>
 				</ul></li>
+			<li><a href="{{docu}}//features/audio.html">Audio & Voice</a></li>
 	</ul></li>
 	<li><a href="{{docu}}/development/ide.html">Development</a>
 		<ul>

--- a/docs/_includes/documentation-menu.html
+++ b/docs/_includes/documentation-menu.html
@@ -8,9 +8,9 @@
 			<li><a href="{{docu}}/concepts/items.html">Items</a></li>
 			<li><a href="{{docu}}/concepts/things.html">Things</a></li>
 			<li><a href="{{docu}}/concepts/categories.html">Categories</a></li>
-			<li><a href="{{docu}}/concepts/discovery.html">Inbox & Discovery</a></li>
+			<li><a href="{{docu}}/concepts/discovery.html">Inbox &amp; Discovery</a></li>
 			<li><a href="{{docu}}/concepts/profiles.html">Profiles</a></li>
-			<li><a href="{{docu}}/concepts/audio.html">Audio & Voice</a></li>
+			<li><a href="{{docu}}/concepts/audio.html">Audio &amp; Voice</a></li>
 			<li><a href="{{docu}}/concepts/units-of-measurement.html">Units of Measurement</a></li>
 		</ul></li>
 	<li><a href="{{docu}}/features/index.html">Features</a>
@@ -36,7 +36,7 @@
 					<li><a href="{{docu}}/features/bindings/hue/readme.html">Philips Hue</a></li>
 					<li><a href="{{docu}}/features/bindings/serialbutton/readme.html">Serial Button</a></li>
 					<li><a href="{{docu}}/features/bindings/sonos/readme.html">Sonos</a></li>
-					<li><a href="{{docu}}/features/bindings/tradfri/readme.html">IKEA Trådfri</a></li>
+					<li><a href="{{docu}}/features/bindings/tradfri/readme.html">IKEA TRÅDFRI</a></li>
 					<li><a href="{{docu}}/features/bindings/weatherunderground/readme.html">Weather Underground</a></li>
 					<li><a href="{{docu}}/features/bindings/yahooweather/readme.html">Yahoo Weather</a></li>
 				</ul></li>
@@ -51,13 +51,13 @@
 					<li><a href="{{docu}}/features/icons.html">Overview</a></li>
 					<li><a href="{{docu}}/features/ui/iconset/classic/readme.html">Classic Icon Set</a></li>
 				</ul></li>
-			<li><a href="{{docu}}//features/audio.html">Audio & Voice</a></li>
+			<li><a href="{{docu}}/features/audio.html">Audio &amp; Voice</a></li>
 	</ul></li>
 	<li><a href="{{docu}}/development/ide.html">Development</a>
 		<ul>
 			<li><a href="{{docu}}/development/ide.html">IDE Setup</a></li>
-            <li><a href="{{docu}}/development/guidelines.html">Guidelines</a></li>
-            <li><a href="{{docu}}/development/notes.html">Notes</a></li>
+			<li><a href="{{docu}}/development/guidelines.html">Guidelines</a></li>
+			<li><a href="{{docu}}/development/notes.html">Notes</a></li>
 			<li><a href="{{docu}}/development/bindings/how-to.html">Bindings</a>
 				<ul>
 					<li><a href="{{docu}}/development/bindings/how-to.html">Binding Tutorial</a></li>


### PR DESCRIPTION
- Changed spelling of TRÅDFRI
- Replaced `&` by `&amp;`

We forgot to add the new documentation from #4963 to the menu.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>