### PR TITLE
GenericItem: Use concurrent set for tags to avoid CME in getTags

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GenericItem.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
@@ -64,7 +65,7 @@ public abstract class GenericItem implements ActiveItem {
 
     protected List<String> groupNames = new ArrayList<String>();
 
-    protected transient volatile Set<String> tags = new HashSet<String>();
+    protected transient volatile Set<String> tags = ConcurrentHashMap.newKeySet();
 
     protected final String name;
 


### PR DESCRIPTION
Fixes #5596

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>