### PR TITLE
enable sat for esh core again after its bump

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core/pom.xml
@@ -20,22 +20,4 @@
     <bundle.namespace>org.eclipse.smarthome.core</bundle.namespace>
   </properties>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.openhab.tools.sat</groupId>
-          <artifactId>sat-plugin</artifactId>
-          <version>${sat.version}</version>
-          <executions>
-            <execution>
-              <id>sat-all</id>
-              <phase>none</phase>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
 </project>


### PR DESCRIPTION
Related to: https://github.com/eclipse/smarthome/pull/5293