### PR TITLE
Child docu generation

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -46,7 +46,7 @@
                 <resource>
                   <directory>${basedir}/../extensions/binding</directory>
                   <includes>
-                    <include>**/README.md</include>
+                    <include>**/*.md</include>
                     <include>**/doc/**</include>
                     <include>**/cfg/**</include>
                   </includes>
@@ -125,18 +125,53 @@
             <configuration>
               <source>
                 def bindings = new File(project.basedir, 'documentation/features/bindings')
+                def bindingIDs = []
 
                 bindings.eachFile {
                   def name = it.name
                   if (name.contains('binding')) {
                     def bindingId = it.name.replace('org.eclipse.smarthome.binding.', '')
+                    bindingIDs &lt;&lt; bindingId
+
+                    // rename folder to binding ID
                     def simpleBindingNameDir = new File(bindings.path, bindingId)
                     it.renameTo(simpleBindingNameDir)
+
+                    // rename all markdown to lowercase
+                    simpleBindingNameDir.eachFileMatch(~/.*\.md$/, { originalFile -> 
+                      def lowerFile = new File(simpleBindingNameDir.path, originalFile.name.toLowerCase())
+                      originalFile.renameTo(lowerFile)
+                    })
+
+                    // insert jekyll header and do-not-edit comment into README.md files
                     def readme = new File(simpleBindingNameDir.path, 'README.md')
                     if (readme.exists()) {
-                      println readme
+                      println "Adjusting ${readme}"
                       readme.write('---\nlayout: documentation\n---\n\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source file --&gt;\n\n{% include base.html %}\n\n' + readme.text)
-                      readme.renameTo(new File(simpleBindingNameDir.path, 'readme.md'))
+                    }
+                  }
+                }
+
+                // join multi-bundle binding docu
+                bindings.eachFile {
+                  def name = it.name
+                  def children = bindingIDs.findAll { it.startsWith(name + '.') }
+                  if (!children.isEmpty()) {
+                    def readme = new File(it.path, 'readme.md')
+                    if (readme.exists()) {
+                      println "Processing placeholders in ${readme} with ${children.join(', ')}"
+
+                      // <!--list-subs-->
+                      readme.write(readme.text.replaceAll('&lt;!--list-subs--&gt;', children.findAll{
+                        new File(bindings.path, it + '/readme.md').exists()
+                      }.collect{
+                        def matcher = new File(bindings.path, it + '/readme.md').text =~/#+ (.*?)\n/
+                        def title = it
+                        if (matcher.find()) {
+                          title = matcher.group(1)
+                        }
+                        return '* [' + title + '](../' + it + '/readme.html)'
+                      }.join('\n')))
                     }
                   }
                 }

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -126,23 +126,19 @@
               <source>
                 def bindings = new File(project.basedir, 'documentation/features/bindings')
 
-                bindings.eachFile
-                {
-                def name = it.name
-                if(name.contains('binding')) {
-                def bindingId =
-                it.name.replace('org.eclipse.smarthome.binding.', '')
-                def simpleBindingNameDir = new
-                File(bindings.path, bindingId)
-                it.renameTo(simpleBindingNameDir)
-                def readme = new
-                File(simpleBindingNameDir.path, 'README.md')
-                if(readme.exists()) {
-                println readme
-                readme.write('---\nlayout: documentation\n---\n\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source file --&gt;\n\n{% include base.html %}\n\n' + readme.text)
-                readme.renameTo(new File(simpleBindingNameDir.path, 'readme.md'))
-                }
-                }
+                bindings.eachFile {
+                  def name = it.name
+                  if (name.contains('binding')) {
+                    def bindingId = it.name.replace('org.eclipse.smarthome.binding.', '')
+                    def simpleBindingNameDir = new File(bindings.path, bindingId)
+                    it.renameTo(simpleBindingNameDir)
+                    def readme = new File(simpleBindingNameDir.path, 'README.md')
+                    if (readme.exists()) {
+                      println readme
+                      readme.write('---\nlayout: documentation\n---\n\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source file --&gt;\n\n{% include base.html %}\n\n' + readme.text)
+                      readme.renameTo(new File(simpleBindingNameDir.path, 'readme.md'))
+                    }
+                  }
                 }
               </source>
             </configuration>
@@ -157,23 +153,20 @@
               <source>
                 def iconsets = new File(project.basedir, 'documentation/features/ui/iconset')
 
-                iconsets.eachFile
-                {
-                def name = it.name
-                if(name.contains('iconset')) {
-                def iconsetId =
-                it.name.replace('org.eclipse.smarthome.ui.iconset.', '')
-                def simpleIconsetNameDir = new
-                File(iconsets.path, iconsetId)
-                it.renameTo(simpleIconsetNameDir)
-                def readme = new
-                File(simpleIconsetNameDir.path, 'README.md')
-                if(readme.exists()) {
-                println readme
-                readme.write('---\nlayout: documentation\n---\n\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source file --&gt;\n\n{% include base.html %}\n\n' + readme.text)
-                readme.renameTo(new File(simpleIconsetNameDir.path, 'readme.md'))
-                }
-                }
+                iconsets.eachFile {
+                  def name = it.name
+                  if (name.contains('iconset')) {
+                    def iconsetId =
+                    it.name.replace('org.eclipse.smarthome.ui.iconset.', '')
+                    def simpleIconsetNameDir = new File(iconsets.path, iconsetId)
+                    it.renameTo(simpleIconsetNameDir)
+                    def readme = new File(simpleIconsetNameDir.path, 'README.md')
+                    if (readme.exists()) {
+                      println readme
+                      readme.write('---\nlayout: documentation\n---\n\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source file --&gt;\n\n{% include base.html %}\n\n' + readme.text)
+                      readme.renameTo(new File(simpleIconsetNameDir.path, 'readme.md'))
+                    }
+                  }
                 }
               </source>
             </configuration>
@@ -188,23 +181,19 @@
               <source>
                 def uis = new File(project.basedir, 'documentation/features/ui')
 
-                uis.eachFile
-                {
-                def name = it.name
-                if(!name.contains('iconset')) {
-                def uiId =
-                it.name.replace('org.eclipse.smarthome.ui.', '')
-                def simpleUINameDir = new
-                File(uis.path, uiId)
-                it.renameTo(simpleUINameDir)
-                def readme = new
-                File(simpleUINameDir.path, 'README.md')
-                if(readme.exists()) {
-                println readme
-                readme.write('---\nlayout: documentation\n---\n\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source file --&gt;\n\n{% include base.html %}\n\n' + readme.text)
-                readme.renameTo(new File(simpleUINameDir.path, 'readme.md'))
-                }
-                }
+                uis.eachFile {
+                  def name = it.name
+                  if (!name.contains('iconset')) {
+                    def uiId = it.name.replace('org.eclipse.smarthome.ui.', '')
+                    def simpleUINameDir = new File(uis.path, uiId)
+                    it.renameTo(simpleUINameDir)
+                    def readme = new File(simpleUINameDir.path, 'README.md')
+                    if (readme.exists()) {
+                      println readme
+                      readme.write('---\nlayout: documentation\n---\n\n&lt;!-- Attention authors: Do not edit directly. Please add your changes to the appropriate source file --&gt;\n\n{% include base.html %}\n\n' + readme.text)
+                      readme.renameTo(new File(simpleUINameDir.path, 'readme.md'))
+                    }
+                  }
                 }
               </source>
             </configuration>

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluez/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluez/README.md
@@ -1,4 +1,4 @@
-## Bluetooth BlueZ Adapter
+# Bluetooth BlueZ Adapter
 
 This extension supports Bluetooth access via BlueZ on Linux (ARMv6hf).
 

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.blukii/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.blukii/README.md
@@ -1,0 +1,53 @@
+# Blukii
+
+This extension adds support for [Blukii](http://www.blukii.com/) Sensor Beacons. 
+
+## Supported Things
+
+Only a single thing type is added by this extension:
+
+| Thing Type ID | Description                                     |
+|---------------|-------------------------------------------------|
+| blukii_beacon | A Blukii Sensor Beacon                          |
+
+## Discovery
+
+As any other Bluetooth device, Blukii Beacons are discovered automatically by the corresponding bridge. 
+
+## Thing Configuration
+
+There is only a single configuration parameter `address`, which corresponds to the Bluetooth address of the device (in format "XX:XX:XX:XX:XX:XX").
+
+## Channels
+
+A Blukii Smart Beacon has the following channels:
+
+| Channel ID    | Item Type              | Description                        |
+|---------------|------------------------|------------------------------------|
+| temperature   | Number:Temperature     | The measured temperature           |
+| humidity      | Number:Dimensionless   | The measured humidity              |
+| pressure      | Number:Pressure        | The measured air pressure          |
+| luminance     | Number:Illuminance     | The measured brightness            |
+| tiltx         | Number:Angle           | The tilt (x-axis)                  |
+| titly         | Number:Angle           | The tilt (y-axis)                  |
+| tiltz         | Number:Angle           | The tilt (z-axis)                  |
+
+## Example
+
+demo.things:
+
+```
+bluetooth:blukii:hci0:beacon  "Blukii Sensor Beacon" (bluetooth:bluez:hci0) [ address="12:34:56:78:9A:BC" ]
+```
+
+demo.items:
+
+```
+Number:Temperature      temperature "Room Temperature [%.1f %unit%]" { channel="bluetooth:blukii:hci0:beacon:temperature" }
+Number:Dimensionless    humidity    "Humidity [%.0f %unit%]"         { channel="bluetooth:blukii:hci0:beacon:humidity" }
+Number:Pressure         pressure    "Air Pressure [%.0f %unit%]"     { channel="bluetooth:blukii:hci0:beacon:pressure" }
+Number:Illuminance      luminance   "Luminance [%.0f %unit%]"        { channel="bluetooth:blukii:hci0:beacon:luminance" }
+Number:Angle            tiltX       "Tilt (X-Axis) [%.0f %unit%]"    { channel="bluetooth:blukii:hci0:beacon:tiltx" }
+Number:Angle            tiltY       "Tilt (Y-Axis) [%.0f %unit%]"    { channel="bluetooth:blukii:hci0:beacon:tilty" }
+Number:Angle            tiltZ       "Tilt (Z-Axis) [%.0f %unit%]"    { channel="bluetooth:blukii:hci0:beacon:tiltz" }
+```

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth/README.md
@@ -2,6 +2,10 @@
 
 This binding provides support for generic Bluetooth devices.
 
+It has the following extensions:
+
+<!--list-subs-->
+
 ## Bridges
 
 In order to function, this binding requires a Bluetoooth adapter to be present, which handles the wireless communication.
@@ -70,3 +74,7 @@ sitemap demo label="Main Menu"
     }
 }
 ```
+
+See also the following extensions for further examples:
+
+<!--list-subs-->


### PR DESCRIPTION
This PR implements the first stage of #5571, so that links to extensions can be rendered generically into the parent page. With this, extension bundles can bring their own `README.md` file and have it linked from the `README.md` file from the main binding bundle.

As en example, I have adapted the bluetooth binding and thereby created a rough draft for the blukii extension. Feel free to further improve it. 

The solution to simply link sub-pages of course is not really powerful and maybe becomes obsolete again with #1853. Nevertheless it gives us a very low-friction way of documenting binding extensions right now. 

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>