### PR TITLE
Add Network Interface Address change listener

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -70,6 +70,7 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.eclipse.smarthome.core.types.util,
  org.osgi.framework,
+ org.osgi.service.cm,
  org.osgi.service.component,
  org.osgi.service.event,
  org.osgi.service.packageadmin,

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -53,8 +53,8 @@ public class ThreadPoolManager {
     public static final String CONFIGURATION_PID = "org.eclipse.smarthome.threadpool";
 
     /**
-     * The common thread pool is reserved for occasional, light weight tasks that runs quickly, and
-     * uses little resources to execute. Tasks that does not fit into this category should setup
+     * The common thread pool is reserved for occasional, light weight tasks that run quickly, and
+     * use little resources to execute. Tasks that do not fit into this category should setup
      * their own dedicated pool or permanent thread.
      */
     public static final String THREAD_POOL_NAME_COMMON = "common";

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -47,9 +47,10 @@ import org.slf4j.LoggerFactory;
  * @author Kai Kreuzer - Initial contribution
  *
  */
-@Component(configurationPid = "org.eclipse.smarthome.threadpool")
+@Component(configurationPid = ThreadPoolManager.CONFIGURATION_PID)
 public class ThreadPoolManager {
 
+    public static final String CONFIGURATION_PID = "org.eclipse.smarthome.threadpool";
     private static final Logger LOGGER = LoggerFactory.getLogger(ThreadPoolManager.class);
 
     protected static final int DEFAULT_THREAD_POOL_SIZE = 5;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -51,6 +51,14 @@ import org.slf4j.LoggerFactory;
 public class ThreadPoolManager {
 
     public static final String CONFIGURATION_PID = "org.eclipse.smarthome.threadpool";
+
+    /**
+     * The common thread pool is reserved for occasional, light weight tasks that runs quickly, and
+     * uses little resources to execute. Tasks that does not fit into this category should setup
+     * their own dedicated pool or permanent thread.
+     */
+    public static final String THREAD_POOL_NAME_COMMON = "common";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ThreadPoolManager.class);
 
     protected static final int DEFAULT_THREAD_POOL_SIZE = 5;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -64,7 +64,7 @@ public class NetUtil implements NetworkAddressService {
 
     private static final String PRIMARY_ADDRESS = "primaryAddress";
     private static final String BROADCAST_ADDRESS = "broadcastAddress";
-    private static final String POLL_INTERVAL = "service.config.network.pollInterval";
+    private static final String POLL_INTERVAL = "pollInterval";
     private static final Logger LOGGER = LoggerFactory.getLogger(NetUtil.class);
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -58,13 +58,13 @@ import org.slf4j.LoggerFactory;
  */
 @Component(configurationPid = "org.eclipse.smarthome.network", property = { "service.pid=org.eclipse.smarthome.network",
         "service.config.description.uri=system:network", "service.config.label=Network Settings",
-        "service.config.category=system", "service.config.network.poll.frequency=60" })
+        "service.config.category=system", "service.config.network.poll.interval=60" })
 @NonNullByDefault
 public class NetUtil implements NetworkAddressService {
 
     private static final String PRIMARY_ADDRESS = "primaryAddress";
     private static final String BROADCAST_ADDRESS = "broadcastAddress";
-    private static final String POLL_FREQUENCY = "service.config.network.poll.frequency";
+    private static final String POLL_INTERVAL = "service.config.network.poll.interval";
     private static final Logger LOGGER = LoggerFactory.getLogger(NetUtil.class);
 
     /**
@@ -126,13 +126,13 @@ public class NetUtil implements NetworkAddressService {
         String pollFrequenceSecondsStr = "";
         int pollFrequenceSeconds = POLL_DEFAULT_FREQUENCY_SECONDS;
         try {
-            Object pollFrequenceSecondsObj = config.get(POLL_FREQUENCY);
+            Object pollFrequenceSecondsObj = config.get(POLL_INTERVAL);
             if (pollFrequenceSecondsObj != null) {
                 pollFrequenceSeconds = Integer.parseInt(pollFrequenceSecondsObj.toString());
             }
         } catch (NullPointerException | NumberFormatException e) {
             LOGGER.debug("Cannot parse value {} from key {}, will use default {}", pollFrequenceSecondsStr,
-                    POLL_FREQUENCY, pollFrequenceSeconds);
+                    POLL_INTERVAL, pollFrequenceSeconds);
         }
 
         scheduleToPollNetworkInterface(pollFrequenceSeconds);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -20,6 +20,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -537,6 +538,8 @@ public class NetUtil implements NetworkAddressService {
                 .filter(lastKnownInterfaceAddr -> !newInterfaceAddresses.contains(lastKnownInterfaceAddr))
                 .collect(Collectors.toList());
 
+        LOGGER.debug("detected {} new network interfaces: {}", added.size(), Arrays.deepToString(added.toArray()));
+        LOGGER.debug("removed {} network interfaces: {}", removed.size(), Arrays.deepToString(removed.toArray()));
         lastKnownInterfaceAddresses = newInterfaceAddresses;
 
         if (!added.isEmpty() || !removed.isEmpty()) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressChangeListener.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressChangeListener.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.net;
+
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * This is an interface that listens for the change of network address.
+ * There are only network address adds, and removes; it makes no effort to correlate
+ * which existing network is changed.
+ *
+ * @author Gary Tse
+ */
+@NonNullByDefault
+public interface NetworkAddressChangeListener {
+
+    /**
+     * When network address is changed, listeners will be notified by this method.
+     *
+     * @param added Unmodifiable list of recently added network addresses
+     * @param removed Unmodifiable list of recently removed network addresses
+     */
+    void onChanged(List<CidrAddress> added, List<CidrAddress> removed);
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressChangeListener.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressChangeListener.java
@@ -17,11 +17,14 @@ import java.util.List;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
- * This is an interface that listens for the change of network address.
+ * This is an interface for listeners who wants to be notified for the change of network address.
  * There are only network address adds, and removes; it makes no effort to correlate
- * which existing network is changed.
+ * which existing network is changed. Listeners should register themselves
+ * with this interface as a service.
  *
- * @author Gary Tse
+ * @see NetUtil
+ *
+ * @author Gary Tse - Initial contribution
  */
 @NonNullByDefault
 public interface NetworkAddressChangeListener {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressChangeListener.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressChangeListener.java
@@ -31,6 +31,8 @@ public interface NetworkAddressChangeListener {
 
     /**
      * When network address is changed, listeners will be notified by this method.
+     * When a network interface changes from "up" to "down", it is considered as "removed".
+     * When a "loopback" or "down" interface is added, the listeners are not notified.
      *
      * @param added Unmodifiable list of recently added network addresses
      * @param removed Unmodifiable list of recently removed network addresses

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressService.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.annotation.Nullable;
  * Interface that provides access to configured network addresses
  *
  * @author Stefan Triller - initial contribution
- * @author Gary Tse - Network address change listener
  *
  */
 @NonNullByDefault
@@ -43,18 +42,4 @@ public interface NetworkAddressService {
      */
     @Nullable
     String getConfiguredBroadcastAddress();
-
-    /**
-     * Add a listener that listens to change of network address of the network interfaces.
-     *
-     * @param listener
-     */
-    void addNetworkAddressChangeListener(NetworkAddressChangeListener listener);
-
-    /**
-     * Removes the listener to stop being notified about network address changes.
-     *
-     * @param listener
-     */
-    void removeNetworkAddressChangeListener(NetworkAddressChangeListener listener);
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressService.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.annotation.Nullable;
  * Interface that provides access to configured network addresses
  *
  * @author Stefan Triller - initial contribution
+ * @author Gary Tse - Network address change listener
  *
  */
 @NonNullByDefault
@@ -42,4 +43,18 @@ public interface NetworkAddressService {
      */
     @Nullable
     String getConfiguredBroadcastAddress();
+
+    /**
+     * Add a listener that listens to change of network address of the network interfaces.
+     *
+     * @param listener
+     */
+    void addNetworkAddressChangeListener(NetworkAddressChangeListener listener);
+
+    /**
+     * Removes the listener to stop being notified about network address changes.
+     *
+     * @param listener
+     */
+    void removeNetworkAddressChangeListener(NetworkAddressChangeListener listener);
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Import-Package:
  javax.jmdns,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.core.net,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.io.transport.mdns,
  org.eclipse.smarthome.io.transport.mdns.discovery,

--- a/docs/documentation/features/frameworkUtilities.md
+++ b/docs/documentation/features/frameworkUtilities.md
@@ -16,6 +16,7 @@ This service is useful for example in the `ThingHandlerFactory` or an `AudioSink
 Some static methods like `getAllBroadcastAddresses()` for retrieving all interface broadcast addresses or `getInterfaceAddresses()` for retrieving all assigned interface addresses might be usefull as well for discovery services.
 
 ### Network Address Change Listener
+
 The `NetworkAddressChangeListener` is a consumer type OSGi service interface. If listeners want to be notified about network interface address changes, they can implement `NetworkAddressChangeListener` and register as an OSGi service.
 
 Please be aware that not all network interface changes are notified to the listeners, only "useful" network interfaces :--

--- a/docs/documentation/features/frameworkUtilities.md
+++ b/docs/documentation/features/frameworkUtilities.md
@@ -15,6 +15,13 @@ This service is useful for example in the `ThingHandlerFactory` or an `AudioSink
 
 Some static methods like `getAllBroadcastAddresses()` for retrieving all interface broadcast addresses or `getInterfaceAddresses()` for retrieving all assigned interface addresses might be usefull as well for discovery services.
 
+### Network Address Change Listener
+The `NetworkAddressChangeListener` is a consumer type OSGi service interface. If listeners want to be notified about network interface address changes, they can implement `NetworkAddressChangeListener` and register as an OSGi service.
+
+Please be aware that not all network interface changes are notified to the listeners, only "useful" network interfaces :--
+When a network interface status changes from "up" to "down", it is considered as "removed".
+When a "loopback" or "down" interface is added, the listeners are not notified.
+
 ## Caching
 
 The framework provides some caching solutions for common scenarios.


### PR DESCRIPTION
Add a network interface address change listener into existing NetworkAddressService.  
The network interface address is polled regularly by a configurable cron expression. 

