### PR TITLE
Self-import org.eclipse.smarthome.automation.core.dto in the automation core bundle

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/META-INF/MANIFEST.MF
@@ -12,6 +12,7 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.core,
+ org.eclipse.smarthome.automation.core.dto,
  org.eclipse.smarthome.automation.core.util,
  org.eclipse.smarthome.automation.dto,
  org.eclipse.smarthome.automation.events,


### PR DESCRIPTION
Reason: "Every exported package of a bundle must be imported by the bundle itself again" according to https://www.eclipse.org/smarthome/documentation/development/guidelines.html.