### PR TITLE
Paper UI: Downgrade npm to 5.6.0

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
@@ -57,7 +57,7 @@
 
         <configuration>
           <nodeVersion>v8.1.2</nodeVersion>
-          <npmVersion>5.8.0</npmVersion>
+          <npmVersion>5.6.0</npmVersion>
           <nodeDownloadRoot>http://nodejs.org/dist/</nodeDownloadRoot>
           <npmDownloadRoot>http://registry.npmjs.org/npm/-/</npmDownloadRoot>
           <environmentVariables>


### PR DESCRIPTION
As suggested in this npm bug report https://github.com/npm/npm/issues/19989 npm 5.8.0 may fail on certain platforms.

Signed-off-by: Henning Treu <henning.treu@telekom.de>