### PR TITLE
disable linux-tests under windows

### DIFF
--- a/bundles/config/pom.xml
+++ b/bundles/config/pom.xml
@@ -28,10 +28,22 @@
     <module>org.eclipse.smarthome.config.discovery.usbserial</module>
     <module>org.eclipse.smarthome.config.discovery.usbserial.test</module>
     <module>org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs</module>
-    <module>org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test</module>
     <module>org.eclipse.smarthome.config.serial</module>
     <module>org.eclipse.smarthome.config.xml</module>
     <module>org.eclipse.smarthome.config.xml.test</module>
   </modules>
 
+  <profiles>
+    <profile>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <modules>
+        <module>org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test</module>
+      </modules>
+    </profile>
+  </profiles>
+  
 </project>


### PR DESCRIPTION
fixes #5369 

this may not be the ultimate solution but makes ESH build again on Windows OS.
Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>