### PR TITLE
changed hard dependency on httpclient feature to a requirement

### DIFF
--- a/features/karaf/esh-tp/src/main/feature/feature.xml
+++ b/features/karaf/esh-tp/src/main/feature/feature.xml
@@ -156,6 +156,7 @@
 
   <feature name="esh-tp-jupnp" description="UPnP/DLNA library for Java" version="${project.version}">
     <capability>esh.tp;feature=jupnp;version=2.3.0</capability>
+    <requirement>esh.tp;filter:="(feature=httpclient)"</requirement>
     <feature dependency="true">http</feature>
     <feature dependency="true">scr</feature>
     <feature dependency="true">esh-tp-httpclient</feature>

--- a/features/karaf/esh-tp/src/main/feature/feature.xml
+++ b/features/karaf/esh-tp/src/main/feature/feature.xml
@@ -159,7 +159,6 @@
     <requirement>esh.tp;filter:="(feature=httpclient)"</requirement>
     <feature dependency="true">http</feature>
     <feature dependency="true">scr</feature>
-    <feature dependency="true">esh-tp-httpclient</feature>
     <bundle>mvn:org.jupnp/org.jupnp/2.3.0</bundle>
   </feature>
 


### PR DESCRIPTION
This is my first attempt to fix https://github.com/eclipse/smarthome/issues/5460, resp. https://github.com/openhab/openhab-distro/issues/692.

@maggu2810 I'd be grateful for your review/input.
What I noticed is that on an freshly installed openHAB distro (no addons), the feature `esh-tp-jupnp` is installed and active - and with it, the Jetty 9.3.15 bundles are already there. 
openHAB comes with its own [httpclient capability](https://github.com/openhab/openhab-core/blob/master/features/openhab-core/src/main/feature/feature.xml#L65-L76), so I'd hope that I can make this being picked up instead. What isn't clear to me yet though is why `esh-tp-jupnp` is at all installed, when no add-on is installed - I would have expected it to be something optional...

Signed-off-by: Kai Kreuzer <kai@openhab.org>