### PR TITLE
Remove Service-Component from serial transport manifest

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/META-INF/MANIFEST.MF
@@ -15,4 +15,3 @@ Import-Package:
  org.osgi.service.cm,
  org.osgi.service.component,
  org.slf4j
-Service-Component: OSGI-INF/*.xml


### PR DESCRIPTION
Fixes:

```
18:45:14.319 [ERROR] [eclipse.smarthome.io.transport.serial] - Component descriptor entry 'OSGI-INF/*.xml' not found
```