### PR TITLE
Upgrade angularjs from 1.4.8 to 1.5.7

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
@@ -10,15 +10,15 @@
     "dev": "gulp serve --development --noMinify"
   },
   "dependencies": {
-    "angular": "1.4.8",
-    "angular-animate": "1.4.8",
-    "angular-aria": "1.4.8",
+    "angular": "1.5.7",
+    "angular-animate": "1.5.7",
+    "angular-aria": "1.5.7",
+    "angular-messages": "1.5.7",
+    "angular-resource": "1.5.7",
+    "angular-route": "1.5.7",
+    "angular-sanitize": "1.5.7",
     "angular-material": "1.0.1",
     "angular-material-expansion-panel": "0.7.2",
-    "angular-messages": "1.4.8",
-    "angular-resource": "1.4.8",
-    "angular-route": "1.4.8",
-    "angular-sanitize": "1.4.8",
     "angular-ui-sortable": "0.13.4",
     "bootstrap": "3.3.2",
     "eventsource-polyfill": "https://github.com/amvtek/EventSource/tarball/53616d4",
@@ -35,7 +35,7 @@
     "node": ">=0.12.3"
   },
   "devDependencies": {
-    "angular-mocks": "1.4.8",
+    "angular-mocks": "1.5.7",
     "browser-sync": "~2.7.12",
     "del": "^2.0.0",
     "gulp": "^3.9.0",


### PR DESCRIPTION
Upgrade angularJS to version 1.5.7.

The following components are upgraded:

* angular
* angular-animate
* angular-aria
* angular-messages
* angular-resource
* angular-route
* angular-sanitize
* angular-mocks

This allows us to use the new `component` API and make a step towards Angular 2+. I'd like to use the new API in a PR providing the Paper UI support for item metadata.

All unit tests and Paper UI in general behave just like expected with the version bump.

Signed-off-by: Henning Treu <henning.treu@telekom.de>