### PR TITLE
Introduce an ItemBuilder

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemBuilderTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemBuilderTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.items;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.eclipse.smarthome.core.items.ActiveItem;
+import org.eclipse.smarthome.core.items.GroupFunction;
+import org.eclipse.smarthome.core.items.GroupItem;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.items.ItemFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/**
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ *
+ */
+public class ItemBuilderTest {
+
+    private ItemRegistryImpl itemRegistry;
+    private @Mock ItemFactory mockFactory;
+    private @Mock ActiveItem mockItem;
+    private @Mock Item originalItem;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        itemRegistry = new ItemRegistryImpl();
+        itemRegistry.addItemFactory(mockFactory);
+    }
+
+    @Test
+    public void testMinimal() {
+        when(mockFactory.createItem(anyString(), anyString())).thenReturn(mockItem);
+
+        Item res = itemRegistry.newItemBuilder("String", "test").build();
+
+        assertSame(mockItem, res);
+        verify(mockFactory).createItem(eq("String"), eq("test"));
+        verify(mockItem).setLabel(isNull());
+        verify(mockItem).setCategory(isNull());
+        verify(mockItem).addGroupNames(eq(Collections.emptyList()));
+    }
+
+    @Test
+    public void testMinimalGroupItem() {
+        Item resItem = itemRegistry.newItemBuilder("Group", "test").build();
+
+        assertEquals(GroupItem.class, resItem.getClass());
+        GroupItem res = (GroupItem) resItem;
+        verifyNoMoreInteractions(mockFactory);
+        assertNull(res.getCategory());
+        assertEquals(Collections.emptyList(), res.getGroupNames());
+        assertNull(res.getLabel());
+        assertNull(res.getFunction());
+        assertNull(res.getBaseItem());
+    }
+
+    @Test
+    public void testFull() {
+        when(mockFactory.createItem(anyString(), anyString())).thenReturn(mockItem);
+
+        Item res = itemRegistry.newItemBuilder("String", "test") //
+                .withCategory("category") //
+                .withGroups("a", "b") //
+                .withLabel("label") //
+                .build();
+
+        assertSame(mockItem, res);
+        verify(mockFactory).createItem(eq("String"), eq("test"));
+        verify(mockItem).setCategory(eq("category"));
+        verify(mockItem).addGroupNames(eq(Arrays.asList("a", "b")));
+        verify(mockItem).setLabel(eq("label"));
+    }
+
+    @Test
+    public void testFullGroupItem() {
+        Item baseItem = mock(Item.class);
+        GroupFunction mockFunction = mock(GroupFunction.class);
+
+        Item resItem = itemRegistry.newItemBuilder("Group", "test") //
+                .withCategory("category") //
+                .withGroups("a", "b") //
+                .withLabel("label") //
+                .withBaseItem(baseItem)//
+                .withGroupFunction(mockFunction) //
+                .build();
+
+        assertEquals(GroupItem.class, resItem.getClass());
+        GroupItem res = (GroupItem) resItem;
+        verifyNoMoreInteractions(mockFactory);
+        assertEquals("category", res.getCategory());
+        assertEquals(Arrays.asList("a", "b"), res.getGroupNames());
+        assertEquals("label", res.getLabel());
+        assertSame(mockFunction, res.getFunction());
+        assertSame(baseItem, res.getBaseItem());
+    }
+
+    @Test
+    public void testClone() {
+        when(originalItem.getType()).thenReturn("type");
+        when(originalItem.getName()).thenReturn("name");
+        when(originalItem.getLabel()).thenReturn("label");
+        when(originalItem.getCategory()).thenReturn("category");
+        when(originalItem.getGroupNames()).thenReturn(Arrays.asList("a", "b"));
+
+        when(mockFactory.createItem(anyString(), anyString())).thenReturn(mockItem);
+
+        Item res = itemRegistry.newItemBuilder(originalItem).build();
+
+        assertSame(mockItem, res);
+        verify(mockFactory).createItem(eq("type"), eq("name"));
+        verify(mockItem).setCategory(eq("category"));
+        verify(mockItem).addGroupNames(eq(Arrays.asList("a", "b")));
+        verify(mockItem).setLabel(eq("label"));
+    }
+
+    @Test
+    public void testCloneGroupItem() {
+        Item baseItem = mock(Item.class);
+        GroupFunction mockFunction = mock(GroupFunction.class);
+        GroupItem originalItem = new GroupItem("name", baseItem, mockFunction);
+        originalItem.setCategory("category");
+        originalItem.setLabel("label");
+        originalItem.addGroupNames("a", "b");
+
+        Item resItem = itemRegistry.newItemBuilder(originalItem).build();
+
+        assertEquals(GroupItem.class, resItem.getClass());
+        GroupItem res = (GroupItem) resItem;
+        verifyNoMoreInteractions(mockFactory);
+        assertEquals("category", res.getCategory());
+        assertEquals(Arrays.asList("a", "b"), res.getGroupNames());
+        assertEquals("label", res.getLabel());
+        assertSame(mockFunction, res.getFunction());
+        assertSame(baseItem, res.getBaseItem());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testNoFactory() {
+        when(mockFactory.createItem(anyString(), anyString())).thenReturn(null);
+        itemRegistry.newItemBuilder("String", "test").build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFunctionOnNonGroupItem() {
+        GroupFunction mockFunction = mock(GroupFunction.class);
+        itemRegistry.newItemBuilder("String", "test").withGroupFunction(mockFunction);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBaseItemOnNonGroupItem() {
+        Item mockItem = mock(Item.class);
+        itemRegistry.newItemBuilder("String", "test").withBaseItem(mockItem);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemBuilderTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemBuilderTest.java
@@ -81,7 +81,7 @@ public class ItemBuilderTest {
 
         Item res = itemRegistry.newItemBuilder("String", "test") //
                 .withCategory("category") //
-                .withGroups("a", "b") //
+                .withGroups(Arrays.asList("a", "b")) //
                 .withLabel("label") //
                 .build();
 
@@ -99,7 +99,7 @@ public class ItemBuilderTest {
 
         Item resItem = itemRegistry.newItemBuilder("Group", "test") //
                 .withCategory("category") //
-                .withGroups("a", "b") //
+                .withGroups(Arrays.asList("a", "b")) //
                 .withLabel("label") //
                 .withBaseItem(baseItem)//
                 .withGroupFunction(mockFunction) //

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemBuilderImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemBuilderImpl.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.smarthome.core.internal.items;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -43,7 +42,6 @@ public class ItemBuilderImpl implements ItemBuilder {
 
     private @Nullable String category;
     private List<String> groups = Collections.emptyList();
-    private List<String> tags = Collections.emptyList();
     private @Nullable String label;
     private @Nullable Item baseItem;
     private @Nullable GroupFunction groupFunction;
@@ -84,12 +82,6 @@ public class ItemBuilderImpl implements ItemBuilder {
     }
 
     @Override
-    public ItemBuilder withGroups(String... groups) {
-        this.groups = Arrays.asList(groups);
-        return this;
-    }
-
-    @Override
     public ItemBuilder withCategory(@Nullable String category) {
         this.category = category;
         return this;
@@ -114,21 +106,6 @@ public class ItemBuilderImpl implements ItemBuilder {
     }
 
     @Override
-    public ItemBuilder withTags(String... tags) {
-        return this;
-    }
-
-    @Override
-    public ItemBuilder withTags(@Nullable Collection<String> tags) {
-        if (tags != null) {
-            this.tags = new LinkedList<>(tags);
-        } else {
-            this.tags = Collections.emptyList();
-        }
-        return this;
-    }
-
-    @Override
     public Item build() {
         Item item = null;
         if (GroupItem.TYPE.equals(itemType)) {
@@ -136,6 +113,9 @@ public class ItemBuilderImpl implements ItemBuilder {
         } else {
             for (ItemFactory itemFactory : itemFactories) {
                 item = itemFactory.createItem(itemType, name);
+                if (item != null) {
+                    break;
+                }
             }
         }
         if (item == null) {
@@ -146,7 +126,6 @@ public class ItemBuilderImpl implements ItemBuilder {
             activeItem.setLabel(label);
             activeItem.setCategory(category);
             activeItem.addGroupNames(groups);
-            activeItem.addTags(tags);
         }
         return item;
     }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemBuilderImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemBuilderImpl.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.items;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.items.ActiveItem;
+import org.eclipse.smarthome.core.items.GroupFunction;
+import org.eclipse.smarthome.core.items.GroupItem;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.items.ItemBuilder;
+import org.eclipse.smarthome.core.items.ItemFactory;
+
+/**
+ * The {@link ItemBuilder} implementation.
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ *
+ */
+@NonNullByDefault
+public class ItemBuilderImpl implements ItemBuilder {
+
+    private final Set<ItemFactory> itemFactories;
+    private final String itemType;
+    private final String name;
+
+    private @Nullable String category;
+    private List<String> groups = Collections.emptyList();
+    private List<String> tags = Collections.emptyList();
+    private @Nullable String label;
+    private @Nullable Item baseItem;
+    private @Nullable GroupFunction groupFunction;
+
+    public ItemBuilderImpl(Set<ItemFactory> itemFactories, Item item) {
+        this.itemFactories = itemFactories;
+        this.itemType = item.getType();
+        this.name = item.getName();
+        this.category = item.getCategory();
+        this.groups = item.getGroupNames();
+        this.label = item.getLabel();
+        if (item instanceof GroupItem) {
+            this.baseItem = ((GroupItem) item).getBaseItem();
+            this.groupFunction = ((GroupItem) item).getFunction();
+        }
+    }
+
+    public ItemBuilderImpl(Set<ItemFactory> itemFactories, String itemType, String itemName) {
+        this.itemFactories = itemFactories;
+        this.itemType = itemType;
+        this.name = itemName;
+    }
+
+    @Override
+    public ItemBuilder withLabel(@Nullable String label) {
+        this.label = label;
+        return this;
+    }
+
+    @Override
+    public ItemBuilder withGroups(@Nullable Collection<String> groups) {
+        if (groups != null) {
+            this.groups = new LinkedList<>(groups);
+        } else {
+            this.groups = Collections.emptyList();
+        }
+        return this;
+    }
+
+    @Override
+    public ItemBuilder withGroups(String... groups) {
+        this.groups = Arrays.asList(groups);
+        return this;
+    }
+
+    @Override
+    public ItemBuilder withCategory(@Nullable String category) {
+        this.category = category;
+        return this;
+    }
+
+    @Override
+    public ItemBuilder withBaseItem(@Nullable Item item) {
+        if (item != null && !GroupItem.TYPE.equals(itemType)) {
+            throw new IllegalArgumentException("Only group items can have a base item");
+        }
+        baseItem = item;
+        return this;
+    }
+
+    @Override
+    public ItemBuilder withGroupFunction(@Nullable GroupFunction function) {
+        if (function != null && !GroupItem.TYPE.equals(itemType)) {
+            throw new IllegalArgumentException("Only group items can have a base item");
+        }
+        groupFunction = function;
+        return this;
+    }
+
+    @Override
+    public ItemBuilder withTags(String... tags) {
+        return this;
+    }
+
+    @Override
+    public ItemBuilder withTags(@Nullable Collection<String> tags) {
+        if (tags != null) {
+            this.tags = new LinkedList<>(tags);
+        } else {
+            this.tags = Collections.emptyList();
+        }
+        return this;
+    }
+
+    @Override
+    public Item build() {
+        Item item = null;
+        if (GroupItem.TYPE.equals(itemType)) {
+            item = new GroupItem(name, baseItem, groupFunction);
+        } else {
+            for (ItemFactory itemFactory : itemFactories) {
+                item = itemFactory.createItem(itemType, name);
+            }
+        }
+        if (item == null) {
+            throw new IllegalStateException("No item factory could handle type " + itemType);
+        }
+        if (item instanceof ActiveItem) {
+            ActiveItem activeItem = (ActiveItem) item;
+            activeItem.setLabel(label);
+            activeItem.setCategory(category);
+            activeItem.addGroupNames(groups);
+            activeItem.addTags(tags);
+        }
+        return item;
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -477,6 +477,9 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     @Override
     public boolean addTags(String itemName, Collection<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return false;
+        }
         tagLock.writeLock().lock();
         try {
             SortedSet<String> itemTags = readTags(itemName);
@@ -495,6 +498,9 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     @Override
     public boolean removeTags(String itemName, Collection<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return false;
+        }
         tagLock.writeLock().lock();
         try {
             SortedSet<String> itemTags = readTags(itemName);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Stream;
@@ -36,6 +37,8 @@ import org.eclipse.smarthome.core.items.ActiveItem;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.items.ItemBuilder;
+import org.eclipse.smarthome.core.items.ItemFactory;
 import org.eclipse.smarthome.core.items.ItemNotFoundException;
 import org.eclipse.smarthome.core.items.ItemNotUniqueException;
 import org.eclipse.smarthome.core.items.ItemProvider;
@@ -82,6 +85,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     private StateDescriptionService stateDescriptionService;
     private MetadataRegistry metadataRegistry;
+    private final Set<ItemFactory> itemFactories = new CopyOnWriteArraySet<>();
 
     private UnitProvider unitProvider;
     private ItemStateConverter itemStateConverter;
@@ -578,6 +582,16 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         registryHooks.remove(hook);
     }
 
+    @Override
+    public ItemBuilder newItemBuilder(Item item) {
+        return new ItemBuilderImpl(itemFactories, item);
+    }
+
+    @Override
+    public ItemBuilder newItemBuilder(String itemType, String itemName) {
+        return new ItemBuilderImpl(itemFactories, itemType, itemName);
+    }
+
     @Activate
     protected void activate(final ComponentContext componentContext) {
         super.activate(componentContext.getBundleContext());
@@ -622,6 +636,15 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     protected void unsetMetadataRegistry(MetadataRegistry metadataRegistry) {
         this.metadataRegistry = null;
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    protected void addItemFactory(ItemFactory itemFactory) {
+        itemFactories.add(itemFactory);
+    }
+
+    protected void removeItemFactory(ItemFactory itemFactory) {
+        itemFactories.remove(itemFactory);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -397,7 +397,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends GenericItem> Collection<T> getItemsByTag(Class<T> typeFilter, String... tags) {
+    public <T extends Item> Collection<T> getItemsByTag(Class<T> typeFilter, String... tags) {
         Collection<T> filteredItems = new ArrayList<T>();
 
         Collection<Item> items = getItemsByTag(tags);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/GroupItem.java
@@ -43,7 +43,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
 
     private final Logger logger = LoggerFactory.getLogger(GroupItem.class);
 
-    protected @Nullable final GenericItem baseItem;
+    protected @Nullable final Item baseItem;
 
     protected final CopyOnWriteArrayList<Item> members;
 
@@ -58,7 +58,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
         this(name, null, null);
     }
 
-    public GroupItem(String name, @Nullable GenericItem baseItem) {
+    public GroupItem(String name, @Nullable Item baseItem) {
         // only baseItem but no function set -> use Equality
         this(name, baseItem, new GroupFunction.Equality());
     }
@@ -70,7 +70,7 @@ public class GroupItem extends GenericItem implements StateChangeListener {
      * @param baseItem type of items in the group
      * @param function function to calculate group status out of member status
      */
-    public GroupItem(String name, @Nullable GenericItem baseItem, @Nullable GroupFunction function) {
+    public GroupItem(String name, @Nullable Item baseItem, @Nullable GroupFunction function) {
         super(TYPE, name);
 
         // we only allow GroupItem with BOTH, baseItem AND function set, or NONE of them set
@@ -223,8 +223,8 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     @Override
     public void setUnitProvider(@Nullable UnitProvider unitProvider) {
         super.setUnitProvider(unitProvider);
-        if (baseItem != null) {
-            baseItem.setUnitProvider(unitProvider);
+        if (baseItem != null && baseItem instanceof GenericItem) {
+            ((GenericItem) baseItem).setUnitProvider(unitProvider);
         }
     }
 
@@ -310,9 +310,9 @@ public class GroupItem extends GenericItem implements StateChangeListener {
             newState = function.getStateAs(getStateMembers(getMembers()), typeClass);
         }
 
-        if (newState == null && baseItem != null) {
+        if (newState == null && baseItem != null && baseItem instanceof GenericItem) {
             // we use the transformation method from the base item
-            baseItem.setState(state);
+            ((GenericItem) baseItem).setState(state);
             newState = baseItem.getStateAs(typeClass);
         }
         if (newState == null) {
@@ -381,8 +381,8 @@ public class GroupItem extends GenericItem implements StateChangeListener {
     @Override
     public void setState(State state) {
         State oldState = this.state;
-        if (baseItem != null) {
-            baseItem.setState(state);
+        if (baseItem != null && baseItem instanceof GenericItem) {
+            ((GenericItem) baseItem).setState(state);
             this.state = baseItem.getState();
         } else {
             this.state = state;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemBuilder.java
@@ -51,14 +51,6 @@ public interface ItemBuilder {
     ItemBuilder withGroups(@Nullable Collection<String> groups);
 
     /**
-     * Set the group membership of the item.
-     *
-     * @param groups the group names the item belongs to
-     * @return the builder itself
-     */
-    ItemBuilder withGroups(String... groups);
-
-    /**
      * Set the category of the item.
      *
      * @param category the category
@@ -83,11 +75,5 @@ public interface ItemBuilder {
      * @throws IllegalArgumentException in case this is not a group item
      */
     ItemBuilder withGroupFunction(@Nullable GroupFunction function);
-
-    @Deprecated
-    ItemBuilder withTags(String... tags);
-
-    @Deprecated
-    ItemBuilder withTags(@Nullable Collection<String> tags);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemBuilder.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.items;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * This class allows the easy construction of an {@link Item} using the builder pattern.
+ *
+ * @author Simon Kaufmann - initial contribution and API
+ *
+ */
+@NonNullByDefault
+public interface ItemBuilder {
+
+    /**
+     * Creates an item with the currently configured values.
+     *
+     * @return an item
+     * @throws IllegalStateException in case no item factory can create the given item type
+     */
+    Item build();
+
+    /**
+     * Set the label of the item.
+     *
+     * @param label the label
+     * @return the builder itself
+     */
+    ItemBuilder withLabel(@Nullable String label);
+
+    /**
+     * Set the group membership of the item.
+     *
+     * @param groups the group names the item belongs to
+     * @return the builder itself
+     */
+    ItemBuilder withGroups(@Nullable Collection<String> groups);
+
+    /**
+     * Set the group membership of the item.
+     *
+     * @param groups the group names the item belongs to
+     * @return the builder itself
+     */
+    ItemBuilder withGroups(String... groups);
+
+    /**
+     * Set the category of the item.
+     *
+     * @param category the category
+     * @return the builder itself
+     */
+    ItemBuilder withCategory(@Nullable String category);
+
+    /**
+     * Set the base item..
+     *
+     * @param baseItem the base item
+     * @return the builder itself
+     * @throws IllegalArgumentException in case this is not a group item
+     */
+    ItemBuilder withBaseItem(@Nullable Item baseItem);
+
+    /**
+     * Set the group function
+     *
+     * @param function the group function
+     * @return the builder itself
+     * @throws IllegalArgumentException in case this is not a group item
+     */
+    ItemBuilder withGroupFunction(@Nullable GroupFunction function);
+
+    @Deprecated
+    ItemBuilder withTags(String... tags);
+
+    @Deprecated
+    ItemBuilder withTags(@Nullable Collection<String> tags);
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemFactory.java
@@ -31,7 +31,7 @@ public interface ItemFactory {
      * @return a new Item of type <code>itemTypeName</code> or <code>null</code> if no matching class is known.
      */
     @Nullable
-    GenericItem createItem(@Nullable String itemTypeName, String itemName);
+    Item createItem(@Nullable String itemTypeName, String itemName);
 
     /**
      * Returns the list of all supported ItemTypes of this Factory.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
@@ -170,4 +170,21 @@ public interface ItemRegistry extends Registry<Item, String> {
      */
     boolean removeTags(String itemName);
 
+    /**
+     * Create a new {@link ItemBuilder}, which is initialized by the given item.
+     *
+     * @param item the template to initialize the builder with
+     * @return an ItemBuilder instance
+     */
+    ItemBuilder newItemBuilder(Item item);
+
+    /**
+     * Create a new {@link ItemBuilder}, which is initialized by the given item.
+     *
+     * @param itemType the item type to create
+     * @param itemName the name of the item to create
+     * @return an ItemBuilder instance
+     */
+    ItemBuilder newItemBuilder(String itemType, String itemName);
+
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
@@ -105,8 +105,7 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @return list of items which contains all of the given tags, which is
      *         filtered by the given type filter.
      */
-    public @NonNull <T extends GenericItem> Collection<T> getItemsByTag(@NonNull Class<T> typeFilter,
-            @NonNull String... tags);
+    public @NonNull <T extends Item> Collection<T> getItemsByTag(@NonNull Class<T> typeFilter, @NonNull String... tags);
 
     /**
      * @see ManagedItemProvider#remove(String, boolean)

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
@@ -121,9 +121,9 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
         return memberNames;
     }
 
-    private GenericItem createItem(@NonNull String itemType, @NonNull String itemName) {
+    private Item createItem(@NonNull String itemType, @NonNull String itemName) {
         for (ItemFactory factory : this.itemFactories) {
-            GenericItem item = factory.createItem(itemType, itemName);
+            Item item = factory.createItem(itemType, itemName);
             if (item != null) {
                 return item;
             }
@@ -156,10 +156,10 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
                 Entry<String, PersistedItem> entry = iterator.next();
                 String itemName = entry.getKey();
                 PersistedItem persistedItem = entry.getValue();
-                ActiveItem item = itemFactory.createItem(persistedItem.itemType, itemName);
-                if (item != null) {
+                Item item = itemFactory.createItem(persistedItem.itemType, itemName);
+                if (item != null && item instanceof ActiveItem) {
                     iterator.remove();
-                    configureItem(persistedItem, item);
+                    configureItem(persistedItem, (ActiveItem) item);
                     notifyListenersAboutAddedElement(item);
                 } else {
                     logger.debug("The added item factory '{}' still could not instantiate item '{}'.", itemFactory,
@@ -189,11 +189,11 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
 
     @Override
     protected Item toElement(String itemName, PersistedItem persistedItem) {
-        ActiveItem item = null;
+        Item item = null;
 
         if (persistedItem.itemType.equals(ITEM_TYPE_GROUP)) {
             if (persistedItem.baseItemType != null) {
-                GenericItem baseItem = createItem(persistedItem.baseItemType, itemName);
+                Item baseItem = createItem(persistedItem.baseItemType, itemName);
                 if (persistedItem.functionName != null) {
                     GroupFunction function = getGroupFunction(persistedItem, baseItem);
                     item = new GroupItem(itemName, baseItem, function);
@@ -207,7 +207,9 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
             item = createItem(persistedItem.itemType, itemName);
         }
 
-        configureItem(persistedItem, item);
+        if (item != null && item instanceof ActiveItem) {
+            configureItem(persistedItem, (ActiveItem) item);
+        }
 
         if (item == null) {
             failedToCreate.put(itemName, persistedItem);
@@ -218,7 +220,7 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
         return item;
     }
 
-    private GroupFunction getGroupFunction(PersistedItem persistedItem, GenericItem baseItem) {
+    private GroupFunction getGroupFunction(PersistedItem persistedItem, Item baseItem) {
         GroupFunctionDTO functionDTO = new GroupFunctionDTO();
         functionDTO.name = persistedItem.functionName;
         if (persistedItem.functionParams != null) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
@@ -78,7 +78,6 @@ public class ItemDTOMapper {
             builder.withLabel(itemDTO.label);
             builder.withCategory(itemDTO.category);
             builder.withGroups(itemDTO.groupNames);
-            builder.withTags(itemDTO.tags);
             try {
                 return builder.build();
             } catch (IllegalStateException e) {

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericItemProvider.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.common.registry.AbstractProvider;
+import org.eclipse.smarthome.core.items.ActiveItem;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupFunction;
 import org.eclipse.smarthome.core.items.GroupItem;
@@ -249,10 +250,10 @@ public class GenericItemProvider extends AbstractProvider<Item>
     }
 
     private Item createItemFromModelItem(ModelItem modelItem) {
-        GenericItem item = null;
+        Item item = null;
         if (modelItem instanceof ModelGroupItem) {
             ModelGroupItem modelGroupItem = (ModelGroupItem) modelItem;
-            GenericItem baseItem;
+            Item baseItem;
             try {
                 baseItem = createItemOfType(modelGroupItem.getType(), modelGroupItem.getName());
             } catch (IllegalArgumentException e) {
@@ -277,7 +278,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
                 return null;
             }
         }
-        if (item != null) {
+        if (item != null && item instanceof ActiveItem) {
             String label = modelItem.getLabel();
             String format = extractFormat(label);
             if (format != null) {
@@ -285,8 +286,8 @@ public class GenericItemProvider extends AbstractProvider<Item>
                 stateDescriptionFragments.put(modelItem.getName(),
                         StateDescriptionFragmentBuilder.create().withPattern(format).build());
             }
-            item.setLabel(label);
-            item.setCategory(modelItem.getIcon());
+            ((ActiveItem) item).setLabel(label);
+            ((ActiveItem) item).setCategory(modelItem.getIcon());
             return item;
         } else {
             return null;
@@ -304,8 +305,7 @@ public class GenericItemProvider extends AbstractProvider<Item>
         return format;
     }
 
-    private GroupItem applyGroupFunction(GenericItem baseItem, ModelGroupItem modelGroupItem,
-            ModelGroupFunction function) {
+    private GroupItem applyGroupFunction(Item baseItem, ModelGroupItem modelGroupItem, ModelGroupFunction function) {
         GroupFunctionDTO dto = new GroupFunctionDTO();
         dto.name = function.getName();
         dto.params = modelGroupItem.getArgs().toArray(new String[modelGroupItem.getArgs().size()]);
@@ -523,13 +523,13 @@ public class GenericItemProvider extends AbstractProvider<Item>
      *
      * @return An Item instance of type {@code itemType} or null if no item factory for it was found.
      */
-    private GenericItem createItemOfType(String itemType, String itemName) {
+    private Item createItemOfType(String itemType, String itemName) {
         if (itemType == null) {
             return null;
         }
 
         for (ItemFactory factory : itemFactorys) {
-            GenericItem item = factory.createItem(itemType, itemName);
+            Item item = factory.createItem(itemType, itemName);
             if (item != null) {
                 logger.trace("Created item '{}' of type '{}'", itemName, itemType);
                 return item;

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.items.ItemBuilder;
 import org.eclipse.smarthome.core.items.ItemNotFoundException;
 import org.eclipse.smarthome.core.items.ItemNotUniqueException;
 import org.eclipse.smarthome.core.items.ItemRegistry;
@@ -1374,6 +1375,24 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
             return itemRegistry.removeTags(itemName);
         } else {
             return false;
+        }
+    }
+
+    @Override
+    public ItemBuilder newItemBuilder(Item item) {
+        if (itemRegistry != null) {
+            return itemRegistry.newItemBuilder(item);
+        } else {
+            throw new IllegalStateException("Cannot create an item builder without the item registry");
+        }
+    }
+
+    @Override
+    public ItemBuilder newItemBuilder(String itemType, String itemName) {
+        if (itemRegistry != null) {
+            return itemRegistry.newItemBuilder(itemType, itemName);
+        } else {
+            throw new IllegalStateException("Cannot create an item builder without the item registry");
         }
     }
 

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -34,7 +34,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
-import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemNotFoundException;
@@ -1222,7 +1221,7 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
     }
 
     @Override
-    public <T extends GenericItem> Collection<T> getItemsByTag(Class<T> typeFilter, String... tags) {
+    public <T extends Item> Collection<T> getItemsByTag(Class<T> typeFilter, String... tags) {
         if (itemRegistry != null) {
             return itemRegistry.getItemsByTag(typeFilter, tags);
         } else {


### PR DESCRIPTION
In continuation of #5449, this PR now aims at adding an `ItemBuilder`. 

In order to facilitate for the dynamic plugging of `ItemFactories`, the `ItemBuilder` has to be somewhat "OSGi-aware". For that purpose, an instance can be obtained from the `ItemRegistry` - under the assumption that the using component will have to interact with the registry anyway. Only the GenericItemProvider suffers from that, as it cannot depend on it. Alternatively we could it make its own service - I'd leave this open for discussion.

At the same time, the API was cleaned of `GenericItem`s, exposing `Item`s instead. Only very few, core places need a checked cast to `GenericItem` at the moment. While these changes are clearly API-breaking, I think they will be acceptable: 
* The change in `ItemRegistry` should be  even binary compatible, thanks to type erasure
* The change in `ItemFactory` is only source-compatible, but _NOT_ binary-compatible. Nevertheless, I wouldn't reckon there are solutions which are binary-consuming extensions which bring their own item factory nor consume item factories directly. Please object if you see any issue with this!

relates to #5449
Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>