### PR TITLE
Add static imports for units in scripts & rules

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
@@ -21,6 +21,7 @@ Export-Package:
  org.eclipse.smarthome.model.rule.validation
 Import-Package: 
  com.google.common.collect,
+ javax.measure,
  org.apache.commons.lang,
  org.apache.commons.logging,
  org.apache.log4j,
@@ -30,6 +31,7 @@ Import-Package:
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.library.items,
  org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.library.unit,
  org.eclipse.smarthome.core.persistence,
  org.eclipse.smarthome.core.service,
  org.eclipse.smarthome.core.thing,

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/engine/ScriptEngineOSGiTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/engine/ScriptEngineOSGiTest.java
@@ -289,6 +289,12 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
     }
 
     @Test
+    public void testToUnit_QuantityType2() throws ScriptParsingException, ScriptExecutionException {
+        assertThat(runScript("new QuantityType(20, CELSIUS).toUnit('°F').doubleValue"), is(Double.valueOf(68)));
+        assertThat(runScript("new QuantityType(68, FAHRENHEIT).toUnit('°C').doubleValue"), is(Double.valueOf(20)));
+    }
+
+    @Test
     public void testEquals_QuantityType_Number() throws ScriptParsingException, ScriptExecutionException {
         assertThat(runScript("20|m.equals(20)"), is(false));
     }

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/engine/ScriptEngineOSGiTest.java
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/src/test/java/org/eclipse/smarthome/model/script/engine/ScriptEngineOSGiTest.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.MetricPrefix;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.model.script.ScriptServiceUtil;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
@@ -292,6 +293,13 @@ public class ScriptEngineOSGiTest extends JavaOSGiTest {
     public void testToUnit_QuantityType2() throws ScriptParsingException, ScriptExecutionException {
         assertThat(runScript("new QuantityType(20, CELSIUS).toUnit('°F').doubleValue"), is(Double.valueOf(68)));
         assertThat(runScript("new QuantityType(68, FAHRENHEIT).toUnit('°C').doubleValue"), is(Double.valueOf(20)));
+    }
+
+    @Test
+    public void testToUnit_QuantityType3() throws ScriptParsingException, ScriptExecutionException {
+        assertThat(runScript("new QuantityType(1, KELVIN)"), is(new QuantityType<>(1, SmartHomeUnits.KELVIN)));
+        assertThat(runScript("new QuantityType(1, MICRO(KELVIN))"),
+                is(new QuantityType<>(1, MetricPrefix.MICRO(SmartHomeUnits.KELVIN))));
     }
 
     @Test

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -19,6 +19,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.smarthome.core.library.unit.ImperialUnits;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.model.persistence.extensions.PersistenceExtensions;
 import org.eclipse.smarthome.model.script.actions.Audio;
 import org.eclipse.smarthome.model.script.actions.BusEvent;
@@ -92,6 +94,9 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
         result.add(Audio.class);
         result.add(Voice.class);
         result.add(ThingAction.class);
+
+        result.add(ImperialUnits.class);
+        result.add(SIUnits.class);
 
         // jodatime static functions
         result.add(DateTime.class);

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/scoping/ScriptImplicitlyImportedTypes.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/scoping/ScriptImplicitlyImportedTypes.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
+import org.eclipse.smarthome.core.library.unit.MetricPrefix;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.model.persistence.extensions.PersistenceExtensions;
 import org.eclipse.smarthome.model.script.actions.Audio;
@@ -97,6 +98,7 @@ public class ScriptImplicitlyImportedTypes extends ImplicitlyImportedFeatures {
 
         result.add(ImperialUnits.class);
         result.add(SIUnits.class);
+        result.add(MetricPrefix.class);
 
         // jodatime static functions
         result.add(DateTime.class);


### PR DESCRIPTION
Fixes #5759.

This allows for creation of QuantityTypes with calculated number values and predefined unit constants.
Usage:

```
val double degreeF = new QuantityType(20, CELSIUS).toUnit('°F').doubleValue
```

Signed-off-by: Henning Treu <henning.treu@telekom.de>