### PR TITLE
log warning if there are multiple sitemaps with the same name

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -328,19 +328,26 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
 
     public Collection<SitemapDTO> getSitemapBeans(URI uri) {
         Collection<SitemapDTO> beans = new LinkedList<SitemapDTO>();
+        Set<String> names = new HashSet<>();
         logger.debug("Received HTTP GET request at '{}'.", UriBuilder.fromUri(uri).build().toASCIIString());
         for (SitemapProvider provider : sitemapProviders) {
             for (String modelName : provider.getSitemapNames()) {
                 Sitemap sitemap = provider.getSitemap(modelName);
                 if (sitemap != null) {
-                    SitemapDTO bean = new SitemapDTO();
-                    bean.name = modelName;
-                    bean.icon = sitemap.getIcon();
-                    bean.label = sitemap.getLabel();
-                    bean.link = UriBuilder.fromUri(uri).path(bean.name).build().toASCIIString();
-                    bean.homepage = new PageDTO();
-                    bean.homepage.link = bean.link + "/" + sitemap.getName();
-                    beans.add(bean);
+                    if (!names.contains(modelName)) {
+                        names.add(modelName);
+                        SitemapDTO bean = new SitemapDTO();
+                        bean.name = modelName;
+                        bean.icon = sitemap.getIcon();
+                        bean.label = sitemap.getLabel();
+                        bean.link = UriBuilder.fromUri(uri).path(bean.name).build().toASCIIString();
+                        bean.homepage = new PageDTO();
+                        bean.homepage.link = bean.link + "/" + sitemap.getName();
+                        beans.add(bean);
+                    } else {
+                        logger.warn("Found duplicate sitemap name '{}' - ignoring it. Please check your configuration.",
+                                modelName);
+                    }
                 }
             }
         }


### PR DESCRIPTION
fixes https://github.com/eclipse/smarthome/issues/5441

Note that the problem here is that we do not have a SitemapRegistry and thus don't have the same mechanism in place as for other entities. I have thus decided to add the warning in the sitemap resource as this is very likely to be requested by remote clients, but also not too often.
As it is a very rare situation (there are probably not many situations where multiple sitemap providers are registered - the main one I am aware of is the `_default` sitemap in openHAB core) and we are about to introduce new sitemaps in ESH as a replacement (https://github.com/eclipse/smarthome/issues/5337), I'd think that this solution is good enough.

Signed-off-by: Kai Kreuzer <kai@openhab.org>