### PR TITLE
Allow tag deletion of missing item

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemRegistryOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemRegistryOSGiJavaTest.java
@@ -169,9 +169,10 @@ public class ItemRegistryOSGiJavaTest extends JavaOSGiTest {
         assertTagsInItem(ITEM_NAME, "foo", "bar");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testAddTagToNonExistingItem() throws Exception {
         itemRegistry.addTag(ITEM_NAME, "hello");
+        assertTagsInMetadata(ITEM_NAME, "hello");
     }
 
     @Test
@@ -194,9 +195,13 @@ public class ItemRegistryOSGiJavaTest extends JavaOSGiTest {
         assertTagsInItem(ITEM_NAME, "foo");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testRemoveTagFromNonExistingItem() throws Exception {
+        prepareMetadata(ITEM_NAME, "hello");
+
         itemRegistry.removeTag(ITEM_NAME, "hello");
+
+        assertTagsInMetadata(ITEM_NAME);
     }
 
     private void prepareItem(String itemName, String... tags) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -274,7 +274,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     @Override
     protected void onAddElement(Item element) throws IllegalArgumentException {
         initializeItem(element);
-        addTags(element, element.getTags());
+        addTags(element.getName(), element.getTags());
     }
 
     @Override
@@ -307,8 +307,8 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         }
         injectServices(item);
 
-        removeTags(oldItem, oldItem.getTags());
-        addTags(item, item.getTags());
+        removeTags(oldItem.getName(), oldItem.getTags());
+        addTags(item.getName(), item.getTags());
     }
 
     @Override
@@ -455,17 +455,9 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     @Override
     public boolean addTags(String itemName, Collection<String> tags) {
-        Item item = get(itemName);
-        if (item == null) {
-            throw new IllegalArgumentException("Item " + itemName + " does not exist");
-        }
-        return addTags(item, tags);
-    }
-
-    private boolean addTags(Item item, Collection<String> tags) {
-        SortedSet<String> itemTags = readTags(item.getName());
+        SortedSet<String> itemTags = readTags(itemName);
         boolean ret = itemTags.addAll(tags);
-        writeTags(item.getName(), itemTags);
+        writeTags(itemName, itemTags);
         return ret;
     }
 
@@ -476,27 +468,17 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     @Override
     public boolean removeTags(String itemName, Collection<String> tags) {
-        Item item = get(itemName);
-        if (item == null) {
-            throw new IllegalArgumentException("Item " + itemName + " does not exist");
-        }
-        return removeTags(item, tags);
+        SortedSet<String> itemTags = readTags(itemName);
+        boolean ret = itemTags.removeAll(tags);
+        writeTags(itemName, itemTags);
+        return ret;
     }
 
     @Override
-    public void removeTags(String itemName) {
-        Item item = get(itemName);
-        if (item == null) {
-            throw new IllegalArgumentException("Item " + itemName + " does not exist");
-        }
-        writeTags(item.getName(), null);
-    }
-
-    private boolean removeTags(Item item, Collection<String> tags) {
-        SortedSet<String> itemTags = readTags(item.getName());
-        boolean ret = itemTags.removeAll(tags);
-        writeTags(item.getName(), itemTags);
-        return ret;
+    public boolean removeTags(String itemName) {
+        SortedSet<String> itemTags = readTags(itemName);
+        writeTags(itemName, null);
+        return !itemTags.isEmpty();
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
@@ -167,7 +167,8 @@ public interface ItemRegistry extends Registry<Item, String> {
      * Removes all tags from the item.
      *
      * @param itemName the name of the item
+     * @return {@code true} if the collection of tags was modified by this operation
      */
-    void removeTags(String itemName);
+    boolean removeTags(String itemName);
 
 }


### PR DESCRIPTION
Whenever a non-managed item was removed, the removal of its
tags should still be possible without the need to hook into
any of the item registries lifecycle methods.
Metadata has its own lifecycle, so tags should do too.

Also, this adapts the signature of

  ItemRegistry.removeTags(String)

to return a boolean like all the other tag related methods do.

fixes #5649
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>