### PR TITLE
Send PLAY_PAUSE command on player control channel

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
@@ -190,10 +190,8 @@ public class CommandExecutor implements AvailableSources {
      * @param command the command is Type of Command
      */
     public void postPlayerControl(Command command) {
-        if (command.equals(PlayPauseType.PLAY)) {
-            postRemoteKey(RemoteKeyType.PLAY);
-        } else if (command.equals(PlayPauseType.PAUSE)) {
-            postRemoteKey(RemoteKeyType.PAUSE);
+        if (command.equals(PlayPauseType.PLAY) || command.equals(PlayPauseType.PAUSE)) {
+            postRemoteKey(RemoteKeyType.PLAY_PAUSE);
         } else if (command.equals(NextPreviousType.NEXT)) {
             postRemoteKey(RemoteKeyType.NEXT_TRACK);
         } else if (command.equals(NextPreviousType.PREVIOUS)) {

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.smarthome.binding.bosesoundtouch.BoseSoundTouchConfiguration;
 import org.eclipse.smarthome.binding.bosesoundtouch.handler.BoseSoundTouchHandler;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.NextPreviousType;
@@ -190,8 +189,14 @@ public class CommandExecutor implements AvailableSources {
      * @param command the command is Type of Command
      */
     public void postPlayerControl(Command command) {
-        if (command.equals(PlayPauseType.PLAY) || command.equals(PlayPauseType.PAUSE)) {
-            postRemoteKey(RemoteKeyType.PLAY_PAUSE);
+        if (command.equals(PlayPauseType.PLAY)) {
+            if (currentOperationMode == OperationModeType.STANDBY) {
+                postRemoteKey(RemoteKeyType.PLAY_PAUSE);
+            } else {
+                postRemoteKey(RemoteKeyType.PLAY);
+            }
+        } else if (command.equals(PlayPauseType.PAUSE)) {
+            postRemoteKey(RemoteKeyType.PAUSE);
         } else if (command.equals(NextPreviousType.NEXT)) {
             postRemoteKey(RemoteKeyType.NEXT_TRACK);
         } else if (command.equals(NextPreviousType.PREVIOUS)) {


### PR DESCRIPTION
Apparently Bose SoundTouch doesn't properly handle separate PLAY and PAUSE commands

Further more - on the remote - both commands are combined in a single button.

As a result - when the player is powered off (it's in StandBy mode) - sending a PLAY command does not bring the device ON
Sending a PLAY_PAUSE command however does and the last playback is started (similar as when pressing the play_pause button on the remote)

Signed-off-by: Ivaylo Ivanov <ivivanov.bg@gmail.com>