### PR TITLE
fix Item confusion

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ItemRegistryOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ItemRegistryOSGiTest.java
@@ -179,7 +179,7 @@ public class ItemRegistryOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void testGroupUpdateWithMofifivationOfLiveInstance() {
+    public void testGroupUpdateWithModificationOfLiveInstance() {
         itemRegistry.add(new StringItem("item"));
         itemRegistry.add(new GroupItem("group"));
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
@@ -193,10 +193,11 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
                 // the given "oldElement" might not be the live instance but
                 // loaded from storage. operate on the real element:
                 E existingElement = get(oldElement.getUID());
-                onUpdateElement(existingElement, element);
+                beforeUpdateElement(existingElement);
+                onUpdateElement(oldElement, element);
                 elements.remove(existingElement);
                 elements.add(element);
-                notifyListenersAboutUpdatedElement(existingElement, element);
+                notifyListenersAboutUpdatedElement(oldElement, element);
             } catch (Exception ex) {
                 logger.warn("Could not update element: {}", ex.getMessage(), ex);
             }
@@ -357,10 +358,20 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
 
     /**
      * This method is called before an element is updated. The implementing
+     * class can override this method to perform specific logic.
+     *
+     * @param existingElement the previously existing element (as held in the element cache)
+     */
+    protected void beforeUpdateElement(E existingElement) {
+        // can be overridden by sub classes
+    }
+
+    /**
+     * This method is called before an element is updated. The implementing
      * class can override this method to perform specific logic or check the
      * validity of the updated element.
      *
-     * @param oldElement old element (before update)
+     * @param oldElement old element (before update, as given by the provider)
      * @param element updated element (after update)
      *            <p>
      *            If the method throws an {@link IllegalArgumentException} the element will not be updated.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -288,11 +288,14 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     }
 
     @Override
-    protected void onUpdateElement(Item oldItem, Item item) {
-        if (oldItem instanceof GenericItem) {
-            ((GenericItem) oldItem).dispose();
+    protected void beforeUpdateElement(Item existingElement) {
+        if (existingElement instanceof GenericItem) {
+            ((GenericItem) existingElement).dispose();
         }
+    }
 
+    @Override
+    protected void onUpdateElement(Item oldItem, Item item) {
         // don't use #initialize and retain order of items in groups:
         List<String> oldNames = oldItem.getGroupNames();
         List<String> newNames = item.getGroupNames();


### PR DESCRIPTION
In #5207 the AbstractRegistry was changed to call
onUpdateElement(...) with the current live instance
instead of the oldElement instance which got handed
in by the provider.

However, the given oldElement was guaranteed to contain
the previous values, while the live instance potentially
is subject to modifications. At least as long as there
are e.g. ActiveItem & GenericItem part of the public API
and allow modification of the entities.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>