### PR TITLE
Make ItemRegistryImpl depend on the CoreItemFactory

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -660,4 +660,13 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         itemFactories.remove(itemFactory);
     }
 
+    @Reference(target = "(component.name=org.eclipse.smarthome.core.library.CoreItemFactory)")
+    protected void setCoreItemFactory(ItemFactory coreItemFactory) {
+        // do nothing - just depend on it
+    }
+
+    protected void unsetCoreItemFactory(ItemFactory coreItemFactory) {
+        // do nothing
+    }
+
 }


### PR DESCRIPTION
...in order to guarantee a correct lifecycle internally.

At least through the item builder, it implicitly has a dependency on it.
Of course, there might be other item factories available in the system,
but as far as I can see it is safe to say that this one is required to
be present.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>