### PR TITLE
Item tags become metadata

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemRegistryOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemRegistryOSGiJavaTest.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.items;
+
+import static org.eclipse.smarthome.core.internal.items.ItemRegistryImpl.*;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.items.ItemNotFoundException;
+import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.items.ManagedItemProvider;
+import org.eclipse.smarthome.core.items.Metadata;
+import org.eclipse.smarthome.core.items.MetadataKey;
+import org.eclipse.smarthome.core.items.MetadataRegistry;
+import org.eclipse.smarthome.core.library.items.StringItem;
+import org.eclipse.smarthome.test.java.JavaOSGiTest;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ *
+ */
+public class ItemRegistryOSGiJavaTest extends JavaOSGiTest {
+
+    private static final String ITEM_NAME = "test";
+
+    private ItemRegistry itemRegistry;
+    private MetadataRegistry metadataRegistry;
+    private ManagedItemProvider managedItemProvider;
+
+    @Before
+    public void setup() {
+        registerVolatileStorageService();
+
+        managedItemProvider = getService(ManagedItemProvider.class);
+        assertNotNull(managedItemProvider);
+
+        metadataRegistry = getService(MetadataRegistry.class);
+        assertNotNull(metadataRegistry);
+
+        itemRegistry = getService(ItemRegistry.class);
+        assertNotNull(itemRegistry);
+    }
+
+    @Test
+    public void testGetTagsFromLegacy() throws Exception {
+        prepareItem(ITEM_NAME, "hello");
+
+        assertTagsInItem(ITEM_NAME, "hello");
+    }
+
+    @Test
+    public void testGetTagsFromExistingMetadata() throws Exception {
+        prepareMetadata(ITEM_NAME, "hello");
+        prepareItem(ITEM_NAME);
+
+        assertTagsInItem(ITEM_NAME, "hello");
+    }
+
+    @Test
+    public void testGetTagsFromNewMetadata() throws Exception {
+        prepareItem(ITEM_NAME);
+        prepareMetadata(ITEM_NAME, "hello");
+
+        assertTagsInItem(ITEM_NAME, "hello");
+    }
+
+    @Test
+    public void testGetTagsFromBoth() throws Exception {
+        prepareMetadata(ITEM_NAME, "foo");
+        prepareItem(ITEM_NAME, "bar");
+
+        assertTagsInItem(ITEM_NAME, "foo", "bar");
+    }
+
+    @Test
+    public void testWriteTagsToMetadataViaAdd() throws Exception {
+        StringItem item = new StringItem(ITEM_NAME);
+        item.addTag("hello");
+        itemRegistry.add(item);
+
+        assertTagsInMetadata(ITEM_NAME, "hello");
+        assertNoTagsPersisted(ITEM_NAME);
+    }
+
+    @Test
+    public void testWriteTagsToMetadataViaUpdate() throws Exception {
+        prepareItem(ITEM_NAME);
+
+        StringItem item = new StringItem(ITEM_NAME);
+        item.addTag("hello");
+        itemRegistry.update(item);
+
+        assertTagsInMetadata(ITEM_NAME, "hello");
+        assertNoTagsPersisted(ITEM_NAME);
+    }
+
+    @Test
+    public void testUpdateTagsInMetadataViaAdd() throws Exception {
+        prepareMetadata(ITEM_NAME, "foo");
+
+        StringItem item = new StringItem(ITEM_NAME);
+        item.addTag("bar");
+        itemRegistry.add(item);
+
+        assertTagsInMetadata(ITEM_NAME, "bar");
+        assertNoTagsPersisted(ITEM_NAME);
+    }
+
+    @Test
+    public void testUpdateTagsInMetadataViaUpdate() throws Exception {
+        prepareItem(ITEM_NAME);
+
+        prepareMetadata(ITEM_NAME, "foo");
+
+        StringItem item = new StringItem(ITEM_NAME);
+        item.addTag("bar");
+        itemRegistry.update(item);
+
+        assertTagsInMetadata(ITEM_NAME, "bar");
+        assertNoTagsPersisted(ITEM_NAME);
+    }
+
+    @Test
+    public void testRemoveTagsInMetadataOnItemDeletion() throws Exception {
+        prepareItem(ITEM_NAME);
+        prepareMetadata(ITEM_NAME, "foo");
+
+        itemRegistry.remove(ITEM_NAME);
+
+        assertTagsInMetadata(ITEM_NAME);
+    }
+
+    @Test
+    public void testAddTagWithPreviousLegacy() throws Exception {
+        prepareItem(ITEM_NAME, "foo");
+
+        itemRegistry.addTag(ITEM_NAME, "bar");
+
+        assertTagsInMetadata(ITEM_NAME, "foo", "bar");
+        assertTagsInItem(ITEM_NAME, "foo", "bar");
+    }
+
+    @Test
+    public void testAddTagWithPreviousMetadata() throws Exception {
+        prepareMetadata(ITEM_NAME, "foo");
+        prepareItem(ITEM_NAME);
+
+        itemRegistry.addTag(ITEM_NAME, "bar");
+
+        assertTagsInMetadata(ITEM_NAME, "foo", "bar");
+        assertTagsInItem(ITEM_NAME, "foo", "bar");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddTagToNonExistingItem() throws Exception {
+        itemRegistry.addTag(ITEM_NAME, "hello");
+    }
+
+    @Test
+    public void testRemoveTag() throws Exception {
+        prepareItem(ITEM_NAME, "foo", "bar");
+
+        itemRegistry.removeTag(ITEM_NAME, "bar");
+
+        assertTagsInMetadata(ITEM_NAME, "foo");
+        assertTagsInItem(ITEM_NAME, "foo");
+    }
+
+    @Test
+    public void testRemoveNonExistingTag() throws Exception {
+        prepareItem(ITEM_NAME, "foo");
+
+        itemRegistry.removeTag(ITEM_NAME, "bar");
+
+        assertTagsInMetadata(ITEM_NAME, "foo");
+        assertTagsInItem(ITEM_NAME, "foo");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRemoveTagFromNonExistingItem() throws Exception {
+        itemRegistry.removeTag(ITEM_NAME, "hello");
+    }
+
+    private void prepareItem(String itemName, String... tags) {
+        StringItem item = new StringItem(itemName);
+        item.addTags(tags);
+        managedItemProvider.add(item);
+    }
+
+    private void prepareMetadata(String itemName, String... tags) {
+        MetadataKey key = new MetadataKey(TAG_NAMESPACE, itemName);
+        Metadata metadata = new Metadata(key, String.join(TAG_SEPARATOR, tags), null);
+        metadataRegistry.add(metadata);
+    }
+
+    private void assertTagsInMetadata(String itemName, String... tags) {
+        MetadataKey key = new MetadataKey(TAG_NAMESPACE, itemName);
+        Metadata metadata = metadataRegistry.get(key);
+        if (tags == null || tags.length == 0) {
+            assertNull(metadata);
+        } else {
+            assertNotNull(metadata);
+            List<String> res = Arrays.asList(metadata.getValue().split("\\" + TAG_SEPARATOR));
+            assertEquals(tags.length, res.size());
+            for (String tag : tags) {
+                assertTrue(tag, res.contains(tag));
+            }
+        }
+    }
+
+    private void assertTagsInItem(String itemName, String... tags) throws ItemNotFoundException {
+        Item item = itemRegistry.getItem(itemName);
+        assertEquals(tags.length, item.getTags().size());
+        Set<@NonNull String> res = item.getTags();
+        for (String tag : tags) {
+            assertTrue(tag, res.contains(tag));
+        }
+    }
+
+    private void assertNoTagsPersisted(String itemName) throws ItemNotFoundException {
+        Item item = managedItemProvider.get(itemName);
+        assertEquals(0, item.getTags().size());
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemRegistryOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemRegistryOSGiJavaTest.java
@@ -218,7 +218,7 @@ public class ItemRegistryOSGiJavaTest extends JavaOSGiTest {
             assertNull(metadata);
         } else {
             assertNotNull(metadata);
-            List<String> res = Arrays.asList(metadata.getValue().split("\\" + TAG_SEPARATOR));
+            List<String> res = Arrays.asList(metadata.getValue().split(TAG_SPLIT_REGEX));
             assertEquals(tags.length, res.size());
             for (String tag : tags) {
                 assertTrue(tag, res.contains(tag));

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ManagedItemProviderOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ManagedItemProviderOSGiTest.java
@@ -151,40 +151,6 @@ public class ManagedItemProviderOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void assertTagsAreStoredAndRetrievedAsWell() {
-        assertThat(itemProvider.getAll().size(), is(0));
-
-        SwitchItem item1 = new SwitchItem("SwitchItem1");
-        SwitchItem item2 = new SwitchItem("SwitchItem2");
-        item1.addTag("tag1");
-        item1.addTag("tag2");
-        item2.addTag("tag3");
-
-        itemProvider.add(item1);
-        itemProvider.add(item2);
-
-        Collection<Item> items = itemProvider.getAll();
-        assertThat(items.size(), is(2));
-
-        Item result1 = itemProvider.remove("SwitchItem1");
-        Item result2 = itemProvider.remove("SwitchItem2");
-
-        assertThat(result1.getName(), is("SwitchItem1"));
-        assertThat(result1.getTags().size(), is(2));
-        assertThat(result1.hasTag("tag1"), is(true));
-        assertThat(result1.hasTag("tag2"), is(true));
-        assertThat(result1.hasTag("tag3"), is(false));
-
-        assertThat(result2.getName(), is("SwitchItem2"));
-        assertThat(result2.getTags().size(), is(1));
-        assertThat(result2.hasTag("tag1"), is(false));
-        assertThat(result2.hasTag("tag2"), is(false));
-        assertThat(result2.hasTag("tag3"), is(true));
-
-        assertThat(itemProvider.getAll().size(), is(0));
-    }
-
-    @Test
     public void assertRemoveRecursivelyWorks() {
         assertThat(itemProvider.getAll().size(), is(0));
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -72,8 +72,11 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     static final String TAG_NAMESPACE = MetadataRegistry.INTERNAL_NAMESPACE_PREFIX + "tags";
     static final String TAG_SEPARATOR = "|";
+    static final String TAG_SPLIT_REGEX = "\\" + TAG_SEPARATOR;
+
     private final Logger logger = LoggerFactory.getLogger(ItemRegistryImpl.class);
     private final List<RegistryHook<Item>> registryHooks = new CopyOnWriteArrayList<>();
+
     private StateDescriptionService stateDescriptionService;
     private MetadataRegistry metadataRegistry;
 
@@ -419,7 +422,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         SortedSet<String> tags = new TreeSet<>();
         Metadata metadata = metadataRegistry.get(key);
         if (metadata != null) {
-            tags.addAll(Arrays.asList(metadata.getValue().split("\\" + TAG_SEPARATOR)));
+            tags.addAll(Arrays.asList(metadata.getValue().split(TAG_SPLIT_REGEX)));
         }
         return tags;
     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
@@ -81,6 +81,11 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
         super.deactivate();
     }
 
+    @Override
+    public boolean isInternalNamespace(String namespace) {
+        return namespace.startsWith(INTERNAL_NAMESPACE_PREFIX);
+    }
+
     @Reference
     protected void setManagedItemProvider(ManagedItemProvider managedItemProvider) {
         managedItemProvider.addProviderChangeListener(itemProviderChangeListener);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
@@ -86,7 +86,7 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
         return namespace.startsWith(INTERNAL_NAMESPACE_PREFIX);
     }
 
-    @Reference
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     protected void setManagedItemProvider(ManagedItemProvider managedItemProvider) {
         managedItemProvider.addProviderChangeListener(itemProviderChangeListener);
     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -64,7 +64,7 @@ public abstract class GenericItem implements ActiveItem {
 
     protected List<String> groupNames = new ArrayList<String>();
 
-    protected Set<String> tags = new HashSet<String>();
+    protected transient volatile Set<String> tags = new HashSet<String>();
 
     protected final String name;
 
@@ -409,9 +409,7 @@ public abstract class GenericItem implements ActiveItem {
      * @return true if state is an acceptedDataType or subclass thereof
      */
     public boolean isAcceptedState(List<Class<? extends State>> acceptedDataTypes, State state) {
-        return acceptedDataTypes.stream()
-                .map(clazz -> clazz.isAssignableFrom(state.getClass()))
-                .filter(found -> found)
+        return acceptedDataTypes.stream().map(clazz -> clazz.isAssignableFrom(state.getClass())).filter(found -> found)
                 .findAny().isPresent();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
@@ -127,4 +127,40 @@ public interface ItemRegistry extends Registry<Item, String> {
      */
     void removeRegistryHook(RegistryHook<Item> hook);
 
+    /**
+     * Adds a tag to the item.
+     *
+     * @param itemName the name of the item
+     * @param tag the tag to be added
+     * @return {@code true} if the collection of tags was modified by this operation
+     */
+    boolean addTag(String itemName, String tag);
+
+    /**
+     * Adds the given tags to the item.
+     *
+     * @param itemName the name of the item
+     * @param tags the tags to be added
+     * @return {@code true} if the collection of tags was modified by this operation
+     */
+    boolean addTags(String itemName, Collection<String> tags);
+
+    /**
+     * Removes a tag from the item.
+     *
+     * @param itemName the name of the item
+     * @param tag the tag to be removed
+     * @return {@code true} if the collection of tags was modified by this operation
+     */
+    boolean removeTag(String itemName, String tag);
+
+    /**
+     * Removes the given tags from the item.
+     *
+     * @param itemName the name of the item
+     * @param tags the tags to be removed
+     * @return {@code true} if the collection of tags was modified by this operation
+     */
+    boolean removeTags(String itemName, Collection<String> tags);
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
@@ -15,7 +15,6 @@ package org.eclipse.smarthome.core.items;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +63,7 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
 
         public @NonNull String itemType;
 
+        @Deprecated // Only read for backward compatibility. Not written anymore.
         public Set<String> tags;
 
         public String label;
@@ -267,7 +267,6 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
 
         persistedItem.label = item.getLabel();
         persistedItem.groupNames = new ArrayList<>(item.getGroupNames());
-        persistedItem.tags = new HashSet<>(item.getTags());
         persistedItem.category = item.getCategory();
 
         return persistedItem;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/MetadataRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/MetadataRegistry.java
@@ -27,4 +27,6 @@ import org.eclipse.smarthome.core.common.registry.Registry;
 @NonNullByDefault
 public interface MetadataRegistry extends Registry<Metadata, MetadataKey> {
 
+    public static final String INTERNAL_NAMESPACE_PREFIX = "_";
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/MetadataRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/MetadataRegistry.java
@@ -29,4 +29,12 @@ public interface MetadataRegistry extends Registry<Metadata, MetadataKey> {
 
     public static final String INTERNAL_NAMESPACE_PREFIX = "_";
 
+    /**
+     * Determines whether the given namespace is internal.
+     *
+     * @param namespace the metadata namespace to check
+     * @return {@code true} if the given namespace is internal, {@code false} otherwise
+     */
+    boolean isInternalNamespace(String namespace);
+
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResourceOSGiTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResourceOSGiTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.UriInfo;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.ItemProvider;
+import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.items.ManagedItemProvider;
 import org.eclipse.smarthome.core.items.Metadata;
 import org.eclipse.smarthome.core.items.MetadataKey;
@@ -64,12 +65,17 @@ public class ItemResourceOSGiTest extends JavaOSGiTest {
     private ItemProvider itemProvider;
 
     private ItemResource itemResource;
+    private ItemRegistry itemRegistry;
 
     private ManagedItemProvider managedItemProvider;
 
     @Before
     public void setup() {
         initMocks(this);
+
+        itemRegistry = getService(ItemRegistry.class);
+        assertNotNull(itemRegistry);
+
         itemResource = getService(ItemResource.class);
         itemResource.uriInfo = mock(UriInfo.class);
 
@@ -86,10 +92,10 @@ public class ItemResourceOSGiTest extends JavaOSGiTest {
 
     @Test
     public void shouldFilterItemsByTag() throws Exception {
-        item1.addTag("Tag1");
-        item2.addTag("Tag1");
-        item2.addTag("Tag2");
-        item3.addTag("Tag2");
+        itemRegistry.addTag(ITEM_NAME1, "Tag1");
+        itemRegistry.addTag(ITEM_NAME2, "Tag1");
+        itemRegistry.addTag(ITEM_NAME2, "Tag2");
+        itemRegistry.addTag(ITEM_NAME3, "Tag2");
 
         Response response = itemResource.getItems(null, null, "Tag1", null, false, null);
         assertThat(readItemNamesFromResponse(response), hasItems(ITEM_NAME1, ITEM_NAME2));
@@ -154,7 +160,7 @@ public class ItemResourceOSGiTest extends JavaOSGiTest {
         registerService(itemProvider);
 
         response = itemResource.addTag("UnmanagedItem", "MyTag");
-        assertThat(response.getStatus(), is(Status.METHOD_NOT_ALLOWED.getStatusCode()));
+        assertThat(response.getStatus(), is(Status.OK.getStatusCode()));
     }
 
     private List<String> readItemNamesFromResponse(Response response) throws IOException {

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
@@ -810,6 +810,6 @@ public class ItemResource implements RESTResource {
     @Override
     public boolean isSatisfied() {
         return itemRegistry != null && managedItemProvider != null && eventPublisher != null && !itemFactories.isEmpty()
-                && dtoMapper != null;
+                && dtoMapper != null && metadataRegistry != null;
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
@@ -212,10 +212,7 @@ public class ItemResource implements RESTResource {
             @DefaultValue("false") @QueryParam("recursive") @ApiParam(value = "get member items recursively", required = false) boolean recursive,
             @QueryParam("fields") @ApiParam(value = "limit output to the given fields (comma separated)", required = false) @Nullable String fields) {
         final Locale locale = LocaleUtil.getLocale(language);
-        final Set<String> namespaces = namespaceSelector == null ? Collections.emptySet()
-                : Arrays.stream(namespaceSelector.split(",")) //
-                        .filter(n -> !n.startsWith(MetadataRegistry.INTERNAL_NAMESPACE_PREFIX)) //
-                        .collect(Collectors.toSet());
+        final Set<String> namespaces = splitAndFilterNamespaces(namespaceSelector);
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
 
         Stream<EnrichedItemDTO> itemStream = getItems(type, tags).stream()
@@ -237,10 +234,7 @@ public class ItemResource implements RESTResource {
             @PathParam("itemname") @ApiParam(value = "item name", required = true) String itemname) {
 
         final Locale locale = LocaleUtil.getLocale(language);
-        final Set<String> namespaces = namespaceSelector == null ? Collections.emptySet()
-                : Arrays.stream(namespaceSelector.split(",")) //
-                        .filter(n -> !n.startsWith(MetadataRegistry.INTERNAL_NAMESPACE_PREFIX)) //
-                        .collect(Collectors.toSet());
+        final Set<String> namespaces = splitAndFilterNamespaces(namespaceSelector);
         logger.debug("Received HTTP GET request at '{}'", uriInfo.getPath());
 
         // get item
@@ -256,6 +250,13 @@ public class ItemResource implements RESTResource {
             logger.info("Received HTTP GET request at '{}' for the unknown item '{}'.", uriInfo.getPath(), itemname);
             return getItemNotFoundResponse(itemname);
         }
+    }
+
+    private Set<String> splitAndFilterNamespaces(@Nullable String namespaceSelector) {
+        return namespaceSelector == null ? Collections.emptySet()
+                : Arrays.stream(namespaceSelector.split(",")) //
+                        .filter(n -> !n.startsWith(MetadataRegistry.INTERNAL_NAMESPACE_PREFIX)) //
+                        .collect(Collectors.toSet());
     }
 
     /**

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/item/ItemResource.java
@@ -255,7 +255,7 @@ public class ItemResource implements RESTResource {
     private Set<String> splitAndFilterNamespaces(@Nullable String namespaceSelector) {
         return namespaceSelector == null ? Collections.emptySet()
                 : Arrays.stream(namespaceSelector.split(",")) //
-                        .filter(n -> !n.startsWith(MetadataRegistry.INTERNAL_NAMESPACE_PREFIX)) //
+                        .filter(n -> !metadataRegistry.isInternalNamespace(n)) //
                         .collect(Collectors.toSet());
     }
 
@@ -524,7 +524,7 @@ public class ItemResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        if (namespace.startsWith(MetadataRegistry.INTERNAL_NAMESPACE_PREFIX)) {
+        if (metadataRegistry.isInternalNamespace(namespace)) {
             logger.info("Received HTTP PUT request at '{}' for internal namespace '{}'.", uriInfo.getPath(), namespace);
             return Response.status(Status.FORBIDDEN).build();
         }
@@ -559,7 +559,7 @@ public class ItemResource implements RESTResource {
             return Response.status(Status.NOT_FOUND).build();
         }
 
-        if (namespace.startsWith(MetadataRegistry.INTERNAL_NAMESPACE_PREFIX)) {
+        if (metadataRegistry.isInternalNamespace(namespace)) {
             logger.info("Received HTTP DELETE request at '{}' for internal namespace '{}'.", uriInfo.getPath(),
                     namespace);
             return Response.status(Status.FORBIDDEN).build();

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/src/org/eclipse/smarthome/model/item/internal/GenericItemProviderTest.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/src/org/eclipse/smarthome/model/item/internal/GenericItemProviderTest.groovy
@@ -50,6 +50,7 @@ class GenericItemProviderTest extends OSGiTest {
 
     @Before
     void setUp() {
+        registerVolatileStorageService()
         itemRegistry = getService ItemRegistry
         assertThat itemRegistry, is(notNullValue())
         modelRepository = getService ModelRepository

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/src/org/eclipse/smarthome/model/item/internal/GenericItemProviderTest.groovy
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/src/org/eclipse/smarthome/model/item/internal/GenericItemProviderTest.groovy
@@ -50,7 +50,6 @@ class GenericItemProviderTest extends OSGiTest {
 
     @Before
     void setUp() {
-        registerVolatileStorageService()
         itemRegistry = getService ItemRegistry
         assertThat itemRegistry, is(notNullValue())
         modelRepository = getService ModelRepository

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -34,6 +34,7 @@ import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemFactory;
 import org.eclipse.smarthome.core.items.ItemProvider;
+import org.eclipse.smarthome.core.items.MetadataRegistry;
 import org.eclipse.smarthome.core.items.dto.GroupFunctionDTO;
 import org.eclipse.smarthome.core.items.dto.ItemDTOMapper;
 import org.eclipse.smarthome.core.types.StateDescription;
@@ -389,7 +390,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
                     logger.error("Binding configuration of type '{}' of item '{}' could not be parsed correctly.",
                             bindingType, item.getName(), e);
                 }
-            } else {
+            } else if (!bindingType.startsWith(MetadataRegistry.INTERNAL_NAMESPACE_PREFIX)) {
                 genericMetaDataProvider.addMetadata(bindingType, item.getName(), config, configuration.getProperties());
             }
         }

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -224,6 +224,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
                     Item item = createItemFromModelItem(modelItem);
                     if (item != null) {
                         internalDispatchBindings(modelName, item, modelItem.getBindings());
+                        provideTags(modelItem);
                     }
                 }
             }
@@ -233,6 +234,15 @@ public class GenericItemProvider extends AbstractProvider<Item>
                 reader.stopConfigurationUpdate(modelName);
             }
         }
+    }
+
+    private void provideTags(ModelItem modelItem) {
+        if (modelItem.getTags() == null || modelItem.getTags().isEmpty()) {
+            return;
+        }
+        String tagString = String.join("|", modelItem.getTags());
+        genericMetaDataProvider.addMetadata(MetadataRegistry.INTERNAL_NAMESPACE_PREFIX + "tags", modelItem.getName(),
+                tagString, null);
     }
 
     private Item createItemFromModelItem(ModelItem modelItem) {
@@ -273,17 +283,9 @@ public class GenericItemProvider extends AbstractProvider<Item>
             }
             item.setLabel(label);
             item.setCategory(modelItem.getIcon());
-            assignTags(modelItem, item);
             return item;
         } else {
             return null;
-        }
-    }
-
-    private void assignTags(ModelItem modelItem, GenericItem item) {
-        List<String> tags = modelItem.getTags();
-        for (String tag : tags) {
-            item.addTag(tag);
         }
     }
 

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -1326,4 +1326,40 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         return null;
     }
 
+    @Override
+    public boolean addTag(String itemName, String tag) {
+        if (itemRegistry != null) {
+            return itemRegistry.addTag(itemName, tag);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean addTags(String itemName, Collection<String> tags) {
+        if (itemRegistry != null) {
+            return itemRegistry.addTags(itemName, tags);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean removeTag(String itemName, String tag) {
+        if (itemRegistry != null) {
+            return itemRegistry.removeTag(itemName, tag);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean removeTags(String itemName, Collection<String> tags) {
+        if (itemRegistry != null) {
+            return itemRegistry.removeTags(itemName, tags);
+        } else {
+            return false;
+        }
+    }
+
 }


### PR DESCRIPTION
With this change, the tags which previously were stored
together with the items now are stored as metadata. This
is completely transparent though, so that users won't
require to migrate any data.

They are, however, stored in a namespace (`_tags`)  which
by its prefix marks it as "internal" and therefore is not
exposed like all other, normal namespaces e.g. through the
REST API.

fixes #5428
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>