### PR TITLE
[Homematic] Provide duty cycle channel for homematic bridges (#5821)

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/ESH-INF/thing/bridge.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/ESH-INF/thing/bridge.xml
@@ -111,6 +111,6 @@
 		<item-type>Number</item-type>
 		<label>Duty Cycle</label>
 		<description>Current duty cycle usage</description>
-		<state readOnly="true" pattern="%d %%"/>
+		<state readOnly="true" min="0" max="100" pattern="%d %%"/>
 	</channel-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/ESH-INF/thing/bridge.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/ESH-INF/thing/bridge.xml
@@ -7,6 +7,11 @@
 	<bridge-type id="bridge">
 		<label>Homematic Bridge</label>
 		<description>The Homematic bridge represents a Homematic gateway</description>
+		
+		<channels>
+			<channel typeId="DUTY_CYCLE_RATIO" id="DUTY_CYCLE_RATIO"/>
+		</channels>
+		
 		<representation-property>serialNumber</representation-property>
 
 		<config-description>
@@ -101,4 +106,11 @@
 
 		</config-description>
 	</bridge-type>
+	
+	<channel-type id="DUTY_CYCLE_RATIO">
+		<item-type>Number</item-type>
+		<label>Duty Cycle</label>
+		<description>Current duty cycle usage</description>
+		<state readOnly="true" pattern="%d %%"/>
+	</channel-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/HomematicBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/HomematicBindingConstants.java
@@ -43,6 +43,8 @@ public class HomematicBindingConstants {
     public static final String ITEM_TYPE_DIMMER = "Dimmer";
     public static final String ITEM_TYPE_DATETIME = "DateTime";
 
+    public static final String CHANNEL_TYPE_DUTY_CYCLE_RATIO = "DUTY_CYCLE_RATIO";
+
     public static final String CATEGORY_BATTERY = "Battery";
     public static final String CATEGORY_ALARM = "Alarm";
     public static final String CATEGORY_HUMIDITY = "Humidity";

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/HomematicGatewayAdapter.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/HomematicGatewayAdapter.java
@@ -68,4 +68,9 @@ public interface HomematicGatewayAdapter {
      */
     public HmDatapointConfig getDatapointConfig(HmDatapoint dp);
 
+    /**
+     * Called when a new value for the duty cycle of the gateway has been received.
+     */
+    public void onDutyCycleRatioUpdate(int dutyCycleRatio);
+
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/parser/ListBidcosInterfacesParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/parser/ListBidcosInterfacesParser.java
@@ -24,6 +24,7 @@ public class ListBidcosInterfacesParser extends CommonRpcParser<Object[], ListBi
     private String type;
     private String gatewayAddress;
     private String firmware;
+    private Integer dutyCycleRatio;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -38,6 +39,7 @@ public class ListBidcosInterfacesParser extends CommonRpcParser<Object[], ListBi
                     type = toString(mapMessage.get("TYPE"));
                     firmware = toString(mapMessage.get("FIRMWARE_VERSION"));
                     gatewayAddress = getSanitizedAddress(mapMessage.get("ADDRESS"));
+                    dutyCycleRatio = toInteger(mapMessage.get("DUTY_CYCLE"));
                 }
             }
         }
@@ -63,5 +65,12 @@ public class ListBidcosInterfacesParser extends CommonRpcParser<Object[], ListBi
      */
     public String getFirmware() {
         return firmware;
+    }
+
+    /**
+     * Returns the duty cycle.
+     */
+    public Integer getDutyCycleRatio() {
+        return dutyCycleRatio;
     }
 }


### PR DESCRIPTION
- Introduces a new channel on the homematic bridge type called
DUTY_CYCLE_RATIO. The channel shows the current duty cycle usage of the
bridge in percent. The bridge is polled for this value every 15 seconds.

- When the bridge reports a duty cycle of 99% or more, the bridge goes
into the status "OFFLINE/DUTY_CYCLE" and goes back online once it drops
below this threshold.

This will make it easier to undersand for the user when the homematic
installation does not work due to the duty cycle.

Addresses issue #5821

Signed-off-by: Florian Stolte <fstolte@itemis.de>