### PR TITLE
Initialize deviceLock

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth/src/main/java/org/eclipse/smarthome/binding/bluetooth/BeaconBluetoothHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth/src/main/java/org/eclipse/smarthome/binding/bluetooth/BeaconBluetoothHandler.java
@@ -45,6 +45,7 @@ public class BeaconBluetoothHandler extends BaseThingHandler implements Bluetoot
 
     public BeaconBluetoothHandler(@NonNull Thing thing) {
         super(thing);
+        deviceLock = new ReentrantLock();
     }
 
     @Override


### PR DESCRIPTION
Initialize deviceLock to fix NullPointerException when calling methods lock() and unlock() on null deviceLock
Signed-off-by: Marcin Szewczyk <szewczykus@gmail.com>