### PR TITLE
Fix pattern parsing

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.item.tests/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider2Test.java
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider2Test.java
@@ -283,4 +283,13 @@ public class GenericItemProvider2Test extends JavaOSGiTest {
         assertEquals(0, item3.getTags().size());
     }
 
+    @Test
+    public void testSquareBracketsInFormat() {
+        String model = "Switch s \"Info [XPATH(/*[name()='liveStreams']/*[name()='stream']):%s]\"";
+        modelRepository.addOrRefreshModel(TESTMODEL_NAME, new ByteArrayInputStream(model.getBytes()));
+        Item item = itemRegistry.get("s");
+        assertNotNull(item);
+        assertEquals("XPATH(/*[name()='liveStreams']/*[name()='stream']):%s", item.getStateDescription().getPattern());
+    }
+
 }

--- a/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
@@ -22,7 +22,6 @@ Export-Package:
 Import-Package: 
  javax.measure,
  javax.measure.quantity,
- org.apache.commons.lang,
  org.apache.log4j,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/AutoUpdateGenericBindingConfigProvider.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.autoupdate.AutoUpdateBindingConfigProvider;
 import org.osgi.service.component.annotations.Component;
@@ -84,7 +83,7 @@ public class AutoUpdateGenericBindingConfigProvider implements AutoUpdateBinding
 
     protected void parseBindingConfig(String bindingConfig, AutoUpdateBindingConfig config)
             throws BindingConfigParseException {
-        if (StringUtils.isNotBlank(bindingConfig)) {
+        if (bindingConfig != null && !bindingConfig.trim().isEmpty()) {
             try {
                 config.autoupdate = Boolean.valueOf(bindingConfig.trim());
             } catch (IllegalArgumentException iae) {

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -280,7 +280,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
         }
         if (item != null) {
             String label = modelItem.getLabel();
-            String format = StringUtils.substringBetween(label, "[", "]");
+            String format = extractFormat(label);
             if (format != null) {
                 label = StringUtils.substringBefore(label, "[").trim();
                 stateDescriptionFragments.put(modelItem.getName(),
@@ -292,6 +292,17 @@ public class GenericItemProvider extends AbstractProvider<Item>
         } else {
             return null;
         }
+    }
+
+    private String extractFormat(String label) {
+        if (label == null) {
+            return null;
+        }
+        String format = null;
+        if (label.contains("[") && label.contains("]")) {
+            format = label.substring(label.indexOf("[") + 1, label.lastIndexOf("]"));
+        }
+        return format;
     }
 
     private GroupItem applyGroupFunction(GenericItem baseItem, ModelGroupItem modelGroupItem,

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang.StringUtils;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
@@ -282,7 +281,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
             String label = modelItem.getLabel();
             String format = extractFormat(label);
             if (format != null) {
-                label = StringUtils.substringBefore(label, "[").trim();
+                label = label.substring(0, label.indexOf("[")).trim();
                 stateDescriptionFragments.put(modelItem.getName(),
                         StateDescriptionFragmentBuilder.create().withPattern(format).build());
             }


### PR DESCRIPTION
...in their transformation pattern.

And while at it anyway I also dropped remaining usages of commons-lang from model.item as there were only two calls to StringUtils. Both of them not really fancy.

fixes #5547
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>