### PR TITLE
Added '@Deprecated' annotation to the constructor of ChannelType

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelType.java
@@ -44,24 +44,12 @@ public class ChannelType extends AbstractDescriptionType {
     private final URI configDescriptionURI;
 
     /**
-     * Creates a new instance of this class with the specified parameters.
+     * @deprecated Use the {@link ChannelTypeBuilder} instead.
      *
-     * @param uid the unique identifier which identifies this Channel type within
-     *            the overall system (must neither be null, nor empty)
-     * @param advanced true if this channel type contains advanced features, otherwise false
-     * @param itemType the item type of this Channel type, e.g. {@code ColorItem} (must neither be null nor empty)
-     * @param label the human readable label for the according type
-     *            (must neither be null nor empty)
-     * @param description the human readable description for the according type
-     *            (could be null or empty)
-     * @param category the category of this Channel type, e.g. {@code TEMPERATURE} (could be null or empty)
-     * @param tags all tags of this {@link ChannelType}, e.g. {@code Alarm} (could be null or empty)
-     * @param state the restrictions of an item state which gives information how to interpret it
-     *            (could be null)
-     * @param configDescriptionURI the link to the concrete ConfigDescription (could be null)
      * @throws IllegalArgumentException if the UID or the item type is null or empty,
      *             or the the meta information is null
      */
+    @Deprecated
     public ChannelType(ChannelTypeUID uid, boolean advanced, String itemType, String label, String description,
             String category, Set<String> tags, StateDescription state, URI configDescriptionURI) {
         this(uid, advanced, itemType, ChannelKind.STATE, label, description, category, tags, state, null,


### PR DESCRIPTION
See https://github.com/eclipse/smarthome/pull/5855#issuecomment-403395204

Is this sufficient? Or shall we crawl the code to find and replace usages of the constructor itself?

CC @triller-telekom 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>