### PR TITLE
Fix memory leak in HttpUtil

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
@@ -536,9 +536,7 @@ public class HttpUtil {
     }
 
     protected void unsetHttpClientFactory(final HttpClientFactory httpClientFactory) {
-        if (HttpUtil.httpClientFactory == httpClientFactory) {
-            HttpUtil.httpClientFactory = null;
-        }
+        HttpUtil.httpClientFactory = null;
     }
 
 }

--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
@@ -41,8 +41,9 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.util.B64Code;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.smarthome.core.library.types.RawType;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,13 +54,15 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution and API
  * @author Svilen Valkanov - replaced Apache HttpClient with Jetty
  */
+@Component(immediate = true)
 public class HttpUtil {
 
     private static Logger logger = LoggerFactory.getLogger(HttpUtil.class);
 
     private static final int DEFAULT_TIMEOUT_MS = 5000;
 
-    private static final HttpClient CLIENT = new HttpClient(new SslContextFactory());
+    private static HttpClientFactory httpClientFactory;
+    private static HttpClient httpClient;
 
     private static class ProxyParams {
         public String proxyHost = null;
@@ -75,8 +78,8 @@ public class HttpUtil {
      * set into the {@link HttpClient}.
      *
      * @param httpMethod the HTTP method to use
-     * @param url the url to execute
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param url        the url to execute
+     * @param timeout    the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -89,12 +92,13 @@ public class HttpUtil {
      * Furthermore the <code>http.proxyXXX</code> System variables are read and
      * set into the {@link HttpClient}.
      *
-     * @param httpMethod the HTTP method to use
-     * @param url the url to execute
-     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be
-     *            send.
+     * @param httpMethod  the HTTP method to use
+     * @param url         the url to execute
+     * @param content     the content to be send to the given <code>url</code> or <code>null</code> if no content should
+     *                        be
+     *                        send.
      * @param contentType the content type of the given <code>content</code>
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param timeout     the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -108,13 +112,14 @@ public class HttpUtil {
      * Furthermore the <code>http.proxyXXX</code> System variables are read and
      * set into the {@link HttpClient}.
      *
-     * @param httpMethod the HTTP method to use
-     * @param url the url to execute
+     * @param httpMethod  the HTTP method to use
+     * @param url         the url to execute
      * @param httpHeaders optional http request headers which has to be sent within request
-     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be
-     *            send.
+     * @param content     the content to be send to the given <code>url</code> or <code>null</code> if no content should
+     *                        be
+     *                        send.
      * @param contentType the content type of the given <code>content</code>
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param timeout     the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -129,16 +134,17 @@ public class HttpUtil {
     /**
      * Executes the given <code>url</code> with the given <code>httpMethod</code>
      *
-     * @param httpMethod the HTTP method to use
-     * @param url the url to execute
-     * @param httpHeaders optional HTTP headers which has to be set on request
-     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be
-     *            send.
-     * @param contentType the content type of the given <code>content</code>
-     * @param timeout the socket timeout in milliseconds to wait for data
-     * @param proxyHost the hostname of the proxy
-     * @param proxyPort the port of the proxy
-     * @param proxyUser the username to authenticate with the proxy
+     * @param httpMethod    the HTTP method to use
+     * @param url           the url to execute
+     * @param httpHeaders   optional HTTP headers which has to be set on request
+     * @param content       the content to be send to the given <code>url</code> or <code>null</code> if no content
+     *                          should be
+     *                          send.
+     * @param contentType   the content type of the given <code>content</code>
+     * @param timeout       the socket timeout in milliseconds to wait for data
+     * @param proxyHost     the hostname of the proxy
+     * @param proxyPort     the port of the proxy
+     * @param proxyUser     the username to authenticate with the proxy
      * @param proxyPassword the password to authenticate with the proxy
      * @param nonProxyHosts the hosts that won't be routed through the proxy
      * @return the response body or <code>NULL</code> when the request went wrong
@@ -160,18 +166,19 @@ public class HttpUtil {
     }
 
     /**
-     * Executes the given <code>url</code> with the given <code>httpMethod</code>
+     * Executes the given <code>url</code> with the given <code>httpMethod</code>.
      *
-     * @param httpMethod the HTTP method to use
-     * @param url the url to execute
-     * @param httpHeaders optional HTTP headers which has to be set on request
-     * @param content the content to be send to the given <code>url</code> or <code>null</code> if no content should be
-     *            send.
-     * @param contentType the content type of the given <code>content</code>
-     * @param timeout the socket timeout in milliseconds to wait for data
-     * @param proxyHost the hostname of the proxy
-     * @param proxyPort the port of the proxy
-     * @param proxyUser the username to authenticate with the proxy
+     * @param httpMethod    the HTTP method to use
+     * @param url           the url to execute
+     * @param httpHeaders   optional HTTP headers which has to be set on request
+     * @param content       the content to be send to the given <code>url</code> or <code>null</code> if no content
+     *                          should be
+     *                          send.
+     * @param contentType   the content type of the given <code>content</code>
+     * @param timeout       the socket timeout in milliseconds to wait for data
+     * @param proxyHost     the hostname of the proxy
+     * @param proxyPort     the port of the proxy
+     * @param proxyUser     the username to authenticate with the proxy
      * @param proxyPassword the password to authenticate with the proxy
      * @param nonProxyHosts the hosts that won't be routed through the proxy
      * @return the response as a ContentResponse object or <code>NULL</code> when the request went wrong
@@ -180,13 +187,21 @@ public class HttpUtil {
     private static ContentResponse executeUrlAndGetReponse(String httpMethod, String url, Properties httpHeaders,
             InputStream content, String contentType, int timeout, String proxyHost, Integer proxyPort, String proxyUser,
             String proxyPassword, String nonProxyHosts) throws IOException {
-        startHttpClient(CLIENT);
+
+        // Get shared http client from factory "on-demand"
+        if (HttpUtil.httpClient == null) {
+            // Bundle was not yet activated or has been deactivated - No better way to handle this case gracefully
+            if (httpClientFactory == null) {
+                throw new IllegalStateException("Http client factory was null probably due to bundle not being ACTIVE");
+            }
+            HttpUtil.httpClient = httpClientFactory.getCommonHttpClient();
+        }
 
         HttpProxy proxy = null;
-        // only configure a proxy if a host is provided
+        // Only configure a proxy if a host is provided
         if (StringUtils.isNotBlank(proxyHost) && proxyPort != null && shouldUseProxy(url, nonProxyHosts)) {
-            AuthenticationStore authStore = CLIENT.getAuthenticationStore();
-            ProxyConfiguration proxyConfig = CLIENT.getProxyConfiguration();
+            AuthenticationStore authStore = httpClient.getAuthenticationStore();
+            ProxyConfiguration proxyConfig = httpClient.getProxyConfiguration();
             List<Proxy> proxies = proxyConfig.getProxies();
 
             proxy = new HttpProxy(proxyHost, proxyPort);
@@ -196,9 +211,9 @@ public class HttpUtil {
                     new BasicAuthentication(proxy.getURI(), Authentication.ANY_REALM, proxyUser, proxyPassword));
         }
 
-        HttpMethod method = HttpUtil.createHttpMethod(httpMethod);
+        final HttpMethod method = HttpUtil.createHttpMethod(httpMethod);
 
-        Request request = CLIENT.newRequest(url).method(method).timeout(timeout, TimeUnit.MILLISECONDS);
+        final Request request = httpClient.newRequest(url).method(method).timeout(timeout, TimeUnit.MILLISECONDS);
 
         if (httpHeaders != null) {
             for (String httpHeaderKey : httpHeaders.stringPropertyNames()) {
@@ -224,7 +239,11 @@ public class HttpUtil {
 
         // add content if a valid method is given ...
         if (content != null && (method.equals(HttpMethod.POST) || method.equals(HttpMethod.PUT))) {
-            request.content(new InputStreamContentProvider(content), contentType);
+            // Close this outmost stream again after use!
+            try (final InputStreamContentProvider inputStreamContentProvider = new InputStreamContentProvider(
+                    content)) {
+                request.content(inputStreamContentProvider, contentType);
+            }
         }
 
         if (logger.isDebugEnabled()) {
@@ -234,7 +253,7 @@ public class HttpUtil {
         try {
             ContentResponse response = request.send();
             int statusCode = response.getStatus();
-            if (statusCode >= HttpStatus.BAD_REQUEST_400) {
+            if (logger.isDebugEnabled() && statusCode >= HttpStatus.BAD_REQUEST_400) {
                 String statusLine = statusCode + " " + response.getReason();
                 logger.debug("Method failed: {}", statusLine);
             }
@@ -245,7 +264,7 @@ public class HttpUtil {
         } finally {
             if (proxy != null) {
                 // Remove the proxy, that has been added for this request
-                CLIENT.getProxyConfiguration().getProxies().remove(proxy);
+                httpClient.getProxyConfiguration().getProxies().remove(proxy);
             }
         }
     }
@@ -321,7 +340,7 @@ public class HttpUtil {
      *
      * @param httpMethodString the name of the {@link HttpMethod} to create
      * @throws IllegalArgumentException if <code>httpMethod</code> is none of <code>GET</code>, <code>PUT</code>,
-     *             <code>POST</POST> or <code>DELETE</code>
+     *                                      <code>POST</POST> or <code>DELETE</code>
      */
     public static HttpMethod createHttpMethod(String httpMethodString) {
         if ("GET".equals(httpMethodString)) {
@@ -334,16 +353,6 @@ public class HttpUtil {
             return HttpMethod.DELETE;
         } else {
             throw new IllegalArgumentException("given httpMethod '" + httpMethodString + "' is unknown");
-        }
-    }
-
-    private static void startHttpClient(HttpClient client) {
-        if (!client.isStarted()) {
-            try {
-                client.start();
-            } catch (Exception e) {
-                logger.warn("Cannot start HttpClient!", e);
-            }
         }
     }
 
@@ -365,7 +374,7 @@ public class HttpUtil {
      *
      * If content type is not found in the headers, the data is scanned to determine the content type.
      *
-     * @param url the URL of the image to be downloaded
+     * @param url     the URL of the image to be downloaded
      * @param timeout the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image
@@ -377,10 +386,10 @@ public class HttpUtil {
     /**
      * Download the image data from an URL.
      *
-     * @param url the URL of the image to be downloaded
+     * @param url               the URL of the image to be downloaded
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *            data size
+     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *                              data size
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
@@ -391,11 +400,11 @@ public class HttpUtil {
     /**
      * Download the image data from an URL.
      *
-     * @param url the URL of the image to be downloaded
+     * @param url               the URL of the image to be downloaded
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *            data size
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *                              data size
+     * @param timeout           the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
@@ -406,11 +415,11 @@ public class HttpUtil {
     /**
      * Download the data from an URL.
      *
-     * @param url the URL of the data to be downloaded
-     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
+     * @param url               the URL of the data to be downloaded
+     * @param contentTypeRegex  the REGEX the content type must match; null to ignore the content type
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *            data size
+     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *                              data size
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */
@@ -422,12 +431,12 @@ public class HttpUtil {
     /**
      * Download the data from an URL.
      *
-     * @param url the URL of the data to be downloaded
-     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
+     * @param url               the URL of the data to be downloaded
+     * @param contentTypeRegex  the REGEX the content type must match; null to ignore the content type
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *            data size
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *                              data size
+     * @param timeout           the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */
@@ -527,6 +536,17 @@ public class HttpUtil {
     private static boolean isJpeg(byte[] data) {
         return (data.length >= 2 && data[0] == (byte) 0xFF && data[1] == (byte) 0xD8
                 && data[data.length - 2] == (byte) 0xFF && data[data.length - 1] == (byte) 0xD9);
+    }
+
+    @Reference
+    protected void setHttpClientFactory(final HttpClientFactory httpClientFactory) {
+        HttpUtil.httpClientFactory = httpClientFactory;
+    }
+
+    protected void unsetHttpClientFactory(final HttpClientFactory httpClientFactory) {
+        if (HttpUtil.httpClientFactory == httpClientFactory) {
+            HttpUtil.httpClientFactory = null;
+        }
     }
 
 }

--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
@@ -62,7 +62,6 @@ public class HttpUtil {
     private static final int DEFAULT_TIMEOUT_MS = 5000;
 
     private static HttpClientFactory httpClientFactory;
-    private static HttpClient httpClient;
 
     private static class ProxyParams {
         public String proxyHost = null;
@@ -78,8 +77,8 @@ public class HttpUtil {
      * set into the {@link HttpClient}.
      *
      * @param httpMethod the HTTP method to use
-     * @param url        the url to execute
-     * @param timeout    the socket timeout in milliseconds to wait for data
+     * @param url the url to execute
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -92,13 +91,12 @@ public class HttpUtil {
      * Furthermore the <code>http.proxyXXX</code> System variables are read and
      * set into the {@link HttpClient}.
      *
-     * @param httpMethod  the HTTP method to use
-     * @param url         the url to execute
-     * @param content     the content to be send to the given <code>url</code> or <code>null</code> if no content should
-     *                        be
-     *                        send.
+     * @param httpMethod the HTTP method to use
+     * @param url the url to execute
+     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should be
+     *            sent.
      * @param contentType the content type of the given <code>content</code>
-     * @param timeout     the socket timeout in milliseconds to wait for data
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -112,14 +110,13 @@ public class HttpUtil {
      * Furthermore the <code>http.proxyXXX</code> System variables are read and
      * set into the {@link HttpClient}.
      *
-     * @param httpMethod  the HTTP method to use
-     * @param url         the url to execute
+     * @param httpMethod the HTTP method to use
+     * @param url the url to execute
      * @param httpHeaders optional http request headers which has to be sent within request
-     * @param content     the content to be send to the given <code>url</code> or <code>null</code> if no content should
-     *                        be
-     *                        send.
+     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should be
+     *            sent.
      * @param contentType the content type of the given <code>content</code>
-     * @param timeout     the socket timeout in milliseconds to wait for data
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -134,17 +131,16 @@ public class HttpUtil {
     /**
      * Executes the given <code>url</code> with the given <code>httpMethod</code>
      *
-     * @param httpMethod    the HTTP method to use
-     * @param url           the url to execute
-     * @param httpHeaders   optional HTTP headers which has to be set on request
-     * @param content       the content to be send to the given <code>url</code> or <code>null</code> if no content
-     *                          should be
-     *                          send.
-     * @param contentType   the content type of the given <code>content</code>
-     * @param timeout       the socket timeout in milliseconds to wait for data
-     * @param proxyHost     the hostname of the proxy
-     * @param proxyPort     the port of the proxy
-     * @param proxyUser     the username to authenticate with the proxy
+     * @param httpMethod the HTTP method to use
+     * @param url the url to execute
+     * @param httpHeaders optional HTTP headers which has to be set on request
+     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should be
+     *            sent.
+     * @param contentType the content type of the given <code>content</code>
+     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param proxyHost the hostname of the proxy
+     * @param proxyPort the port of the proxy
+     * @param proxyUser the username to authenticate with the proxy
      * @param proxyPassword the password to authenticate with the proxy
      * @param nonProxyHosts the hosts that won't be routed through the proxy
      * @return the response body or <code>NULL</code> when the request went wrong
@@ -166,19 +162,18 @@ public class HttpUtil {
     }
 
     /**
-     * Executes the given <code>url</code> with the given <code>httpMethod</code>.
+     * Executes the given <code>url</code> with the given <code>httpMethod</code>
      *
-     * @param httpMethod    the HTTP method to use
-     * @param url           the url to execute
-     * @param httpHeaders   optional HTTP headers which has to be set on request
-     * @param content       the content to be send to the given <code>url</code> or <code>null</code> if no content
-     *                          should be
-     *                          send.
-     * @param contentType   the content type of the given <code>content</code>
-     * @param timeout       the socket timeout in milliseconds to wait for data
-     * @param proxyHost     the hostname of the proxy
-     * @param proxyPort     the port of the proxy
-     * @param proxyUser     the username to authenticate with the proxy
+     * @param httpMethod the HTTP method to use
+     * @param url the url to execute
+     * @param httpHeaders optional HTTP headers which has to be set on request
+     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should be
+     *            sent.
+     * @param contentType the content type of the given <code>content</code>
+     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param proxyHost the hostname of the proxy
+     * @param proxyPort the port of the proxy
+     * @param proxyUser the username to authenticate with the proxy
      * @param proxyPassword the password to authenticate with the proxy
      * @param nonProxyHosts the hosts that won't be routed through the proxy
      * @return the response as a ContentResponse object or <code>NULL</code> when the request went wrong
@@ -188,14 +183,12 @@ public class HttpUtil {
             InputStream content, String contentType, int timeout, String proxyHost, Integer proxyPort, String proxyUser,
             String proxyPassword, String nonProxyHosts) throws IOException {
 
-        // Get shared http client from factory "on-demand"
-        if (HttpUtil.httpClient == null) {
-            // Bundle was not yet activated or has been deactivated - No better way to handle this case gracefully
-            if (httpClientFactory == null) {
-                throw new IllegalStateException("Http client factory was null probably due to bundle not being ACTIVE");
-            }
-            HttpUtil.httpClient = httpClientFactory.getCommonHttpClient();
+        // Referenced http client factory not available
+        if (httpClientFactory == null) {
+            throw new IllegalStateException("Http client factory not available");
         }
+        // Get shared http client from factory "on-demand"
+        final HttpClient httpClient = httpClientFactory.getCommonHttpClient();
 
         HttpProxy proxy = null;
         // Only configure a proxy if a host is provided
@@ -340,7 +333,7 @@ public class HttpUtil {
      *
      * @param httpMethodString the name of the {@link HttpMethod} to create
      * @throws IllegalArgumentException if <code>httpMethod</code> is none of <code>GET</code>, <code>PUT</code>,
-     *                                      <code>POST</POST> or <code>DELETE</code>
+     *             <code>POST</POST> or <code>DELETE</code>
      */
     public static HttpMethod createHttpMethod(String httpMethodString) {
         if ("GET".equals(httpMethodString)) {
@@ -374,7 +367,7 @@ public class HttpUtil {
      *
      * If content type is not found in the headers, the data is scanned to determine the content type.
      *
-     * @param url     the URL of the image to be downloaded
+     * @param url the URL of the image to be downloaded
      * @param timeout the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image
@@ -386,10 +379,10 @@ public class HttpUtil {
     /**
      * Download the image data from an URL.
      *
-     * @param url               the URL of the image to be downloaded
+     * @param url the URL of the image to be downloaded
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *                              data size
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
@@ -400,11 +393,11 @@ public class HttpUtil {
     /**
      * Download the image data from an URL.
      *
-     * @param url               the URL of the image to be downloaded
+     * @param url the URL of the image to be downloaded
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *                              data size
-     * @param timeout           the socket timeout in milliseconds to wait for data
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
@@ -415,11 +408,11 @@ public class HttpUtil {
     /**
      * Download the data from an URL.
      *
-     * @param url               the URL of the data to be downloaded
-     * @param contentTypeRegex  the REGEX the content type must match; null to ignore the content type
+     * @param url the URL of the data to be downloaded
+     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *                              data size
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */
@@ -431,12 +424,12 @@ public class HttpUtil {
     /**
      * Download the data from an URL.
      *
-     * @param url               the URL of the data to be downloaded
-     * @param contentTypeRegex  the REGEX the content type must match; null to ignore the content type
+     * @param url the URL of the data to be downloaded
+     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *                              data size
-     * @param timeout           the socket timeout in milliseconds to wait for data
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */

--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
@@ -77,8 +77,8 @@ public class HttpUtil {
      * set into the {@link HttpClient}.
      *
      * @param httpMethod the HTTP method to use
-     * @param url the url to execute
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param url        the url to execute
+     * @param timeout    the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -91,12 +91,12 @@ public class HttpUtil {
      * Furthermore the <code>http.proxyXXX</code> System variables are read and
      * set into the {@link HttpClient}.
      *
-     * @param httpMethod the HTTP method to use
-     * @param url the url to execute
-     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should be
-     *            sent.
+     * @param httpMethod  the HTTP method to use
+     * @param url         the url to execute
+     * @param content     the content to be sent to the given <code>url</code> or <code>null</code> if no content should
+     *                        be sent.
      * @param contentType the content type of the given <code>content</code>
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param timeout     the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -110,13 +110,13 @@ public class HttpUtil {
      * Furthermore the <code>http.proxyXXX</code> System variables are read and
      * set into the {@link HttpClient}.
      *
-     * @param httpMethod the HTTP method to use
-     * @param url the url to execute
+     * @param httpMethod  the HTTP method to use
+     * @param url         the url to execute
      * @param httpHeaders optional http request headers which has to be sent within request
-     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should be
-     *            sent.
+     * @param content     the content to be sent to the given <code>url</code> or <code>null</code> if no content should
+     *                        be sent.
      * @param contentType the content type of the given <code>content</code>
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param timeout     the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -131,16 +131,16 @@ public class HttpUtil {
     /**
      * Executes the given <code>url</code> with the given <code>httpMethod</code>
      *
-     * @param httpMethod the HTTP method to use
-     * @param url the url to execute
-     * @param httpHeaders optional HTTP headers which has to be set on request
-     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should be
-     *            sent.
-     * @param contentType the content type of the given <code>content</code>
-     * @param timeout the socket timeout in milliseconds to wait for data
-     * @param proxyHost the hostname of the proxy
-     * @param proxyPort the port of the proxy
-     * @param proxyUser the username to authenticate with the proxy
+     * @param httpMethod    the HTTP method to use
+     * @param url           the url to execute
+     * @param httpHeaders   optional HTTP headers which has to be set on request
+     * @param content       the content to be sent to the given <code>url</code> or <code>null</code> if no content
+     *                          should be sent.
+     * @param contentType   the content type of the given <code>content</code>
+     * @param timeout       the socket timeout in milliseconds to wait for data
+     * @param proxyHost     the hostname of the proxy
+     * @param proxyPort     the port of the proxy
+     * @param proxyUser     the username to authenticate with the proxy
      * @param proxyPassword the password to authenticate with the proxy
      * @param nonProxyHosts the hosts that won't be routed through the proxy
      * @return the response body or <code>NULL</code> when the request went wrong
@@ -164,16 +164,16 @@ public class HttpUtil {
     /**
      * Executes the given <code>url</code> with the given <code>httpMethod</code>
      *
-     * @param httpMethod the HTTP method to use
-     * @param url the url to execute
-     * @param httpHeaders optional HTTP headers which has to be set on request
-     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should be
-     *            sent.
-     * @param contentType the content type of the given <code>content</code>
-     * @param timeout the socket timeout in milliseconds to wait for data
-     * @param proxyHost the hostname of the proxy
-     * @param proxyPort the port of the proxy
-     * @param proxyUser the username to authenticate with the proxy
+     * @param httpMethod    the HTTP method to use
+     * @param url           the url to execute
+     * @param httpHeaders   optional HTTP headers which has to be set on request
+     * @param content       the content to be sent to the given <code>url</code> or <code>null</code> if no content
+     *                          should be sent.
+     * @param contentType   the content type of the given <code>content</code>
+     * @param timeout       the socket timeout in milliseconds to wait for data
+     * @param proxyHost     the hostname of the proxy
+     * @param proxyPort     the port of the proxy
+     * @param proxyUser     the username to authenticate with the proxy
      * @param proxyPassword the password to authenticate with the proxy
      * @param nonProxyHosts the hosts that won't be routed through the proxy
      * @return the response as a ContentResponse object or <code>NULL</code> when the request went wrong
@@ -328,12 +328,11 @@ public class HttpUtil {
     }
 
     /**
-     * Factory method to create a {@link HttpMethod}-object according to the
-     * given String <code>httpMethodString</code>
+     * Factory method to create a {@link HttpMethod}-object according to the given String <code>httpMethodString</code>
      *
      * @param httpMethodString the name of the {@link HttpMethod} to create
      * @throws IllegalArgumentException if <code>httpMethod</code> is none of <code>GET</code>, <code>PUT</code>,
-     *             <code>POST</POST> or <code>DELETE</code>
+     *                                      <code>POST</POST> or <code>DELETE</code>
      */
     public static HttpMethod createHttpMethod(String httpMethodString) {
         if ("GET".equals(httpMethodString)) {
@@ -367,7 +366,7 @@ public class HttpUtil {
      *
      * If content type is not found in the headers, the data is scanned to determine the content type.
      *
-     * @param url the URL of the image to be downloaded
+     * @param url     the URL of the image to be downloaded
      * @param timeout the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image
@@ -379,10 +378,10 @@ public class HttpUtil {
     /**
      * Download the image data from an URL.
      *
-     * @param url the URL of the image to be downloaded
+     * @param url               the URL of the image to be downloaded
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *            data size
+     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *                              data size
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
@@ -393,11 +392,11 @@ public class HttpUtil {
     /**
      * Download the image data from an URL.
      *
-     * @param url the URL of the image to be downloaded
+     * @param url               the URL of the image to be downloaded
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *            data size
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *                              data size
+     * @param timeout           the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
@@ -408,11 +407,11 @@ public class HttpUtil {
     /**
      * Download the data from an URL.
      *
-     * @param url the URL of the data to be downloaded
-     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
+     * @param url               the URL of the data to be downloaded
+     * @param contentTypeRegex  the REGEX the content type must match; null to ignore the content type
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *            data size
+     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *                              data size
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */
@@ -424,12 +423,12 @@ public class HttpUtil {
     /**
      * Download the data from an URL.
      *
-     * @param url the URL of the data to be downloaded
-     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
+     * @param url               the URL of the data to be downloaded
+     * @param contentTypeRegex  the REGEX the content type must match; null to ignore the content type
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *            data size
-     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *                              data size
+     * @param timeout           the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */


### PR DESCRIPTION
Addresses #5739

Refactored HttpUtil to be an OSGi component to be able to use the HttpClientFactory for retrieval of the shared http client which itself is tied to the HttpClientFactory lifecycle

Signed-off-by: Jan Hendriks <Jan.Hendriks@telekom.de>