### PR TITLE
Fix IllegalArgumentException when mapping boolean configuration parameters within a service

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/ConfigMapper.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/ConfigMapper.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Map an OSGi configuration map {@code Map<String, Object>} to an individual configuration bean.
- * 
+ *
  * @author David Graeff - initial contribution
  *
  */
@@ -88,14 +88,14 @@ public class ConfigMapper {
                         .getActualTypeArguments()[0];
                 final List<Object> lst = new ArrayList<>(c.size());
                 for (final Object it : c) {
-                    final Object normalized = numberConvert(it, innerClass);
+                    final Object normalized = objectConvert(it, innerClass);
                     lst.add(normalized);
                 }
                 value = lst;
             }
 
             try {
-                value = numberConvert(value, type);
+                value = objectConvert(value, type);
                 logger.trace("Setting value ({}) {} to field '{}' in configuration class {}", type.getSimpleName(),
                         value, fieldName, configurationClass.getName());
                 FieldUtils.writeField(configuration, fieldName, value, true);
@@ -126,7 +126,7 @@ public class ConfigMapper {
         return fields;
     }
 
-    private static Object numberConvert(Object value, Class<?> type) {
+    private static Object objectConvert(Object value, Class<?> type) {
         Object result = value;
         // Handle the conversion case of BigDecimal to Float,Double,Long,Integer and the respective
         // primitive types
@@ -143,7 +143,7 @@ public class ConfigMapper {
                 result = bdValue.intValue();
             }
         } else
-        // Handle the conversion case of String to Float,Double,Long,Integer,BigDecimal and the respective
+        // Handle the conversion case of String to Float,Double,Long,Integer,BigDecimal,Boolean and the respective
         // primitive types
         if (value instanceof String && !type.equals(String.class)) {
             String bdValue = (String) value;
@@ -157,6 +157,8 @@ public class ConfigMapper {
                 result = new BigDecimal(bdValue);
             } else if (type.equals(Integer.class) || typeName.equals("int")) {
                 result = Integer.valueOf(bdValue);
+            } else if (type.equals(Boolean.class) || typeName.equals("boolean")) {
+                result = Boolean.valueOf(bdValue);
             }
         }
         return result;


### PR DESCRIPTION
This PR fixes an IAE that occurs when the ConfigMapper converts boolean configuration parameters from within a service.

The exception occurs with the Netwrok Binding when the following configuration lines are added to `conf/services/runtime.cfg` in openHAB:

```
binding.network:allowSystemPings=false
binding.network:allowDHCPlisten=false
binding.network:cacheDeviceStateTimeInMS=1234
binding.network:arpPingToolPath=/usr/bin/arping
```

The binding converts these parameters in the [NetworkHandlerFactory](https://github.com/openhab/openhab2-addons/blob/aad5d532437ac3b760b7f23308874d5142c6439a/addons/binding/org.openhab.binding.network/src/main/java/org/openhab/binding/network/internal/NetworkHandlerFactory.java#L63):

```java
    @Modified
    protected void modified(Map<String, Object> config) {
        // We update instead of replace the configuration object, so that if the user updates the
        // configuration, the values are automatically available in all handlers. Because they all
        // share the same instance.
        configuration.update(new Configuration(config).as(NetworkBindingConfiguration.class));
    }
```

The logged exception is:

```
18:56:59.228 [WARN ] [ome.config.core.internal.ConfigMapper] - Could not set field value for field 'allowSystemPings': Can not set java.lang.Boolean field org.openhab.binding.network.internal.NetworkBindingConfiguration.allowSystemPings to java.lang.String
java.lang.IllegalArgumentException: Can not set java.lang.Boolean field org.openhab.binding.network.internal.NetworkBindingConfiguration.allowSystemPings to java.lang.String
	at sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:167) [?:?]
	at sun.reflect.UnsafeFieldAccessorImpl.throwSetIllegalArgumentException(UnsafeFieldAccessorImpl.java:171) [?:?]
	at sun.reflect.UnsafeObjectFieldAccessorImpl.set(UnsafeObjectFieldAccessorImpl.java:81) [?:?]
	at java.lang.reflect.Field.set(Field.java:764) [?:?]
	at org.apache.commons.lang.reflect.FieldUtils.writeField(FieldUtils.java:523) [38:org.apache.commons.lang:2.6.0]
	at org.apache.commons.lang.reflect.FieldUtils.writeField(FieldUtils.java:500) [38:org.apache.commons.lang:2.6.0]
	at org.apache.commons.lang.reflect.FieldUtils.writeField(FieldUtils.java:560) [38:org.apache.commons.lang:2.6.0]
	at org.eclipse.smarthome.config.core.internal.ConfigMapper.as(ConfigMapper.java:101) [96:org.eclipse.smarthome.config.core:0.10.0.201804200816]
	at org.eclipse.smarthome.config.core.Configuration.as(Configuration.java:54) [96:org.eclipse.smarthome.config.core:0.10.0.201804200816]
	at org.openhab.binding.network.internal.NetworkHandlerFactory.modified(NetworkHandlerFactory.java:63) [223:org.openhab.binding.network:2.3.0.201804230838]
	at org.openhab.binding.network.internal.NetworkHandlerFactory.activate(NetworkHandlerFactory.java:49) [223:org.openhab.binding.network:2.3.0.201804230838]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:?]
	at org.apache.felix.scr.impl.inject.BaseMethod.invokeMethod(BaseMethod.java:229) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.inject.BaseMethod.access$500(BaseMethod.java:39) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.inject.BaseMethod$Resolved.invoke(BaseMethod.java:650) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.inject.BaseMethod.invoke(BaseMethod.java:506) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.inject.ActivateMethod.invoke(ActivateMethod.java:307) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.inject.ActivateMethod.invoke(ActivateMethod.java:299) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.SingleComponentManager.createImplementationObject(SingleComponentManager.java:298) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.SingleComponentManager.createComponent(SingleComponentManager.java:109) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getService(SingleComponentManager.java:906) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.SingleComponentManager.getServiceInternal(SingleComponentManager.java:879) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.activateInternal(AbstractComponentManager.java:749) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.enableInternal(AbstractComponentManager.java:675) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.AbstractComponentManager.enable(AbstractComponentManager.java:430) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.manager.ConfigurableComponentHolder.enableComponents(ConfigurableComponentHolder.java:657) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.BundleComponentActivator.initialEnable(BundleComponentActivator.java:341) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.Activator.loadComponents(Activator.java:390) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.Activator.access$200(Activator.java:54) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.scr.impl.Activator$ScrExtension.start(Activator.java:265) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.utils.extender.AbstractExtender.createExtension(AbstractExtender.java:254) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.utils.extender.AbstractExtender.modifiedBundle(AbstractExtender.java:227) [39:org.apache.felix.scr:2.0.12]
	at org.apache.felix.utils.extender.AbstractExtender.addingBundle(AbstractExtender.java:187) [39:org.apache.felix.scr:2.0.12]
	at org.osgi.util.tracker.BundleTracker$Tracked.customizerAdding(BundleTracker.java:469) [?:?]
	at org.osgi.util.tracker.BundleTracker$Tracked.customizerAdding(BundleTracker.java:415) [?:?]
	at org.osgi.util.tracker.AbstractTracked.trackAdding(AbstractTracked.java:256) [?:?]
	at org.osgi.util.tracker.AbstractTracked.track(AbstractTracked.java:229) [?:?]
	at org.osgi.util.tracker.BundleTracker$Tracked.bundleChanged(BundleTracker.java:444) [?:?]
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:908) [?:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230) [?:?]
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148) [?:?]
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEventPrivileged(EquinoxEventPublisher.java:213) [?:?]
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:120) [?:?]
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:112) [?:?]
	at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor.publishModuleEvent(EquinoxContainerAdaptor.java:168) [?:?]
	at org.eclipse.osgi.container.Module.publishEvent(Module.java:476) [?:?]
	at org.eclipse.osgi.container.Module.start(Module.java:467) [?:?]
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1634) [?:?]
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1613) [?:?]
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1585) [?:?]
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1528) [?:?]
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1) [?:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230) [?:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:340) [?:?]
```
