### PR TITLE
delay child handler initialization while bridge OFFLINE

### DIFF
--- a/docs/documentation/concepts/things.md
+++ b/docs/documentation/concepts/things.md
@@ -71,12 +71,13 @@ A status is detailed further with a status detail object.
 The following table lists the different status details for each status:
 
 <table>
-<tr valign="top"><td rowspan="6">UNINITIALIZED</td><td>NONE</td><td>No further status details available.</td></tr>
+<tr valign="top"><td rowspan="7">UNINITIALIZED</td><td>NONE</td><td>No further status details available.</td></tr>
 <tr valign="top">                                  <td>HANDLER_MISSING_ERROR</td><td>The handler cannot be initialized, because the responsible binding is not available or started.</td></tr>
 <tr valign="top">                                  <td>HANDLER_REGISTERING_ERROR</td><td>The handler failed in the service registration phase.</td></tr>
 <tr valign="top">                                  <td>HANDLER_CONFIGURATION_PENDING</td><td>The handler is registered but can not be initialized caused by missing configuration parameters.</td></tr>
 <tr valign="top">                                  <td>HANDLER_INITIALIZING_ERROR</td><td>The handler failed in the initialization phase.</td></tr>
 <tr valign="top">                                  <td>BRIDGE_UNINITIALIZED</td><td>The bridge associated with this thing is not initialized.</td></tr>
+<tr valign="top">                                  <td>BRIDGE_OFFLINE</td><td>The bridge associated with this thing is offline.</td></tr>
 <tr valign="top"><td>INITIALIZING</td>             <td>NONE</td><td>No further status details available.</td></tr>
 <tr valign="top"><td>UNKNOWN</td>                  <td>NONE</td><td>No further status details available.</td></tr>
 <tr valign="top"><td rowspan="2">ONLINE</td>       <td>NONE</td><td>No further status details available.</td></tr>


### PR DESCRIPTION
Under the assumption that a bridge enables communication with the devices, it doesn't really make sense to let the child handlers find out that they cannot initialize themselves while their bridge is OFFLINE. Child handler so far had to implement `bridgeStatusChanged()` and run their `initialize()` logic then.

Therefore this commit now keeps child things in `UNINITIALIZED/BRIDGE_OFFLINE` until the bridge leaves the `OFFLINE` status. 

fixes #5552
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>