### PR TITLE
Remove the 'Bug: ' line from the example commit messages on contributing page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,6 @@ Here is a sample _good_ Git commit log message:
 
     Write just like if you were discussing with fellows :-)
 
-    Bug: https://github.com/eclipse/smarthome/issues/1
     Also-By: Somebody who also contributed parts of this code <foo@bar.com>
     Signed-off-by: Yourself <baz@foobar.org>
 


### PR DESCRIPTION
It appears that adding a line of the form `Bug: https://github.com/eclipse/smarthome/issues/<issue-number>` to a commit message and creating a PR for that commit, the `eclipsewebmaster` will link to an unrelated eclipse issue in the PR (cf. https://github.com/eclipse/smarthome/pull/5544).

Adding such a line is mentioned in the contribution guidelines; as mentioned by @kaikreuzer in personal discussion, this line still comes from a time when the issue tracker was Bugzilla; this PR removes the line.