### PR TITLE
fix project name

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/.project
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.smarthome.automation.sample.java.demo</name>
+	<name>org.eclipse.smarthome.automation.sample.json.demo</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
It seems the project file has been copied from
`automation.sample.java.demo` to `automation.sample.json.demo`
