### PR TITLE
[Tradfri] further improve connection handling

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
@@ -337,11 +337,6 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
         // are we still connected at all?
         if (endPoint != null) {
             updateStatus(status, statusDetail);
-            if (status == ThingStatus.OFFLINE && statusDetail == ThingStatusDetail.COMMUNICATION_ERROR) {
-                endPoint.stop();
-                endPoint = new TradfriCoapEndpoint(dtlsConnector, NetworkConfig.getStandard());
-                deviceClient.setEndpoint(endPoint);
-            }
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriThingHandler.java
@@ -120,11 +120,11 @@ public abstract class TradfriThingHandler extends BaseThingHandler implements Co
     @Override
     public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
         super.bridgeStatusChanged(bridgeStatusInfo);
-
-        if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
-            // the status might have changed because the bridge is completely reconfigured - so we need to re-establish
-            // our CoAP connection as well
+        // the status might have changed because the bridge is completely reconfigured - so we need to re-establish
+        // our CoAP connection as well
+        if (bridgeStatusInfo.getStatus() == ThingStatus.OFFLINE) {
             dispose();
+        } else if (bridgeStatusInfo.getStatus() == ThingStatus.ONLINE) {
             initialize();
         }
     }


### PR DESCRIPTION
This change continues #5623 by doing some small additional
improvements in order to let the GC do its job.

Furthermore, with #5623 in place, the restart of the transport
layer as done in #3675 turned out to be not needed anymore.
Therefore it is reverted in this PR again. This allows the
reliability layer to do its job and e.g. re-deliver commands
within a certain timeframe in case of a short connection loss.

relates to #5622
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>