### PR TITLE
[core] Removed access to ConfigDescriptionValidator from BaseThingHandler

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/groovy/org/eclipse/smarthome/core/thing/binding/BindingBaseClassesOSGiTest.groovy
@@ -541,7 +541,7 @@ class BindingBaseClassesOSGiTest extends OSGiTest {
         assertThat thing.getConfiguration().get("parameter"), is("before")
 
         // let it fail next time...
-        thing.getHandler().callback = [thingUpdated: {updatedThing -> throw new IllegalStateException()}] as ThingHandlerCallback
+        thing.getHandler().callback = [validateConfigurationParameters: {updatedThing, configurationParameters -> }, thingUpdated: {updatedThing -> throw new IllegalStateException()}] as ThingHandlerCallback
         try {
             thingRegistry.updateConfiguration(thingUID, [parameter: "after"] as Map)
             fail("There should have been an exception!")

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/BaseThingHandler.java
@@ -35,7 +35,6 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
-import org.eclipse.smarthome.core.thing.type.ThingTypeRegistry;
 import org.eclipse.smarthome.core.thing.util.ThingHandlerHelper;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
@@ -78,10 +77,6 @@ public abstract class BaseThingHandler implements ThingHandler {
 
     @Deprecated // this must not be used by bindings!
     @NonNullByDefault({})
-    protected ThingTypeRegistry thingTypeRegistry;
-
-    @Deprecated // this must not be used by bindings!
-    @NonNullByDefault({})
     protected BundleContext bundleContext;
 
     protected Thing thing;
@@ -89,9 +84,6 @@ public abstract class BaseThingHandler implements ThingHandler {
     @SuppressWarnings("rawtypes")
     @NonNullByDefault({})
     private ServiceTracker thingRegistryServiceTracker;
-    @SuppressWarnings("rawtypes")
-    @NonNullByDefault({})
-    private ServiceTracker thingTypeRegistryServiceTracker;
 
     private @Nullable ThingHandlerCallback callback;
 
@@ -122,27 +114,10 @@ public abstract class BaseThingHandler implements ThingHandler {
             }
         };
         thingRegistryServiceTracker.open();
-        thingTypeRegistryServiceTracker = new ServiceTracker(this.bundleContext, ThingTypeRegistry.class.getName(),
-                null) {
-            @Override
-            public Object addingService(final @Nullable ServiceReference reference) {
-                thingTypeRegistry = (ThingTypeRegistry) bundleContext.getService(reference);
-                return thingTypeRegistry;
-            }
-
-            @Override
-            public void removedService(final @Nullable ServiceReference reference, final @Nullable Object service) {
-                synchronized (BaseThingHandler.this) {
-                    thingTypeRegistry = null;
-                }
-            }
-        };
-        thingTypeRegistryServiceTracker.open();
     }
 
     public void unsetBundleContext(final BundleContext bundleContext) {
         thingRegistryServiceTracker.close();
-        thingTypeRegistryServiceTracker.close();
         this.bundleContext = null;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
@@ -12,8 +12,11 @@
  */
 package org.eclipse.smarthome.core.thing.binding;
 
+import java.util.Map;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
@@ -66,6 +69,16 @@ public interface ThingHandlerCallback {
      * @throws IllegalStateException if the {@link Thing} is read-only.
      */
     void thingUpdated(Thing thing);
+
+    /**
+     * Validates the given configuration parameters against the configuration description.
+     *
+     * @param thing thing with the updated configuration (must no be null)
+     * @param configurationParameters the configuration parameters to be validated
+     * @throws ConfigValidationException if one or more of the given configuration parameters do not match
+     *             their declarations in the configuration description
+     */
+    void validateConfigurationParameters(Thing thing, Map<String, Object> configurationParameters);
 
     /**
      * Informs about an updated configuration of a thing.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -38,6 +38,7 @@ import org.eclipse.smarthome.config.core.ConfigDescription;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;
 import org.eclipse.smarthome.config.core.ConfigDescriptionRegistry;
 import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.config.core.validation.ConfigDescriptionValidator;
 import org.eclipse.smarthome.core.common.SafeCaller;
 import org.eclipse.smarthome.core.common.ThreadPoolManager;
 import org.eclipse.smarthome.core.common.registry.Identifiable;
@@ -257,6 +258,14 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
         }
 
         @Override
+        public void validateConfigurationParameters(Thing thing, Map<String, Object> configurationParameters) {
+            ThingType thingType = thingTypeRegistry.getThingType(thing.getThingTypeUID());
+            if (thingType != null && thingType.getConfigDescriptionURI() != null) {
+                configDescriptionValidator.validate(configurationParameters, thingType.getConfigDescriptionURI());
+            }
+        }
+
+        @Override
         public void configurationUpdated(Thing thing) {
             initializeHandler(thing);
         }
@@ -287,6 +296,7 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
     private BundleResolver bundleResolver;
 
     private ConfigDescriptionRegistry configDescriptionRegistry;
+    private ConfigDescriptionValidator configDescriptionValidator;
 
     private final Set<Thing> things = new CopyOnWriteArraySet<>();
 
@@ -1079,6 +1089,15 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
 
     protected void unsetConfigDescriptionRegistry(ConfigDescriptionRegistry configDescriptionRegistry) {
         this.configDescriptionRegistry = null;
+    }
+
+    @Reference
+    protected void setConfigDescriptionValidator(ConfigDescriptionValidator configDescriptionValidator) {
+        this.configDescriptionValidator = configDescriptionValidator;
+    }
+
+    protected void unsetConfigDescriptionValidator(ConfigDescriptionValidator configDescriptionValidator) {
+        this.configDescriptionValidator = null;
     }
 
     @Reference


### PR DESCRIPTION
- Moved `ConfigDescriptionValidator` from `BaseThingHandler` to `ThingHandlerCallback`
- Removed `ThingTypeRegistry` from `BaseThingHandler`

I crawled ESH / OH2 bindings for usage of the `configDescriptionValidator` and `thingTypeRegistry` but none of them uses the services in other ways.

In the light of #5182.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>