### PR TITLE
Fix compilation error in metadata test

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/java/org/eclipse/smarthome/config/core/internal/metadata/MetadataConfigDescriptionProviderImplTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/java/org/eclipse/smarthome/config/core/internal/metadata/MetadataConfigDescriptionProviderImplTest.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.smarthome.config.core.internal.items;
+package org.eclipse.smarthome.config.core.internal.metadata;
 
 import static org.eclipse.smarthome.config.core.internal.metadata.MetadataConfigDescriptionProviderImpl.*;
 import static org.junit.Assert.*;
@@ -26,9 +26,10 @@ import java.util.Locale;
 import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
-import org.eclipse.smarthome.config.core.metadata.MetadataConfigDescriptionProvider;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameterBuilder;
 import org.eclipse.smarthome.config.core.ParameterOption;
+import org.eclipse.smarthome.config.core.internal.metadata.MetadataConfigDescriptionProviderImpl;
+import org.eclipse.smarthome.config.core.metadata.MetadataConfigDescriptionProvider;
 import org.eclipse.smarthome.test.java.JavaTest;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
At least my IDE shows compile errors in the `MetadataConfigDescriptionProviderImplTest`. This refactors the package and organises imports accordingly.

Signed-off-by: Henning Treu <henning.treu@telekom.de>