### PR TITLE
[5322] Honor prerequisite version for firmwares

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServicePrerequisiteVersionTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServicePrerequisiteVersionTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.firmware;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Locale;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.eclipse.smarthome.core.thing.binding.firmware.Firmware;
+import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareBuilder;
+import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler;
+import org.eclipse.smarthome.test.java.JavaOSGiTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Tests that the {@link FirmwareUpdateService} honors the prerequisite version of {@link Firmware}s.
+ *
+ * @author Henning Sudbrock - initial contribution
+ */
+public class FirmwareUpdateServicePrerequisiteVersionTest extends JavaOSGiTest {
+
+    private ThingTypeUID thingTypeUID;
+
+    private Firmware firmwareV1;
+    private Firmware firmwareV2;
+    private Firmware firmwareV3;
+
+    private Thing thingWithFirmwareV1;
+    private Thing thingWithFirmwareV2;
+
+    @Before
+    public void setup() {
+        thingTypeUID = new ThingTypeUID("binding:thingtype");
+
+        firmwareV1 = FirmwareBuilder.create(thingTypeUID, "1.0.0").build();
+        firmwareV2 = FirmwareBuilder.create(thingTypeUID, "2.0.0").build();
+        firmwareV3 = FirmwareBuilder.create(thingTypeUID, "3.0.0").withPrerequisiteVersion("2.0.0").build();
+
+        thingWithFirmwareV1 = createThing(thingTypeUID, "thingWithFirmwareV1", firmwareV1);
+        thingWithFirmwareV2 = createThing(thingTypeUID, "thingWithFirmwareV2", firmwareV2);
+
+        registerService(createFirmwareProvider(thingWithFirmwareV1, firmwareV1, firmwareV2, firmwareV3));
+        registerService(createFirmwareProvider(thingWithFirmwareV2, firmwareV1, firmwareV2, firmwareV3));
+        registerService(createFirmwareUpdateHandler(thingWithFirmwareV1));
+        registerService(createFirmwareUpdateHandler(thingWithFirmwareV2));
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testGetFirmwareStatusInfoWithUnsatisfiedPrerequisiteVersion() {
+        FirmwareUpdateService firmwareUpdateService = getService(FirmwareUpdateService.class);
+
+        FirmwareStatusInfo firmwareStatusInfo = firmwareUpdateService
+                .getFirmwareStatusInfo(thingWithFirmwareV1.getUID());
+        assertThat(firmwareStatusInfo, notNullValue());
+
+        // Since firmware version 3.0.0 has prerequisite version 2.0.0, and the thing has firmware version 1.0.0, the
+        // expectation is that the version of the firmware to which one can update is 2.0.0.
+        assertThat(firmwareStatusInfo.getUpdatableFirmwareVersion(), equalTo("2.0.0"));
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testGetFirmwareStatusInfoWithSatisfiedPrerequisiteVersion() {
+        FirmwareUpdateService firmwareUpdateService = getService(FirmwareUpdateService.class);
+
+        FirmwareStatusInfo firmwareStatusInfo = firmwareUpdateService
+                .getFirmwareStatusInfo(thingWithFirmwareV2.getUID());
+        assertThat(firmwareStatusInfo, notNullValue());
+
+        // Since firmware version 3.0.0 has prerequisite version 2.0.0, and the thing has firmware version 2.0.0, the
+        // expectation is that the version of the firmware to which one can update is 3.0.0.
+        assertThat(firmwareStatusInfo.getUpdatableFirmwareVersion(), equalTo("3.0.0"));
+    }
+
+    private Thing createThing(ThingTypeUID thingTypeUID, String thingUID, Firmware firmware) {
+        Thing thing = mock(Thing.class);
+        when(thing.getThingTypeUID()).thenReturn(thingTypeUID);
+        when(thing.getUID()).thenReturn(new ThingUID(thingTypeUID, thingUID));
+        when(thing.getProperties()).thenReturn(ImmutableMap.<String, String> builder()
+                .put(Thing.PROPERTY_FIRMWARE_VERSION, firmware.getVersion()).build());
+        return thing;
+    }
+
+    private FirmwareProvider createFirmwareProvider(Thing thing, Firmware... firmwares) {
+        FirmwareProvider firmwareProvider = mock(FirmwareProvider.class);
+        when(firmwareProvider.getFirmwares(eq(thing), any(Locale.class)))
+                .thenReturn(new HashSet<>(Arrays.asList(firmwares)));
+        return firmwareProvider;
+    }
+
+    private FirmwareUpdateHandler createFirmwareUpdateHandler(Thing thing) {
+        FirmwareUpdateHandler firmwareUpdateHandler = mock(FirmwareUpdateHandler.class);
+        when(firmwareUpdateHandler.getThing()).thenReturn(thing);
+        when(firmwareUpdateHandler.isUpdateExecutable()).thenReturn(true);
+        return firmwareUpdateHandler;
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServicePrerequisiteVersionTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareUpdateServicePrerequisiteVersionTest.java
@@ -19,8 +19,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -31,8 +33,6 @@ import org.eclipse.smarthome.core.thing.binding.firmware.FirmwareUpdateHandler;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Tests that the {@link FirmwareUpdateService} honors the prerequisite version of {@link Firmware}s.
@@ -97,10 +97,14 @@ public class FirmwareUpdateServicePrerequisiteVersionTest extends JavaOSGiTest {
 
     private Thing createThing(ThingTypeUID thingTypeUID, String thingUID, Firmware firmware) {
         Thing thing = mock(Thing.class);
+
         when(thing.getThingTypeUID()).thenReturn(thingTypeUID);
         when(thing.getUID()).thenReturn(new ThingUID(thingTypeUID, thingUID));
-        when(thing.getProperties()).thenReturn(ImmutableMap.<String, String> builder()
-                .put(Thing.PROPERTY_FIRMWARE_VERSION, firmware.getVersion()).build());
+
+        Map<String, String> propertiesMap = new HashMap<>();
+        propertiesMap.put(Thing.PROPERTY_FIRMWARE_VERSION, firmware.getVersion());
+        when(thing.getProperties()).thenReturn(propertiesMap);
+
         return thing;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceTest.java
@@ -581,9 +581,8 @@ public class FirmwareUpdateServiceTest extends JavaOSGiTest {
         assertThat(firmwareUpdateService.getFirmwareStatusInfo(THING1_UID), is(updateExecutableInfoFw113));
 
         thrown.expect(IllegalArgumentException.class);
-        thrown.expectMessage(equalTo(String.format(
-                "Firmware %s requires at least firmware version %s to get installed. But the current firmware version of the thing with UID %s is %s.",
-                FW113_EN, FW113_EN.getPrerequisiteVersion(), THING1_UID, V111)));
+        thrown.expectMessage(
+                equalTo(String.format("Firmware %s is not suitable for thing with UID %s.", FW113_EN, THING1_UID)));
 
         firmwareUpdateService.updateFirmware(THING1_UID, V113, null);
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/Firmware.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/firmware/Firmware.java
@@ -113,6 +113,9 @@ public interface Firmware extends Comparable<Firmware> {
 
     /**
      * Returns the prerequisite version of the firmware.
+     * <p/>
+     * A non-null prerequisite firmware version indicates that this firmware can only be installed on things for which
+     * the installed firmware has a version greater or equal to the prerequisite firmware version.
      *
      * @return the prerequisite version of the firmware (can be null)
      */
@@ -177,19 +180,7 @@ public interface Firmware extends Comparable<Firmware> {
     public boolean isSuccessorVersion(@Nullable String firmwareVersion);
 
     /**
-     * Returns true, if this firmware is a valid prerequisite version of the given firmware version, otherwise false.
-     * If this firmware does not have a prerequisite version or if the given firmware version is null, then this
-     * operation will return false.
-     *
-     * @param firmwareVersion the firmware version to be checked if this firmware is valid prerequisite version of the
-     *            given firmware version
-     * @return true, if this firmware is valid prerequisite version of the given firmware version, otherwise false
-     */
-    public boolean isPrerequisiteVersion(@Nullable String firmwareVersion);
-
-    /**
-     * Checks whether this firmware is suitable for the given thing by checking the thing type and the model
-     * restrictions (if any).
+     * Checks whether this firmware is suitable for the given thing.
      *
      * @param thing to be checked for suitability with the current firmware
      * @return <code>true</code> if the current firmware is suitable for the given thing and <code>false</code>

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareImpl.java
@@ -256,7 +256,6 @@ public final class FirmwareImpl implements Firmware {
         private final String[] parts;
 
         private Version(String versionString) {
-            ParameterChecks.checkNotNull(versionString, "versionString");
             this.versionString = versionString;
             this.parts = versionString.split("-|_|\\.");
         }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
@@ -364,13 +364,6 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
             throw new IllegalArgumentException(
                     String.format("Firmware %s is not suitable for thing with UID %s.", firmware, thing.getUID()));
         }
-
-        String thingFirmwareVersion = getThingFirmwareVersion(firmwareUpdateHandler);
-        if (firmware.getPrerequisiteVersion() != null && !firmware.isPrerequisiteVersion(thingFirmwareVersion)) {
-            throw new IllegalArgumentException(String.format(
-                    "Firmware %s requires at least firmware version %s to get installed. But the current firmware version of the thing with UID %s is %s.",
-                    firmware, firmware.getPrerequisiteVersion(), thing.getUID(), thingFirmwareVersion));
-        }
     }
 
     private Firmware getFirmware(Thing thing, String firmwareVersion) {


### PR DESCRIPTION
This PR addresses https://github.com/eclipse/smarthome/issues/5322, by adding the check for the prerequisite firmware version into the method `Firmware#isSuitableFor(thing)`. A firmware is no longer deemed suitable for a thing, if the firmware has a prerequisite version, and the firmware version currently installed on the thing has a lower version than this prerequisite version.

With this change, the `FirmwareRegistryImpl` will check prerequisite versions when getting the list of available firmwares for a thing (as it calls `isSuitableFor`) - and, in consequence, the `FirmwareStatusInfo` will no longer return firmwares for a thing that are not suitable due to prerequisite version restrictions.

(As `FirmwareUpdateServiceImpl#validateFirmwareSuitability(...)` calls `Firmware#isSuitableFor(thing)`, the explicit check for the prerequisite version in that method is removed with this PR.)

Besides this fix, this PR also contains small refactorings in the `FirmwareImpl`, and a change in the `Firmware` interface: The method `Firmare#isPrerequisiteVersion(firmwareVersion)` is removed, because (a) I see no need for that method anymore as prerequisite version constraints are now checked in `Firmware.isSuitableFor(thing)`, and (b) I found that method somewhat confusing, as it is not immediately clear in which direction the check of `firmware.isPrerequisiteVersion(firmwareVersion)` goes (and I think that the JavaDoc even described it the wrong way round, at least the way I interpreted it). This removal is an API-breaking change.