### PR TITLE
request full stacktrace in SafeCalleImplTest

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/common/SafeCallerImplTest.java
@@ -559,7 +559,7 @@ public class SafeCallerImplTest extends JavaTest {
     private static String printThreadDump(String threadNamePrefix) {
         final StringBuilder sb = new StringBuilder();
         final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-        for (ThreadInfo threadInfo : threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds())) {
+        for (ThreadInfo threadInfo : threadMXBean.getThreadInfo(threadMXBean.getAllThreadIds(), Integer.MAX_VALUE)) {
             if (!threadInfo.getThreadName().startsWith(threadNamePrefix)) {
                 continue;
             }


### PR DESCRIPTION
...as omitting the maxDepth parameter as done in #5362 apparently leads to completely useless output like this:

```
"testAsyncExceedingThreadPool_differentIdentifier-queue" java.lang.Thread$State: TIMED_WAITING"testAsyncExceedingThreadPool_differentIdentifier-3" java.lang.Thread$State: TIMED_WAITING"testAsyncExceedingThreadPool_differentIdentifier-2" java.lang.Thread$State: TIMED_WAITING"testAsyncExceedingThreadPool_differentIdentifier-1" java.lang.Thread$State: TIMED_WAITING
```

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>