### PR TITLE
[LIFX] Convert discovered Long properties to Strings

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightDiscovery.java
@@ -346,10 +346,10 @@ public class LifxLightDiscovery extends AbstractDiscoveryService {
 
         builder.withProperty(LifxBindingConstants.CONFIG_PROPERTY_DEVICE_ID, macAsLabel);
         builder.withProperty(LifxBindingConstants.PROPERTY_MAC_ADDRESS, macAsLabel);
-        builder.withProperty(LifxBindingConstants.PROPERTY_PRODUCT_ID, product.getProduct());
+        builder.withProperty(LifxBindingConstants.PROPERTY_PRODUCT_ID, Long.toString(product.getProduct()));
         builder.withProperty(LifxBindingConstants.PROPERTY_PRODUCT_NAME, product.getName());
-        builder.withProperty(LifxBindingConstants.PROPERTY_PRODUCT_VERSION, light.productVersion);
-        builder.withProperty(LifxBindingConstants.PROPERTY_VENDOR_ID, product.getVendor());
+        builder.withProperty(LifxBindingConstants.PROPERTY_PRODUCT_VERSION, Long.toString(light.productVersion));
+        builder.withProperty(LifxBindingConstants.PROPERTY_VENDOR_ID, Long.toString(product.getVendor()));
         builder.withProperty(LifxBindingConstants.PROPERTY_VENDOR_NAME, product.getVendorName());
 
         return builder.build();


### PR DESCRIPTION
The productId, productVersion and vendorId properties have Long values.
Without the proper String conversion the discovered property values would get a .0 suffix added.