### PR TITLE
Suppress package-lock error message by npm

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/.npmrc
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
As discussed with @htreu, it's not intended/desirable to to lock the npm package versions / dependency graph by committing the `package-lock.json` file. Consequently, we should suppress the error message by npm complaining that the `package-lock.json` file is not committed.

Signed-off-by: Patrick Fink <mail@pfink.de>