### PR TITLE
correctly support Dimmer and Color items in toggle profile

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonToggleSwitchProfileTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonToggleSwitchProfileTest.java
@@ -12,11 +12,12 @@
  */
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.thing.CommonTriggerEvents;
 import org.eclipse.smarthome.core.thing.profiles.ProfileCallback;
 import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
@@ -51,15 +52,26 @@ public class RawButtonToggleSwitchProfileTest {
     }
 
     @Test
+    public void testDimmerItem() {
+        TriggerProfile profile = new RawButtonToggleSwitchProfile(mockCallback);
+        verifyAction(profile, UnDefType.NULL, OnOffType.ON);
+        verifyAction(profile, PercentType.HUNDRED, OnOffType.OFF);
+        verifyAction(profile, PercentType.ZERO, OnOffType.ON);
+        verifyAction(profile, new PercentType(50), OnOffType.OFF);
+    }
+
+    @Test
     public void testColorItem() {
         TriggerProfile profile = new RawButtonToggleSwitchProfile(mockCallback);
         verifyAction(profile, UnDefType.NULL, OnOffType.ON);
         verifyAction(profile, HSBType.WHITE, OnOffType.OFF);
         verifyAction(profile, HSBType.BLACK, OnOffType.ON);
+        verifyAction(profile, new HSBType("0,50,50"), OnOffType.OFF);
     }
 
     private void verifyAction(TriggerProfile profile, State preCondition, Command expectation) {
         reset(mockCallback);
+        profile.onStateUpdateFromItem(preCondition);
         profile.onTriggerFromHandler(CommonTriggerEvents.PRESSED);
         verify(mockCallback, times(1)).sendCommand(eq(expectation));
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonToggleSwitchProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/RawButtonToggleSwitchProfile.java
@@ -59,7 +59,7 @@ public class RawButtonToggleSwitchProfile implements TriggerProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        previousState = state;
+        previousState = state.as(OnOffType.class);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -36,15 +36,15 @@ public interface SystemProfiles {
     StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
 
     TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle").withSupportedItemTypes(CoreItemFactory.SWITCH)
+            .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle")
+            .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER, CoreItemFactory.COLOR)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWBUTTON.getUID()).build();
 
-    TriggerProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")
+    TriggerProfileType RAWROCKER_ON_OFF_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_ON_OFF, "Raw Rocker To On Off")
             .withSupportedItemTypes(CoreItemFactory.SWITCH, CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 
-    TriggerProfileType RAWROCKER_DIMMER_TYPE = ProfileTypeBuilder
-            .newTrigger(RAWROCKER_DIMMER, "Raw Rocker To Dimmer").withSupportedItemTypes(CoreItemFactory.DIMMER)
+    TriggerProfileType RAWROCKER_DIMMER_TYPE = ProfileTypeBuilder.newTrigger(RAWROCKER_DIMMER, "Raw Rocker To Dimmer")
+            .withSupportedItemTypes(CoreItemFactory.DIMMER)
             .withSupportedChannelTypeUIDs(DefaultSystemChannelTypeProvider.SYSTEM_RAWROCKER.getUID()).build();
 }


### PR DESCRIPTION
The profile so far didn't register itself for Dimmer and Color items.
Furthermore, it didn't correctly map states to ON/OFF values and the tests were wrong, so they didn't notice it.
This PR registers the profile for Dimmer and Color, fixes the tests and adds some further tests.

Signed-off-by: Kai Kreuzer <kai@openhab.org>