### PR TITLE
Annotate types with null annotations

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PointTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/PointTypeTest.java
@@ -23,12 +23,6 @@ import org.junit.Test;
 public class PointTypeTest {
 
     @Test(expected = IllegalArgumentException.class)
-    public void testConstructorNull() {
-        @SuppressWarnings("unused")
-        PointType errorGenerator = new PointType(null);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
     public void testConstructorEmpty() {
         @SuppressWarnings("unused")
         PointType errorGenerator = new PointType("");

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/StringTypeTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/library/types/StringTypeTest.java
@@ -22,17 +22,26 @@ import org.junit.Test;
 public class StringTypeTest {
 
     @Test
+    @SuppressWarnings("unlikely-arg-type")
     public void testEquals() {
         StringType empty = new StringType("");
         StringType expected1 = new StringType("expected1");
         StringType expected2 = new StringType("expected2");
 
         assertEquals(empty.hashCode(), StringType.EMPTY.hashCode());
+        assertEquals(empty.hashCode(), new StringType("").hashCode());
+        assertEquals(empty.hashCode(), new StringType().hashCode());
+        assertEquals(empty.hashCode(), new StringType(null).hashCode());
+
         assertEquals(expected1.hashCode(), new StringType("expected1").hashCode());
         assertEquals(expected2.hashCode(), new StringType("expected2").hashCode());
         assertFalse(expected1.hashCode() == new StringType("expected2").hashCode());
 
         assertEquals(empty, StringType.EMPTY);
+        assertEquals(empty, new StringType(""));
+        assertEquals(empty, new StringType());
+        assertEquals(empty, new StringType(null));
+
         assertEquals(expected1, new StringType("expected1"));
         assertEquals(expected2, new StringType("expected2"));
         assertEquals(false, expected1.equals(new StringType("expected2")));
@@ -44,8 +53,8 @@ public class StringTypeTest {
         assertEquals(false, expected1.equals("expected2"));
 
         assertEquals(true, new StringType(null).equals(new StringType(null)));
-        assertEquals(false, new StringType("").equals(new StringType(null)));
-        assertEquals(false, new StringType(null).equals(new StringType("")));
+        assertEquals(true, new StringType("").equals(new StringType(null)));
+        assertEquals(true, new StringType(null).equals(new StringType("")));
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemStateConverterImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemStateConverterImpl.java
@@ -91,6 +91,8 @@ public class ItemStateConverterImpl implements ItemStateConverter {
             } else {
                 State convertedState = state.as(DecimalType.class);
                 if (convertedState != null) {
+                    // convertedState is always returned because the state is an instance
+                    // of QuantityType which never returns null for as(DecimalType.class)
                     return convertedState;
                 }
             }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemStateConverterImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemStateConverterImpl.java
@@ -89,7 +89,10 @@ public class ItemStateConverterImpl implements ItemStateConverter {
 
                 return state;
             } else {
-                return state.as(DecimalType.class);
+                State convertedState = state.as(DecimalType.class);
+                if (convertedState != null) {
+                    return convertedState;
+                }
             }
         }
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DateTimeType.java
@@ -22,6 +22,8 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
@@ -32,6 +34,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Erdoan Hadzhiyusein - Refactored to use ZonedDateTime
  * @author Jan N. Klug - add ability to use time or date only
  */
+@NonNullByDefault
 public class DateTimeType implements PrimitiveType, State, Command {
 
     // external format patterns for output
@@ -98,9 +101,7 @@ public class DateTimeType implements PrimitiveType, State, Command {
             throw new IllegalArgumentException(zonedValue + " is not in a valid format.", invalidFormatException);
         }
 
-        if (date != null) {
-            zonedDateTime = date;
-        }
+        zonedDateTime = date;
     }
 
     /**
@@ -120,7 +121,7 @@ public class DateTimeType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public String format(String pattern) {
+    public String format(@Nullable String pattern) {
         if (pattern == null) {
             return DateTimeFormatter.ofPattern(DATE_PATTERN).format(zonedDateTime);
         }
@@ -151,7 +152,7 @@ public class DateTimeType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/DecimalType.java
@@ -15,6 +15,8 @@ package org.eclipse.smarthome.core.library.types;
 import java.math.BigDecimal;
 import java.util.IllegalFormatConversionException;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
@@ -26,6 +28,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public class DecimalType extends Number implements PrimitiveType, State, Command, Comparable<DecimalType> {
 
     private static final long serialVersionUID = 4226845847123464690L;
@@ -99,7 +102,7 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }
@@ -145,12 +148,12 @@ public class DecimalType extends Number implements PrimitiveType, State, Command
         return value.longValue();
     }
 
-    protected <T extends State> T defaultConversion(Class<T> target) {
+    protected <T extends State> @Nullable T defaultConversion(@Nullable Class<T> target) {
         return State.super.as(target);
     }
 
     @Override
-    public <T extends State> T as(Class<T> target) {
+    public <T extends State> @Nullable T as(@Nullable Class<T> target) {
         if (target == OnOffType.class) {
             return target.cast(equals(ZERO) ? OnOffType.OFF : OnOffType.ON);
         } else if (target == PercentType.class) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -20,6 +20,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.ComplexType;
 import org.eclipse.smarthome.core.types.PrimitiveType;
@@ -33,6 +35,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Chris Jackson - Added fromRGB
  *
  */
+@NonNullByDefault
 public class HSBType extends PercentType implements ComplexType, State, Command {
 
     private static final long serialVersionUID = 322902950356613226L;
@@ -71,18 +74,13 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
     }
 
     public HSBType(String value) {
-        if (value != null) {
-            List<String> constituents = Arrays.stream(value.split(",")).map(in -> in.trim())
-                    .collect(Collectors.toList());
-            if (constituents.size() == 3) {
-                this.hue = new BigDecimal(constituents.get(0));
-                this.saturation = new BigDecimal(constituents.get(1));
-                this.value = new BigDecimal(constituents.get(2));
-            } else {
-                throw new IllegalArgumentException(value + " is not a valid HSBType syntax");
-            }
+        List<String> constituents = Arrays.stream(value.split(",")).map(in -> in.trim()).collect(Collectors.toList());
+        if (constituents.size() == 3) {
+            this.hue = new BigDecimal(constituents.get(0));
+            this.saturation = new BigDecimal(constituents.get(1));
+            this.value = new BigDecimal(constituents.get(2));
         } else {
-            throw new IllegalArgumentException("Constructor argument must not be null");
+            throw new IllegalArgumentException(value + " is not a valid HSBType syntax");
         }
     }
 
@@ -163,8 +161,8 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
     }
 
     @Override
-    public SortedMap<String, PrimitiveType> getConstituents() {
-        TreeMap<String, PrimitiveType> map = new TreeMap<String, PrimitiveType>();
+    public SortedMap<String, @Nullable PrimitiveType> getConstituents() {
+        TreeMap<String, @Nullable PrimitiveType> map = new TreeMap<>();
         map.put(KEY_HUE, getHue());
         map.put(KEY_SATURATION, getSaturation());
         map.put(KEY_BRIGHTNESS, getBrightness());
@@ -220,14 +218,14 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
 
     @Override
     public int hashCode() {
-        int tmp = 10000 * (getHue() == null ? 0 : getHue().hashCode());
-        tmp += 100 * (getSaturation() == null ? 0 : getSaturation().hashCode());
-        tmp += (getBrightness() == null ? 0 : getBrightness().hashCode());
+        int tmp = 10000 * getHue().hashCode();
+        tmp += 100 * getSaturation().hashCode();
+        tmp += getBrightness().hashCode();
         return tmp;
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }
@@ -238,13 +236,6 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
             return false;
         }
         HSBType other = (HSBType) obj;
-        if ((getHue() != null && other.getHue() == null) || (getHue() == null && other.getHue() != null)
-                || (getSaturation() != null && other.getSaturation() == null)
-                || (getSaturation() == null && other.getSaturation() != null)
-                || (getBrightness() != null && other.getBrightness() == null)
-                || (getBrightness() == null && other.getBrightness() != null)) {
-            return false;
-        }
         if (!getHue().equals(other.getHue()) || !getSaturation().equals(other.getSaturation())
                 || !getBrightness().equals(other.getBrightness())) {
             return false;
@@ -364,7 +355,7 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
     }
 
     @Override
-    public <T extends State> T as(Class<T> target) {
+    public <T extends State> @Nullable T as(@Nullable Class<T> target) {
         if (target == OnOffType.class) {
             // if brightness is not completely off, we consider the state to be on
             return target.cast(getBrightness().equals(PercentType.ZERO) ? OnOffType.OFF : OnOffType.ON);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/HSBType.java
@@ -161,8 +161,8 @@ public class HSBType extends PercentType implements ComplexType, State, Command 
     }
 
     @Override
-    public SortedMap<String, @Nullable PrimitiveType> getConstituents() {
-        TreeMap<String, @Nullable PrimitiveType> map = new TreeMap<>();
+    public SortedMap<String, PrimitiveType> getConstituents() {
+        TreeMap<String, PrimitiveType> map = new TreeMap<>();
         map.put(KEY_HUE, getHue());
         map.put(KEY_SATURATION, getSaturation());
         map.put(KEY_BRIGHTNESS, getBrightness());

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/IncreaseDecreaseType.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 
@@ -19,6 +20,7 @@ import org.eclipse.smarthome.core.types.PrimitiveType;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public enum IncreaseDecreaseType implements PrimitiveType, Command {
     INCREASE,
     DECREASE;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/NextPreviousType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/NextPreviousType.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.items.PlayerItem;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
@@ -21,6 +22,7 @@ import org.eclipse.smarthome.core.types.PrimitiveType;
  *
  * @author Alex Tugarev
  */
+@NonNullByDefault
 public enum NextPreviousType implements PrimitiveType, Command {
     NEXT,
     PREVIOUS;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OnOffType.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
@@ -20,6 +22,7 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public enum OnOffType implements PrimitiveType, State, Command {
     ON,
     OFF;
@@ -40,7 +43,7 @@ public enum OnOffType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public <T extends State> T as(Class<T> target) {
+    public <T extends State> @Nullable T as(@Nullable Class<T> target) {
         if (target == DecimalType.class) {
             return target.cast(this == ON ? new DecimalType(1) : DecimalType.ZERO);
         } else if (target == PercentType.class) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/OpenClosedType.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
@@ -20,6 +22,7 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public enum OpenClosedType implements PrimitiveType, State, Command {
     OPEN,
     CLOSED;
@@ -40,7 +43,7 @@ public enum OpenClosedType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public <T extends State> T as(Class<T> target) {
+    public <T extends State> @Nullable T as(@Nullable Class<T> target) {
         if (target == DecimalType.class) {
             return target.cast(this == OPEN ? new DecimalType(1) : DecimalType.ZERO);
         } else if (target == PercentType.class) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PercentType.java
@@ -15,6 +15,8 @@ package org.eclipse.smarthome.core.library.types;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.types.State;
 
@@ -24,6 +26,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public class PercentType extends DecimalType {
 
     private static final long serialVersionUID = -9066279845951780879L;
@@ -61,7 +64,7 @@ public class PercentType extends DecimalType {
     }
 
     @Override
-    public <T extends State> T as(Class<T> target) {
+    public <T extends State> @Nullable T as(@Nullable Class<T> target) {
         if (target == OnOffType.class) {
             return target.cast(equals(ZERO) ? OnOffType.OFF : OnOffType.ON);
         } else if (target == DecimalType.class) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PlayPauseType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PlayPauseType.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.items.PlayerItem;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
@@ -22,6 +23,7 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Alex Tugarev
  */
+@NonNullByDefault
 public enum PlayPauseType implements PrimitiveType, State, Command {
     PLAY,
     PAUSE;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
@@ -180,8 +180,8 @@ public class PointType implements ComplexType, Command, State {
     }
 
     @Override
-    public SortedMap<String, @Nullable PrimitiveType> getConstituents() {
-        SortedMap<String, @Nullable PrimitiveType> result = new TreeMap<>();
+    public SortedMap<String, PrimitiveType> getConstituents() {
+        SortedMap<String, PrimitiveType> result = new TreeMap<>();
         result.put(KEY_LATITUDE, getLatitude());
         result.put(KEY_LONGITUDE, getLongitude());
         result.put(KEY_ALTITUDE, getAltitude());

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/PointType.java
@@ -19,6 +19,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.ComplexType;
 import org.eclipse.smarthome.core.types.PrimitiveType;
@@ -32,6 +34,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author John Cocula
  *
  */
+@NonNullByDefault
 public class PointType implements ComplexType, Command, State {
 
     public static final double EARTH_GRAVITATIONAL_CONSTANT = 3.986004418e14;
@@ -78,9 +81,6 @@ public class PointType implements ComplexType, Command, State {
     }
 
     public PointType(String value) {
-        if (value == null) {
-            throw new IllegalArgumentException("Constructor argument must not be null");
-        }
         if (!value.isEmpty()) {
             List<String> elements = Arrays.stream(value.split(",")).map(in -> in.trim()).collect(Collectors.toList());
             if (elements.size() >= 2) {
@@ -180,8 +180,8 @@ public class PointType implements ComplexType, Command, State {
     }
 
     @Override
-    public SortedMap<String, PrimitiveType> getConstituents() {
-        SortedMap<String, PrimitiveType> result = new TreeMap<String, PrimitiveType>();
+    public SortedMap<String, @Nullable PrimitiveType> getConstituents() {
+        SortedMap<String, @Nullable PrimitiveType> result = new TreeMap<>();
         result.put(KEY_LATITUDE, getLatitude());
         result.put(KEY_LONGITUDE, getLongitude());
         result.put(KEY_ALTITUDE, getAltitude());
@@ -221,14 +221,14 @@ public class PointType implements ComplexType, Command, State {
 
     @Override
     public int hashCode() {
-        int tmp = 10000 * (getLatitude() == null ? 0 : getLatitude().hashCode());
-        tmp += 100 * (getLongitude() == null ? 0 : getLongitude().hashCode());
-        tmp += (getAltitude() == null ? 0 : getAltitude().hashCode());
+        int tmp = 10000 * getLatitude().hashCode();
+        tmp += 100 * getLongitude().hashCode();
+        tmp += getAltitude().hashCode();
         return tmp;
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }
@@ -239,14 +239,6 @@ public class PointType implements ComplexType, Command, State {
             return false;
         }
         PointType other = (PointType) obj;
-        if ((getLatitude() != null && other.getLatitude() == null)
-                || (getLatitude() == null && other.getLatitude() != null)
-                || (getLongitude() != null && other.getLongitude() == null)
-                || (getLongitude() == null && other.getLongitude() != null)
-                || (getAltitude() != null && other.getAltitude() == null)
-                || (getAltitude() == null && other.getAltitude() != null)) {
-            return false;
-        }
         if (!getLatitude().equals(other.getLatitude()) || !getLongitude().equals(other.getLongitude())
                 || !getAltitude().equals(other.getAltitude())) {
             return false;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
@@ -278,7 +278,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
     }
 
     @Override
-    public <U extends State> U as(@Nullable Class<U> target) {
+    public <U extends State> @Nullable U as(@Nullable Class<U> target) {
         if (target == OnOffType.class) {
             if (intValue() == 0) {
                 return target.cast(OnOffType.OFF);

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RawType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RawType.java
@@ -15,6 +15,8 @@ package org.eclipse.smarthome.core.library.types;
 import java.util.Arrays;
 import java.util.Base64;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
 
@@ -26,6 +28,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Laurent Garnier - add MIME type
  *
  */
+@NonNullByDefault
 public class RawType implements PrimitiveType, State {
 
     public static final String DEFAULT_MIME_TYPE = "application/octet-stream";
@@ -44,9 +47,7 @@ public class RawType implements PrimitiveType, State {
     }
 
     public RawType(byte[] bytes, String mimeType) {
-        if (mimeType == null) {
-            throw new IllegalArgumentException("mimeType argument must not be null");
-        } else if (mimeType.isEmpty()) {
+        if (mimeType.isEmpty()) {
             throw new IllegalArgumentException("mimeType argument must not be blank");
         }
         this.bytes = bytes;
@@ -63,9 +64,7 @@ public class RawType implements PrimitiveType, State {
 
     public static RawType valueOf(String value) {
         int idx, idx2;
-        if (value == null) {
-            throw new IllegalArgumentException("Argument must not be null");
-        } else if (value.isEmpty()) {
+        if (value.isEmpty()) {
             throw new IllegalArgumentException("Argument must not be blank");
         } else if (!value.startsWith("data:") || ((idx = value.indexOf(",")) < 0)) {
             throw new IllegalArgumentException("Invalid data URI syntax for argument " + value);
@@ -99,7 +98,7 @@ public class RawType implements PrimitiveType, State {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RewindFastforwardType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/RewindFastforwardType.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.items.PlayerItem;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
@@ -22,6 +23,7 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Alex Tugarev
  */
+@NonNullByDefault
 public enum RewindFastforwardType implements PrimitiveType, State, Command {
     REWIND,
     FASTFORWARD;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StopMoveType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StopMoveType.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.core.library.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 
@@ -19,6 +20,7 @@ import org.eclipse.smarthome.core.types.PrimitiveType;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public enum StopMoveType implements PrimitiveType, Command {
     STOP,
     MOVE;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringListType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringListType.java
@@ -19,6 +19,7 @@ import java.util.Formatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 
@@ -29,6 +30,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Gaël L'hopital - port to Eclipse SmartHome
  *
  */
+@NonNullByDefault
 public class StringListType implements Command, State {
 
     protected List<String> typeDetails;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/StringType.java
@@ -14,6 +14,8 @@ package org.eclipse.smarthome.core.library.types;
 
 import java.util.Objects;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
@@ -22,6 +24,7 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public class StringType implements PrimitiveType, State, Command {
 
     public static final StringType EMPTY = new StringType();
@@ -32,8 +35,8 @@ public class StringType implements PrimitiveType, State, Command {
         this("");
     }
 
-    public StringType(String value) {
-        this.value = value;
+    public StringType(@Nullable String value) {
+        this.value = value != null ? value : "";
     }
 
     @Override
@@ -46,7 +49,7 @@ public class StringType implements PrimitiveType, State, Command {
         return value;
     }
 
-    public static StringType valueOf(String value) {
+    public static StringType valueOf(@Nullable String value) {
         return new StringType(value);
     }
 
@@ -61,7 +64,7 @@ public class StringType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/UpDownType.java
@@ -14,6 +14,8 @@ package org.eclipse.smarthome.core.library.types;
 
 import java.math.BigDecimal;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.PrimitiveType;
 import org.eclipse.smarthome.core.types.State;
@@ -22,6 +24,7 @@ import org.eclipse.smarthome.core.types.State;
  *
  * @author Kai Kreuzer - Initial contribution
  */
+@NonNullByDefault
 public enum UpDownType implements PrimitiveType, State, Command {
     UP,
     DOWN;
@@ -42,7 +45,7 @@ public enum UpDownType implements PrimitiveType, State, Command {
     }
 
     @Override
-    public <T extends State> T as(Class<T> target) {
+    public <T extends State> @Nullable T as(@Nullable Class<T> target) {
         if (target == DecimalType.class) {
             return target.cast(equals(UP) ? DecimalType.ZERO : new DecimalType(new BigDecimal("1.0")));
         } else if (target == PercentType.class) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Command.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Command.java
@@ -12,12 +12,15 @@
  */
 package org.eclipse.smarthome.core.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * This is a marker interface for all command types.
  *
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public interface Command extends Type {
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/ComplexType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/ComplexType.java
@@ -15,7 +15,6 @@ package org.eclipse.smarthome.core.types;
 import java.util.SortedMap;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
-import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * A complex type consists out of a sorted list of primitive constituents.
@@ -32,6 +31,6 @@ public interface ComplexType extends Type {
      *
      * @return all constituents with their names
      */
-    public SortedMap<String, @Nullable PrimitiveType> getConstituents();
+    public SortedMap<String, PrimitiveType> getConstituents();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/ComplexType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/ComplexType.java
@@ -14,6 +14,9 @@ package org.eclipse.smarthome.core.types;
 
 import java.util.SortedMap;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * A complex type consists out of a sorted list of primitive constituents.
  * Each constituent can be referred to by a unique name.
@@ -21,13 +24,14 @@ import java.util.SortedMap;
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public interface ComplexType extends Type {
 
     /**
      * Returns all constituents with their names as a sorted map
-     * 
+     *
      * @return all constituents with their names
      */
-    public SortedMap<String, PrimitiveType> getConstituents();
+    public SortedMap<String, @Nullable PrimitiveType> getConstituents();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/EventType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/EventType.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * Due to the duality of some types (which can be states and commands at the
  * same time), we need to be able to differentiate what the meaning of a
@@ -22,9 +24,11 @@ package org.eclipse.smarthome.core.types;
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public enum EventType {
 
-    COMMAND("command"), UPDATE("update");
+    COMMAND("command"),
+    UPDATE("update");
 
     private String name;
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/PrimitiveType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/PrimitiveType.java
@@ -12,12 +12,15 @@
  */
 package org.eclipse.smarthome.core.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * A primitive type consists of a single value like a string, a number, etc.
  *
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public interface PrimitiveType extends Type {
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/RefreshType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/RefreshType.java
@@ -12,10 +12,13 @@
  */
 package org.eclipse.smarthome.core.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  *
  * @author Oliver Libutzki - Initial contribution
  */
+@NonNullByDefault
 public enum RefreshType implements PrimitiveType, Command {
 
     REFRESH;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/State.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/State.java
@@ -12,12 +12,16 @@
  */
 package org.eclipse.smarthome.core.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
 /**
  * This is a marker interface for all state types.
  *
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public interface State extends Type {
 
     /**
@@ -27,7 +31,7 @@ public interface State extends Type {
      * @return the {@link State}'s value in the given type's representation, or <code>null</code> if the conversion was
      *         not possible
      */
-    default <T extends State> T as(Class<T> target) {
+    default <T extends @Nullable State> @Nullable T as(@Nullable Class<T> target) {
         if (target != null && target.isInstance(this)) {
             return target.cast(this);
         } else {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Type.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/Type.java
@@ -14,6 +14,8 @@ package org.eclipse.smarthome.core.types;
 
 import java.util.Formatter;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * This is a parent interface for all states and commands.
  * It was introduced as many states can be commands at the same time and
@@ -25,6 +27,7 @@ import java.util.Formatter;
  * @author Kai Kreuzer - Initial contribution and API
  * @author Markus Rathgeb - Add the simple and full type string methods
  */
+@NonNullByDefault
 public interface Type {
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/UnDefType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/UnDefType.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.core.types;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
 /**
  * There are situations when item states do not have any defined value.
  * This might be because they have not been initialized yet (never
@@ -22,6 +24,7 @@ package org.eclipse.smarthome.core.types;
  * @author Kai Kreuzer - Initial contribution and API
  *
  */
+@NonNullByDefault
 public enum UnDefType implements PrimitiveType, State {
     UNDEF,
     NULL;

--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/HttpUtil.java
@@ -81,8 +81,8 @@ public class HttpUtil {
      * set into the {@link HttpClient}.
      *
      * @param httpMethod the HTTP method to use
-     * @param url        the url to execute
-     * @param timeout    the socket timeout in milliseconds to wait for data
+     * @param url the url to execute
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -95,12 +95,12 @@ public class HttpUtil {
      * Furthermore the <code>http.proxyXXX</code> System variables are read and
      * set into the {@link HttpClient}.
      *
-     * @param httpMethod  the HTTP method to use
-     * @param url         the url to execute
-     * @param content     the content to be sent to the given <code>url</code> or <code>null</code> if no content should
-     *                        be sent.
+     * @param httpMethod the HTTP method to use
+     * @param url the url to execute
+     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should
+     *            be sent.
      * @param contentType the content type of the given <code>content</code>
-     * @param timeout     the socket timeout in milliseconds to wait for data
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -114,13 +114,13 @@ public class HttpUtil {
      * Furthermore the <code>http.proxyXXX</code> System variables are read and
      * set into the {@link HttpClient}.
      *
-     * @param httpMethod  the HTTP method to use
-     * @param url         the url to execute
+     * @param httpMethod the HTTP method to use
+     * @param url the url to execute
      * @param httpHeaders optional http request headers which has to be sent within request
-     * @param content     the content to be sent to the given <code>url</code> or <code>null</code> if no content should
-     *                        be sent.
+     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content should
+     *            be sent.
      * @param contentType the content type of the given <code>content</code>
-     * @param timeout     the socket timeout in milliseconds to wait for data
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return the response body or <code>NULL</code> when the request went wrong
      * @throws IOException when the request execution failed, timed out or it was interrupted
      */
@@ -135,16 +135,16 @@ public class HttpUtil {
     /**
      * Executes the given <code>url</code> with the given <code>httpMethod</code>
      *
-     * @param httpMethod    the HTTP method to use
-     * @param url           the url to execute
-     * @param httpHeaders   optional HTTP headers which has to be set on request
-     * @param content       the content to be sent to the given <code>url</code> or <code>null</code> if no content
-     *                          should be sent.
-     * @param contentType   the content type of the given <code>content</code>
-     * @param timeout       the socket timeout in milliseconds to wait for data
-     * @param proxyHost     the hostname of the proxy
-     * @param proxyPort     the port of the proxy
-     * @param proxyUser     the username to authenticate with the proxy
+     * @param httpMethod the HTTP method to use
+     * @param url the url to execute
+     * @param httpHeaders optional HTTP headers which has to be set on request
+     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content
+     *            should be sent.
+     * @param contentType the content type of the given <code>content</code>
+     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param proxyHost the hostname of the proxy
+     * @param proxyPort the port of the proxy
+     * @param proxyUser the username to authenticate with the proxy
      * @param proxyPassword the password to authenticate with the proxy
      * @param nonProxyHosts the hosts that won't be routed through the proxy
      * @return the response body or <code>NULL</code> when the request went wrong
@@ -168,16 +168,16 @@ public class HttpUtil {
     /**
      * Executes the given <code>url</code> with the given <code>httpMethod</code>
      *
-     * @param httpMethod    the HTTP method to use
-     * @param url           the url to execute
-     * @param httpHeaders   optional HTTP headers which has to be set on request
-     * @param content       the content to be sent to the given <code>url</code> or <code>null</code> if no content
-     *                          should be sent.
-     * @param contentType   the content type of the given <code>content</code>
-     * @param timeout       the socket timeout in milliseconds to wait for data
-     * @param proxyHost     the hostname of the proxy
-     * @param proxyPort     the port of the proxy
-     * @param proxyUser     the username to authenticate with the proxy
+     * @param httpMethod the HTTP method to use
+     * @param url the url to execute
+     * @param httpHeaders optional HTTP headers which has to be set on request
+     * @param content the content to be sent to the given <code>url</code> or <code>null</code> if no content
+     *            should be sent.
+     * @param contentType the content type of the given <code>content</code>
+     * @param timeout the socket timeout in milliseconds to wait for data
+     * @param proxyHost the hostname of the proxy
+     * @param proxyPort the port of the proxy
+     * @param proxyUser the username to authenticate with the proxy
      * @param proxyPassword the password to authenticate with the proxy
      * @param nonProxyHosts the hosts that won't be routed through the proxy
      * @return the response as a ContentResponse object or <code>NULL</code> when the request went wrong
@@ -336,7 +336,7 @@ public class HttpUtil {
      *
      * @param httpMethodString the name of the {@link HttpMethod} to create
      * @throws IllegalArgumentException if <code>httpMethod</code> is none of <code>GET</code>, <code>PUT</code>,
-     *                                      <code>POST</POST> or <code>DELETE</code>
+     *             <code>POST</POST> or <code>DELETE</code>
      */
     public static HttpMethod createHttpMethod(String httpMethodString) {
         // @formatter:off
@@ -364,7 +364,7 @@ public class HttpUtil {
      *
      * If content type is not found in the headers, the data is scanned to determine the content type.
      *
-     * @param url     the URL of the image to be downloaded
+     * @param url the URL of the image to be downloaded
      * @param timeout the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image
@@ -376,10 +376,10 @@ public class HttpUtil {
     /**
      * Download the image data from an URL.
      *
-     * @param url               the URL of the image to be downloaded
+     * @param url the URL of the image to be downloaded
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *                              data size
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
@@ -390,11 +390,11 @@ public class HttpUtil {
     /**
      * Download the image data from an URL.
      *
-     * @param url               the URL of the image to be downloaded
+     * @param url the URL of the image to be downloaded
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *                              data size
-     * @param timeout           the socket timeout in milliseconds to wait for data
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the image, null if the content type could not be found or the content type is
      *         not an image or the data size is too big
      */
@@ -405,11 +405,11 @@ public class HttpUtil {
     /**
      * Download the data from an URL.
      *
-     * @param url               the URL of the data to be downloaded
-     * @param contentTypeRegex  the REGEX the content type must match; null to ignore the content type
+     * @param url the URL of the data to be downloaded
+     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *                              data size
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */
@@ -421,12 +421,12 @@ public class HttpUtil {
     /**
      * Download the data from an URL.
      *
-     * @param url               the URL of the data to be downloaded
-     * @param contentTypeRegex  the REGEX the content type must match; null to ignore the content type
+     * @param url the URL of the data to be downloaded
+     * @param contentTypeRegex the REGEX the content type must match; null to ignore the content type
      * @param scanTypeInContent true to allow the scan of data to determine the content type if not found in the headers
-     * @param maxContentLength  the maximum data size in bytes to trigger the download; any negative value to ignore the
-     *                              data size
-     * @param timeout           the socket timeout in milliseconds to wait for data
+     * @param maxContentLength the maximum data size in bytes to trigger the download; any negative value to ignore the
+     *            data size
+     * @param timeout the socket timeout in milliseconds to wait for data
      * @return a RawType object containing the downloaded data, null if the content type does not match the expected
      *         type or the data size is too big
      */
@@ -440,7 +440,10 @@ public class HttpUtil {
                     proxyParams.proxyHost, proxyParams.proxyPort, proxyParams.proxyUser, proxyParams.proxyPassword,
                     proxyParams.nonProxyHosts);
             byte[] data = response.getContent();
-            long length = (data == null) ? 0 : data.length;
+            if (data == null) {
+                data = new byte[0];
+            }
+            long length = data.length;
             String mediaType = response.getMediaType();
             LOGGER.debug("Media download response: status {} content length {} media type {} (URL {})",
                     response.getStatus(), length, mediaType, url);


### PR DESCRIPTION
After encountering a NumberFormatException with the DecimalType (https://github.com/openhab/openhab2-addons/issues/3717#issuecomment-404602197), I thought it might be a good idea to add null annotations to the types.

The only type I haven't annotated is the StringType because that required some more rework.

The issue with that type is that if the constructor allows for a `@Nullable` parameter, the `value` field of the class also becomes `@Nullable`. This again results in the `toString` and `toFullString` methods becoming `@Nullable`... which would require all types to have these methods `@Nullable` because of inheritance.

It seems to cause less issues to not allow for a nullable parameter in the `StringType` constructor. But this would still require some rework especially in the transform bundles. So I'd rather not do that now or only if you agree this is indeed how this type should be annotated.