### PR TITLE
don't serialize unit for unitless quantities

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
@@ -268,7 +268,11 @@ public class QuantityType<T extends Quantity<T>> extends Number
 
     @Override
     public String toFullString() {
-        return quantity.toString();
+        if (quantity.getUnit() == AbstractUnit.ONE) {
+            return quantity.getValue().toString();
+        } else {
+            return quantity.toString();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/5445