### PR TITLE
ManagedItemProvider depend on ManagedMetadataProvider

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ManagedItemProvider.java
@@ -297,4 +297,14 @@ public class ManagedItemProvider extends AbstractManagedProvider<Item, String, P
         super.unsetStorageService(storageService);
     }
 
+    @Reference
+    protected void setManagedMetadataProvider(ManagedMetadataProvider mmp) {
+        // no-op
+        // just make it a required dependency to ensure tags can be migrated successfully
+    }
+
+    protected void unsetManagedMetadataProvider(ManagedMetadataProvider mmp) {
+        // no-op
+    }
+
 }


### PR DESCRIPTION
...in order to allow the ItemRegistry to migrate tags successfully to their
new home.

Technically they are independent, but logically they are for this very reason.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>