### PR TITLE
Fixed problems with PaperUI builds.

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -11,7 +11,7 @@ var angularFilesort = require('gulp-angular-filesort'),
     uglify = require('gulp-uglify'),
     inject = require('gulp-inject'),
     util = require('gulp-util'),
-	merge = require('merge-stream'),
+    merge = require('merge-stream'),
     Server = require('karma').Server;
 var isDevelopment = !!util.env.development;
 var noMinify = util.env.noMinify
@@ -142,7 +142,7 @@ gulp.task('copyJSLibs', function () {
 });
 
 gulp.task('copyJQUI', function() {
-	var streams = merge();
+    var streams = merge();
     paths.JQUI.forEach(function (obj) {
         streams.add(gulp.src(obj.src)
             .pipe(concat(obj.name))
@@ -153,8 +153,8 @@ gulp.task('copyJQUI', function() {
             .pipe(uglify())
             .pipe(gulp.dest('./web/js')));
     });
-	
-	return streams;
+
+    return streams;
 });
 
 gulp.task('copyJSMisc', function () {
@@ -178,7 +178,7 @@ gulp.task('copyFontLibs', function () {
 });
 
 gulp.task('concat', function () {
-	var streams = merge();
+    var streams = merge();
     paths.concat.forEach(function (obj) {
         var result = gulp.src(obj.src)
             .pipe(angularFilesort())
@@ -195,8 +195,8 @@ gulp.task('concat', function () {
             
         streams.add(result);
     });
-	
-	return streams;
+
+    return streams;
 });
 
 gulp.task('clean', function () {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/gulpfile.js
@@ -11,6 +11,7 @@ var angularFilesort = require('gulp-angular-filesort'),
     uglify = require('gulp-uglify'),
     inject = require('gulp-inject'),
     util = require('gulp-util'),
+	merge = require('merge-stream'),
     Server = require('karma').Server;
 var isDevelopment = !!util.env.development;
 var noMinify = util.env.noMinify
@@ -141,16 +142,19 @@ gulp.task('copyJSLibs', function () {
 });
 
 gulp.task('copyJQUI', function() {
-    return paths.JQUI.forEach(function (obj) {
-        return gulp.src(obj.src)
+	var streams = merge();
+    paths.JQUI.forEach(function (obj) {
+        streams.add(gulp.src(obj.src)
             .pipe(concat(obj.name))
             .pipe(rename(function (path) {
                 path.basename += '.min';
                 return path;
             }))
             .pipe(uglify())
-            .pipe(gulp.dest('./web/js'));
+            .pipe(gulp.dest('./web/js')));
     });
+	
+	return streams;
 });
 
 gulp.task('copyJSMisc', function () {
@@ -174,7 +178,8 @@ gulp.task('copyFontLibs', function () {
 });
 
 gulp.task('concat', function () {
-    return paths.concat.forEach(function (obj) {
+	var streams = merge();
+    paths.concat.forEach(function (obj) {
         var result = gulp.src(obj.src)
             .pipe(angularFilesort())
             .pipe(concat(obj.name))
@@ -188,8 +193,10 @@ gulp.task('concat', function () {
         }
         result = result.pipe(gulp.dest('./web/js'));
             
-        return result;
+        streams.add(result);
     });
+	
+	return streams;
 });
 
 gulp.task('clean', function () {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/package.json
@@ -53,6 +53,7 @@
     "karma-jasmine": "^1.0.2",
     "karma-junit7-sonarqube-reporter": "0.0.5",
     "karma-phantomjs-launcher": "^1.0.1",
-    "karma-spec-reporter": "0.0.26"
+    "karma-spec-reporter": "0.0.26",
+    "merge-stream": "^1.0.1"
   }
 }

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
@@ -27,8 +27,8 @@
         <version>1.0</version>
 
         <configuration>
-          <nodeVersion>v8.1.2</nodeVersion>
-          <npmVersion>5.8.0</npmVersion>
+          <nodeVersion>v10.4.0</nodeVersion>
+          <npmVersion>6.1.0</npmVersion>
           <nodeDownloadRoot>http://nodejs.org/dist/</nodeDownloadRoot>
           <npmDownloadRoot>http://registry.npmjs.org/npm/-/</npmDownloadRoot>
           <environmentVariables>


### PR DESCRIPTION
I noticed that sometimes the paperUI builds fail with:
`[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.0:npm (gulp build) on project org.eclipse.smarthome.ui.paper: Failed to run task: 'npm run build' failed. (error code 1)` 

When comparing failed builds to successful builds I found out that in failing builds the script `js/controllers.min.js` file that is being generated is not injected in the html.  I believe the cause of this is that the gulp task is considered finished but the file is not yet generated. In order for the task to finish when the file is generated we need to return streams from the task. This should fix the issue.

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>