### PR TITLE
Add strong reference to ECA in the contribution docs

### DIFF
--- a/docs/documentation/community/contributing.md
+++ b/docs/documentation/community/contributing.md
@@ -41,6 +41,7 @@ Bugs which are crucial for the security of the project should be reported as a s
 # Code Contributions
 
 If you want to become a contributor to the project, please check our guidelines first. If you can't wait to get your hands dirty have a look at the open issues where we [need your help](https://github.com/eclipse/smarthome/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) or one of the [open bugs](https://github.com/eclipse/smarthome/issues?q=is%3Aissue+is%3Aopen+label%3Abug).
+Be aware that you are required to sign the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php) in order for us to accept your contribution.
 
 ## Pull requests are always welcome
 
@@ -65,10 +66,11 @@ We recommend discussing your plans in the [Discussion Forum](https://www.eclipse
 The process to create a pull request is then the following:
 
 1. Create an account at Eclipse if you do not have one yet.
-1. Sign the Contributor License Agreement (CLA).
+1. Sign the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php).
+For legal reasons you are required to sign the ECA before we can accept your pull request.
 1. Fork the sources of Eclipse SmartHome on GitHub.
 1. Do the coding!
 1. Make sure your code applies to the [Coding Guidelines](../development/guidelines.html).
 1. Make sure there is a [GitHub issue](https://github.com/eclipse/smarthome/issues?utf8=%E2%9C%93&q=is%3Aissue) for your contribution. If it does not exist yet, [create one](https://github.com/eclipse/smarthome/issues/new).
-1. Add a "Signed-off-by" line and a ["Bug"](https://github.com/eclipse/smarthome/issues?utf8=%E2%9C%93&q=is%3Aissue) line to every commit you do - see the [Eclipse wiki](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git) for details.
+1. Add a "Signed-off-by" line to every commit you do - see the [Eclipse wiki here](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#Signing_off_on_a_commit) and [here](https://wiki.eclipse.org/Development_Resources/Contributing_via_Git#via_GitHub) for details.
 1. Create a pull request, referencing the GitHub issue number.


### PR DESCRIPTION
Due to recurring contributions w/o Signed-Off-By footer and invalid ECA this adds two references to the contribution docs. 

Signed-off-by: Henning Treu <henning.treu@telekom.de>