### PR TITLE
Persistence: Use previous timestamp when duplicating binary values

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/internal/persistence/PersistenceResourceTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/src/test/java/org/eclipse/smarthome/io/rest/core/internal/persistence/PersistenceResourceTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.io.rest.core.internal.persistence;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.eclipse.smarthome.core.i18n.TimeZoneProvider;
+import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.persistence.HistoricItem;
+import org.eclipse.smarthome.core.persistence.PersistenceServiceRegistry;
+import org.eclipse.smarthome.core.persistence.QueryablePersistenceService;
+import org.eclipse.smarthome.core.persistence.dto.ItemHistoryDTO;
+import org.eclipse.smarthome.core.persistence.dto.ItemHistoryDTO.HistoryDataBean;
+import org.eclipse.smarthome.core.types.State;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for PersistenceItem Restresource
+ *
+ * @author Stefan Triller - initial contribution
+ *
+ */
+public class PersistenceResourceTest {
+
+    private final static String PERSISTENCE_SERVICE_ID = "TestServiceID";
+
+    private PersistenceResource pResource;
+    private ArrayList<HistoricItem> items;
+
+    @Before
+    public void setup() {
+        pResource = new PersistenceResource();
+
+        int startValue = 2016;
+        int endValue = 2018;
+        items = new ArrayList<HistoricItem>(endValue - startValue);
+        for (int i = startValue; i <= endValue; i++) {
+            final int year = i;
+            items.add(new HistoricItem() {
+                @Override
+                public Date getTimestamp() {
+                    return new Date(year - 1900, 0, 1);
+                }
+
+                @Override
+                public State getState() {
+                    if (year % 2 == 0) {
+                        return OnOffType.ON;
+                    } else {
+                        return OnOffType.OFF;
+                    }
+                }
+
+                @Override
+                public String getName() {
+                    return "Test";
+                }
+            });
+        }
+
+        QueryablePersistenceService pService = mock(QueryablePersistenceService.class);
+        when(pService.query(any())).thenReturn(items);
+
+        TimeZoneProvider timeZoneProvider = mock(TimeZoneProvider.class);
+        when(timeZoneProvider.getTimeZone()).thenReturn(TimeZone.getDefault().toZoneId());
+
+        PersistenceServiceRegistry pServiceRegistry = mock(PersistenceServiceRegistry.class);
+        when(pServiceRegistry.get(PERSISTENCE_SERVICE_ID)).thenReturn(pService);
+
+        pResource.setPersistenceServiceRegistry(pServiceRegistry);
+        pResource.setTimeZoneProvider(timeZoneProvider);
+    }
+
+    @Test
+    public void testGetPersistenceItemData() {
+        // pResource.httpGetPersistenceItemData(headers, serviceId, itemName, startTime, endTime, pageNumber,
+        // pageLength, boundary)
+        ItemHistoryDTO dto = pResource.createDTO(PERSISTENCE_SERVICE_ID, "testItem", null, null, 1, 5, false);
+
+        assertEquals(5, Integer.parseInt(dto.datapoints));
+
+        // since we added binary state type elements, all except the first have to be repeated but with the timestamp of
+        // the following item
+        HistoryDataBean item0 = dto.data.get(0);
+        HistoryDataBean item1 = dto.data.get(1);
+
+        assertEquals(item0.state, item1.state);
+        assertNotEquals(item0.time, item1.time);
+
+        HistoryDataBean item2 = dto.data.get(2);
+
+        assertEquals(item1.time, item2.time);
+        assertNotEquals(item1.state, item2.state);
+
+        HistoryDataBean item3 = dto.data.get(3);
+
+        assertEquals(item2.state, item3.state);
+        assertNotEquals(item2.time, item3.time);
+
+        HistoryDataBean item4 = dto.data.get(4);
+
+        assertEquals(item3.time, item4.time);
+        assertNotEquals(item3.state, item4.state);
+    }
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/persistence/PersistenceResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/persistence/PersistenceResource.java
@@ -308,6 +308,7 @@ public class PersistenceResource implements RESTResource {
             Iterator<HistoricItem> it = result.iterator();
 
             // Iterate through the data
+            HistoricItem lastItem = null;
             while (it.hasNext()) {
                 HistoricItem historicItem = it.next();
                 state = historicItem.getState();
@@ -315,11 +316,15 @@ public class PersistenceResource implements RESTResource {
                 // For 'binary' states, we need to replicate the data
                 // to avoid diagonal lines
                 if (state instanceof OnOffType || state instanceof OpenClosedType) {
-                    dto.addData(historicItem.getTimestamp().getTime(), state);
+                    if (lastItem != null) {
+                        dto.addData(lastItem.getTimestamp().getTime(), state);
+                        quantity++;
+                    }
                 }
 
                 dto.addData(historicItem.getTimestamp().getTime(), state);
                 quantity++;
+                lastItem = historicItem;
             }
         }
 


### PR DESCRIPTION
Also count these duplicates into the number of datapoints

Fixes #5628

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>