### PR TITLE
[website] set do-not-track indicator for twitter widget

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="twitter:dnt" content="on">
  {% include base.html %}
 <link rel="shortcut icon" href="https://www.eclipse.org/smarthome/img/favicon.png"></link>
 <title>Eclipse SmartHome - A Flexible Framework for the Smart

--- a/docs/index.html
+++ b/docs/index.html
@@ -221,7 +221,7 @@ layout: landing
 				<h1>Latest Tweets</h1>
 				<a class="twitter-timeline" href="https://twitter.com/smarthome"
 					data-tweet-limit="3" data-widget-id="604245239797305344"
-					data-chrome="noborders nofooter" data-border-color="#0288d1">Tweets
+					data-chrome="noborders nofooter" data-border-color="#0288d1" data-dnt="true">Tweets
 					von @smarthome </a>
 				<script>
 					if (window.hasCookieConsent()) {


### PR DESCRIPTION
Although the twitter widget since #5585 only gets included if
the user opted in, I still think it would make sense to set the
DNT flags which are available according to
https://dev.twitter.com/web/overview/privacy

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>