### PR TITLE
LocationProvider: Fix NPE

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/i18n/I18nProviderImpl.java
@@ -222,7 +222,7 @@ public class I18nProviderImpl
                 logger.warn("Could not set new location: {}, keeping old one, error message: {}", location,
                         e.getMessage());
             }
-            if (!this.location.equals(oldLocation)) {
+            if (this.location != null && !this.location.equals(oldLocation)) {
                 logger.info("Location set to '{}'.", this.location);
             }
         }


### PR DESCRIPTION
This NPE occurred on my OH2 system because on start-up there was a wrongly
formatted location string in the configuration.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>