### PR TITLE
removed todo in JaasAuthenticationProvider

### DIFF
--- a/bundles/auth/org.eclipse.smarthome.auth.jaas/src/main/java/org/eclipse/smarthome/auth/jaas/internal/JaasAuthenticationProvider.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.jaas/src/main/java/org/eclipse/smarthome/auth/jaas/internal/JaasAuthenticationProvider.java
@@ -71,7 +71,6 @@ public class JaasAuthenticationProvider implements AuthenticationProvider {
             });
             loginContext.login();
 
-            // TODO shall we call logout method on login context?
             return getAuthentication(name, loginContext.getSubject());
         } catch (LoginException e) {
             throw new AuthenticationException("Could not obtain authentication over login context", e);


### PR DESCRIPTION
Authentication code is about to be completely revisited, so the current classes won't be further changed - thus removing the to-do comment.

fixes https://github.com/eclipse/smarthome/issues/5256

Signed-off-by: Kai Kreuzer <kai@openhab.org>