### PR TITLE
Add the bundles for discovery of usb devices providing a serial port to p2 and karaf features

### DIFF
--- a/features/karaf/esh-core/src/main/feature/feature.xml
+++ b/features/karaf/esh-core/src/main/feature/feature.xml
@@ -330,6 +330,12 @@
     <bundle>mvn:org.eclipse.smarthome.config/org.eclipse.smarthome.config.discovery.upnp/${project.version}</bundle>
   </feature>
 
+  <feature name="esh-io-discovery-usb-serial" version="${project.version}">
+    <feature>esh-base</feature>
+    <bundle>mvn:org.eclipse.smarthome.config/org.eclipse.smarthome.config.discovery.usbserial/${project.version}</bundle>
+    <bundle>mvn:org.eclipse.smarthome.config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/${project.version}</bundle>
+  </feature>
+
   <feature name="esh-model-item" version="${project.version}">
     <feature>esh-base</feature>
     <bundle>mvn:org.eclipse.smarthome.model/org.eclipse.smarthome.model.item/${project.version}</bundle>

--- a/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
@@ -193,6 +193,20 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.smarthome.config.discovery.usbserial"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.smarthome.config.xml"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
The bundles `o.e.sh.config.discovery.usbserial` and `o.e.sh.config.discovery.usbserial.linuxsysfs` were recently added (in https://github.com/eclipse/smarthome/pull/5315), but they were not added to the p2 and karaf features. This PR adds them to p2 and karaf features.

I have one question for reviewers: I chose `esh-io-discovery-usb-serial` as Karaf feature name to be aligned with the existing (and somewhat similar) mDNS and UPnP discoveries, although both new bundles are in the `o.e.sh.config` namespace. Should this rather be `esh-config-discovery-usb-serial`, or left as is?