### PR TITLE
Restart jUPNP router after network change

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.upnp/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.upnp/META-INF/MANIFEST.MF
@@ -11,11 +11,13 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.discovery,
  org.eclipse.smarthome.config.discovery.upnp,
+ org.eclipse.smarthome.core.net,
  org.eclipse.smarthome.core.thing,
  org.jupnp,
  org.jupnp.controlpoint,
  org.jupnp.model.meta,
  org.jupnp.registry,
+ org.jupnp.transport,
  org.osgi.framework,
  org.osgi.service.component,
  org.slf4j

--- a/bundles/config/org.eclipse.smarthome.config.discovery.upnp/src/main/java/org/eclipse/smarthome/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.upnp/src/main/java/org/eclipse/smarthome/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.config.discovery.upnp.internal;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -22,6 +23,8 @@ import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.config.discovery.upnp.UpnpDiscoveryParticipant;
+import org.eclipse.smarthome.core.net.CidrAddress;
+import org.eclipse.smarthome.core.net.NetworkAddressChangeListener;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.jupnp.UpnpService;
@@ -29,6 +32,7 @@ import org.jupnp.model.meta.LocalDevice;
 import org.jupnp.model.meta.RemoteDevice;
 import org.jupnp.registry.Registry;
 import org.jupnp.registry.RegistryListener;
+import org.jupnp.transport.RouterException;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
@@ -45,8 +49,8 @@ import org.slf4j.LoggerFactory;
  * @author Andre Fuechsel - Added call of removeOlderResults
  *
  */
-@Component(immediate = true, service = DiscoveryService.class, configurationPid = "discovery.upnp")
-public class UpnpDiscoveryService extends AbstractDiscoveryService implements RegistryListener {
+@Component(immediate = true, service = {DiscoveryService.class, NetworkAddressChangeListener.class}, configurationPid = "discovery.upnp")
+public class UpnpDiscoveryService extends AbstractDiscoveryService implements RegistryListener, NetworkAddressChangeListener {
 
     private final Logger logger = LoggerFactory.getLogger(UpnpDiscoveryService.class);
 
@@ -210,6 +214,25 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService implements Re
                 logger.error("Participant '{}' threw an exception", participant.getClass().getName(), e);
             }
         }
+    }
+
+    @Override
+    public void onChanged(final List<CidrAddress> added, final List<CidrAddress> removed) {
+        scheduler.execute(() -> {
+            if (!removed.isEmpty()) {
+                upnpService.getRegistry().removeAllRemoteDevices();
+            }
+
+            try {
+                upnpService.getRouter().disable();
+                upnpService.getRouter().enable();
+
+                startScan();
+            } catch (RouterException e) {
+                logger.error("Could not retstart UPnP network components.", e);
+            }
+        });
+
     }
 
     @Override


### PR DESCRIPTION
Restart jUPNP router after network change. The router component of jUPNP needs to be restarted in order to recreate its UDP sockets otherwise it can't send or receive messages. 

If a network interface gets removed the UPNP registry is cleared in order to remove devices from the old network from the inbox.

Signed-off-by: velichko.stoykov <velichko.stoykov@musala.com>