### PR TITLE
[homematic] Improve Robustness of ThingHandler

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/GatewayNotAvailableException.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/GatewayNotAvailableException.java
@@ -13,14 +13,14 @@
 package org.eclipse.smarthome.binding.homematic.handler;
 
 /**
- * Exception if the BridgeHandler is not available.
+ * Exception if the HomematicGateway is not available.
  *
  * @author Gerhard Riegler - Initial contribution
  */
-public class BridgeHandlerNotAvailableException extends Exception {
+public class GatewayNotAvailableException extends Exception {
     private static final long serialVersionUID = 95628391238530L;
 
-    public BridgeHandlerNotAvailableException(String message) {
+    public GatewayNotAvailableException(String message) {
         super(message);
     }
 


### PR DESCRIPTION
The initialize() method of the HomematicThingHandler contained two cases in its exception handling that did not set a ThingStatus. However, a ThingHandler should always set a status during initialization, so that the thing does not stay in "INITIALIZE" indefinitely. Therefore, this PR improves the error handling of the ThingHandler so that this can never happen.

Moreover, the cause for the exception BridgeHandlerNotAvailableException should never be that the bridge handler is not available, since it is only thrown during/after thing initialization and the framework ensures that the handler of a bridge is initialized before the handler of any of its child things.
Renamed this exception to "GatewayNotAvailableException" since this better describes the scenario in which it might be thrown (which is only in the getHomematicGateway() method).

Signed-off-by: Florian Stolte <fstolte@itemis.de>