### PR TITLE
add Automatic-Module-Name

### DIFF
--- a/bundles/auth/org.eclipse.smarthome.auth.jaas/META-INF/MANIFEST.MF
+++ b/bundles/auth/org.eclipse.smarthome.auth.jaas/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.osgi.service.cm,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.auth.jaas

--- a/bundles/automation/org.eclipse.smarthome.automation.api/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/META-INF/MANIFEST.MF
@@ -29,3 +29,4 @@ Import-Package:
  org.eclipse.smarthome.core.storage,
  org.osgi.framework,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.automation.api

--- a/bundles/automation/org.eclipse.smarthome.automation.commands/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.commands/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.commands

--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.eclipse.smarthome.test.java,
  org.eclipse.smarthome.test.storage
 Require-Bundle: org.junit
+Automatic-Module-Name: org.eclipse.smarthome.automation.core.test

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
@@ -43,3 +43,4 @@ Require-Bundle:
  org.eclipse.smarthome.automation.parser.gson,
  org.eclipse.smarthome.automation.providers,
  org.junit
+Automatic-Module-Name: org.eclipse.smarthome.automation.event.test

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
@@ -47,3 +47,4 @@ Require-Bundle:
  org.eclipse.smarthome.automation.providers,
  org.eclipse.smarthome.io.console,
  org.junit
+Automatic-Module-Name: org.eclipse.smarthome.automation.integration.test

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Require-Bundle:
  org.eclipse.smarthome.automation.parser.gson,
  org.eclipse.smarthome.automation.providers,
  org.junit
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.core.test

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.core

--- a/bundles/automation/org.eclipse.smarthome.automation.module.media/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.media/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.media

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.script.defaultscope

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/META-INF/MANIFEST.MF
@@ -43,3 +43,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.script.rulesupport

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
@@ -45,3 +45,4 @@ Require-Bundle:
  org.eclipse.smarthome.automation.module.script.defaultscope,
  org.eclipse.smarthome.automation.parser.gson,
  org.eclipse.smarthome.automation.providers
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.script.test

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.script

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
@@ -46,3 +46,4 @@ Require-Bundle:
  org.eclipse.smarthome.automation.parser.gson,
  org.eclipse.smarthome.automation.providers,
  org.junit
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.timer.test

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Import-Package:
  org.eclipse.smarthome.core.scheduler,
  org.osgi.framework,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.automation.module.timer

--- a/bundles/automation/org.eclipse.smarthome.automation.parser.gson/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.parser.gson/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.eclipse.smarthome.core.common,
  org.osgi.framework
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.parser.gson

--- a/bundles/automation/org.eclipse.smarthome.automation.provider.file/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.provider.file/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.provider.file

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.providers

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.eclipse.smarthome.io.rest,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.rest

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Import-Package:
  org.eclipse.smarthome.io.console.extensions,
  org.osgi.framework,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.automation.sample.extension.java

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.osgi.service.event,
  org.osgi.util.tracker,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.automation.sample.extension.json

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package:
  org.osgi.service.http,
  org.osgi.util.tracker,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.automation.sample.rest.api

--- a/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Import-Package:
  org.mockito,
  org.mockito.invocation,
  org.mockito.stubbing
+Automatic-Module-Name: org.eclipse.smarthome.config.core.test

--- a/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
@@ -37,3 +37,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.config.core

--- a/bundles/config/org.eclipse.smarthome.config.discovery.mdns.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.mdns.test/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package:
  org.mockito.stubbing,
  org.mockito.verification,
  org.osgi.service.cm
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery.mdns.test

--- a/bundles/config/org.eclipse.smarthome.config.discovery.mdns/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.mdns/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery.mdns

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/META-INF/MANIFEST.MF
@@ -32,3 +32,4 @@ Import-Package:
  org.mockito.invocation,
  org.mockito.stubbing,
  org.mockito.verification
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery.test

--- a/bundles/config/org.eclipse.smarthome.config.discovery.upnp/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.upnp/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery.upnp

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package:
  org.mockito.invocation,
  org.mockito.stubbing,
  org.mockito.verification
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.test/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Import-Package:
  org.osgi.service.cm
 Export-Package: 
   org.eclipse.smarthome.config.discovery.usbserial.testutil
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery.usbserial.test

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.slf4j
 Service-Component: OSGI-INF/*.xml
 Eclipse-ExtensibleAPI: true
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery.usbserial

--- a/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
@@ -36,3 +36,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.config.discovery

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package:
  org.mockito,
  org.osgi.framework,
  org.osgi.service.component
+Automatic-Module-Name: org.eclipse.smarthome.config.dispatch.test

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package: com.google.gson,
  org.osgi.service.cm,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.config.dispatch

--- a/bundles/config/org.eclipse.smarthome.config.serial/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.serial/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.config.serial

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package:
  org.hamcrest;core=split,
  org.junit;version="4.0.0",
  org.osgi.service.component
+Automatic-Module-Name: org.eclipse.smarthome.config.xml.test

--- a/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml/META-INF/MANIFEST.MF
@@ -54,3 +54,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.config.xml

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Import-Package:
  org.hamcrest;core=split,
  org.junit,
  org.osgi.framework
+Automatic-Module-Name: org.eclipse.smarthome.core.audio.test

--- a/bundles/core/org.eclipse.smarthome.core.audio/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.audio/META-INF/MANIFEST.MF
@@ -33,3 +33,4 @@ Import-Package:
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.audio

--- a/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.autoupdate/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.slf4j
 Private-Package: org.eclipse.smarthome.core.autoupdate.internal
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.autoupdate

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.hamcrest;core=split,
  org.junit;version="4.0.0",
  org.osgi.service.cm
+Automatic-Module-Name: org.eclipse.smarthome.core.binding.xml.test

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.binding.xml

--- a/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.extension.sample/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Import-Package:
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.extension
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.extension.sample

--- a/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id.test/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.hamcrest;core=split,
  org.junit;version="4.0.0",
  org.osgi.framework
+Automatic-Module-Name: org.eclipse.smarthome.core.id.test

--- a/bundles/core/org.eclipse.smarthome.core.id/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.id/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.eclipse.smarthome.io.rest;resolution:=optional,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.id

--- a/bundles/core/org.eclipse.smarthome.core.persistence/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.persistence

--- a/bundles/core/org.eclipse.smarthome.core.scheduler/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.scheduler/META-INF/MANIFEST.MF
@@ -82,3 +82,4 @@ Import-Package:
  org.quartz.xml,
  org.slf4j
 Private-Package: org.eclipse.smarthome.core.scheduler.internal
+Automatic-Module-Name: org.eclipse.smarthome.core.scheduler

--- a/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Import-Package:
  org.mockito.invocation,
  org.mockito.stubbing,
  org.osgi.service.cm
+Automatic-Module-Name: org.eclipse.smarthome.core.test

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/META-INF/MANIFEST.MF
@@ -42,3 +42,4 @@ Import-Package:
  org.osgi.framework,
  org.osgi.service.cm,
  org.osgi.service.component
+Automatic-Module-Name: org.eclipse.smarthome.core.thing.test

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package: org.apache.commons.io,
  org.hamcrest.collection,
  org.junit;version="4.0.0",
  org.osgi.service.component
+Automatic-Module-Name: org.eclipse.smarthome.core.thing.xml.test

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.thing.xml

--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -73,3 +73,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.thing

--- a/bundles/core/org.eclipse.smarthome.core.transform.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.mockito.hamcrest,
  org.mockito.stubbing,
  org.osgi.service.cm
+Automatic-Module-Name: org.eclipse.smarthome.core.transform.test

--- a/bundles/core/org.eclipse.smarthome.core.transform/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.transform/META-INF/MANIFEST.MF
@@ -29,3 +29,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Private-Package: org.eclipse.smarthome.binding.http.internal
+Automatic-Module-Name: org.eclipse.smarthome.core.transform

--- a/bundles/core/org.eclipse.smarthome.core.voice.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.voice.test/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.junit.runner,
  org.junit.runners,
  org.osgi.service.cm
+Automatic-Module-Name: org.eclipse.smarthome.core.voice.test

--- a/bundles/core/org.eclipse.smarthome.core.voice/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.voice/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core.voice

--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -85,3 +85,4 @@ Private-Package: org.eclipse.smarthome.core.internal,org.eclipse.smartho
  me.core.internal.events,org.eclipse.smarthome.core.internal.items,org.e
  clipse.smarthome.core.internal.logging,org.eclipse.smarthome.core.internal.items.group
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.core

--- a/bundles/io/org.eclipse.smarthome.io.console.eclipse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.eclipse/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package:
  org.eclipse.smarthome.io.console.extensions,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.console.eclipse

--- a/bundles/io/org.eclipse.smarthome.io.console.rfc147/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console.rfc147/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.console.rfc147

--- a/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.console/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Import-Package:
  org.slf4j
 Originally-Created-By: Apache Maven Bundle Plugin
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.console

--- a/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.slf4j
 Private-Package: org.eclipse.smarthome.core.monitor.internal
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.monitor

--- a/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package:
  org.junit;version="4.0.0",
  org.mockito,
  org.mockito.stubbing
+Automatic-Module-Name: org.eclipse.smarthome.io.net.test

--- a/bundles/io/org.eclipse.smarthome.io.net/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net/META-INF/MANIFEST.MF
@@ -33,3 +33,4 @@ Import-Package:
  org.slf4j
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.net

--- a/bundles/io/org.eclipse.smarthome.io.rest.auth.basic/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.auth.basic/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.eclipse.smarthome.io.rest.auth,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.auth.basic

--- a/bundles/io/org.eclipse.smarthome.io.rest.auth/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.auth/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package:
  org.eclipse.smarthome.core.auth,
  org.eclipse.smarthome.io.rest.auth,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.auth

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/META-INF/MANIFEST.MF
@@ -49,3 +49,4 @@ Import-Package:
  org.mockito.invocation,
  org.mockito.stubbing,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.core.test

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -69,3 +69,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.core

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.eclipse.smarthome.io.rest,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.log

--- a/bundles/io/org.eclipse.smarthome.io.rest.mdns/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.mdns/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.mdns

--- a/bundles/io/org.eclipse.smarthome.io.rest.optimize/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.optimize/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.optimize

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap.test/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.mockito,
  org.mockito.stubbing,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.sitemap.test

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
@@ -35,3 +35,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.sitemap

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Import-Package:
  org.eclipse.smarthome.test,
  org.hamcrest;core=split,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.sse.test

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
@@ -48,3 +48,4 @@ Import-Package:
  org.osgi.service.event,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.sse

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Import-Package:
  org.hamcrest.object,
  org.junit;version="4.0.0",
  org.mockito
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.test

--- a/bundles/io/org.eclipse.smarthome.io.rest.voice/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.voice/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.eclipse.smarthome.io.rest,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.rest.voice

--- a/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
@@ -36,3 +36,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.rest

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.transport.mdns

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.mockito,
  org.mockito.invocation,
  org.mockito.stubbing
+Automatic-Module-Name: org.eclipse.smarthome.io.transport.mqtt.test

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.transport.mqtt

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Import-Package: javax.comm,
 Provide-Capability: osgi.service;objectClass:List<String>="org.eclipse
  .smarthome.io.transport.serial.SerialPortManager"
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.transport.serial.javacomm

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package: gnu.io,
 Service-Component: OSGI-INF/*.xml
 Provide-Capability: osgi.service;objectClass:List<String>="org.eclipse
  .smarthome.io.transport.serial.SerialPortManager"
+Automatic-Module-Name: org.eclipse.smarthome.io.transport.serial.rxtx

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Import-Package:
  org.osgi.service.cm,
  org.osgi.service.component,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.io.transport.serial

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.junit;version="4.0.0",
  org.mockito,
  org.mockito.stubbing
+Automatic-Module-Name: org.eclipse.smarthome.io.transport.upnp.test

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.transport.upnp

--- a/bundles/model/org.eclipse.smarthome.model.codegen/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.codegen/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Require-Bundle:
  org.eclipse.smarthome.model.thing,
  org.eclipse.xtext.generator,
  org.objectweb.asm;bundle-version="3.3.1";resolution:=optional
+Automatic-Module-Name: org.eclipse.smarthome.model.codegen

--- a/bundles/model/org.eclipse.smarthome.model.core.test/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.mockito.stubbing,
  org.osgi.framework,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.model.core.test

--- a/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.core/META-INF/MANIFEST.MF
@@ -37,3 +37,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.core

--- a/bundles/model/org.eclipse.smarthome.model.item.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.ide/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle:
  org.eclipse.smarthome.model.item,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.lib
+Automatic-Module-Name: org.eclipse.smarthome.model.item.ide

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.item
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.item.runtime

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/META-INF/MANIFEST.MF
@@ -33,3 +33,4 @@ Require-Bundle:
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtext.xbase.testing
+Automatic-Module-Name: org.eclipse.smarthome.model.item.tests

--- a/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.item/META-INF/MANIFEST.MF
@@ -57,3 +57,4 @@ Require-Bundle:
  org.eclipse.xtext.util,
  org.eclipse.xtext.xbase.lib
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.item

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle:
  org.eclipse.xtext,
  org.eclipse.xtext.ecore,
  org.eclipse.xtext.generator
+Automatic-Module-Name: org.eclipse.smarthome.model.lazygen

--- a/bundles/model/org.eclipse.smarthome.model.lsp.test/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lsp.test/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.junit.runners;version="4.0.0",
  org.mockito,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.model.lsp.test

--- a/bundles/model/org.eclipse.smarthome.model.lsp/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.lsp/META-INF/MANIFEST.MF
@@ -35,3 +35,4 @@ Require-Bundle: org.eclipse.smarthome.model.item.ide,
  org.eclipse.smarthome.model.sitemap,
  org.eclipse.smarthome.model.thing
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.lsp

--- a/bundles/model/org.eclipse.smarthome.model.persistence.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.ide/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Require-Bundle:
  org.eclipse.smarthome.model.persistence,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.lib
+Automatic-Module-Name: org.eclipse.smarthome.model.persistence.ide

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.persistence
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.persistence.runtime

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.joda.time,
  org.joda.time.base,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.model.persistence.tests

--- a/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/META-INF/MANIFEST.MF
@@ -67,3 +67,4 @@ Require-Bundle:
  ibility:=reexport,
  org.eclipse.xtext;bundle-version="2.1.0";visibility:=reexport
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.persistence

--- a/bundles/model/org.eclipse.smarthome.model.rule.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.ide/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle:
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
  org.eclipse.xtext.xbase.lib
+Automatic-Module-Name: org.eclipse.smarthome.model.rule.ide

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/META-INF/MANIFEST.MF
@@ -35,3 +35,4 @@ Import-Package:
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.rule
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.rule.runtime

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Require-Bundle:
  org.eclipse.xtend.lib,
  org.eclipse.xtext.xbase.lib,
  org.hamcrest
+Automatic-Module-Name: org.eclipse.smarthome.model.rule.tests

--- a/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.rule/META-INF/MANIFEST.MF
@@ -72,3 +72,4 @@ Require-Bundle:
  org.eclipse.xtext;visibility:=reexport,
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.rule

--- a/bundles/model/org.eclipse.smarthome.model.script.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.ide/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Require-Bundle:
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.ide,
  org.eclipse.xtext.xbase.lib
+Automatic-Module-Name: org.eclipse.smarthome.model.script.ide

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package:
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.script
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.script.runtime

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/META-INF/MANIFEST.MF
@@ -36,3 +36,4 @@ Require-Bundle:
  org.eclipse.core.runtime,
  org.eclipse.xtend.lib,
  org.eclipse.xtext.xbase.lib
+Automatic-Module-Name: org.eclipse.smarthome.model.script.tests

--- a/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.script/META-INF/MANIFEST.MF
@@ -85,3 +85,4 @@ Require-Bundle:
  org.eclipse.xtext;visibility:=reexport,
  org.objectweb.asm;resolution:=optional
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.script

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.ide/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle:
  org.eclipse.smarthome.model.sitemap,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.lib
+Automatic-Module-Name: org.eclipse.smarthome.model.sitemap.ide

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.sitemap
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.sitemap.runtime

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/META-INF/MANIFEST.MF
@@ -41,3 +41,4 @@ Require-Bundle:
  org.eclipse.xtext.util,
  org.eclipse.xtext.xbase.lib
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.sitemap

--- a/bundles/model/org.eclipse.smarthome.model.thing.ide/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.ide/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Require-Bundle:
  org.eclipse.smarthome.model.thing,
  org.eclipse.xtext.ide,
  org.eclipse.xtext.xbase.lib
+Automatic-Module-Name: org.eclipse.smarthome.model.thing.ide

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.slf4j
 Require-Bundle: org.eclipse.smarthome.model.thing
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.thing.runtime

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/META-INF/MANIFEST.MF
@@ -39,3 +39,4 @@ Import-Package:
 Require-Bundle: 
  org.eclipse.core.runtime
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.thing.tests

--- a/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.thing/META-INF/MANIFEST.MF
@@ -60,3 +60,4 @@ Require-Bundle:
  org.eclipse.xtext;visibility:=reexport,
  org.objectweb.asm;bundle-version="[5.0.1,6.0.0)";resolution:=optional
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.model.thing

--- a/bundles/storage/org.eclipse.smarthome.storage.json.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.json.test/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.hamcrest;core=split,
  org.junit.matchers;version="4.0.0",
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.storage.json.test

--- a/bundles/storage/org.eclipse.smarthome.storage.json/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package:
  org.osgi.service.event,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.storage.json

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.test.java,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.storage.mapdb.test

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Import-Package:
  org.osgi.service.event,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.storage.mapdb

--- a/bundles/test/org.eclipse.smarthome.magic.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic.test/META-INF/MANIFEST.MF
@@ -24,3 +24,4 @@ Import-Package:
  org.osgi.framework,
  org.osgi.service.device,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.magic.test

--- a/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
@@ -38,3 +38,4 @@ Import-Package:
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.magic

--- a/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
@@ -43,3 +43,4 @@ Require-Bundle:
  net.bytebuddy.byte-buddy-agent;bundle-version="1.7.0";
  visibility:=reexport,
  org.objenesis;bundle-version="2.6.0";visibility:=reexport
+Automatic-Module-Name: org.eclipse.smarthome.test

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package:
  org.eclipse.smarthome.test,
  org.hamcrest;core=split,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.ui.icon.test

--- a/bundles/ui/org.eclipse.smarthome.ui.icon/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Import-Package:
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.ui.icon

--- a/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.junit;version="4.0.0",
  org.mockito,
  org.mockito.stubbing
+Automatic-Module-Name: org.eclipse.smarthome.ui.test

--- a/bundles/ui/org.eclipse.smarthome.ui/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.eclipse.smarthome.ui/META-INF/MANIFEST.MF
@@ -51,3 +51,4 @@ Import-Package:
  org.slf4j
 Private-Package: org.eclipse.smarthome.ui.internal
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.ui

--- a/extensions/binding/org.eclipse.smarthome.binding.astro.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro.test/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Import-Package:
  org.mockito,
  org.mockito.stubbing,
  org.osgi.framework
+Automatic-Module-Name: org.eclipse.smarthome.binding.astro.test

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/META-INF/MANIFEST.MF
@@ -33,3 +33,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.astro

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluez/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluez/META-INF/MANIFEST.MF
@@ -35,3 +35,4 @@ Service-Component: OSGI-INF/*.xml
 Export-Package: org.eclipse.smarthome.binding.bluetooth.bluez,
  org.eclipse.smarthome.binding.bluetooth.bluez.handler
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.smarthome.binding.bluetooth.bluez

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.blukii/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.blukii/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Export-Package:
  org.eclipse.smarthome.binding.bluetooth.blukii,
  org.eclipse.smarthome.binding.bluetooth.blukii.handler
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.smarthome.binding.bluetooth.blukii

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.test/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package: org.eclipse.smarthome.binding.bluetooth,
  org.osgi.framework,
  org.osgi.service.device,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.binding.bluetooth.test

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Export-Package: org.eclipse.smarthome.binding.bluetooth,
  org.eclipse.smarthome.binding.bluetooth.discovery,
  org.eclipse.smarthome.binding.bluetooth.notification
 Bundle-ActivationPolicy: lazy
+Automatic-Module-Name: org.eclipse.smarthome.binding.bluetooth

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
@@ -37,3 +37,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.digitalstrom

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/META-INF/MANIFEST.MF
@@ -41,3 +41,4 @@ Import-Package:
  org.osgi.service.device,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.dmx.test

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.dmx

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/META-INF/MANIFEST.MF
@@ -32,3 +32,4 @@ Import-Package: javax.servlet,
  org.mockito,
  org.osgi.framework,
  org.osgi.service.http
+Automatic-Module-Name: org.eclipse.smarthome.binding.fsinternetradio.test

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
@@ -34,3 +34,4 @@ Import-Package:
  org.jupnp.model.meta,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.fsinternetradio

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/META-INF/MANIFEST.MF
@@ -31,3 +31,4 @@ Import-Package:
  org.mockito,
  org.mockito.stubbing,
  org.osgi.service.device
+Automatic-Module-Name: org.eclipse.smarthome.binding.hue.test

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/META-INF/MANIFEST.MF
@@ -32,3 +32,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.hue

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/META-INF/MANIFEST.MF
@@ -29,3 +29,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.lifx

--- a/extensions/binding/org.eclipse.smarthome.binding.lirc/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.lirc/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.lirc

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp.test/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Import-Package:
  org.mockito.stubbing,
  org.osgi.framework,
  org.osgi.service.component
+Automatic-Module-Name: org.eclipse.smarthome.binding.ntp.test

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
@@ -27,3 +27,4 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.ntp

--- a/extensions/binding/org.eclipse.smarthome.binding.serialbutton/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.serialbutton/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Import-Package:
  org.eclipse.smarthome.io.transport.serial,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.serialbutton

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
@@ -36,3 +36,4 @@ Import-Package:
  org.xml.sax,
  org.xml.sax.helpers
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.sonos

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
@@ -26,3 +26,4 @@ Import-Package:
  org.osgi.framework,
  org.osgi.service.device,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.binding.tradfri.test

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
@@ -39,3 +39,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.tradfri

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
@@ -32,3 +32,4 @@ Import-Package: com.google.common.collect,
  org.eclipse.smarthome.io.net.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.weatherunderground

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/META-INF/MANIFEST.MF
@@ -29,3 +29,4 @@ Import-Package:
  org.mockito.hamcrest,
  org.mockito.stubbing
 Require-Bundle: org.eclipse.smarthome.core
+Automatic-Module-Name: org.eclipse.smarthome.binding.wemo.test

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo/META-INF/MANIFEST.MF
@@ -34,3 +34,4 @@ Import-Package:
  org.w3c.dom,
  org.xml.sax
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.wemo

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
@@ -28,3 +28,4 @@ Import-Package: javax.measure,
  org.eclipse.smarthome.io.net.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.yahooweather

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.automation/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.extensionservice.marketplace.automation

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Import-Package:
  org.junit;version="4.0.0",
  org.mockito,
  org.mockito.stubbing
+Automatic-Module-Name: org.eclipse.smarthome.extensionservice.marketplace.test

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/META-INF/MANIFEST.MF
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace/META-INF/MANIFEST.MF
@@ -25,3 +25,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.extensionservice.marketplace

--- a/extensions/io/org.eclipse.smarthome.io.javasound/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.javasound/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.javasound

--- a/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker.test/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker.test/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package: org.eclipse.smarthome.core.common.registry,
  org.osgi.framework,
  org.osgi.service.device,
  org.slf4j
+Automatic-Module-Name: org.eclipse.smarthome.io.mqttembeddedbroker.test

--- a/extensions/io/org.eclipse.smarthome.io.webaudio/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.webaudio/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.osgi.service.component,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.webaudio

--- a/extensions/transform/org.eclipse.smarthome.transform.exec/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.eclipse.smarthome.io.net.exec,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.transform.exec

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.transform.javascript

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Import-Package:
  org.hamcrest;core=split,
  org.hamcrest.core,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.transform.jsonpath.test

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/META-INF/MANIFEST.MF
@@ -22,3 +22,4 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.transform.jsonpath

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
@@ -11,3 +11,4 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.hamcrest.core,
  org.junit
+Automatic-Module-Name: org.eclipse.smarthome.transform.map.test

--- a/extensions/transform/org.eclipse.smarthome.transform.map/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.transform.map

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Fragment-Host: org.eclipse.smarthome.transform.regex
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.transform.regex.test

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.transform.regex

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
@@ -10,3 +10,4 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.hamcrest.core,
  org.junit
+Automatic-Module-Name: org.eclipse.smarthome.transform.scale.test

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.transform.scale

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Fragment-Host: org.eclipse.smarthome.transform.xpath
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.transform.xpath.test

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.w3c.dom,
  org.xml.sax
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.transform.xpath

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Fragment-Host: org.eclipse.smarthome.transform.xslt
 Import-Package: 
  org.eclipse.jdt.annotation;resolution:=optional,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.transform.xslt.test

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package:
  org.eclipse.smarthome.core.types,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.transform.xslt

--- a/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/META-INF/MANIFEST.MF
+++ b/extensions/ui/iconset/org.eclipse.smarthome.ui.iconset.classic/META-INF/MANIFEST.MF
@@ -12,3 +12,4 @@ Import-Package:
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.ui.iconset.classic

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/META-INF/MANIFEST.MF
@@ -42,3 +42,4 @@ Import-Package:
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.ui.basic

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/META-INF/MANIFEST.MF
@@ -39,3 +39,4 @@ Import-Package:
  org.slf4j
 Private-Package: org.eclipse.smarthome.ui.webapp.internal
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.ui.classic

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/META-INF/MANIFEST.MF
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Import-Package:
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.ui.paper

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Import-Package:
  org.eclipse.smarthome.core.voice,
  org.hamcrest.core,
  org.junit;version="4.0.0"
+Automatic-Module-Name: org.eclipse.smarthome.voice.mactts.test

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Import-Package:
  org.eclipse.smarthome.core.voice,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.voice.mactts


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/5822