### PR TITLE
Initialize deviceLock

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth/src/main/java/org/eclipse/smarthome/binding/bluetooth/BeaconBluetoothHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth/src/main/java/org/eclipse/smarthome/binding/bluetooth/BeaconBluetoothHandler.java
@@ -41,7 +41,7 @@ public class BeaconBluetoothHandler extends BaseThingHandler implements Bluetoot
     protected BluetoothAdapter adapter;
     protected BluetoothAddress address;
     protected BluetoothDevice device;
-    protected ReentrantLock deviceLock;
+    protected final ReentrantLock deviceLock;
 
     public BeaconBluetoothHandler(@NonNull Thing thing) {
         super(thing);


### PR DESCRIPTION
Initialize deviceLock to fix NullPointer on null object deviceLock when calling methods lock() and unlock()
Signed-off-by: Marcin Szewczyk <szewczykus@gmail.com>