### PR TITLE
Sonos: implement a dynamic state description option provider

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
@@ -21,6 +21,7 @@ Import-Package:
  org.eclipse.smarthome.core.net,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.thing.util,
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.io.net.http,

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosHandlerFactory.java
@@ -53,6 +53,7 @@ public class SonosHandlerFactory extends BaseThingHandlerFactory {
     private UpnpIOService upnpIOService;
     private AudioHTTPServer audioHTTPServer;
     private NetworkAddressService networkAddressService;
+    private SonosStateDescriptionOptionProvider stateDescriptionProvider;
 
     private final Map<String, ServiceRegistration<AudioSink>> audioSinkRegistrations = new ConcurrentHashMap<>();
 
@@ -95,7 +96,7 @@ public class SonosHandlerFactory extends BaseThingHandlerFactory {
             logger.debug("Creating a ZonePlayerHandler for thing '{}' with UDN '{}'", thing.getUID(),
                     thing.getConfiguration().get(UDN));
 
-            ZonePlayerHandler handler = new ZonePlayerHandler(thing, upnpIOService, opmlUrl);
+            ZonePlayerHandler handler = new ZonePlayerHandler(thing, upnpIOService, opmlUrl, stateDescriptionProvider);
 
             // register the speaker as an audio sink
             String callbackUrl = createCallbackUrl();
@@ -176,4 +177,12 @@ public class SonosHandlerFactory extends BaseThingHandlerFactory {
         this.networkAddressService = null;
     }
 
+    @Reference
+    protected void setDynamicStateDescriptionProvider(SonosStateDescriptionOptionProvider stateDescriptionProvider) {
+        this.stateDescriptionProvider = stateDescriptionProvider;
+    }
+
+    protected void unsetDynamicStateDescriptionProvider(SonosStateDescriptionOptionProvider stateDescriptionProvider) {
+        this.stateDescriptionProvider = null;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosResourceMetaData.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosResourceMetaData.java
@@ -17,8 +17,8 @@ import java.io.Serializable;
 /**
  * Contains the resource meta data within a browse response result
  * "<r:resMD>..</r:resMD>". This is used for SONOS favorites.
- * 
- * @author Dan Cunningham
+ *
+ * @author Dan Cunningham - Initial contribution
  *
  */
 public class SonosResourceMetaData implements Serializable {
@@ -41,7 +41,7 @@ public class SonosResourceMetaData implements Serializable {
 
     /**
      * The parent id for the resource meta data
-     * 
+     *
      * @return
      */
     public String getId() {
@@ -50,7 +50,7 @@ public class SonosResourceMetaData implements Serializable {
 
     /**
      * The parent id for the resource meta data
-     * 
+     *
      * @return
      */
     public String getParentId() {
@@ -59,7 +59,7 @@ public class SonosResourceMetaData implements Serializable {
 
     /**
      * title from the resource meta data
-     * 
+     *
      * @return
      */
     public String getTitle() {
@@ -70,7 +70,7 @@ public class SonosResourceMetaData implements Serializable {
      * The upnp class for the resource meta data. This can be different from the
      * parent meta data class and should be used to match the play type over the
      * parent value.
-     * 
+     *
      * @return
      */
     public String getUpnpClass() {
@@ -80,7 +80,7 @@ public class SonosResourceMetaData implements Serializable {
     /**
      * The desc text for the resource meta data. This contains the service login
      * id for streaming accounts (pandora, spotify, etc..)
-     * 
+     *
      * @return
      */
     public String getDesc() {

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosStateDescriptionOptionProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosStateDescriptionOptionProvider.java
@@ -32,8 +32,7 @@ import org.osgi.service.component.annotations.Deactivate;
  *
  * @author Laurent Garnier - Initial contribution
  */
-@Component(service = { DynamicStateDescriptionProvider.class,
-        SonosStateDescriptionOptionProvider.class }, immediate = true)
+@Component(service = { DynamicStateDescriptionProvider.class, SonosStateDescriptionOptionProvider.class })
 @NonNullByDefault
 public class SonosStateDescriptionOptionProvider implements DynamicStateDescriptionProvider {
     private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosStateDescriptionOptionProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosStateDescriptionOptionProvider.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2018 by the respective copyright holders.
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.smarthome.binding.sonos.internal;
 

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosStateDescriptionOptionProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/SonosStateDescriptionOptionProvider.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.smarthome.binding.sonos.internal;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
+import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateOption;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * Dynamic provider of state options while leaving other state description fields as original.
+ *
+ * @author Laurent Garnier - Initial contribution
+ */
+@Component(service = { DynamicStateDescriptionProvider.class,
+        SonosStateDescriptionOptionProvider.class }, immediate = true)
+@NonNullByDefault
+public class SonosStateDescriptionOptionProvider implements DynamicStateDescriptionProvider {
+    private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
+
+    public @Nullable List<StateOption> getStateOptions(ChannelUID channelUID) {
+        return channelOptionsMap.get(channelUID);
+    }
+
+    public void setStateOptions(ChannelUID channelUID, List<StateOption> options) {
+        channelOptionsMap.put(channelUID, options);
+    }
+
+    @Override
+    public @Nullable StateDescription getStateDescription(Channel channel, @Nullable StateDescription original,
+            @Nullable Locale locale) {
+        List<StateOption> options = channelOptionsMap.get(channel.getUID());
+        if (options == null) {
+            return null;
+        }
+
+        if (original != null) {
+            return new StateDescription(original.getMinimum(), original.getMaximum(), original.getStep(),
+                    original.getPattern(), original.isReadOnly(), options);
+        }
+
+        return new StateDescription(null, null, null, null, false, options);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        channelOptionsMap.clear();
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/handler/ZonePlayerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/src/main/java/org/eclipse/smarthome/binding/sonos/internal/handler/ZonePlayerHandler.java
@@ -408,35 +408,7 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                 }
             }
 
-            if (service.equals("ContentDirectory") && variable.equals("SavedQueuesUpdateID")) {
-                List<StateOption> options = new ArrayList<>();
-                for (SonosEntry entry : getPlayLists()) {
-                    options.add(new StateOption(entry.getTitle(), entry.getTitle()));
-                }
-                stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), PLAYLIST), options);
-            }
-
-            if (service.equals("ContentDirectory") && variable.equals("FavoritesUpdateID")) {
-                List<StateOption> options = new ArrayList<>();
-                for (SonosEntry entry : getFavorites()) {
-                    options.add(new StateOption(entry.getTitle(), entry.getTitle()));
-                }
-                stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), FAVORITE), options);
-            }
-
-            // For favorite radios, we should have checked the state variable named RadioFavoritesUpdateID
-            // Due to a bug in the data type definition of this state variable, it is not set.
-            // As a workaround, we check the state variable named ContainerUpdateIDs.
-            if (service.equals("ContentDirectory") && variable.equals("ContainerUpdateIDs")) {
-                if (value.startsWith("R:0,") || stateDescriptionProvider
-                        .getStateOptions(new ChannelUID(getThing().getUID(), RADIO)) == null) {
-                    List<StateOption> options = new ArrayList<>();
-                    for (SonosEntry entry : getFavoriteRadios()) {
-                        options.add(new StateOption(entry.getTitle(), entry.getTitle()));
-                    }
-                    stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), RADIO), options);
-                }
-            }
+            List<StateOption> options = new ArrayList<>();
 
             // update the appropriate channel
             switch (variable) {
@@ -541,6 +513,30 @@ public class ZonePlayerHandler extends BaseThingHandler implements UpnpIOPartici
                     break;
                 case "CurrentTuneInStationId":
                     updateChannel(TUNEINSTATIONID);
+                    break;
+                case "SavedQueuesUpdateID": // service ContentDirectoy
+                    for (SonosEntry entry : getPlayLists()) {
+                        options.add(new StateOption(entry.getTitle(), entry.getTitle()));
+                    }
+                    stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), PLAYLIST), options);
+                    break;
+                case "FavoritesUpdateID": // service ContentDirectoy
+                    for (SonosEntry entry : getFavorites()) {
+                        options.add(new StateOption(entry.getTitle(), entry.getTitle()));
+                    }
+                    stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), FAVORITE), options);
+                    break;
+                // For favorite radios, we should have checked the state variable named RadioFavoritesUpdateID
+                // Due to a bug in the data type definition of this state variable, it is not set.
+                // As a workaround, we check the state variable named ContainerUpdateIDs.
+                case "ContainerUpdateIDs": // service ContentDirectoy
+                    if (value.startsWith("R:0,") || stateDescriptionProvider
+                            .getStateOptions(new ChannelUID(getThing().getUID(), RADIO)) == null) {
+                        for (SonosEntry entry : getFavoriteRadios()) {
+                            options.add(new StateOption(entry.getTitle(), entry.getTitle()));
+                        }
+                        stateDescriptionProvider.setStateOptions(new ChannelUID(getThing().getUID(), RADIO), options);
+                    }
                     break;
                 default:
                     break;


### PR DESCRIPTION
Used to define dynamically the state options for the channels radio, favorite and playlist

Fixes issue #5003

Signed-off-by: Laurent Garnier <lg.hc@free.fr>