### PR TITLE
Ensure an item's metadata is removed at the end

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ItemRegistryOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ItemRegistryOSGiTest.java
@@ -12,17 +12,20 @@
  */
 package org.eclipse.smarthome.core.items;
 
+import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
-import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventSubscriber;
 import org.eclipse.smarthome.core.items.events.ItemAddedEvent;
 import org.eclipse.smarthome.core.items.events.ItemRemovedEvent;
@@ -35,8 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
-import com.google.common.collect.Sets;
+import org.mockito.Mock;
 
 /**
  * The {@link ItemRegistryOSGiTest} runs inside an OSGi container and tests the {@link ItemRegistry}.
@@ -59,8 +61,11 @@ public class ItemRegistryOSGiTest extends JavaOSGiTest {
     private ItemRegistry itemRegistry;
     private ManagedItemProvider itemProvider;
 
+    private @Mock EventSubscriber eventSubscriber;
+
     @Before
     public void setUp() {
+        initMocks(this);
         registerVolatileStorageService();
 
         itemRegistry = getService(ItemRegistry.class);
@@ -268,35 +273,46 @@ public class ItemRegistryOSGiTest extends JavaOSGiTest {
     }
 
     @Test
-    public void assertItemRegistryEventSubscribersReceiveEventsAboutItemChanges() {
-        EventSubscriber eventSubscriber = mock(EventSubscriber.class);
-        when(eventSubscriber.getSubscribedEventTypes())
-                .thenReturn(Sets.newHashSet(ItemAddedEvent.TYPE, ItemRemovedEvent.TYPE, ItemUpdatedEvent.TYPE));
-
+    public void testItemAddedEvent() {
+        when(eventSubscriber.getSubscribedEventTypes()).thenReturn(Stream.of(ItemAddedEvent.TYPE).collect(toSet()));
         registerService(eventSubscriber);
 
-        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+        Item item = new SwitchItem("SomeSwitch");
+        itemRegistry.add(item);
 
-        // add new item
-        itemProvider.add(new SwitchItem("SomeSwitch"));
-        waitForAssert(() -> {
-            verify(eventSubscriber, times(1)).receive(eventCaptor.capture());
-        });
-        assertThat(eventCaptor.getValue(), is(instanceOf(ItemAddedEvent.class)));
+        waitForAssert(() -> verify(eventSubscriber).receive(isA(ItemAddedEvent.class)));
+    }
 
-        // update item
-        itemProvider.update(new SwitchItem("SomeSwitch"));
-        waitForAssert(() -> {
-            verify(eventSubscriber, times(2)).receive(eventCaptor.capture());
-        });
-        assertThat(eventCaptor.getValue(), is(instanceOf(ItemUpdatedEvent.class)));
+    @Test
+    public void testItemUpdatedEvent() {
+        itemRegistry.add(new SwitchItem("SomeSwitch"));
 
-        // remove item
-        itemProvider.remove(new SwitchItem("SomeSwitch").getUID());
-        waitForAssert(() -> {
-            verify(eventSubscriber, times(3)).receive(eventCaptor.capture());
-        });
-        assertThat(eventCaptor.getValue(), is(instanceOf(ItemRemovedEvent.class)));
+        when(eventSubscriber.getSubscribedEventTypes()).thenReturn(Stream.of(ItemUpdatedEvent.TYPE).collect(toSet()));
+        registerService(eventSubscriber);
+
+        SwitchItem item = new SwitchItem("SomeSwitch");
+        item.addTag(OTHER_TAG);
+        itemRegistry.update(item);
+
+        ArgumentCaptor<ItemUpdatedEvent> captor = ArgumentCaptor.forClass(ItemUpdatedEvent.class);
+        waitForAssert(() -> verify(eventSubscriber).receive(captor.capture()));
+        assertTrue(captor.getValue().getItem().tags.contains(OTHER_TAG));
+    }
+
+    @Test
+    public void testItemRemovedEvent() {
+        SwitchItem item = new SwitchItem("SomeSwitch");
+        item.addTag(OTHER_TAG);
+        itemRegistry.add(item);
+
+        when(eventSubscriber.getSubscribedEventTypes()).thenReturn(Stream.of(ItemRemovedEvent.TYPE).collect(toSet()));
+        registerService(eventSubscriber);
+
+        itemRegistry.remove("SomeSwitch");
+
+        ArgumentCaptor<ItemRemovedEvent> captor = ArgumentCaptor.forClass(ItemRemovedEvent.class);
+        waitForAssert(() -> verify(eventSubscriber).receive(captor.capture()));
+        assertTrue(captor.getValue().getItem().tags.contains(OTHER_TAG));
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -556,6 +556,11 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         for (RegistryHook<Item> registryHook : registryHooks) {
             registryHook.afterRemoving(element);
         }
+        if (provider instanceof ManagedItemProvider) {
+            // remove our metadata for that item
+            logger.debug("Item {} was removed, trying to clean up corresponding metadata", element.getUID());
+            metadataRegistry.removeItemMetadata(element.getName());
+        }
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
@@ -13,11 +13,7 @@
 package org.eclipse.smarthome.core.internal.items;
 
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
-import org.eclipse.smarthome.core.common.registry.Provider;
-import org.eclipse.smarthome.core.common.registry.ProviderChangeListener;
 import org.eclipse.smarthome.core.events.EventPublisher;
-import org.eclipse.smarthome.core.items.Item;
-import org.eclipse.smarthome.core.items.ManagedItemProvider;
 import org.eclipse.smarthome.core.items.ManagedMetadataProvider;
 import org.eclipse.smarthome.core.items.Metadata;
 import org.eclipse.smarthome.core.items.MetadataKey;
@@ -30,8 +26,6 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This is the main implementing class of the {@link MetadataRegistry} interface. It
@@ -43,27 +37,6 @@ import org.slf4j.LoggerFactory;
 @Component(immediate = true, service = { MetadataRegistry.class })
 public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey, MetadataProvider>
         implements MetadataRegistry {
-
-    private final Logger logger = LoggerFactory.getLogger(MetadataRegistryImpl.class);
-
-    private final ProviderChangeListener<Item> itemProviderChangeListener = new ProviderChangeListener<Item>() {
-        @Override
-        public void added(Provider<Item> provider, Item element) {
-        }
-
-        @Override
-        public void removed(Provider<Item> provider, Item element) {
-            if (managedProvider != null) {
-                // remove our metadata for that item
-                logger.debug("Item {} was removed, trying to clean up corresponding metadata", element.getUID());
-                ((ManagedMetadataProvider) managedProvider).removeItemMetadata(element.getName());
-            }
-        }
-
-        @Override
-        public void updated(Provider<Item> provider, Item oldelement, Item element) {
-        }
-    };
 
     public MetadataRegistryImpl() {
         super(MetadataProvider.class);
@@ -87,15 +60,6 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
     }
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
-    protected void setManagedItemProvider(ManagedItemProvider managedItemProvider) {
-        managedItemProvider.addProviderChangeListener(itemProviderChangeListener);
-    }
-
-    protected void unsetManagedItemProvider(ManagedItemProvider managedItemProvider) {
-        managedItemProvider.removeProviderChangeListener(itemProviderChangeListener);
-    }
-
-    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
     @Override
     protected void setEventPublisher(EventPublisher eventPublisher) {
         super.setEventPublisher(eventPublisher);
@@ -113,6 +77,14 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
 
     protected void unsetManagedProvider(ManagedMetadataProvider managedProvider) {
         super.removeManagedProvider(managedProvider);
+    }
+
+    @Override
+    public void removeItemMetadata(String itemName) {
+        if (managedProvider != null) {
+            // remove our metadata for that item
+            ((ManagedMetadataProvider) managedProvider).removeItemMetadata(itemName);
+        }
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/MetadataRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/MetadataRegistry.java
@@ -37,4 +37,11 @@ public interface MetadataRegistry extends Registry<Metadata, MetadataKey> {
      */
     boolean isInternalNamespace(String namespace);
 
+    /**
+     * Remove all metadata of a given item
+     *
+     * @param itemname the name of the item for which the metadata is to be removed.
+     */
+    void removeItemMetadata(String name);
+
 }


### PR DESCRIPTION
...as so far it was non-deterministic whether the MetadataRegistry
or the ItemRegistry were first informed about it.

Now, the ItemRegistry takes care of that, so it is ensured that all other
ProviderChangeListeners and the ItemRemovedEvent subscribers still have all
metadata available.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>