### PR TITLE
Bindings Archetype: Move Handler and Constants into internal package

### DIFF
--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Export-Package: ${package};uses:="org.eclipse.smarthome.test"
 Fragment-Host: ${package}
 Import-Package: 
  ${package},
- ${package}.handler,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.events,

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Version: ${version.replaceAll("-SNAPSHOT", ".qualifier")}
 Export-Package: ${package};uses:="org.eclipse.smarthome.test"
 Fragment-Host: ${package}
 Import-Package: 
- ${package},
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.common.registry,
  org.eclipse.smarthome.core.events,

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__HandlerTest.java
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__HandlerTest.java
@@ -25,7 +25,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import ${package}.internal.handler.${bindingIdCamelCase}Handler;
+import ${package}.internal.${bindingIdCamelCase}Handler;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__HandlerTest.java
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__HandlerTest.java
@@ -25,7 +25,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import ${package}.handler.${bindingIdCamelCase}Handler;
+import ${package}.internal.handler.${bindingIdCamelCase}Handler;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__OSGiTest.java
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__OSGiTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
-import ${package}.handler.${bindingIdCamelCase}Handler;
+import ${package}.internal.handler.${bindingIdCamelCase}Handler;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.ThingProvider;

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__OSGiTest.java
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__OSGiTest.java
@@ -23,7 +23,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
-import ${package}.internal.handler.${bindingIdCamelCase}Handler;
+import ${package}.internal.${bindingIdCamelCase}Handler;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.ThingProvider;

--- a/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-SymbolicName: ${artifactId};singleton:=true
 Bundle-Vendor: ${vendorName}
 Bundle-Version: ${version.replaceAll("-SNAPSHOT", ".qualifier")}
 Import-Package: 
- ${package},
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,

--- a/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -7,12 +7,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ${artifactId};singleton:=true
 Bundle-Vendor: ${vendorName}
 Bundle-Version: ${version.replaceAll("-SNAPSHOT", ".qualifier")}
-Export-Package: 
- ${package},
- ${package}.handler
 Import-Package: 
  ${package},
- ${package}.handler,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__BindingConstants.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__BindingConstants.java
@@ -17,7 +17,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package ${package};
+package ${package}.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
@@ -17,7 +17,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package ${package}.internal.handler;
+package ${package}.internal;
 
 import static ${package}.internal.${bindingIdCamelCase}BindingConstants.*;
 

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import ${package}.internal.handler.${bindingIdCamelCase}Handler;
+import ${package}.internal.${bindingIdCamelCase}Handler;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -19,14 +19,14 @@
  */
 package ${package}.internal;
 
-import static ${package}.${bindingIdCamelCase}BindingConstants.*;
+import static ${package}.internal.${bindingIdCamelCase}BindingConstants.*;
 
 import java.util.Collections;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import ${package}.handler.${bindingIdCamelCase}Handler;
+import ${package}.internal.handler.${bindingIdCamelCase}Handler;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/handler/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/handler/__bindingIdCamelCase__Handler.java
@@ -17,9 +17,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package ${package}.handler;
+package ${package}.internal.handler;
 
-import static ${package}.${bindingIdCamelCase}BindingConstants.*;
+import static ${package}.internal.${bindingIdCamelCase}BindingConstants.*;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;


### PR DESCRIPTION
As discussed in #4330 it makes sense to export handlers to create a derived
handler in another bundle. We do have this for the bluetooth binding and
will have it for the zigbee binding as well.

These two bindings are the rare exception and their handler APIs have been
throught through, i.e. they have a stable API and do not expose internal
classes.

Thus for newly created bindings it makes sense to NOT export the handlers
and if there should be a derived handler at some point in the future we
know the use-cases for the derived handler and can design a proper API
for the handler at that time and then export the handler.

Fixes #4330

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>