### PR TITLE
Set suppression for XML files

### DIFF
--- a/tools/static-code-analysis/checkstyle/suppressions.xml
+++ b/tools/static-code-analysis/checkstyle/suppressions.xml
@@ -8,19 +8,21 @@
     <suppress files=".+[\\/]internal[\\/].+\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
     <suppress files=".+DTO\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck" />
     <suppress files=".+Impl\.java" checks="JavadocType|JavadocVariable|JavadocMethod|JavadocFilterCheck"/>
-	<suppress files=".+\\pom\.xml" checks="OnlyTabIdentationInXmlFilesCheck"/>
+    <suppress files=".+[\\/]pom\.xml" checks="OnlyTabIndentationInXmlFilesCheck"/>
+    <suppress files=".+[\\/]OSGI-INF[\\/]org.eclipse.smarthome.+\.xml" checks="OnlyTabIndentationInXmlFilesCheck|NewlineAtEndOfFileCheck"/>
+
     <!-- All generated files will skip the author tag check -->
     <suppress files=".+[\\/]gen[\\/].+\.java" checks="AuthorTagCheck"/>
     <!-- Some checks will be supressed for test bundles -->
     <suppress files=".+.test[\\/].+" checks="RequireBundleCheck|OutsideOfLibExternalLibrariesCheck|ManifestExternalLibrariesCheck|BuildPropertiesExternalLibrariesCheck"/>
-    
+
     <!-- Eclipse SmartHome specific suppressions-->
     <!-- These bundles are generated trough XText -->
     <suppress files=".+org.eclipse.smarthome.model.+" checks="RequireBundleCheck|ExportInternalPackageCheck|ManifestPackageVersionCheck|ImportExportedPackagesCheck|PackageExportsNameCheck"/>
     <!-- Some source files have different headers -->
     <suppress files=".+org.eclipse.smarthome.automation.+" checks="HeaderCheck"/>
     <suppress files=".+org.eclipse.smarthome.config.dispatch.test.+" checks="ServiceComponentManifestCheck"/>
-    
+
     <!--remove me after EPL-2.0 PRs are done -->
     <suppress files="build.properties" checks="AboutHtmlCheck" />
 


### PR DESCRIPTION
@wborn As you suggested I added a suppression filter for the generated XML files from DS annotations for 
NewlineAtEndOfFileCheck and OnlyTabIndentationInXmlFilesCheck.

Signed-off-by: Tanya D. Georgieva <tanya.dancheva.georgieva@gmail.com>