### PR TITLE
[homematic] Fix for a potential NPE

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicBridgeHandler.java
@@ -341,17 +341,11 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
 
     @Override
     public void onDutyCycleRatioUpdate(int dutyCycleRatio) {
-        ThingHandlerCallback callback = getCallback();
-        if (callback == null) {
-            logger.debug(
-                    "Duty Cycle ratio update is skipped for the homematic bridge '{}' because the handler is not initialized yet.",
-                    thing.getUID());
-            return;
-        }
-
         synchronized (dutyCycleRatioUpdateLock) {
-            callback.stateUpdated(thing.getChannel(CHANNEL_TYPE_DUTY_CYCLE_RATIO).getUID(),
-                    new DecimalType(dutyCycleRatio));
+            Channel dutyCycleRatioChannel = thing.getChannel(CHANNEL_TYPE_DUTY_CYCLE_RATIO);
+            if (dutyCycleRatioChannel != null) {
+                this.updateState(dutyCycleRatioChannel.getUID(), new DecimalType(dutyCycleRatio));
+            }
 
             if (!isInDutyCycle && dutyCycleRatio >= DUTY_CYCLE_RATIO_LIMIT) {
                 logger.info("Duty cycle threshold exceeded by homematic bridge {}, it will go OFFLINE.",


### PR DESCRIPTION
This PR provides a small fix for a potential bug in the homematic binding that was introduced in the PR #5826.

If a bridge is created manually (e.g. via BridgeBuilder), it might not
have the DutyCycleRatio channel. In this case there was potential for a
NPE in onDutyCycleRatioUpdate(), which is fixed now.

Also, simplified the onDutyCycleRatioUpdate() method by using the convenience method
updateState(ChannelUID, State) of BaseThingHandler instead of accessing
the ThingHandlerCallback directly.

Signed-off-by: Florian Stolte <fstolte@itemis.de>