### PR TITLE
added deprecated info to ActiveItem

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ActiveItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ActiveItem.java
@@ -24,8 +24,11 @@ import org.eclipse.jdt.annotation.Nullable;
  * category.
  *
  * @author Dennis Nobel - Initial contribution
+ *
+ * @deprecated This class is not meant as a public API - it should only be used internally from within the framework
  */
 @NonNullByDefault
+@Deprecated
 public interface ActiveItem extends Item {
 
     /**


### PR DESCRIPTION
This PR makes it clear that `ActiveItem` must not be considered public API - imho, we should move towards removing it and replacing it by the builder pattern as discussed for Rules and Things as well.

Signed-off-by: Kai Kreuzer <kai@openhab.org>