### PR TITLE
Activate ThingHandlerFactories on demand

### DIFF
--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
@@ -40,7 +40,7 @@ import com.google.common.collect.Sets;
  *
  * @author Henning Treu - Initial contribution
  */
-@Component(immediate = true, service = ThingHandlerFactory.class, configurationPid = "binding.magic")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.magic")
 public class MagicHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.newHashSet(THING_TYPE_EXTENSIBLE_THING,

--- a/docs/documentation/development/bindings/how-to.md
+++ b/docs/documentation/development/bindings/how-to.md
@@ -113,9 +113,11 @@ When a new *Thing* is added, the Eclipse SmartHome runtime queries every `ThingH
 The `YahooWeatherHandlerFactory` supports only one *ThingType* and instantiates a new `YahooWeatherHandler` for a given thing:
 
 ```java
+@NonNullByDefault
+@Component(configurationPid = "binding.yahooweather", service = ThingHandlerFactory.class)
 public class YahooWeatherHandlerFactory extends BaseThingHandlerFactory {
     
-    private final static Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Lists.newArrayList(YahooWeatherBindingConstants.THING_TYPE_WEATHER);
+    private static final Collection<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(YahooWeatherBindingConstants.THING_TYPE_WEATHER);
     
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -123,11 +125,10 @@ public class YahooWeatherHandlerFactory extends BaseThingHandlerFactory {
     }
 
     @Override
-    protected ThingHandler createHandler(Thing thing) {
-
+    protected @Nullable ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID.equals(YahooWeatherBindingConstants.THING_TYPE_WEATHER)) {
+        if (YahooWeatherBindingConstants.THING_TYPE_WEATHER.equals(thingTypeUID)) {
             return new YahooWeatherHandler(thing);
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/AstroHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/src/main/java/org/eclipse/smarthome/binding/astro/internal/AstroHandlerFactory.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Gerhard Riegler - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true)
+@Component(service = ThingHandlerFactory.class)
 public class AstroHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Stream
@@ -55,7 +55,7 @@ public class AstroHandlerFactory extends BaseThingHandlerFactory {
     @Override
     protected ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
-        AstroThingHandler thingHandler = null;      
+        AstroThingHandler thingHandler = null;
         if (thingTypeUID.equals(THING_TYPE_SUN)) {
             thingHandler = new SunHandler(thing);
         } else if (thingTypeUID.equals(THING_TYPE_MOON)) {
@@ -81,7 +81,7 @@ public class AstroHandlerFactory extends BaseThingHandlerFactory {
     protected void unsetTimeZoneProvider(TimeZoneProvider timeZone) {
         PropertyUtils.unsetTimeZone();
     }
-    
+
     public static AstroThingHandler getHandler(String thingUid) {
         return ASTRO_THING_HANDLERS.get(thingUid);
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluez/src/main/java/org/eclipse/smarthome/binding/bluetooth/bluez/internal/BlueZHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluez/src/main/java/org/eclipse/smarthome/binding/bluetooth/bluez/internal/BlueZHandlerFactory.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Kai Kreuzer - Initial contribution and API
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.bluetooth.bluez")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.bluetooth.bluez")
 public class BlueZHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.blukii/src/main/java/org/eclipse/smarthome/binding/bluetooth/blukii/internal/BlukiiHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.blukii/src/main/java/org/eclipse/smarthome/binding/bluetooth/blukii/internal/BlukiiHandlerFactory.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.blukii")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.blukii")
 public class BlukiiHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth/src/main/java/org/eclipse/smarthome/binding/bluetooth/internal/BluetoothHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth/src/main/java/org/eclipse/smarthome/binding/bluetooth/internal/BluetoothHandlerFactory.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Kai Kreuzer - Initial contribution and API
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.bluetooth")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.bluetooth")
 public class BluetoothHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>();

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/DigitalSTROMHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/DigitalSTROMHandlerFactory.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * @author Michael Ochel - Initial contribution
  * @author Mathias Siegele - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.digitalstrom")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.digitalstrom")
 public class DigitalSTROMHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(DigitalSTROMHandlerFactory.class);

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/DmxHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/DmxHandlerFactory.java
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Jan N. Klug - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, name = "binding.dmx")
+@Component(service = ThingHandlerFactory.class, name = "binding.dmx")
 public class DmxHandlerFactory extends BaseThingHandlerFactory {
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/src/main/java/org/eclipse/smarthome/binding/fsinternetradio/internal/FSInternetRadioHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/src/main/java/org/eclipse/smarthome/binding/fsinternetradio/internal/FSInternetRadioHandlerFactory.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Patrick Koenemann - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.fsinternetradio")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.fsinternetradio")
 public class FSInternetRadioHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_RADIO);

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueThingHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueThingHandlerFactory.java
@@ -47,7 +47,7 @@ import org.osgi.service.component.annotations.Component;
  *
  */
 @NonNullByDefault
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.hue")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.hue")
 public class HueThingHandlerFactory extends BaseThingHandlerFactory {
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Stream

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxHandlerFactory.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Dennis Nobel - Initial contribution
  * @author Karel Goderis - Remove dependency on external libraries
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.lifx")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.lifx")
 public class LifxHandlerFactory extends BaseThingHandlerFactory {
 
     private LifxChannelFactory channelFactory;

--- a/extensions/binding/org.eclipse.smarthome.binding.lirc/src/main/java/org/eclipse/smarthome/binding/lirc/internal/LIRCHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lirc/src/main/java/org/eclipse/smarthome/binding/lirc/internal/LIRCHandlerFactory.java
@@ -39,10 +39,10 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Andrew Nagle - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.lirc")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.lirc")
 public class LIRCHandlerFactory extends BaseThingHandlerFactory {
 
-    private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/NtpHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/src/main/java/org/eclipse/smarthome/binding/ntp/internal/NtpHandlerFactory.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Marcel Verpaalen - Initial contribution
  * @author Markus Rathgeb - Add locale provider support
  */
-@Component(service = ThingHandlerFactory.class, immediate = true)
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.ntp")
 public class NtpHandlerFactory extends BaseThingHandlerFactory {
 
     private LocaleProvider localeProvider;

--- a/extensions/binding/org.eclipse.smarthome.binding.serialbutton/src/main/java/org/eclipse/smarthome/binding/serialbutton/internal/SerialButtonHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.serialbutton/src/main/java/org/eclipse/smarthome/binding/serialbutton/internal/SerialButtonHandlerFactory.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.serialbutton")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.serialbutton")
 @NonNullByDefault
 public class SerialButtonHandlerFactory extends BaseThingHandlerFactory {
 

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosHandlerFactory.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Karel Goderis - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.sonos")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.sonos")
 public class SonosHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(SonosHandlerFactory.class);

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/TradfriHandlerFactory.java
@@ -43,7 +43,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Kai Kreuzer - Initial contribution
  * @author Christoph Weitkamp - Added support for remote controller and motion sensor devices (read-only battery level)
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.tradfri")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.tradfri")
 public class TradfriHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Stream

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/WeatherUndergroundHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/internal/WeatherUndergroundHandlerFactory.java
@@ -34,7 +34,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Laurent Garnier - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true)
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.weatherunderground")
 public class WeatherUndergroundHandlerFactory extends BaseThingHandlerFactory {
 
     private LocaleProvider localeProvider;

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/WemoHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/src/main/java/org/eclipse/smarthome/binding/wemo/internal/WemoHandlerFactory.java
@@ -48,10 +48,10 @@ import org.slf4j.LoggerFactory;
  * @author Hans-Jörg Merk - Initial contribution
  * @author Kai Kreuzer - some refactoring for performance and simplification
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.wemo")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.wemo")
 public class WemoHandlerFactory extends BaseThingHandlerFactory {
 
-    private Logger logger = LoggerFactory.getLogger(WemoHandlerFactory.class);
+    private final Logger logger = LoggerFactory.getLogger(WemoHandlerFactory.class);
 
     private UpnpIOService upnpIOService;
 
@@ -62,7 +62,7 @@ public class WemoHandlerFactory extends BaseThingHandlerFactory {
         return SUPPORTED_THING_TYPES.contains(thingTypeUID);
     }
 
-    private Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
 
     @Override
     protected ThingHandler createHandler(Thing thing) {

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/src/main/java/org/eclipse/smarthome/binding/yahooweather/internal/YahooWeatherHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/src/main/java/org/eclipse/smarthome/binding/yahooweather/internal/YahooWeatherHandlerFactory.java
@@ -30,7 +30,7 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author Kai Kreuzer - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.yahooweather")
+@Component(service = ThingHandlerFactory.class, configurationPid = "binding.yahooweather")
 public class YahooWeatherHandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__HandlerFactory.java
@@ -40,8 +40,8 @@ import org.osgi.service.component.annotations.Component;
  *
  * @author ${author} - Initial contribution
  */
-@Component(service = ThingHandlerFactory.class, immediate = true, configurationPid = "binding.${bindingId}")
 @NonNullByDefault
+@Component(configurationPid = "binding.${bindingId}", service = ThingHandlerFactory.class)
 public class ${bindingIdCamelCase}HandlerFactory extends BaseThingHandlerFactory {
 
     private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_SAMPLE);


### PR DESCRIPTION
...instead of immediately.

Also:
* added `configurationPid=...` parameter where missing
* adapted archetype accordingly
* amended sample in the docu (binding how-to) accordingly

fixes #5163
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>