### PR TITLE
[WeatherUnderground] Fix NPEs when channels are linked while weatherData is null

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/handler/WeatherUndergroundHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/src/main/java/org/eclipse/smarthome/binding/weatherunderground/handler/WeatherUndergroundHandler.java
@@ -458,10 +458,12 @@ public class WeatherUndergroundHandler extends BaseThingHandler {
     private void updateChannel(String channelId) {
         if (isLinked(channelId)) {
             State state = null;
-            if (channelId.startsWith("current")) {
-                state = updateCurrentObservationChannel(channelId, weatherData.getCurrent());
-            } else if (channelId.startsWith("forecast")) {
-                state = updateForecastChannel(channelId, weatherData.getForecast());
+            if (weatherData != null) {
+                if (channelId.startsWith("current")) {
+                    state = updateCurrentObservationChannel(channelId, weatherData.getCurrent());
+                } else if (channelId.startsWith("forecast")) {
+                    state = updateForecastChannel(channelId, weatherData.getForecast());
+                }
             }
 
             logger.debug("Update channel {} with state {}", channelId, (state == null) ? "null" : state.toString());


### PR DESCRIPTION
The weatherData is updated with a refreshJob so it may be null when channels are linked causing the following NPE:

```
23:36:28.556 [ERROR] [home.core.thing.link.ThingLinkManager] - Exception occurred while informing handler: null
java.lang.NullPointerException: null
	at org.eclipse.smarthome.binding.weatherunderground.handler.WeatherUndergroundHandler.updateChannel(WeatherUndergroundHandler.java:462) ~[?:?]
	at org.eclipse.smarthome.binding.weatherunderground.handler.WeatherUndergroundHandler.handleCommand(WeatherUndergroundHandler.java:446) ~[?:?]
	at org.eclipse.smarthome.core.thing.binding.BaseThingHandler.channelLinked(BaseThingHandler.java:278) ~[?:?]
	at org.eclipse.smarthome.core.thing.link.ThingLinkManager.lambda$0(ThingLinkManager.java:300) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
	at java.lang.Thread.run(Thread.java:748) [?:?]
23:36:28.558 [INFO ] [ome.event.ThingStatusInfoChangedEvent] - 'weatherunderground:weather:local' changed from INITIALIZING to OFFLINE (COMMUNICATION_ERROR): An error occurred while running the Weather Underground request.
```