### PR TITLE
Bose Soundtouch: Remove zone channels from thing-types

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouch10.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouch10.xml
@@ -14,12 +14,9 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="operationMode" typeId="operationMode_BST_10_20_30" />
 			<channel id="playerControl" typeId="playerControl" />
-			<channel id="zoneAdd" typeId="zoneAdd" />
-			<channel id="zoneRemove" typeId="zoneRemove" />
 			<channel id="preset" typeId="preset" />
 			<channel id="saveAsPreset" typeId="saveAsPreset" />
 			<channel id="keyCode" typeId="keyCode" />
-			<channel id="zoneInfo" typeId="zoneInfo" />
 			<channel id="rateEnabled" typeId="rateEnabled" />
 			<channel id="skipEnabled" typeId="skipEnabled" />
 			<channel id="skipPreviousEnabled" typeId="skipPreviousEnabled" />

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouch20.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouch20.xml
@@ -14,12 +14,9 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="operationMode" typeId="operationMode_BST_10_20_30" />
 			<channel id="playerControl" typeId="playerControl" />
-			<channel id="zoneAdd" typeId="zoneAdd" />
-			<channel id="zoneRemove" typeId="zoneRemove" />
 			<channel id="preset" typeId="preset" />
 			<channel id="saveAsPreset" typeId="saveAsPreset" />
 			<channel id="keyCode" typeId="keyCode" />
-			<channel id="zoneInfo" typeId="zoneInfo" />
 			<channel id="rateEnabled" typeId="rateEnabled" />
 			<channel id="skipEnabled" typeId="skipEnabled" />
 			<channel id="skipPreviousEnabled" typeId="skipPreviousEnabled" />

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouch30.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouch30.xml
@@ -14,12 +14,9 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="operationMode" typeId="operationMode_BST_10_20_30" />
 			<channel id="playerControl" typeId="playerControl" />
-			<channel id="zoneAdd" typeId="zoneAdd" />
-			<channel id="zoneRemove" typeId="zoneRemove" />
 			<channel id="preset" typeId="preset" />
 			<channel id="saveAsPreset" typeId="saveAsPreset" />
 			<channel id="keyCode" typeId="keyCode" />
-			<channel id="zoneInfo" typeId="zoneInfo" />
 			<channel id="rateEnabled" typeId="rateEnabled" />
 			<channel id="skipEnabled" typeId="skipEnabled" />
 			<channel id="skipPreviousEnabled" typeId="skipPreviousEnabled" />

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouch300.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouch300.xml
@@ -13,12 +13,9 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="operationMode" typeId="operationMode_BST_300" />
 			<channel id="playerControl" typeId="playerControl" />
-			<channel id="zoneAdd" typeId="zoneAdd" />
-			<channel id="zoneRemove" typeId="zoneRemove" />
 			<channel id="preset" typeId="preset" />
 			<channel id="saveAsPreset" typeId="saveAsPreset" />
 			<channel id="keyCode" typeId="keyCode" />
-			<channel id="zoneInfo" typeId="zoneInfo" />
 			<channel id="rateEnabled" typeId="rateEnabled" />
 			<channel id="skipEnabled" typeId="skipEnabled" />
 			<channel id="skipPreviousEnabled" typeId="skipPreviousEnabled" />

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouchSA5Amplifier.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouchSA5Amplifier.xml
@@ -14,12 +14,9 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="operationMode" typeId="operationMode_BST_SA5_Amplifier" />
 			<channel id="playerControl" typeId="playerControl" />
-			<channel id="zoneAdd" typeId="zoneAdd" />
-			<channel id="zoneRemove" typeId="zoneRemove" />
 			<channel id="preset" typeId="preset" />
 			<channel id="saveAsPreset" typeId="saveAsPreset" />
 			<channel id="keyCode" typeId="keyCode" />
-			<channel id="zoneInfo" typeId="zoneInfo" />
 			<channel id="rateEnabled" typeId="rateEnabled" />
 			<channel id="skipEnabled" typeId="skipEnabled" />
 			<channel id="skipPreviousEnabled" typeId="skipPreviousEnabled" />

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouchWirelessLinkAdapter.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/SoundTouchWirelessLinkAdapter.xml
@@ -13,12 +13,9 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="operationMode" typeId="operationMode_BST_WLA" />
 			<channel id="playerControl" typeId="playerControl" />
-			<channel id="zoneAdd" typeId="zoneAdd" />
-			<channel id="zoneRemove" typeId="zoneRemove" />
 			<channel id="preset" typeId="preset" />
 			<channel id="saveAsPreset" typeId="saveAsPreset" />
 			<channel id="keyCode" typeId="keyCode" />
-			<channel id="zoneInfo" typeId="zoneInfo" />
 			<channel id="rateEnabled" typeId="rateEnabled" />
 			<channel id="skipEnabled" typeId="skipEnabled" />
 			<channel id="skipPreviousEnabled" typeId="skipPreviousEnabled" />

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/UnknownSoundTouch.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/UnknownSoundTouch.xml
@@ -14,12 +14,9 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="operationMode" typeId="operationMode_default" />
 			<channel id="playerControl" typeId="playerControl" />
-			<channel id="zoneAdd" typeId="zoneAdd" />
-			<channel id="zoneRemove" typeId="zoneRemove" />
 			<channel id="preset" typeId="preset" />
 			<channel id="saveAsPreset" typeId="saveAsPreset" />
 			<channel id="keyCode" typeId="keyCode" />
-			<channel id="zoneInfo" typeId="zoneInfo" />
 			<channel id="rateEnabled" typeId="rateEnabled" />
 			<channel id="skipEnabled" typeId="skipEnabled" />
 			<channel id="skipPreviousEnabled" typeId="skipPreviousEnabled" />

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/WaveSoundTouchMusicSystemIV.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/ESH-INF/thing/WaveSoundTouchMusicSystemIV.xml
@@ -14,12 +14,9 @@
 			<channel id="mute" typeId="mute" />
 			<channel id="operationMode" typeId="operationMode_default" />
 			<channel id="playerControl" typeId="playerControl" />
-			<channel id="zoneAdd" typeId="zoneAdd" />
-			<channel id="zoneRemove" typeId="zoneRemove" />
 			<channel id="preset" typeId="preset" />
 			<channel id="saveAsPreset" typeId="saveAsPreset" />
 			<channel id="keyCode" typeId="keyCode" />
-			<channel id="zoneInfo" typeId="zoneInfo" />
 			<channel id="rateEnabled" typeId="rateEnabled" />
 			<channel id="skipEnabled" typeId="skipEnabled" />
 			<channel id="skipPreviousEnabled" typeId="skipPreviousEnabled" />


### PR DESCRIPTION
The zone channels do not have a channel-type defined. By this, the thing-type definitions cannot be retrieved via the REST interface.

Signed-off-by: Henning Treu <henning.treu@telekom.de>