### PR TITLE
RfC: How to treat addition/substraction for temperature values

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/lib/NumberExtensionsTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/lib/NumberExtensionsTest.java
@@ -40,6 +40,8 @@ public class NumberExtensionsTest {
     private static final QuantityType<Temperature> Q_CELSIUS_1 = new QuantityType<Temperature>("1 °C");
     private static final QuantityType<Temperature> Q_CELSIUS_2 = new QuantityType<Temperature>("2 °C");
 
+    private static final QuantityType<Temperature> Q_KELVIN = new QuantityType<Temperature>("1 K");
+
     private static final QuantityType<Length> Q_LENGTH_1m = new QuantityType<Length>("1 m");
     private static final QuantityType<Length> Q_LENGTH_2cm = new QuantityType<Length>("2 cm");
 
@@ -59,6 +61,11 @@ public class NumberExtensionsTest {
     @Test
     public void operatorPlus_Quantity_Quantity() {
         assertThat(NumberExtensions.operator_plus(Q_CELSIUS_1, Q_CELSIUS_2), is(QuantityType.valueOf("3 °C")));
+    }
+
+    @Test
+    public void operatorPlus_Quantity_Quantity_withDifferentUnit() {
+        assertThat(NumberExtensions.operator_plus(Q_CELSIUS_1, Q_KELVIN), is(QuantityType.valueOf("2 °C")));
     }
 
     @Test


### PR DESCRIPTION
I came across this when thinking about the [System Offset Profile](https://github.com/eclipse/smarthome/pull/5679): If a sensor value is not correct, you might want to adjust it by e.g. adding "0.5 °C" to it using that profile.

I have tried this within some rules for the moment. Adding `20 °C + 2 °C` resulted in the expected `22 °C`. 

Considering that we cannot rely on a specific unit, it can definitely happen that temperature values with two different units are added. Doing a `20 °C + 2 K`, the result is a surprising `-251.15 °C`. Clearly the calculation first converts the K to °C and then calculates the sum - but it does not really reflect the expectation of `22 °C` here.

Reading https://physics.stackexchange.com/questions/132720/how-do-you-add-temperatures, the issue is that temperatures cannot be really added, one can only add/substract "temperature differences" - which unfortunately cannot be cleanly identified.

Nonetheless, when such a calculation is done, the only logical interpretation hence seems to be to treat the second operand as a temperature difference. And if we do so, we have to treat the above result as a bug - the added unit test (which fails) shows this situation.

As the code in question is in tec-uom and not in ESH - @keilw, could you please comment and either tell me where my reasoning is wrong or confirm that it is a bug that needs to be reported at tec-uom? Thanks!


Signed-off-by: Kai Kreuzer <kai@openhab.org>