### PR TITLE
Convert decimal commands to QuantityType for UoM channels

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Import-Package:
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.library.unit,
  org.eclipse.smarthome.core.storage,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.thing.binding,

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/CommunicationManagerTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/CommunicationManagerTest.java
@@ -21,15 +21,23 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.measure.quantity.Temperature;
+
 import org.eclipse.smarthome.core.common.SafeCaller;
 import org.eclipse.smarthome.core.events.EventPublisher;
+import org.eclipse.smarthome.core.i18n.UnitProvider;
 import org.eclipse.smarthome.core.items.ItemRegistry;
 import org.eclipse.smarthome.core.items.events.ItemEventFactory;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.library.items.SwitchItem;
+import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.HSBType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.service.StateDescriptionService;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -53,6 +61,7 @@ import org.eclipse.smarthome.core.thing.profiles.TriggerProfile;
 import org.eclipse.smarthome.core.thing.type.ChannelKind;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
+import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,23 +78,29 @@ public class CommunicationManagerTest extends JavaOSGiTest {
     private static final String EVENT = "event";
     private static final String ITEM_NAME_1 = "testItem1";
     private static final String ITEM_NAME_2 = "testItem2";
+    private static final String ITEM_NAME_3 = "testItem3";
     private static final SwitchItem ITEM_1 = new SwitchItem(ITEM_NAME_1);
     private static final SwitchItem ITEM_2 = new SwitchItem(ITEM_NAME_2);
+    private static final NumberItem ITEM_3 = new NumberItem(ITEM_NAME_3);
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("test", "type");
     private static final ThingUID THING_UID = new ThingUID("test", "thing");
     private static final ChannelUID STATE_CHANNEL_UID_1 = new ChannelUID(THING_UID, "state-channel1");
     private static final ChannelUID STATE_CHANNEL_UID_2 = new ChannelUID(THING_UID, "state-channel2");
+    private static final ChannelUID STATE_CHANNEL_UID_3 = new ChannelUID(THING_UID, "state-channel3");
     private static final ChannelUID TRIGGER_CHANNEL_UID_1 = new ChannelUID(THING_UID, "trigger-channel1");
     private static final ChannelUID TRIGGER_CHANNEL_UID_2 = new ChannelUID(THING_UID, "trigger-channel2");
     private static final ItemChannelLink LINK_1_S1 = new ItemChannelLink(ITEM_NAME_1, STATE_CHANNEL_UID_1);
     private static final ItemChannelLink LINK_1_S2 = new ItemChannelLink(ITEM_NAME_1, STATE_CHANNEL_UID_2);
     private static final ItemChannelLink LINK_2_S2 = new ItemChannelLink(ITEM_NAME_2, STATE_CHANNEL_UID_2);
+    private static final ItemChannelLink LINK_3_S3 = new ItemChannelLink(ITEM_NAME_3, STATE_CHANNEL_UID_3);
     private static final ItemChannelLink LINK_1_T1 = new ItemChannelLink(ITEM_NAME_1, TRIGGER_CHANNEL_UID_1);
     private static final ItemChannelLink LINK_1_T2 = new ItemChannelLink(ITEM_NAME_1, TRIGGER_CHANNEL_UID_2);
     private static final ItemChannelLink LINK_2_T2 = new ItemChannelLink(ITEM_NAME_2, TRIGGER_CHANNEL_UID_2);
     private static final Thing THING = ThingBuilder.create(THING_TYPE_UID, THING_UID)
             .withChannels(ChannelBuilder.create(STATE_CHANNEL_UID_1, "").withKind(ChannelKind.STATE).build(),
                     ChannelBuilder.create(STATE_CHANNEL_UID_2, "").withKind(ChannelKind.STATE).build(),
+                    ChannelBuilder.create(STATE_CHANNEL_UID_3, "Number:Temperature").withKind(ChannelKind.STATE)
+                            .build(),
                     ChannelBuilder.create(TRIGGER_CHANNEL_UID_1, "").withKind(ChannelKind.TRIGGER).build(),
                     ChannelBuilder.create(TRIGGER_CHANNEL_UID_2, "").withKind(ChannelKind.TRIGGER).build())
             .build();
@@ -159,13 +174,15 @@ public class CommunicationManagerTest extends JavaOSGiTest {
         ItemChannelLinkRegistry iclRegistry = new ItemChannelLinkRegistry() {
             @Override
             public Stream<ItemChannelLink> stream() {
-                return Arrays.asList(LINK_1_S1, LINK_1_S2, LINK_2_S2, LINK_1_T1, LINK_1_T2, LINK_2_T2).stream();
+                return Arrays.asList(LINK_1_S1, LINK_1_S2, LINK_2_S2, LINK_1_T1, LINK_1_T2, LINK_2_T2, LINK_3_S3)
+                        .stream();
             }
         };
         manager.setItemChannelLinkRegistry(iclRegistry);
 
         when(itemRegistry.get(eq(ITEM_NAME_1))).thenReturn(ITEM_1);
         when(itemRegistry.get(eq(ITEM_NAME_2))).thenReturn(ITEM_2);
+        when(itemRegistry.get(eq(ITEM_NAME_3))).thenReturn(ITEM_3);
         manager.setItemRegistry(itemRegistry);
 
         THING.setHandler(mockHandler);
@@ -174,6 +191,10 @@ public class CommunicationManagerTest extends JavaOSGiTest {
         manager.setThingRegistry(thingRegistry);
 
         manager.addItemFactory(new CoreItemFactory());
+
+        UnitProvider unitProvider = mock(UnitProvider.class);
+        when(unitProvider.getUnit(Temperature.class)).thenReturn(SIUnits.CELSIUS);
+        ITEM_3.setUnitProvider(unitProvider);
     }
 
     @Test
@@ -221,6 +242,33 @@ public class CommunicationManagerTest extends JavaOSGiTest {
         manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_2, OnOffType.ON));
         waitForAssert(() -> {
             verify(stateProfile).onCommandFromItem(eq(OnOffType.ON));
+        });
+        verifyNoMoreInteractions(stateProfile);
+        verifyNoMoreInteractions(triggerProfile);
+    }
+
+    @Test
+    public void testItemCommandEvent_Decimal2Quantity() {
+        // Take unit from accepted item type (see channel built from STATE_CHANNEL_UID_3)
+        manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_3, DecimalType.valueOf("20")));
+        waitForAssert(() -> {
+            verify(stateProfile).onCommandFromItem(eq(QuantityType.valueOf("20 °C")));
+        });
+        verifyNoMoreInteractions(stateProfile);
+        verifyNoMoreInteractions(triggerProfile);
+    }
+
+    @Test
+    public void testItemCommandEvent_Decimal2Quantity_2() {
+        // Take unit from state description
+        StateDescriptionService stateDescriptionService = mock(StateDescriptionService.class);
+        when(stateDescriptionService.getStateDescription(ITEM_NAME_3, null)).thenReturn(
+                StateDescriptionFragmentBuilder.create().withPattern("%.1f °F").build().toStateDescription());
+        ITEM_3.setStateDescriptionService(stateDescriptionService);
+
+        manager.receive(ItemEventFactory.createCommandEvent(ITEM_NAME_3, DecimalType.valueOf("20")));
+        waitForAssert(() -> {
+            verify(stateProfile).onCommandFromItem(eq(QuantityType.valueOf("20 °F")));
         });
         verifyNoMoreInteractions(stateProfile);
         verifyNoMoreInteractions(triggerProfile);

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/CommunicationManagerTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/CommunicationManagerTest.java
@@ -272,6 +272,8 @@ public class CommunicationManagerTest extends JavaOSGiTest {
         });
         verifyNoMoreInteractions(stateProfile);
         verifyNoMoreInteractions(triggerProfile);
+
+        ITEM_3.setStateDescriptionService(null);
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
@@ -336,9 +336,6 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
     private <T extends Type> @Nullable T toAcceptedType(T originalType, Channel channel,
             Function<@Nullable String, @Nullable List<Class<? extends T>>> acceptedTypesFunction, Item item) {
         String acceptedItemType = channel.getAcceptedItemType();
-        if (acceptedItemType == null) {
-            return originalType;
-        }
 
         // DecimalType command sent to a NumberItem with dimension defined:
         if (originalType instanceof DecimalType && hasDimension(item, acceptedItemType)) {
@@ -347,6 +344,10 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
             if (quantityType != null) {
                 return (T) quantityType;
             }
+        }
+
+        if (acceptedItemType == null) {
+            return originalType;
         }
 
         List<Class<? extends T>> acceptedTypes = acceptedTypesFunction.apply(acceptedItemType);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
@@ -341,7 +341,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
 
         if (!(originalType instanceof QuantityType) && item instanceof NumberItem) {
             @Nullable
-            T quantityType = convertToQquantityType(originalType, item, acceptedItemType);
+            T quantityType = convertToQuantityType(originalType, item, acceptedItemType);
             if (quantityType != null) {
                 return quantityType;
             }
@@ -375,7 +375,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends Type> @Nullable T convertToQquantityType(T originalType, Item item,
+    private <T extends Type> @Nullable T convertToQuantityType(T originalType, Item item,
             @Nullable String acceptedItemType) {
         NumberItem numberItem = (NumberItem) item;
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/CommunicationManager.java
@@ -340,7 +340,7 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
             return originalType;
         }
 
-        // DecimalType command send to a NumberItem with dimension defined:
+        // DecimalType command sent to a NumberItem with dimension defined:
         if (originalType instanceof DecimalType && hasDimension(item, acceptedItemType)) {
             @Nullable
             QuantityType<?> quantityType = convertToQuantityType((DecimalType) originalType, item, acceptedItemType);
@@ -385,15 +385,14 @@ public class CommunicationManager implements EventSubscriber, RegistryChangeList
             @Nullable String acceptedItemType) {
         NumberItem numberItem = (NumberItem) item;
 
-        // DecimalType command send via a NumberItem with dimension:
+        // DecimalType command sent via a NumberItem with dimension:
         Class<? extends Quantity<?>> dimension = numberItem.getDimension();
 
         if (dimension == null) {
-            // DecimalType command send via a plain NumberItem w/o dimension.
+            // DecimalType command sent via a plain NumberItem w/o dimension.
             // We try to guess the correct unit from the channel-type's expected item dimension
             // or from the item's state description.
             dimension = getDimension(acceptedItemType);
-
         }
 
         if (dimension != null) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
@@ -27,12 +27,10 @@ import org.eclipse.smarthome.core.items.ItemUtil;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
-import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
-import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.types.util.UnitUtils;
 
@@ -159,22 +157,19 @@ public class NumberItem extends GenericItem {
     }
 
     /**
-     * Try to convert a {@link DecimalType} or {@link StringType} into a new {@link QuantityType}. The unit for the new
+     * Try to convert a {@link DecimalType} into a new {@link QuantityType}. The unit for the new
      * type is derived either from the state description (which might also give a hint on items w/o dimension) or from
      * the system default unit of the given dimension.
      *
-     * @param originalType the source type, either {@link DecimalType} or {@link StringType}.
+     * @param originalType the source {@link DecimalType}.
      * @param dimension    the dimension to which the new {@link QuantityType} should adhere.
-     * @return the new {@link QuantityType} from the given originalType, {@code null} if originalType does not match.
+     * @return the new {@link QuantityType} from the given originalType, {@code null} if a unit could not be calculated.
      */
-    public @Nullable QuantityType<?> toQuantityType(Type originalType,
+    public @Nullable QuantityType<?> toQuantityType(DecimalType originalType,
             @Nullable Class<? extends Quantity<?>> dimension) {
         Unit<? extends Quantity<?>> itemUnit = getUnit(dimension);
-        if (itemUnit != null && originalType instanceof DecimalType) {
-            return new QuantityType<>(((DecimalType) originalType).toBigDecimal(), itemUnit);
-        }
-        if (originalType instanceof StringType) {
-            return new QuantityType<>(((StringType) originalType).toFullString());
+        if (itemUnit != null) {
+            return new QuantityType<>(originalType.toBigDecimal(), itemUnit);
         }
 
         return null;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
@@ -27,10 +27,12 @@ import org.eclipse.smarthome.core.items.ItemUtil;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.types.util.UnitUtils;
 
@@ -165,6 +167,18 @@ public class NumberItem extends GenericItem {
 
         if (dimension != null && unitProvider != null) {
             return unitProvider.getUnit((Class<Quantity>) dimension);
+        }
+
+        return null;
+    }
+
+    public @Nullable QuantityType<?> toQuantityType(Type originalType) {
+        Unit<? extends Quantity<?>> itemUnit = getUnit();
+        if (itemUnit != null && originalType instanceof DecimalType) {
+            return new QuantityType<>(((DecimalType) originalType).toBigDecimal(), itemUnit);
+        }
+        if (originalType instanceof StringType) {
+            return new QuantityType<>(((StringType) originalType).toFullString());
         }
 
         return null;


### PR DESCRIPTION
DecimalType or StringType commands which are send to channels expecting UoM QuantityType commands will be converted according to the item's state description or the default unit for the corresponding dimension as a last resort.

Fixes #5725.