### PR TITLE
split event manager and event publisher

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventManager.java
@@ -12,11 +12,6 @@
  */
 package org.eclipse.smarthome.core.internal.events;
 
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.util.Dictionary;
-import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -24,10 +19,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.smarthome.core.common.SafeCaller;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFactory;
-import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.events.EventSubscriber;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -35,9 +27,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.event.EventAdmin;
 import org.osgi.service.event.EventHandler;
-import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * The {@link OSGiEventManager} provides an OSGi based default implementation of the Eclipse SmartHome event bus.
@@ -46,80 +36,38 @@ import org.osgi.util.tracker.ServiceTracker;
  * implementing the OSGi {@link EventHandler} interface) and dispatches the received OSGi events as ESH {@link Event}s
  * to the {@link EventSubscriber}s if the provided filter applies.
  *
- * The {@link OSGiEventManager} also serves as {@link EventPublisher} by implementing the EventPublisher interface.
- * Events are send in an asynchronous way via OSGi Event Admin mechanism.
- *
  * @author Stefan Bußweiler - Initial contribution
  * @author Markus Rathgeb - Return on received events as fast as possible (handle event in another thread)
  */
 @Component(immediate = true, property = { "event.topics:String=smarthome" })
-public class OSGiEventManager implements EventHandler, EventPublisher {
-
-    @SuppressWarnings("rawtypes")
-    private class EventSubscriberServiceTracker extends ServiceTracker {
-
-        @SuppressWarnings("unchecked")
-        public EventSubscriberServiceTracker(BundleContext context) {
-            super(context, EventSubscriber.class.getName(), null);
-        }
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public Object addingService(ServiceReference reference) {
-            EventSubscriber eventSubscriber = (EventSubscriber) this.context.getService(reference);
-            if (eventSubscriber != null) {
-                eventHandler.addEventSubscriber(eventSubscriber);
-                return eventSubscriber;
-            } else {
-                return null;
-            }
-        }
-
-        @Override
-        public void removedService(ServiceReference reference, Object service) {
-            eventHandler.removeEventSubscriber((EventSubscriber) service);
-        }
-
-    }
+public class OSGiEventManager implements EventHandler {
 
     private final Map<String, EventFactory> typedEventFactories = new ConcurrentHashMap<String, EventFactory>();
 
     private ThreadedEventHandler eventHandler;
-
-    private EventSubscriberServiceTracker eventSubscriberServiceTracker;
-
-    private EventAdmin osgiEventAdmin;
 
     private SafeCaller safeCaller;
 
     @Activate
     protected void activate(ComponentContext componentContext) {
         eventHandler = new ThreadedEventHandler(typedEventFactories, safeCaller);
-
-        eventSubscriberServiceTracker = new EventSubscriberServiceTracker(componentContext.getBundleContext());
-        eventSubscriberServiceTracker.open();
     }
 
     @Deactivate
     protected void deactivate(ComponentContext componentContext) {
-        if (eventSubscriberServiceTracker != null) {
-            eventSubscriberServiceTracker.close();
-            eventSubscriberServiceTracker = null;
-        }
-
         if (eventHandler != null) {
             eventHandler.close();
             eventHandler = null;
         }
     }
 
-    @Reference
-    protected void setEventAdmin(EventAdmin eventAdmin) {
-        this.osgiEventAdmin = eventAdmin;
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    protected void addEventSubscriber(EventSubscriber eventSubscriber) {
+        eventHandler.addEventSubscriber(eventSubscriber);
     }
 
-    protected void unsetEventAdmin(EventAdmin eventAdmin) {
-        this.osgiEventAdmin = null;
+    protected void removeEventSubscriber(EventSubscriber eventSubscriber) {
+        eventHandler.removeEventSubscriber(eventSubscriber);
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -155,61 +103,6 @@ public class OSGiEventManager implements EventHandler, EventPublisher {
     @Override
     public void handleEvent(org.osgi.service.event.Event osgiEvent) {
         eventHandler.handleEvent(osgiEvent);
-    }
-
-    @Override
-    public void post(final Event event) throws IllegalArgumentException, IllegalStateException {
-        EventAdmin eventAdmin = this.osgiEventAdmin;
-        assertValidArgument(event);
-        assertValidState(eventAdmin);
-        postAsOSGiEvent(eventAdmin, event);
-    }
-
-    private void postAsOSGiEvent(final EventAdmin eventAdmin, final Event event) throws IllegalStateException {
-        try {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                @Override
-                public Void run() throws Exception {
-                    Dictionary<String, Object> properties = new Hashtable<String, Object>(3);
-                    properties.put("type", event.getType());
-                    properties.put("payload", event.getPayload());
-                    properties.put("topic", event.getTopic());
-                    if (event.getSource() != null) {
-                        properties.put("source", event.getSource());
-                    }
-                    eventAdmin.postEvent(new org.osgi.service.event.Event("smarthome", properties));
-                    return null;
-                }
-            });
-        } catch (PrivilegedActionException pae) {
-            Exception e = pae.getException();
-            throw new IllegalStateException("Cannot post the event via the event bus. Error message: " + e.getMessage(),
-                    e);
-        }
-    }
-
-    private void assertValidArgument(Event event) throws IllegalArgumentException {
-        String errorMsg = "The %s of the 'event' argument must not be null or empty.";
-        String value;
-
-        if (event == null) {
-            throw new IllegalArgumentException("Argument 'event' must not be null.");
-        }
-        if ((value = event.getType()) == null || value.isEmpty()) {
-            throw new IllegalArgumentException(String.format(errorMsg, "type"));
-        }
-        if ((value = event.getPayload()) == null || value.isEmpty()) {
-            throw new IllegalArgumentException(String.format(errorMsg, "payload"));
-        }
-        if ((value = event.getTopic()) == null || value.isEmpty()) {
-            throw new IllegalArgumentException(String.format(errorMsg, "topic"));
-        }
-    }
-
-    private void assertValidState(EventAdmin eventAdmin) throws IllegalStateException {
-        if (eventAdmin == null) {
-            throw new IllegalStateException("The event bus module is not available!");
-        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventPublisher.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/events/OSGiEventPublisher.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.events;
+
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.eclipse.smarthome.core.events.Event;
+import org.eclipse.smarthome.core.events.EventPublisher;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.event.EventAdmin;
+
+/**
+ * The {@link OSGiEventPublisher} provides an OSGi based default implementation of the Eclipse SmartHome event
+ * publisher.
+ *
+ * Events are send in an asynchronous way via OSGi Event Admin mechanism.
+ *
+ * @author Stefan Bußweiler - Initial contribution
+ * @author Simon Kaufmann - separated from OSGiEventManager
+ */
+@Component
+public class OSGiEventPublisher implements EventPublisher {
+
+    private EventAdmin osgiEventAdmin;
+
+    @Reference
+    protected void setEventAdmin(EventAdmin eventAdmin) {
+        this.osgiEventAdmin = eventAdmin;
+    }
+
+    protected void unsetEventAdmin(EventAdmin eventAdmin) {
+        this.osgiEventAdmin = null;
+    }
+
+    @Override
+    public void post(final Event event) throws IllegalArgumentException, IllegalStateException {
+        EventAdmin eventAdmin = this.osgiEventAdmin;
+        assertValidArgument(event);
+        assertValidState(eventAdmin);
+        postAsOSGiEvent(eventAdmin, event);
+    }
+
+    private void postAsOSGiEvent(final EventAdmin eventAdmin, final Event event) throws IllegalStateException {
+        try {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+                @Override
+                public Void run() throws Exception {
+                    Dictionary<String, Object> properties = new Hashtable<String, Object>(3);
+                    properties.put("type", event.getType());
+                    properties.put("payload", event.getPayload());
+                    properties.put("topic", event.getTopic());
+                    if (event.getSource() != null) {
+                        properties.put("source", event.getSource());
+                    }
+                    eventAdmin.postEvent(new org.osgi.service.event.Event("smarthome", properties));
+                    return null;
+                }
+            });
+        } catch (PrivilegedActionException pae) {
+            Exception e = pae.getException();
+            throw new IllegalStateException("Cannot post the event via the event bus. Error message: " + e.getMessage(),
+                    e);
+        }
+    }
+
+    private void assertValidArgument(Event event) throws IllegalArgumentException {
+        String errorMsg = "The %s of the 'event' argument must not be null or empty.";
+        String value;
+
+        if (event == null) {
+            throw new IllegalArgumentException("Argument 'event' must not be null.");
+        }
+        if ((value = event.getType()) == null || value.isEmpty()) {
+            throw new IllegalArgumentException(String.format(errorMsg, "type"));
+        }
+        if ((value = event.getPayload()) == null || value.isEmpty()) {
+            throw new IllegalArgumentException(String.format(errorMsg, "payload"));
+        }
+        if ((value = event.getTopic()) == null || value.isEmpty()) {
+            throw new IllegalArgumentException(String.format(errorMsg, "topic"));
+        }
+    }
+
+    private void assertValidState(EventAdmin eventAdmin) throws IllegalStateException {
+        if (eventAdmin == null) {
+            throw new IllegalStateException("The event bus module is not available!");
+        }
+    }
+
+}


### PR DESCRIPTION
...in order to resolve the circular dependencies, caused by
many EventSubscriber implementation also requiring an EventPublisher.

The service tracker which was included in the OSGiEventManager was
just attempting to hide these circular dependencies from the SCR,
but still caused some trouble sometimes.

fixes #4356
fixes #4775
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>