### PR TITLE
serial: remove unused service component declaration

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/META-INF/MANIFEST.MF
@@ -15,4 +15,3 @@ Import-Package:
  org.osgi.service.cm,
  org.osgi.service.component,
  org.slf4j
-Service-Component: OSGI-INF/*.xml


### PR DESCRIPTION
Eclipse Equinox shows a warning if "*.xml" is used in the service
component declaration but there is no file that match that pattern in
the "OSGI-INF" directory.
As the plain serial bundle does not contains a DS component we could
remove that declaration.

Related to: https://github.com/eclipse/smarthome/pull/5313#issuecomment-379501569