### PR TITLE
Added ItemRegistry#removeTags(String) to remove ALL tags for an item.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ItemRegistryOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ItemRegistryOSGiTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -124,6 +125,40 @@ public class ItemRegistryOSGiTest extends JavaOSGiTest {
     @Test
     public void assertGetItemsByTagReturnsNoItemFromRegisteredItemProvider() {
         assertThat(itemRegistry.getItemsByTag(OTHER_TAG).size(), is(0));
+    }
+
+    @Test
+    public void assertThatRemoveTagIsRemovingATag() {
+        Item item = itemRegistry.get(CAMERA_ITEM_NAME2);
+        assertThat(item.getTags().size(), is(2));
+        assertThat(item.getTags().contains(CAMERA_TAG), is(true));
+        assertThat(item.getTags().contains(SENSOR_TAG), is(true));
+        itemRegistry.removeTag(CAMERA_ITEM_NAME2, CAMERA_TAG);
+        item = itemRegistry.get(CAMERA_ITEM_NAME2);
+        assertThat(item.getTags().size(), is(1));
+        assertThat(item.getTags().contains(SENSOR_TAG), is(true));
+    }
+
+    @Test
+    public void assertThatRemoveTagsIsRemovingTags() {
+        Item item = itemRegistry.get(CAMERA_ITEM_NAME2);
+        assertThat(item.getTags().size(), is(2));
+        assertThat(item.getTags().contains(CAMERA_TAG), is(true));
+        assertThat(item.getTags().contains(SENSOR_TAG), is(true));
+        assertThat(itemRegistry.removeTags(CAMERA_ITEM_NAME2, Arrays.asList(CAMERA_TAG, SENSOR_TAG)), is(true));
+        item = itemRegistry.get(CAMERA_ITEM_NAME2);
+        assertThat(item.getTags().size(), is(0));
+    }
+
+    @Test
+    public void assertThatRemoveAllTagsIsRemovingAllTags() {
+        Item item = itemRegistry.get(CAMERA_ITEM_NAME2);
+        assertThat(item.getTags().size(), is(2));
+        assertThat(item.getTags().contains(CAMERA_TAG), is(true));
+        assertThat(item.getTags().contains(SENSOR_TAG), is(true));
+        itemRegistry.removeTags(CAMERA_ITEM_NAME2);
+        item = itemRegistry.get(CAMERA_ITEM_NAME2);
+        assertThat(item.getTags().size(), is(0));
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -98,11 +98,9 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     private void setTagsFromMetadata(Item item) {
         if (item instanceof ActiveItem) {
             SortedSet<String> tags = readTags(item.getName());
-            if (!tags.isEmpty()) {
-                ActiveItem activeItem = (ActiveItem) item;
-                activeItem.removeAllTags();
-                activeItem.addTags(tags);
-            }
+            ActiveItem activeItem = (ActiveItem) item;
+            activeItem.removeAllTags();
+            activeItem.addTags(tags);
         }
     }
 
@@ -483,6 +481,15 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
             throw new IllegalArgumentException("Item " + itemName + " does not exist");
         }
         return removeTags(item, tags);
+    }
+
+    @Override
+    public void removeTags(String itemName) {
+        Item item = get(itemName);
+        if (item == null) {
+            throw new IllegalArgumentException("Item " + itemName + " does not exist");
+        }
+        writeTags(item.getName(), null);
     }
 
     private boolean removeTags(Item item, Collection<String> tags) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
@@ -163,4 +163,11 @@ public interface ItemRegistry extends Registry<Item, String> {
      */
     boolean removeTags(String itemName, Collection<String> tags);
 
+    /**
+     * Removes all tags from the item.
+     *
+     * @param itemName the name of the item
+     */
+    void removeTags(String itemName);
+
 }

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -1364,4 +1364,11 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
         }
     }
 
+    @Override
+    public void removeTags(String itemName) {
+        if (itemRegistry != null) {
+            itemRegistry.removeTags(itemName);
+        }
+    }
+
 }


### PR DESCRIPTION
Also fixed the bug for deleting all tags.

Signed-off-by: Andre Fuechsel <andre.fuechsel@telekom.de>