### PR TITLE
reduced logging level and moved exception handling one level up

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTOMapper.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/item/EnrichedItemDTOMapper.java
@@ -22,10 +22,13 @@ import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.dto.ItemDTO;
 import org.eclipse.smarthome.core.items.dto.ItemDTOMapper;
+import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationHelper;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.io.rest.core.internal.RESTCoreActivator;
 import org.eclipse.smarthome.io.rest.core.internal.item.ItemResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link EnrichedItemDTOMapper} is a utility class to map items into enriched item data transform objects (DTOs).
@@ -34,6 +37,8 @@ import org.eclipse.smarthome.io.rest.core.internal.item.ItemResource;
  * @author Jochen Hiller - Fix #473630 - handle optional dependency to TransformationHelper
  */
 public class EnrichedItemDTOMapper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnrichedItemDTOMapper.class);
 
     /**
      * Maps item into enriched item DTO object.
@@ -109,6 +114,10 @@ public class EnrichedItemDTOMapper {
             } catch (NoClassDefFoundError ex) {
                 // TransformationHelper is optional dependency, so ignore if class not found
                 // return state as it is without transformation
+                return state;
+            } catch (TransformationException e) {
+                LOGGER.debug("Failed transforming the state '{}' with pattern '{}': {}", state,
+                        stateDescription.getPattern(), e.getMessage());
                 return state;
             }
         } else {


### PR DESCRIPTION
On startup, we have ugly warnings from the `TransformationHelper` as [reported here](https://community.openhab.org/t/openhab-2-3-release-candidate-available/45318/11?u=kai).

Looking at it, it imho makes sense to have the helper simply throw the exception and have the caller handle it, instead of silently swallow the fact that there was an issue and just logging a warning that cannot be suppressed.

Likewise, the `getTransformationService` method must not log a warning itself as it already returns null and thus informs its caller that no service has been found.


Signed-off-by: Kai Kreuzer <kai@openhab.org>