### PR TITLE
add nullness annotations to JavaTest, JavaOSGiTest

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryOSGiTest.java
@@ -50,6 +50,7 @@ import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * {@link ThingRegistryOSGiTest} tests the {@link ThingRegistry}.
@@ -60,7 +61,7 @@ import org.junit.Test;
 public class ThingRegistryOSGiTest extends JavaOSGiTest {
 
     ManagedThingProvider managedThingProvider;
-    ThingHandlerFactory thingHandlerFactory;
+    ServiceRegistration<?> thingHandlerFactoryServiceReg;
 
     private static final ThingTypeUID THING_TYPE_UID = new ThingTypeUID("binding:type");
     private static final ThingUID THING_UID = new ThingUID(THING_TYPE_UID, "id");
@@ -241,13 +242,13 @@ public class ThingRegistryOSGiTest extends JavaOSGiTest {
 
     private void registerThingHandlerFactory(ThingHandlerFactory thingHandlerFactory) {
         unregisterCurrentThingHandlerFactory();
-        this.thingHandlerFactory = thingHandlerFactory;
-        registerService(thingHandlerFactory, ThingHandlerFactory.class.getName());
+        thingHandlerFactoryServiceReg = registerService(thingHandlerFactory, ThingHandlerFactory.class.getName());
     }
 
     private void unregisterCurrentThingHandlerFactory() {
-        if (this.thingHandlerFactory != null) {
-            unregisterService(thingHandlerFactory);
+        if (thingHandlerFactoryServiceReg != null) {
+            unregisterService(thingHandlerFactoryServiceReg);
+            thingHandlerFactoryServiceReg = null;
         }
     }
 

--- a/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/java/JavaOSGiTest.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/java/JavaOSGiTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.autoupdate.AutoUpdateBindingConfigProvider;
 import org.eclipse.smarthome.test.OSGiTest;
@@ -44,10 +45,11 @@ import org.osgi.framework.ServiceRegistration;
  *
  * @author Markus Rathgeb - Create a pure Java implementation based on the Groovy {@link OSGiTest} class
  */
+@NonNullByDefault
 public class JavaOSGiTest extends JavaTest {
 
     private final Map<String, List<ServiceRegistration<?>>> registeredServices = new HashMap<>();
-    protected BundleContext bundleContext;
+    protected @NonNullByDefault({}) BundleContext bundleContext;
 
     @Before
     public void bindBundleContext() {
@@ -56,14 +58,14 @@ public class JavaOSGiTest extends JavaTest {
     }
 
     /**
-     * Initialise the {@link BundleContext}, which is used for registration and unregistration of OSGi services.
+     * Initialize the {@link BundleContext}, which is used for registration and unregistration of OSGi services.
      *
      * <p>
      * This uses the bundle context of the test class itself.
      *
      * @return bundle context
      */
-    private BundleContext initBundleContext() {
+    private @Nullable BundleContext initBundleContext() {
         final Bundle bundle = FrameworkUtil.getBundle(this.getClass());
         if (bundle != null) {
             return bundle.getBundleContext();
@@ -72,7 +74,7 @@ public class JavaOSGiTest extends JavaTest {
         }
     }
 
-    private <T> T unrefService(final ServiceReference<T> serviceReference) {
+    private <T> @Nullable T unrefService(final @Nullable ServiceReference<T> serviceReference) {
         if (serviceReference == null) {
             return null;
         } else {
@@ -86,7 +88,7 @@ public class JavaOSGiTest extends JavaTest {
      * @param clazz class under which the OSGi service is registered
      * @return OSGi service or null if no service can be found for the given class
      */
-    protected <T> T getService(Class<T> clazz) {
+    protected <T> @Nullable T getService(Class<T> clazz) {
         @SuppressWarnings("unchecked")
         final ServiceReference<T> serviceReference = (ServiceReference<T>) bundleContext
                 .getServiceReference(clazz.getName());
@@ -106,7 +108,7 @@ public class JavaOSGiTest extends JavaTest {
      * @param filter
      * @return OSGi service or null if no service can be found for the given class
      */
-    protected <T> T getService(Class<T> clazz, Predicate<ServiceReference<T>> filter) {
+    protected <T> @Nullable T getService(Class<T> clazz, Predicate<ServiceReference<T>> filter) {
         final ServiceReference<T> serviceReferences[] = getServices(clazz);
 
         if (serviceReferences == null) {
@@ -129,7 +131,7 @@ public class JavaOSGiTest extends JavaTest {
         }
     }
 
-    private <T> ServiceReference<T>[] getServices(final Class<T> clazz) {
+    private <T> ServiceReference<T> @Nullable [] getServices(final Class<T> clazz) {
         try {
             @SuppressWarnings("unchecked")
             ServiceReference<T> serviceReferences[] = (ServiceReference<T>[]) bundleContext
@@ -147,7 +149,7 @@ public class JavaOSGiTest extends JavaTest {
      * @param implementationClass the implementation class
      * @return OSGi service or null if no service can be found for the given class
      */
-    protected <T, I extends T> I getService(Class<T> clazz, Class<I> implementationClass) {
+    protected <T, I extends T> @Nullable I getService(Class<T> clazz, Class<I> implementationClass) {
         @SuppressWarnings("unchecked")
         final I service = (I) getService(clazz, srvRef -> implementationClass.isInstance(unrefService(srvRef)));
         return service;
@@ -203,7 +205,7 @@ public class JavaOSGiTest extends JavaTest {
      * @return service registration object
      */
     protected ServiceRegistration<?> registerService(final Object service, final String interfaceName,
-            final Dictionary<String, ?> properties) {
+            final @Nullable Dictionary<String, ?> properties) {
         assertThat(interfaceName, is(notNullValue()));
         final ServiceRegistration<?> srvReg = bundleContext.registerService(interfaceName, service, properties);
         saveServiceRegistration(interfaceName, srvReg);
@@ -252,7 +254,7 @@ public class JavaOSGiTest extends JavaTest {
      * @param service the service
      * @return the service registration that was unregistered or null if no service could be found
      */
-    protected ServiceRegistration<?> unregisterService(final Object service) {
+    protected @Nullable ServiceRegistration<?> unregisterService(final Object service) {
         return unregisterService(getInterfaceName(service));
     }
 
@@ -262,7 +264,7 @@ public class JavaOSGiTest extends JavaTest {
      * @param interfaceName the interface name of the service
      * @return the first service registration that was unregistered or null if no service could be found
      */
-    protected ServiceRegistration<?> unregisterService(final String interfaceName) {
+    protected @Nullable ServiceRegistration<?> unregisterService(final String interfaceName) {
         ServiceRegistration<?> reg = null;
         List<ServiceRegistration<?>> regList = registeredServices.remove(interfaceName);
         if (regList != null) {
@@ -276,14 +278,16 @@ public class JavaOSGiTest extends JavaTest {
      * Returns the interface name for a given service object by choosing the first interface.
      *
      * @param service service object
-     * @return name of the first interface or null if the object has no interfaces
+     * @return name of the first interface if interfaces are implemented
+     * @throws IllegalArgumentException if no interface is implemented
      */
     protected String getInterfaceName(final Object service) {
         Class<?>[] classes = service.getClass().getInterfaces();
         if (classes.length >= 1) {
             return classes[0].getName();
         } else {
-            return null;
+            throw new IllegalArgumentException(String
+                    .format("The given reference (class: %s) does not implement an interface.", service.getClass()));
         }
     }
 

--- a/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/java/JavaTest.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/java/JavaTest.java
@@ -16,11 +16,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * {@link JavaTest} is an abstract base class for tests which are not necessarily based on OSGi.
  *
  * @author Simon Kaufmann - factored out of JavaOSGiTest
  */
+@NonNullByDefault
 public class JavaTest {
 
     protected static final int DFL_TIMEOUT = 10000;
@@ -112,7 +116,7 @@ public class JavaTest {
      * @param beforeLastCall logic to execute in front of the last call to ${code assertion}
      * @param sleepTime interval for checking the condition
      */
-    protected void waitForAssert(Runnable assertion, Runnable beforeLastCall, long timeout, long sleepTime) {
+    protected void waitForAssert(Runnable assertion, @Nullable Runnable beforeLastCall, long timeout, long sleepTime) {
         waitForAssert(assertion, beforeLastCall, null, timeout, sleepTime);
     }
 
@@ -124,16 +128,10 @@ public class JavaTest {
      * @param afterLastCall logic to execute after the last call to ${code assertion}
      * @param sleepTime interval for checking the condition
      */
-    protected void waitForAssert(Runnable assertion, Runnable beforeLastCall, Runnable afterLastCall, long timeout,
-            long sleepTime) {
+    protected void waitForAssert(Runnable assertion, @Nullable Runnable beforeLastCall,
+            @Nullable Runnable afterLastCall, long timeout, long sleepTime) {
         long waitingTime = 0;
         while (waitingTime < timeout) {
-            if (assertion == null) {
-                waitingTime += sleepTime;
-                internalSleep(sleepTime);
-                continue;
-            }
-
             try {
                 assertion.run();
 
@@ -162,6 +160,12 @@ public class JavaTest {
     /**
      * Useful for testing @NonNull annotated parameters
      *
+     * <p>
+     * This method can be used if you want to check the behavior of a method if you supply null to a non-null marked
+     * argument.
+     * If you use null directly the compiler will raise an error. Using this method allows you to work around that
+     * compiler check by using a null value that is marked as non-null.
+     *
      * @return null for testing purpose
      */
     protected static <T> T giveNull() {
@@ -176,7 +180,8 @@ public class JavaTest {
      * @param sleepTime interval for checking the condition
      * @return the return value of the supplied assertion object's function on success
      */
-    private <T> T waitForAssert(Supplier<T> assertion, Runnable beforeLastCall, long timeout, long sleepTime) {
+    private <T> T waitForAssert(Supplier<T> assertion, @Nullable Runnable beforeLastCall, long timeout,
+            long sleepTime) {
         final long timeoutNs = TimeUnit.MILLISECONDS.toNanos(timeout);
         final long startingTime = System.nanoTime();
         while (System.nanoTime() - startingTime < timeoutNs) {


### PR DESCRIPTION
**add nullness annotations to JavaTest**

There is a waitForAssert method that check if the given runnable
"assertion" is null on some place. So it seems it supports the usage of
a nullable reference. But later `assertion.run()` is called without
handling a null reference. I cannot find any LOC that uses a null
reference and so I leave that member non-null.

I identified a method used by the firmware tests that intention is only
to return null to workaround the nullness checks at compile time. I
improved the JavaDoc to explain its intention more detailed. I am not
sure if we should provide such a method at all, but I assume for testing
purposes it could perhaps make sense. So I leave it as it is. If we want
to use another logic and remove that method, it could be done in a
separate commit / PR later.