### PR TITLE
remove javax.sound.sampled import from o.e.sh.io.javasound

### DIFF
--- a/extensions/io/org.eclipse.smarthome.io.javasound/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.javasound/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-SymbolicName: org.eclipse.smarthome.io.javasound
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Import-Package: 
- javax.sound.sampled,
  org.apache.commons.collections,
  org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,


### PR DESCRIPTION
...as I don't see any obvious reasons why it (still) did so.

fixes #5328
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>