### PR TITLE
Serialize degree celsius with °C, drop special char

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/QuantityTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/QuantityTypeTest.java
@@ -38,6 +38,7 @@ import tec.uom.se.quantity.QuantityDimension;
 /**
  * @author Gaël L'hopital - initial contribution
  */
+@SuppressWarnings({ "rawtypes", "unchecked", "null" })
 public class QuantityTypeTest {
 
     @Before
@@ -190,7 +191,7 @@ public class QuantityTypeTest {
     public void toFullStringShouldParseToEqualState() {
         QuantityType<Temperature> temp = new QuantityType<>("20 °C");
 
-        assertThat(temp.toFullString(), is("20 ℃"));
+        assertThat(temp.toFullString(), is("20 °C"));
         assertThat(QuantityType.valueOf(temp.toFullString()), is(temp));
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
@@ -134,6 +134,8 @@ public class SmartHomeUnitsTest {
         QuantityType<Temperature> celsius = new QuantityType<>("20 ℃");
         assertThat(celsius, is(new QuantityType<>("20 °C")));
         assertThat(celsius.toFullString(), is("20 °C"));
+
+        assertThat(celsius.getUnit().toString(), is("°C"));
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
@@ -130,6 +130,13 @@ public class SmartHomeUnitsTest {
     }
 
     @Test
+    public void testCelsiusSpecialChar() {
+        QuantityType<Temperature> celsius = new QuantityType<>("20 ℃");
+        assertThat(celsius, is(new QuantityType<>("20 °C")));
+        assertThat(celsius.toFullString(), is("20 °C"));
+    }
+
+    @Test
     public void testKmh2Mih() {
         Quantity<Speed> kmh = Quantities.getQuantity(BigDecimal.TEN, SIUnits.KILOMETRE_PER_HOUR);
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SIUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SIUnits.java
@@ -24,6 +24,7 @@ import javax.measure.spi.SystemOfUnits;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
+import tec.uom.se.format.SimpleUnitFormat;
 import tec.uom.se.unit.Units;
 
 /**
@@ -74,5 +75,10 @@ public class SIUnits extends SmartHomeUnits {
     private static <U extends Unit<?>> U addUnit(U unit) {
         INSTANCE.units.add(unit);
         return unit;
+    }
+
+    static {
+        // Override the default unit symbol ℃ to better support TTS and UIs:
+        SimpleUnitFormat.getInstance().label(CELSIUS, "°C");
     }
 }

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/engine/ScriptEngineOSGiTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/engine/ScriptEngineOSGiTest.java
@@ -114,7 +114,7 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
         State numberState = itemRegistry.get(NUMBER_ITEM_TEMPERATURE).getState();
         assertNotNull(numberState);
         assertEquals("org.eclipse.smarthome.core.library.types.QuantityType", numberState.getClass().getName());
-        assertEquals("20.0 ℃", numberState.toString());
+        assertEquals("20.0 °C", numberState.toString());
     }
 
     @SuppressWarnings("null")

--- a/bundles/ui/org.eclipse.smarthome.ui.test/src/test/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/src/test/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
@@ -37,6 +37,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
@@ -81,8 +82,11 @@ public class ItemUIRegistryImplTest {
         when(widget.getItem()).thenReturn("Item");
         when(registry.getItem("Item")).thenReturn(item);
 
+        // only used to initialise unit conversions && formatter
         @SuppressWarnings("unused")
-        Unit<?> fahrenheit = ImperialUnits.FAHRENHEIT; // only used to initialise ESHUnits for conversion
+        Unit<?> celsius = SIUnits.CELSIUS;
+        @SuppressWarnings("unused")
+        Unit<?> fahrenheit = ImperialUnits.FAHRENHEIT;
     }
 
     @Test
@@ -164,7 +168,7 @@ public class ItemUIRegistryImplTest {
         when(widget.getLabel()).thenReturn(testLabel);
         when(item.getState()).thenReturn(new QuantityType<>("" + 10f / 3f + " °C"));
         String label = uiRegistry.getLabel(widget);
-        assertEquals("Label [3" + sep + "333 ℃]", label);
+        assertEquals("Label [3" + sep + "333 °C]", label);
     }
 
     @Test
@@ -174,7 +178,7 @@ public class ItemUIRegistryImplTest {
         when(widget.getLabel()).thenReturn(testLabel);
         when(item.getState()).thenReturn(new QuantityType<>("" + 10f / 3f + " °C"));
         String label = uiRegistry.getLabel(widget);
-        assertEquals("Label [3 ℃]", label);
+        assertEquals("Label [3 °C]", label);
     }
 
     @Test

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SelectionRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SelectionRenderer.java
@@ -129,10 +129,6 @@ public class SelectionRenderer extends AbstractWidgetRenderer {
             String unit = getUnitForWidget(w);
             command = StringUtils.replace(command, UnitUtils.UNIT_PLACEHOLDER, unit);
             label = StringUtils.replace(label, UnitUtils.UNIT_PLACEHOLDER, unit);
-
-            // Special treatment for °C since uom library uses a single character: ℃
-            // This will ensure the current state matches the cmd and the buttonClass is set accordingly.
-            command = StringUtils.replace(command, "°C", "℃");
         }
 
         rowSnippet = StringUtils.replace(rowSnippet, "%item%", w.getItem() != null ? w.getItem() : "");

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SwitchRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SwitchRenderer.java
@@ -115,10 +115,6 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
                     String unit = getUnitForWidget(w);
                     command = StringUtils.replace(command, UnitUtils.UNIT_PLACEHOLDER, unit);
                     label = StringUtils.replace(label, UnitUtils.UNIT_PLACEHOLDER, unit);
-
-                    // Special treatment for °C since uom library uses a single character: ℃
-                    // This will ensure the current state matches the cmd and the buttonClass is set accordingly.
-                    command = StringUtils.replace(command, "°C", "℃");
                 }
 
                 button = StringUtils.replace(button, "%item%", w.getItem());

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SelectionRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SelectionRenderer.java
@@ -108,10 +108,6 @@ public class SelectionRenderer extends AbstractWidgetRenderer {
             String unit = getUnitForWidget(w);
             command = StringUtils.replace(command, UnitUtils.UNIT_PLACEHOLDER, unit);
             label = StringUtils.replace(label, UnitUtils.UNIT_PLACEHOLDER, unit);
-
-            // Special treatment for °C since uom library uses a single character: ℃
-            // This will ensure the current state matches the cmd and the buttonClass is set accordingly.
-            command = StringUtils.replace(command, "°C", "℃");
         }
 
         rowSnippet = StringUtils.replace(rowSnippet, "%item%", w.getItem() != null ? w.getItem() : "");

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SwitchRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/src/main/java/org/eclipse/smarthome/ui/classic/internal/render/SwitchRenderer.java
@@ -107,10 +107,6 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
                     String unit = getUnitForWidget(w);
                     command = StringUtils.replace(command, UnitUtils.UNIT_PLACEHOLDER, unit);
                     label = StringUtils.replace(label, UnitUtils.UNIT_PLACEHOLDER, unit);
-
-                    // Special treatment for °C since uom library uses a single character: ℃
-                    // This will ensure the current state matches the cmd and the buttonClass is set accordingly.
-                    command = StringUtils.replace(command, "°C", "℃");
                 }
 
                 button = StringUtils.replace(button, "%item%", w.getItem());


### PR DESCRIPTION
Fixes #5669.

Note: During parsing the special character `℃` is still supported.

Signed-off-by: Henning Treu <henning.treu@telekom.de>