### PR TITLE
[5483] Selective auto-approval of inbox entries

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/InboxAutoApprovePredicate.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/InboxAutoApprovePredicate.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.config.discovery.inbox;
+
+import java.util.function.Predicate;
+
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.internal.AutomaticInboxProcessor;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * {@link Component}s implementing this interface participate in the {@link AutomaticInboxProcessor}'s decision whether
+ * to automatically approve an inbox result or not.
+ * <p/>
+ * If this {@link Predicate} returns <code>true</code> the {@link DiscoveryResult} will be automatically approved by the
+ * {@link AutomaticInboxProcessor}.
+ * <p/>
+ * Note that if this {@link Predicate} returns <code>false</code> the {@link DiscoveryResult} might still be
+ * automatically approved (e.g., because another such {@link Predicate} returned <code>true</code>) - i.e., it is not
+ * possible to veto the automatic approval of a {@link DiscoveryResult}.
+ * <p/>
+ * Please note that this interface is intended to be implemented by solutions integrating Eclipse SmartHome. This
+ * interface is <em>not</em> intended to be implemented by Eclipse SmartHome addons (like, e.g., bindings).
+ *
+ * @author Henning Sudbrock - initial contribution
+ */
+public interface InboxAutoApprovePredicate extends Predicate<DiscoveryResult> {
+
+}


### PR DESCRIPTION
This PR addresses https://github.com/eclipse/smarthome/issues/5483.

With this PR, bundles can hook into the auto-approval of discovery results performed by the `o.e.sh.config.discovery.internal.AutomaticInboxProcessor`. To hook into it, they must provide an implementation of the `o.e.sh.config.discovery.InboxAutoApprovePredicate`, which determines based on the discovery result whether it should be automatically approved.

As indicated in the JavaDoc of the `InboxAutoApprovePredicate`, this is intended to be used by solutions integrating Eclipse SmartHome, but not for Eclipse SmartHome addons (like, e.g., bindings).

One open question for me is how to deal with "evil" `InboxAutoApprovePredicate`s that throw `RuntimeException`s. In this PR, it is implemented such that if this happens, then all remaining `InboxAutoApprovePredicate`s will be skipped, as the exception is not caught. Should this exception be caught (using a `catch (RuntimeException e)` in `AutomaticInboxProcessor.isToBeAutoApproved`)? Or can we live with that - in particular as such predicates will only be provided by solutions and not by ESH addons? (There is a currently ignored test illustrating this (edge?) case - I will un-ignore respectively remove it depending on feedback in this PR.)

 I would be happy about any other feedback as well!