### PR TITLE
[Metadata] delay metadata modifications if the managed provider is mi…

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -97,9 +97,12 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     private void setTagsFromMetadata(Item item) {
         if (item instanceof ActiveItem) {
-            ActiveItem activeItem = (ActiveItem) item;
-            activeItem.removeAllTags();
-            activeItem.addTags(readTags(item.getName()));
+            SortedSet<String> tags = readTags(item.getName());
+            if (!tags.isEmpty()) {
+                ActiveItem activeItem = (ActiveItem) item;
+                activeItem.removeAllTags();
+                activeItem.addTags(tags);
+            }
         }
     }
 
@@ -439,7 +442,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
                 metadataRegistry.add(metadata);
             }
         } catch (IllegalStateException e) {
-            logger.warn("Could not persist tags of item '{}', presumably no ManagedMetadataProvider was available",
+            logger.debug("Could not persist tags of item '{}', presumably no ManagedMetadataProvider was available",
                     itemName);
         }
     }


### PR DESCRIPTION
…ssing

Until now, metadata simply was not persisted if the managed provider was not
available.

This became obvious in #5490 when storing tags was not possible suring startup,
but actually all other use-cases related to metadata would be affected too.
Therefore this is fixed in the metadata registry directly and not only for tags
in the item registry.

fixes #5490
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>