### PR TITLE
Fix some issues of the digitalSTROM-Binding

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -84,7 +84,6 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.event.EventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/README.md
@@ -376,7 +376,10 @@ The digitalSTROM-Server
 
 *Generally:*
 
-* The dSS only inform about scene-commands. So if you set the output value of devices e.g. through  the dSS-App, the binding will not be informed about the changes and you have to send a "refresh-command" to update the channel.
+* The digitalSTROM-Server only informs the binding about scene-commands. So if you set the output value of devices e.g. through  the dSS-App, the binding will not be informed about the changes and you have to send a "refresh-command" to update the channel.
+* If you press a physical switch at your digitalSTROM-installation and the called scene-value is not red out yet, it can take a bit time to read it out and change the state of the channel.
+It the scene-value is red out, the state will change immediately.
+See also *General-Informations/digitalSTROM-Scenes*.   
 
 *Channels with accepted command type increase and decrease:*
 

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/README.md
@@ -374,6 +374,10 @@ The digitalSTROM-Server
 
 **Notes: **
 
+*Generally:*
+
+* The dSS only inform about scene-commands. So if you set the output value of devices e.g. through  the dSS-App, the binding will not be informed about the changes and you have to send a "refresh-command" to update the channel.
+
 *Channels with accepted command type increase and decrease:*
 
   * digitalSTROM will only evaluate increase and decrease commands, if a scene was called before which turn the device on. 

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/BridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/BridgeHandler.java
@@ -560,12 +560,10 @@ public class BridgeHandler extends BaseBridgeHandler
             case APPLICATION_TOKEN_GENERATED:
                 if (connMan != null) {
                     Configuration config = this.getConfig();
-                    if (config != null) {
-                        config.remove(USER_NAME);
-                        config.remove(PASSWORD);
-                        config.put(APPLICATION_TOKEN, connMan.getApplicationToken());
-                        this.updateConfiguration(config);
-                    }
+                    config.remove(USER_NAME);
+                    config.remove(PASSWORD);
+                    config.put(APPLICATION_TOKEN, connMan.getApplicationToken());
+                    this.updateConfiguration(config);
                 }
                 return;
             default:

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/CircuitHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/CircuitHandler.java
@@ -80,8 +80,9 @@ public class CircuitHandler extends BaseThingHandler implements DeviceStatusList
         logger.debug("Initializing CircuitHandler.");
         if (StringUtils.isNotBlank((String) getConfig().get(DigitalSTROMBindingConstants.DEVICE_DSID))) {
             dSID = getConfig().get(DigitalSTROMBindingConstants.DEVICE_DSID).toString();
-            if (getBridge() != null) {
-                bridgeStatusChanged(getBridge().getStatusInfo());
+            final Bridge bridge = getBridge();
+            if (bridge != null) {
+                bridgeStatusChanged(bridge.getStatusInfo());
             } else {
                 // Set status to OFFLINE if no bridge is available e.g. because the bridge has been removed and the
                 // Thing was reinitialized.
@@ -187,7 +188,7 @@ public class CircuitHandler extends BaseThingHandler implements DeviceStatusList
         if (device instanceof Circuit) {
             this.circuit = null;
             if (this.getThing().getStatus().equals(ThingStatus.ONLINE)) {
-                if (device != null && !((Device) circuit).isPresent()) {
+                if (!((Device) circuit).isPresent()) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "Circuit is not present in the digitalSTROM-System.");
                 } else {

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/DeviceHandler.java
@@ -110,8 +110,9 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
         logger.debug("Initializing DeviceHandler.");
         if (StringUtils.isNotBlank((String) getConfig().get(DigitalSTROMBindingConstants.DEVICE_DSID))) {
             dSID = getConfig().get(DigitalSTROMBindingConstants.DEVICE_DSID).toString();
-            if (getBridge() != null) {
-                bridgeStatusChanged(getBridge().getStatusInfo());
+            final Bridge bridge = getBridge();
+            if (bridge != null) {
+                bridgeStatusChanged(bridge.getStatusInfo());
             } else {
                 // Set status to OFFLINE if no bridge is available e.g. because the bridge has been removed and the
                 // Thing was reinitialized.
@@ -421,7 +422,7 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
         if (device instanceof Device) {
             this.device = null;
             if (this.getThing().getStatus().equals(ThingStatus.ONLINE)) {
-                if (device != null && !((Device) device).isPresent()) {
+                if (!((Device) device).isPresent()) {
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE,
                             "Device is not present in the digitalSTROM-System.");
                 } else {
@@ -930,7 +931,7 @@ public class DeviceHandler extends BaseThingHandler implements DeviceStatusListe
                 logger.debug("Save scene configuration: [{}] to thing with UID {}", saveScene, getThing().getUID());
                 super.updateProperty(key, saveScene);
                 // persist the new property
-                super.updateThing(getThing());
+                // super.updateThing(editThing().build());
             }
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/SceneHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/SceneHandler.java
@@ -97,8 +97,9 @@ public class SceneHandler extends BaseThingHandler implements SceneStatusListene
     @Override
     public void initialize() {
         logger.debug("Initializing SceneHandler");
-        if (getBridge() != null) {
-            bridgeStatusChanged(getBridge().getStatusInfo());
+        final Bridge bridge = getBridge();
+        if (bridge != null) {
+            bridgeStatusChanged(bridge.getStatusInfo());
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/ZoneTemperatureControlHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/ZoneTemperatureControlHandler.java
@@ -103,8 +103,9 @@ public class ZoneTemperatureControlHandler extends BaseThingHandler implements T
     public void initialize() {
         logger.debug("Initializing DeviceHandler.");
         if (getConfig().get(DigitalSTROMBindingConstants.ZONE_ID) != null) {
-            if (getBridge() != null) {
-                bridgeStatusChanged(getBridge().getStatusInfo());
+            final Bridge bridge = getBridge();
+            if (bridge != null) {
+                bridgeStatusChanged(bridge.getStatusInfo());
             } else {
                 // Set status to OFFLINE, if no bridge is available e.g. because the bridge has been removed and the
                 // Thing was reinitialized.

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/ZoneTemperatureControlHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/handler/ZoneTemperatureControlHandler.java
@@ -270,7 +270,7 @@ public class ZoneTemperatureControlHandler extends BaseThingHandler implements T
 
     @Override
     public synchronized void configChanged(TemperatureControlStatus tempControlStatus) {
-        if (tempControlStatus != null && tempControlStatus.getIsConfigured()) {
+        if (tempControlStatus != null && tempControlStatus.isNotSetOff()) {
             ControlModes controlMode = ControlModes.getControlMode(tempControlStatus.getControlMode());
             ControlStates controlState = ControlStates.getControlState(tempControlStatus.getControlState());
             if (controlMode != null && controlState != null) {

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/DigitalSTROMHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/DigitalSTROMHandlerFactory.java
@@ -12,14 +12,10 @@
  */
 package org.eclipse.smarthome.binding.digitalstrom.internal;
 
-import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toSet;
 import static org.eclipse.smarthome.binding.digitalstrom.DigitalSTROMBindingConstants.*;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.binding.digitalstrom.DigitalSTROMBindingConstants;
@@ -57,22 +53,15 @@ public class DigitalSTROMHandlerFactory extends BaseThingHandlerFactory {
     private final Logger logger = LoggerFactory.getLogger(DigitalSTROMHandlerFactory.class);
     private final HashMap<String, DiscoveryServiceManager> discoveryServiceManagers = new HashMap<String, DiscoveryServiceManager>();
 
-    /**
-     * Contains all supported {@link ThingTypeUID}'s.
-     */
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Stream.of( //
-            SceneHandler.SUPPORTED_THING_TYPES.stream(), //
-            BridgeHandler.SUPPORTED_THING_TYPES.stream(), //
-            DeviceHandler.SUPPORTED_THING_TYPES.stream(), //
-            ZoneTemperatureControlHandler.SUPPORTED_THING_TYPES.stream(), //
-            CircuitHandler.SUPPORTED_THING_TYPES.stream()) //
-            .flatMap(identity()).collect(toSet());
-
     private HashMap<ThingUID, BridgeHandler> bridgeHandlers;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
-        return SUPPORTED_THING_TYPES.contains(thingTypeUID);
+        return BridgeHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)
+                || SceneHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)
+                || DeviceHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)
+                || ZoneTemperatureControlHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)
+                || CircuitHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID);
     }
 
     @Override
@@ -151,7 +140,7 @@ public class DigitalSTROMHandlerFactory extends BaseThingHandlerFactory {
     private ThingUID getDeviceUID(ThingTypeUID thingTypeUID, ThingUID thingUID, Configuration configuration,
             ThingUID bridgeUID) {
         if (thingUID == null && StringUtils.isNotBlank((String) configuration.get(DEVICE_DSID))) {
-            thingUID = new ThingUID(thingTypeUID, bridgeUID, configuration.get(DEVICE_DSID).toString());
+            return new ThingUID(thingTypeUID, bridgeUID, configuration.get(DEVICE_DSID).toString());
         }
         return thingUID;
     }
@@ -161,7 +150,7 @@ public class DigitalSTROMHandlerFactory extends BaseThingHandlerFactory {
         if (thingUID == null) {
             Integer zoneID = ZoneTemperatureControlHandler.getZoneID(configuration, bridgeHandlers.get(bridgeUID));
             if (zoneID > ZoneTemperatureControlHandler.ZONE_ID_NOT_EXISTS) {
-                thingUID = new ThingUID(thingTypeUID, bridgeUID, zoneID.toString());
+                return new ThingUID(thingTypeUID, bridgeUID, zoneID.toString());
             } else {
                 switch (zoneID) {
                     case ZoneTemperatureControlHandler.ZONE_ID_NOT_EXISTS:

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/DigitalSTROMHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/DigitalSTROMHandlerFactory.java
@@ -118,10 +118,6 @@ public class DigitalSTROMHandlerFactory extends BaseThingHandlerFactory {
     protected ThingHandler createHandler(Thing thing) {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
-        if (thingTypeUID == null) {
-            return null;
-        }
-
         if (BridgeHandler.SUPPORTED_THING_TYPES.contains(thingTypeUID)) {
             BridgeHandler handler = new BridgeHandler((Bridge) thing);
             if (bridgeHandlers == null) {

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/DeviceDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/DeviceDiscoveryService.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.binding.digitalstrom.DigitalSTROMBindingConstants;
 import org.eclipse.smarthome.binding.digitalstrom.handler.BridgeHandler;
-import org.eclipse.smarthome.binding.digitalstrom.handler.DeviceHandler;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.Circuit;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.Device;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.GeneralDeviceInformation;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/DiscoveryServiceManager.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/DiscoveryServiceManager.java
@@ -231,9 +231,9 @@ public class DiscoveryServiceManager
     @Override
     public void configChanged(TemperatureControlStatus tempControlStatus) {
         // currently only this thing-type exists
-        if (discoveryServices.get(DigitalSTROMBindingConstants.THING_TYPE_ZONE_TEMERATURE_CONTROL) != null) {
+        if (discoveryServices.get(DigitalSTROMBindingConstants.THING_TYPE_ZONE_TEMERATURE_CONTROL.toString()) != null) {
             ((ZoneTemperatureControlDiscoveryService) discoveryServices
-                    .get(DigitalSTROMBindingConstants.THING_TYPE_ZONE_TEMERATURE_CONTROL))
+                    .get(DigitalSTROMBindingConstants.THING_TYPE_ZONE_TEMERATURE_CONTROL.toString()))
                             .configChanged(tempControlStatus);
         }
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/SceneDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/SceneDiscoveryService.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.Map;
 
 import org.eclipse.smarthome.binding.digitalstrom.handler.BridgeHandler;
-import org.eclipse.smarthome.binding.digitalstrom.handler.SceneHandler;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.FuncNameAndColorGroupEnum;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.scene.InternalScene;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.scene.constants.SceneEnum;
@@ -92,7 +91,7 @@ public class SceneDiscoveryService extends AbstractDiscoveryService {
 
     private void onSceneAddedInternal(InternalScene scene) {
         logger.debug("{}", scene.getSceneType());
-        if (scene != null && scene.getSceneType().equals(sceneType)) {
+        if (scene.getSceneType().equals(sceneType)) {
             if (!ignoredScene(scene.getSceneID()) && !ignoreGroup(scene.getGroupID())) {
                 ThingUID thingUID = getThingUID(scene);
                 if (thingUID != null) {

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/ZoneTemperatureControlDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/ZoneTemperatureControlDiscoveryService.java
@@ -96,7 +96,7 @@ public class ZoneTemperatureControlDiscoveryService extends AbstractDiscoverySer
         if (tempControlStatus == null) {
             return;
         }
-        if (tempControlStatus.getIsConfigured()) {
+        if (tempControlStatus.isNotSetOff()) {
             logger.debug("found configured zone TemperatureControlStatus = {}", tempControlStatus);
 
             ThingUID thingUID = getThingUID(tempControlStatus);

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/ZoneTemperatureControlDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/discovery/ZoneTemperatureControlDiscoveryService.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.binding.digitalstrom.DigitalSTROMBindingConstants;
 import org.eclipse.smarthome.binding.digitalstrom.handler.BridgeHandler;
-import org.eclipse.smarthome.binding.digitalstrom.handler.ZoneTemperatureControlHandler;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.climate.jsonresponsecontainer.impl.TemperatureControlStatus;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/BaseTemperatureControl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/BaseTemperatureControl.java
@@ -86,7 +86,7 @@ public abstract class BaseTemperatureControl extends BaseZoneIdentifier {
      * Returns true, if heating for this zone is not set off (set {@link ControlModes} = {@link ControlModes#OFF}),
      * otherwise false.
      *
-     * @return the true, if the set {@link ControlModes} is not {@link ControlModes#OFF}
+     * @return true, if the set {@link ControlModes} is not {@link ControlModes#OFF}
      */
     public Boolean isNotSetOff() {
         return !ControlModes.OFF.getID().equals(controlMode);

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/BaseTemperatureControl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/BaseTemperatureControl.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.binding.digitalstrom.internal.lib.climate.jsonresponsecontainer;
 
+import org.eclipse.smarthome.binding.digitalstrom.internal.lib.climate.constants.ControlModes;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.serverconnection.constants.JSONApiResponseKeysEnum;
 
 import com.google.gson.JsonObject;
@@ -27,7 +28,6 @@ public abstract class BaseTemperatureControl extends BaseZoneIdentifier {
 
     protected String controlDSUID;
     protected Short controlMode;
-    protected Boolean isConfigured;
 
     /**
      * Creates a new {@link BaseTemperatureControl} through the {@link JsonObject} which will be returned by an zone
@@ -41,17 +41,7 @@ public abstract class BaseTemperatureControl extends BaseZoneIdentifier {
      */
     public BaseTemperatureControl(JsonObject jObject, Integer zoneID, String zoneName) {
         super(zoneID, zoneName);
-        if (jObject.get(JSONApiResponseKeysEnum.IS_CONFIGURED.getKey()) != null) {
-            this.isConfigured = jObject.get(JSONApiResponseKeysEnum.IS_CONFIGURED.getKey()).getAsBoolean();
-        }
-        if (isConfigured) {
-            if (jObject.get(JSONApiResponseKeysEnum.CONTROL_MODE.getKey()) != null) {
-                this.controlMode = jObject.get(JSONApiResponseKeysEnum.CONTROL_MODE.getKey()).getAsShort();
-            }
-            if (jObject.get(JSONApiResponseKeysEnum.CONTROL_DSUID.getKey()) != null) {
-                this.controlDSUID = jObject.get(JSONApiResponseKeysEnum.CONTROL_DSUID.getKey()).getAsString();
-            }
-        }
+        init(jObject);
     }
 
     /**
@@ -62,16 +52,15 @@ public abstract class BaseTemperatureControl extends BaseZoneIdentifier {
      */
     public BaseTemperatureControl(JsonObject jObject) {
         super(jObject);
-        if (jObject.get(JSONApiResponseKeysEnum.IS_CONFIGURED.getKey()) != null) {
-            this.isConfigured = jObject.get(JSONApiResponseKeysEnum.IS_CONFIGURED.getKey()).getAsBoolean();
+        init(jObject);
+    }
+
+    private void init(JsonObject jObject) {
+        if (jObject.get(JSONApiResponseKeysEnum.CONTROL_MODE.getKey()) != null) {
+            this.controlMode = jObject.get(JSONApiResponseKeysEnum.CONTROL_MODE.getKey()).getAsShort();
         }
-        if (isConfigured) {
-            if (jObject.get(JSONApiResponseKeysEnum.CONTROL_MODE.getKey()) != null) {
-                this.controlMode = jObject.get(JSONApiResponseKeysEnum.CONTROL_MODE.getKey()).getAsShort();
-            }
-            if (jObject.get(JSONApiResponseKeysEnum.CONTROL_DSUID.getKey()) != null) {
-                this.controlDSUID = jObject.get(JSONApiResponseKeysEnum.CONTROL_DSUID.getKey()).getAsString();
-            }
+        if (jObject.get(JSONApiResponseKeysEnum.CONTROL_DSUID.getKey()) != null) {
+            this.controlDSUID = jObject.get(JSONApiResponseKeysEnum.CONTROL_DSUID.getKey()).getAsString();
         }
     }
 
@@ -94,12 +83,13 @@ public abstract class BaseTemperatureControl extends BaseZoneIdentifier {
     }
 
     /**
-     * Returns true, if heating for this zone is configured, otherwise false.
+     * Returns true, if heating for this zone is not set off (set {@link ControlModes} = {@link ControlModes#OFF}),
+     * otherwise false.
      *
-     * @return the isConfigured
+     * @return the true, if the set {@link ControlModes} is not {@link ControlModes#OFF}
      */
-    public Boolean getIsConfigured() {
-        return isConfigured;
+    public Boolean isNotSetOff() {
+        return !ControlModes.OFF.getID().equals(controlMode);
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/impl/TemperatureControlConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/impl/TemperatureControlConfig.java
@@ -69,7 +69,7 @@ public class TemperatureControlConfig extends BaseTemperatureControl {
     }
 
     private void init(JsonObject jObject) {
-        if (isConfigured) {
+        if (isNotSetOff()) {
             if (controlMode == 1) {
                 if (jObject.get(JSONApiResponseKeysEnum.EMERGENCY_VALUE.getKey()) != null) {
                     this.emergencyValue = jObject.get(JSONApiResponseKeysEnum.EMERGENCY_VALUE.getKey()).getAsFloat();

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/impl/TemperatureControlInternals.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/impl/TemperatureControlInternals.java
@@ -52,7 +52,7 @@ public class TemperatureControlInternals extends BaseTemperatureControl {
      */
     public TemperatureControlInternals(JsonObject jObject, Integer zoneID, String zoneName) {
         super(jObject, zoneID, zoneName);
-        if (isConfigured) {
+        if (isNotSetOff()) {
             if (jObject.get(JSONApiResponseKeysEnum.CONTROL_STATE.getKey()) != null) {
                 this.controlState = jObject.get(JSONApiResponseKeysEnum.CONTROL_STATE.getKey()).getAsShort();
             }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/impl/TemperatureControlStatus.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/climate/jsonresponsecontainer/impl/TemperatureControlStatus.java
@@ -70,7 +70,7 @@ public class TemperatureControlStatus extends BaseTemperatureControl {
     }
 
     private void init(JsonObject jObject) {
-        if (isConfigured) {
+        if (isNotSetOff()) {
             if (jObject.get(JSONApiResponseKeysEnum.CONTROL_STATE.getKey()) != null) {
                 this.controlState = jObject.get(JSONApiResponseKeysEnum.CONTROL_STATE.getKey()).getAsShort();
             }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/DeviceStatusManagerImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/DeviceStatusManagerImpl.java
@@ -343,7 +343,7 @@ public class DeviceStatusManagerImpl implements DeviceStatusManager {
                     if (deviceDiscovery != null) {
                         // only informs discovery, if the device is a output or a sensor device
                         deviceDiscovery.onDeviceAdded(currentDevice);
-                        logger.debug("inform DeviceStatusListener: {} about removed device with dSID {}",
+                        logger.debug("inform DeviceStatusListener: {} about added device with dSID {}",
                                 DeviceStatusListener.DEVICE_DISCOVERY, currentDevice.getDSID().getValue());
                     } else {
                         logger.debug(

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/SceneManagerImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/SceneManagerImpl.java
@@ -201,10 +201,9 @@ public class SceneManagerImpl implements SceneManager {
 
     private boolean isEcho(String dsid, short sceneId) {
         // sometimes the dS-event has a dSUID saved in the dSID
-        if (structureManager.getDeviceByDSUID(dsid) != null) {
-            dsid = structureManager.getDeviceByDSUID(dsid).getDSID().getValue();
-        }
-        String echo = dsid + "-" + sceneId;
+        String echo = (structureManager.getDeviceByDSUID(dsid) != null
+                ? structureManager.getDeviceByDSUID(dsid).getDSID().getValue()
+                : dsid) + "-" + sceneId;
         logger.debug("An echo scene event was detected: {}", echo);
         return isEcho(echo);
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/TemperatureControlManager.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/TemperatureControlManager.java
@@ -252,13 +252,10 @@ public class TemperatureControlManager implements EventHandler, TemperatureContr
                 this.discovery = null;
                 return;
             }
-            if (temperatureControlStatusListener != null) {
-                temperatureControlStatusListener = zoneTemperationControlListenerMap
-                        .remove(temperatureControlStatusListener.getTemperationControlStatusListenrID());
-                if (discovery != null && temperatureControlStatusListener != null) {
-                    discovery.configChanged(temperationControlStatus
-                            .get(temperatureControlStatusListener.getTemperationControlStatusListenrID()));
-                }
+            if (discovery != null && zoneTemperationControlListenerMap
+                    .remove(temperatureControlStatusListener.getTemperationControlStatusListenrID()) != null) {
+                discovery.configChanged(temperationControlStatus
+                        .get(temperatureControlStatusListener.getTemperationControlStatusListenrID()));
             }
         }
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/TemperatureControlManager.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/manager/impl/TemperatureControlManager.java
@@ -272,7 +272,7 @@ public class TemperatureControlManager implements EventHandler, TemperatureContr
      */
     public TemperatureControlStatus checkAndGetTemperatureControlStatus(Integer zoneID) {
         TemperatureControlStatus tempConStat = this.temperationControlStatus.get(zoneID);
-        if (tempConStat.getIsConfigured()) {
+        if (tempConStat.isNotSetOff()) {
             return tempConStat;
         }
         return null;
@@ -340,7 +340,7 @@ public class TemperatureControlManager implements EventHandler, TemperatureContr
     }
 
     private void addTemperatureControlStatus(TemperatureControlStatus temperationControlStatus) {
-        if (temperationControlStatus.getIsConfigured()) {
+        if (temperationControlStatus.isNotSetOff()) {
             if (this.temperationControlStatus == null) {
                 this.temperationControlStatus = new HashMap<Integer, TemperatureControlStatus>();
             }

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorjobexecutor/CircuitScheduler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/sensorjobexecutor/CircuitScheduler.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CircuitScheduler {
 
-    private Logger logger = LoggerFactory.getLogger(CircuitScheduler.class);
+    private final Logger logger = LoggerFactory.getLogger(CircuitScheduler.class);
 
     private class SensorJobComparator implements Comparator<SensorJob> {
 
@@ -43,8 +43,8 @@ public class CircuitScheduler {
 
     private final DSID meterDSID;
     private long nextExecutionTime = System.currentTimeMillis();
-    private PriorityQueue<SensorJob> sensorJobQueue = new PriorityQueue<SensorJob>(10, new SensorJobComparator());
-    private Config config;
+    private final PriorityQueue<SensorJob> sensorJobQueue = new PriorityQueue<SensorJob>(10, new SensorJobComparator());
+    private final Config config;
 
     /**
      * Creates a new {@link CircuitScheduler}.
@@ -108,8 +108,7 @@ public class CircuitScheduler {
             for (Iterator<SensorJob> iter = sensorJobQueue.iterator(); iter.hasNext();) {
                 SensorJob existSensorJob = iter.next();
                 if (existSensorJob.equals(sensorJob)) {
-                    if (existSensorJob != null
-                            && sensorJob.getInitalisationTime() < existSensorJob.getInitalisationTime()) {
+                    if (sensorJob.getInitalisationTime() < existSensorJob.getInitalisationTime()) {
                         iter.remove();
                         sensorJobQueue.add(sensorJob);
                         return true;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverconnection/impl/DsAPIImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverconnection/impl/DsAPIImpl.java
@@ -1114,9 +1114,7 @@ public class DsAPIImpl implements DsAPI {
                     while (iter.hasNext()) {
                         TemperatureControlStatus tContStat = new TemperatureControlStatus(
                                 iter.next().getAsJsonObject());
-                        if (tContStat != null) {
-                            list.add(tContStat);
-                        }
+                        list.add(tContStat);
                     }
                     return list;
                 }
@@ -1143,9 +1141,7 @@ public class DsAPIImpl implements DsAPI {
                     while (iter.hasNext()) {
                         TemperatureControlConfig tContConf = new TemperatureControlConfig(
                                 iter.next().getAsJsonObject());
-                        if (tContConf != null) {
-                            map.put(tContConf.getZoneID(), tContConf);
-                        }
+                        map.put(tContConf.getZoneID(), tContConf);
                     }
                     return map;
                 }
@@ -1171,9 +1167,7 @@ public class DsAPIImpl implements DsAPI {
                     Iterator<JsonElement> iter = jArray.iterator();
                     while (iter.hasNext()) {
                         TemperatureControlValues tContVal = new TemperatureControlValues(iter.next().getAsJsonObject());
-                        if (tContVal != null) {
-                            map.put(tContVal.getZoneID(), tContVal);
-                        }
+                        map.put(tContVal.getZoneID(), tContVal);
                     }
                     return map;
                 }
@@ -1198,9 +1192,7 @@ public class DsAPIImpl implements DsAPI {
                     Iterator<JsonElement> iter = jArray.iterator();
                     while (iter.hasNext()) {
                         AssignedSensors assignedSensors = new AssignedSensors(iter.next().getAsJsonObject());
-                        if (assignedSensors != null) {
-                            map.put(assignedSensors.getZoneID(), assignedSensors);
-                        }
+                        map.put(assignedSensors.getZoneID(), assignedSensors);
                     }
                     return map;
                 }
@@ -1226,9 +1218,7 @@ public class DsAPIImpl implements DsAPI {
                     Iterator<JsonElement> iter = jArray.iterator();
                     while (iter.hasNext()) {
                         SensorValues sensorValues = new SensorValues(iter.next().getAsJsonObject());
-                        if (sensorValues != null) {
-                            map.put(sensorValues.getZoneID(), sensorValues);
-                        }
+                        map.put(sensorValues.getZoneID(), sensorValues);
                     }
                     map.put(GeneralLibConstance.BROADCAST_ZONE_GROUP_ID, weather);
                     return map;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverconnection/impl/HttpTransportImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/serverconnection/impl/HttpTransportImpl.java
@@ -43,7 +43,6 @@ import javax.net.ssl.X509TrustManager;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.config.Config;
-import org.eclipse.smarthome.binding.digitalstrom.internal.lib.listener.ConnectionListener;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.manager.ConnectionManager;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.serverconnection.HttpTransport;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.serverconnection.simpledsrequestbuilder.constants.ParameterKeys;
@@ -266,7 +265,8 @@ public class HttpTransportImpl implements HttpTransport {
                     }
                 }
                 connection.disconnect();
-                if (response == null && connectionManager != null && loginCounter <= MAY_A_NEW_SESSION_TOKEN_IS_NEEDED) {
+                if (response == null && connectionManager != null
+                        && loginCounter <= MAY_A_NEW_SESSION_TOKEN_IS_NEEDED) {
                     if (connection.getResponseCode() == HttpURLConnection.HTTP_FORBIDDEN) {
                         execute(addSessionToken(request, connectionManager.getNewSessionToken()), connectTimeout,
                                 readTimeout);

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceparameters/impl/DeviceSensorValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/deviceparameters/impl/DeviceSensorValue.java
@@ -19,9 +19,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 
-import org.eclipse.smarthome.binding.digitalstrom.internal.lib.event.constants.EventNames;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.event.constants.EventResponseEnum;
-import org.eclipse.smarthome.binding.digitalstrom.internal.lib.serverconnection.DsAPI;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.serverconnection.constants.JSONApiResponseKeysEnum;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.SensorEnum;
 import org.slf4j.Logger;

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImpl.java
@@ -1510,111 +1510,118 @@ public class DeviceImpl extends AbstractGeneralDeviceInformations implements Dev
 
     @Override
     public synchronized void updateInternalDeviceState(DeviceStateUpdate deviceStateUpdate) {
-        if (deviceStateUpdate != null) {
-            logger.debug("internal set outputvalue");
-            switch (deviceStateUpdate.getType()) {
-                case DeviceStateUpdate.OUTPUT_DECREASE:
-                    deviceStateUpdate = new DeviceStateUpdateImpl(DeviceStateUpdate.OUTPUT_DECREASE,
-                            internalSetOutputValue(outputValue - getDimmStep()));
-                    break;
-                case DeviceStateUpdate.OUTPUT_INCREASE:
-                    deviceStateUpdate = new DeviceStateUpdateImpl(DeviceStateUpdate.OUTPUT_INCREASE,
-                            internalSetOutputValue(outputValue + getDimmStep()));
-                    break;
-                case DeviceStateUpdate.OUTPUT:
-                    internalSetOutputValue(deviceStateUpdate.getValueAsInteger());
-                    break;
-                case DeviceStateUpdate.ON_OFF:
-                    if (deviceStateUpdate.getValueAsInteger() < 0) {
-                        internalSetOutputValue(0);
-                    } else {
-                        internalSetOutputValue(maxOutputValue);
-                    }
-                    break;
-                case DeviceStateUpdate.OPEN_CLOSE:
-                    if (deviceStateUpdate.getValueAsInteger() < 0) {
-                        internalSetOutputValue(0);
-                    } else {
-                        internalSetOutputValue(maxSlatPosition);
-                    }
-                    break;
-                case DeviceStateUpdate.OPEN_CLOSE_ANGLE:
-                    if (deviceStateUpdate.getValueAsInteger() < 0) {
-                        internalSetAngleValue(0);
-                    } else {
-                        internalSetAngleValue(maxSlatAngle);
-                    }
-                    break;
-                case DeviceStateUpdate.SLAT_DECREASE:
-                    deviceStateUpdate = new DeviceStateUpdateImpl(DeviceStateUpdate.SLAT_DECREASE,
-                            internalSetOutputValue(slatPosition - getDimmStep()));
-                    break;
-                case DeviceStateUpdate.SLAT_INCREASE:
-                    deviceStateUpdate = new DeviceStateUpdateImpl(DeviceStateUpdate.SLAT_INCREASE,
-                            internalSetOutputValue(slatPosition + getDimmStep()));
-                case DeviceStateUpdate.SLATPOSITION:
-                    internalSetOutputValue(deviceStateUpdate.getValueAsInteger());
-                    break;
-                case DeviceStateUpdate.SLAT_ANGLE_DECREASE:
-                    deviceStateUpdate = new DeviceStateUpdateImpl(DeviceStateUpdate.SLAT_ANGLE_DECREASE,
-                            internalSetAngleValue(slatAngle - DeviceConstants.ANGLE_STEP_SLAT));
-                    break;
-                case DeviceStateUpdate.SLAT_ANGLE_INCREASE:
-                    deviceStateUpdate = new DeviceStateUpdateImpl(DeviceStateUpdate.SLAT_ANGLE_INCREASE,
-                            internalSetAngleValue(slatAngle + DeviceConstants.ANGLE_STEP_SLAT));
-                    break;
-                case DeviceStateUpdate.SLAT_ANGLE:
-                    internalSetAngleValue(deviceStateUpdate.getValueAsInteger());
-                    break;
-                case DeviceStateUpdate.UPDATE_CALL_SCENE:
-                    this.internalCallScene(deviceStateUpdate.getValueAsShort());
-                    return;
-                case DeviceStateUpdate.UPDATE_UNDO_SCENE:
-                    this.internalUndoScene();
-                    return;
-                default:
-                    if (deviceStateUpdate.isSensorUpdateType()) {
-                        SensorEnum sensorType = deviceStateUpdate.getTypeAsSensorEnum();
-                        setFloatSensorValue(sensorType, deviceStateUpdate.getValueAsFloat());
-                    }
-                    return;
-            }
+        DeviceStateUpdate deviceStateUpdateInt = internalSetOutputValue(deviceStateUpdate);
+        if (deviceStateUpdateInt != null) {
+            validateActiveScene();
+            informListenerAboutStateUpdate(deviceStateUpdate);
         }
-        if (activeScene != null) {
-            Integer[] sceneOutput = getStandartSceneOutput(activeScene.getSceneID());
-            if (sceneOutput == null) {
-                sceneOutput = sceneOutputMap.get(activeScene.getSceneID());
-            }
-            if (sceneOutput != null) {
-                boolean outputChanged = false;
-                if (isShade()) {
-                    if (isBlind() && sceneOutput[1] != slatAngle) {
-                        logger.debug("Scene output angle: {} setted output value {}", sceneOutput[1], slatAngle);
-                        outputChanged = true;
-                    }
-                    if (sceneOutput[0] != slatPosition) {
-                        logger.debug("Scene output value: {} setted output value {}", sceneOutput[0], slatPosition);
-                        outputChanged = true;
-                    }
-                } else {
-                    if (sceneOutput[0] != outputValue) {
-                        logger.debug("Scene output value: {} setted output value {}", sceneOutput[0], outputValue);
-                        outputChanged = true;
-                    }
-                }
-                if (outputChanged) {
-                    logger.debug("Device output from Device with dSID {} changed deactivate scene {}", dsid.getValue(),
-                            activeScene.getID());
-                    activeScene.deviceSceneChanged((short) -1);
-                    lastScene = null;
-                    activeScene = null;
-                }
+    }
 
-            } else {
-                lastScene = null;
-            }
+    private DeviceStateUpdate internalSetOutputValue(DeviceStateUpdate deviceStateUpdate) {
+        if (deviceStateUpdate == null) {
+            return null;
         }
-        informListenerAboutStateUpdate(deviceStateUpdate);
+        logger.debug("internal set outputvalue");
+        switch (deviceStateUpdate.getType()) {
+            case DeviceStateUpdate.OUTPUT_DECREASE:
+                return new DeviceStateUpdateImpl(DeviceStateUpdate.OUTPUT_DECREASE,
+                        internalSetOutputValue(outputValue - getDimmStep()));
+            case DeviceStateUpdate.OUTPUT_INCREASE:
+                return new DeviceStateUpdateImpl(DeviceStateUpdate.OUTPUT_INCREASE,
+                        internalSetOutputValue(outputValue + getDimmStep()));
+            case DeviceStateUpdate.OUTPUT:
+                internalSetOutputValue(deviceStateUpdate.getValueAsInteger());
+                break;
+            case DeviceStateUpdate.ON_OFF:
+                if (deviceStateUpdate.getValueAsInteger() < 0) {
+                    internalSetOutputValue(0);
+                } else {
+                    internalSetOutputValue(maxOutputValue);
+                }
+                break;
+            case DeviceStateUpdate.OPEN_CLOSE:
+                if (deviceStateUpdate.getValueAsInteger() < 0) {
+                    internalSetOutputValue(0);
+                } else {
+                    internalSetOutputValue(maxSlatPosition);
+                }
+                break;
+            case DeviceStateUpdate.OPEN_CLOSE_ANGLE:
+                if (deviceStateUpdate.getValueAsInteger() < 0) {
+                    internalSetAngleValue(0);
+                } else {
+                    internalSetAngleValue(maxSlatAngle);
+                }
+                break;
+            case DeviceStateUpdate.SLAT_DECREASE:
+                return new DeviceStateUpdateImpl(DeviceStateUpdate.SLAT_DECREASE,
+                        internalSetOutputValue(slatPosition - getDimmStep()));
+            case DeviceStateUpdate.SLAT_INCREASE:
+                return new DeviceStateUpdateImpl(DeviceStateUpdate.SLAT_INCREASE,
+                        internalSetOutputValue(slatPosition + getDimmStep()));
+            case DeviceStateUpdate.SLATPOSITION:
+                internalSetOutputValue(deviceStateUpdate.getValueAsInteger());
+                break;
+            case DeviceStateUpdate.SLAT_ANGLE_DECREASE:
+                return new DeviceStateUpdateImpl(DeviceStateUpdate.SLAT_ANGLE_DECREASE,
+                        internalSetAngleValue(slatAngle - DeviceConstants.ANGLE_STEP_SLAT));
+            case DeviceStateUpdate.SLAT_ANGLE_INCREASE:
+                return new DeviceStateUpdateImpl(DeviceStateUpdate.SLAT_ANGLE_INCREASE,
+                        internalSetAngleValue(slatAngle + DeviceConstants.ANGLE_STEP_SLAT));
+            case DeviceStateUpdate.SLAT_ANGLE:
+                internalSetAngleValue(deviceStateUpdate.getValueAsInteger());
+                break;
+            case DeviceStateUpdate.UPDATE_CALL_SCENE:
+                this.internalCallScene(deviceStateUpdate.getValueAsShort());
+                return null;
+            case DeviceStateUpdate.UPDATE_UNDO_SCENE:
+                this.internalUndoScene();
+                return null;
+            default:
+                if (deviceStateUpdate.isSensorUpdateType()) {
+                    SensorEnum sensorType = deviceStateUpdate.getTypeAsSensorEnum();
+                    setFloatSensorValue(sensorType, deviceStateUpdate.getValueAsFloat());
+                }
+                return null;
+        }
+        return deviceStateUpdate;
+    }
+
+    private void validateActiveScene() {
+        if (activeScene == null) {
+            return;
+        }
+        Integer[] sceneOutput = getStandartSceneOutput(activeScene.getSceneID());
+        if (sceneOutput == null) {
+            sceneOutput = sceneOutputMap.get(activeScene.getSceneID());
+        }
+        if (sceneOutput != null) {
+            boolean outputChanged = false;
+            if (isShade()) {
+                if (isBlind() && sceneOutput[1] != slatAngle) {
+                    logger.debug("Scene output angle: {} setted output value {}", sceneOutput[1], slatAngle);
+                    outputChanged = true;
+                }
+                if (sceneOutput[0] != slatPosition) {
+                    logger.debug("Scene output value: {} setted output value {}", sceneOutput[0], slatPosition);
+                    outputChanged = true;
+                }
+            } else {
+                if (sceneOutput[0] != outputValue) {
+                    logger.debug("Scene output value: {} setted output value {}", sceneOutput[0], outputValue);
+                    outputChanged = true;
+                }
+            }
+            if (outputChanged) {
+                logger.debug("Device output from Device with dSID {} changed deactivate scene {}", dsid.getValue(),
+                        activeScene.getID());
+                activeScene.deviceSceneChanged((short) -1);
+                lastScene = null;
+                activeScene = null;
+            }
+        } else {
+            lastScene = null;
+        }
     }
 
     @Override
@@ -1659,18 +1666,19 @@ public class DeviceImpl extends AbstractGeneralDeviceInformations implements Dev
      */
     private void informListenerAboutStateUpdate(DeviceStateUpdate deviceStateUpdate) {
         if (listener != null) {
-            if (isSwitch() && deviceStateUpdate.getType().equals(DeviceStateUpdate.OUTPUT)) {
-                if (deviceStateUpdate.getValueAsInteger() >= switchPercentOff) {
-                    deviceStateUpdate = new DeviceStateUpdateImpl(DeviceStateUpdate.ON_OFF, DeviceStateUpdate.ON_VALUE);
-                } else {
-                    deviceStateUpdate = new DeviceStateUpdateImpl(DeviceStateUpdate.ON_OFF,
-                            DeviceStateUpdate.OFF_VALUE);
-                }
-            }
-            logger.debug("Inform listener about device state changed: type: {}",
-                    deviceStateUpdate.getType() + ", value: " + deviceStateUpdate.getValue());
-            listener.onDeviceStateChanged(deviceStateUpdate);
+            listener.onDeviceStateChanged(correctDeviceStatusUpdate(deviceStateUpdate));
         }
+    }
+
+    private DeviceStateUpdate correctDeviceStatusUpdate(DeviceStateUpdate deviceStateUpdate) {
+        if (isSwitch() && deviceStateUpdate.getType().equals(DeviceStateUpdate.OUTPUT)) {
+            if (deviceStateUpdate.getValueAsInteger() >= switchPercentOff) {
+                return new DeviceStateUpdateImpl(DeviceStateUpdate.ON_OFF, DeviceStateUpdate.ON_VALUE);
+            } else {
+                return new DeviceStateUpdateImpl(DeviceStateUpdate.ON_OFF, DeviceStateUpdate.OFF_VALUE);
+            }
+        }
+        return deviceStateUpdate;
     }
 
     private void informListenerAboutConfigChange(ChangeableDeviceConfigEnum changedConfig) {

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/lib/structure/devices/impl/DeviceImpl.java
@@ -981,13 +981,11 @@ public class DeviceImpl extends AbstractGeneralDeviceInformations implements Dev
         if (sensorType != null) {
             DeviceSensorValue devSenVal = getDeviceSensorValue(sensorType);
             if (devSenVal.getValid()) {
-                if (devSenVal != null) {
-                    int refresh = Config.DEFAULT_SENSORDATA_REFRESH_INTERVAL;
-                    if (config != null) {
-                        refresh = config.getSensordataRefreshInterval();
-                    }
-                    return (devSenVal.getTimestamp().getTime() + refresh) > System.currentTimeMillis();
+                int refresh = Config.DEFAULT_SENSORDATA_REFRESH_INTERVAL;
+                if (config != null) {
+                    refresh = config.getSensordataRefreshInterval();
                 }
+                return (devSenVal.getTimestamp().getTime() + refresh) > System.currentTimeMillis();
             }
         }
         return false;
@@ -1229,20 +1227,18 @@ public class DeviceImpl extends AbstractGeneralDeviceInformations implements Dev
     @Override
     public void setDeviceSensorByEvent(EventItem event) {
         DeviceSensorValue devSenVal = new DeviceSensorValue(event.getProperties());
-        if (devSenVal != null) {
-            SensorEnum sensorType = devSenVal.getSensorType();
-            if (!isEchoSensor(sensorType)) {
-                logger.debug("Event is no echo, set values {} for sensorType {}", devSenVal, devSenVal.getSensorType());
-                if (SensorEnum.isPowerSensor(sensorType) && getSensorDataReadingInitialized(sensorType)) {
-                    logger.debug("SensorJob was initialized, remove sensorjob for sensorType: {}",
-                            devSenVal.getSensorType());
-                    deviceStateUpdates.add(new DeviceStateUpdateImpl(sensorType, -1));
-                }
-                setDeviceSensorValue(devSenVal);
-            } else {
-                logger.debug("Event is echo remove sensorType {} from echoBox", devSenVal.getSensorType());
-                sensorEchoBox.remove(devSenVal.getSensorType());
+        SensorEnum sensorType = devSenVal.getSensorType();
+        if (!isEchoSensor(sensorType)) {
+            logger.debug("Event is no echo, set values {} for sensorType {}", devSenVal, devSenVal.getSensorType());
+            if (SensorEnum.isPowerSensor(sensorType) && getSensorDataReadingInitialized(sensorType)) {
+                logger.debug("SensorJob was initialized, remove sensorjob for sensorType: {}",
+                        devSenVal.getSensorType());
+                deviceStateUpdates.add(new DeviceStateUpdateImpl(sensorType, -1));
             }
+            setDeviceSensorValue(devSenVal);
+        } else {
+            logger.debug("Event is echo remove sensorType {} from echoBox", devSenVal.getSensorType());
+            sensorEchoBox.remove(devSenVal.getSensorType());
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/providers/DsChannelTypeProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/providers/DsChannelTypeProvider.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.eclipse.smarthome.binding.digitalstrom.DigitalSTROMBindingConstants;
-import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.Device;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.DeviceBinarayInputEnum;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.FunctionalColorGroupEnum;
 import org.eclipse.smarthome.binding.digitalstrom.internal.lib.structure.devices.deviceparameters.constants.MeteringTypeEnum;


### PR DESCRIPTION
* Change BaseTemperatureControl#isConfigured() to isNotSetOff(), due to changes of the dS-API (the parameter is removed  now). The method use the ControlMode#OFF to identify, if the temperature-control is activated (configured), now. I hope that the climate-control will continue to work. Fixed #5651
* add a note to the readme, that point out that directly set output values are not recognized. Fixed #5554

@maieralex maybe you can test the first point.

Also-by: Matthias Siegele <digitalSTROM-ESH-binding@web.de>
Signed-off-by: Michael Ochel <michael.ochel@koeln.de>