### PR TITLE
JSONStorage: Do not use invalid fileNames for some file-systems

### DIFF
--- a/bundles/storage/org.eclipse.smarthome.storage.json.test/src/main/java/org/eclipse/smarthome/storage/json/internal/JsonStorageServiceOSGiTest.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.json.test/src/main/java/org/eclipse/smarthome/storage/json/internal/JsonStorageServiceOSGiTest.java
@@ -13,10 +13,11 @@
 package org.eclipse.smarthome.storage.json.internal;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
@@ -52,6 +53,25 @@ public class JsonStorageServiceOSGiTest extends JavaOSGiTest {
 
         // clean up database files ...
         FileUtils.deleteDirectory(new File("./runtime"));
+    }
+
+    @Test
+    public void testOnlyAlphanumericCharsInFileName() throws UnsupportedEncodingException {
+        JsonStorageService st = (JsonStorageService) storageService;
+
+        String escaped = st.urlEscapeUnwantedChars("Strange:File-Name~with#Chars");
+        assertEquals("Strange%3AFile-Name%7Ewith%23Chars", escaped);
+
+        // test cut after 127 chars
+        escaped = st.urlEscapeUnwantedChars(
+                "AveryLongFileNameThatNeverEndsAveryLongFileNameThatNeverEndsAveryLongFileNameThatNeverEndsAveryLongFileNameThatNeverEndsAveryLongFileNameThatNeverEnds.json");
+        assertEquals(
+                "AveryLongFileNameThatNeverEndsAveryLongFileNameThatNeverEndsAveryLongFileNameThatNeverEndsAveryLongFileNameThatNeverEndsAveryLo",
+                escaped);
+
+        // test with valid file name
+        escaped = st.urlEscapeUnwantedChars("Allowed.File.Name123");
+        assertEquals("Allowed.File.Name123", escaped);
     }
 
     @Test
@@ -113,7 +133,7 @@ public class JsonStorageServiceOSGiTest extends JavaOSGiTest {
     }
 
     public static class DummyObject {
-        private Configuration configuration = new Configuration();
+        private final Configuration configuration = new Configuration();
     }
 
     public static class PersistedItem {

--- a/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/internal/JsonStorageService.java
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/src/main/java/org/eclipse/smarthome/storage/json/internal/JsonStorageService.java
@@ -13,6 +13,8 @@
 package org.eclipse.smarthome.storage.json.internal;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,6 +32,8 @@ import org.slf4j.LoggerFactory;
  * @author Chris Jackson - Initial Contribution
  */
 public class JsonStorageService implements StorageService {
+
+    private static final int MAX_FILENAME_LENGTH = 127;
 
     private final Logger logger = LoggerFactory.getLogger(JsonStorageService.class);
 
@@ -98,8 +102,13 @@ public class JsonStorageService implements StorageService {
 
     @Override
     public <T> Storage<T> getStorage(String name, ClassLoader classLoader) {
-        File file = new File(dbFolderName, name + ".json");
+        File legacyFile = new File(dbFolderName, name + ".json");
+        File escapedFile = new File(dbFolderName, urlEscapeUnwantedChars(name) + ".json");
 
+        File file = escapedFile;
+        if (legacyFile.exists()) {
+            file = legacyFile;
+        }
         if (!storageList.containsKey(name)) {
             storageList.put(name, (JsonStorage<Object>) new JsonStorage<T>(file, classLoader, maxBackupFiles,
                     writeDelay, maxDeferredPeriod));
@@ -110,5 +119,23 @@ public class JsonStorageService implements StorageService {
     @Override
     public <T> Storage<T> getStorage(String name) {
         return getStorage(name, null);
+    }
+
+    /**
+     * Escapes all invalid url characters and strips the maximum length to 127 to be used as a file name
+     *
+     * @param s the string to be escaped
+     * @return url-encoded string or the original string if UTF-8 is not supported on the system
+     */
+    protected String urlEscapeUnwantedChars(String s) {
+        String result;
+        try {
+            result = URLEncoder.encode(s, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            logger.warn("Encoding UTF-8 is not supported, might generate invalid filenames.");
+            result = s;
+        }
+        int length = Math.min(result.length(), MAX_FILENAME_LENGTH);
+        return result.substring(0, length);
     }
 }


### PR DESCRIPTION
Windows has a rather long list of forbidden characters in filenames, see

https://msdn.microsoft.com/en-us/library/aa365247(VS.85).aspx

Linux-like systems only disallow / and the null-byte.

https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words

By URLencoding the string, all of these characters are safely transformed
into %<HexValue> and % is an allowed character. This encoding is even
reversible.

Given that we will not run on RT-11 systems we should be safe.

I use a maximum length of 127 to be safe even on android systems:
https://stackoverflow.com/questions/13204807/max-file-name-length-in-android

The down-side is that even spaces are now converted into %20, but I chose
to use URLencoder.encode instead of implementing the conversion by myself.

For existing storages I check whether a file exists and keep using it.

Fixes #5687

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>