### PR TITLE
Releasing of sitemap SSE subscriptions improved

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap.test/src/test/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResourceTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap.test/src/test/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResourceTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -75,11 +76,15 @@ public class SitemapResourceTest extends JavaTest {
     private static final String WIDGET2_LABEL = "widget 2";
     private static final String WIDGET1_ID = "00";
     private static final String WIDGET2_ID = "01";
+    private static final String CLIENT_IP = "127.0.0.1";
 
     private SitemapResource sitemapResource;
 
     @Mock
     private UriInfo uriInfo;
+
+    @Mock
+    private HttpServletRequest request;
 
     @Mock
     private SitemapProvider sitemapProvider;
@@ -108,6 +113,9 @@ public class SitemapResourceTest extends JavaTest {
         when(uriInfo.getAbsolutePathBuilder()).thenReturn(UriBuilder.fromPath(SITEMAP_PATH));
         when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromPath(SITEMAP_PATH));
         sitemapResource.uriInfo = uriInfo;
+
+        when(request.getRemoteAddr()).thenReturn(CLIENT_IP);
+        sitemapResource.request = request;
 
         item = new TestItem(ITEM_NAME);
         visibilityRuleItem = new TestItem(VISIBILITY_RULE_ITEM_NAME);

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/META-INF/MANIFEST.MF
@@ -20,6 +20,7 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.auth,
+ org.eclipse.smarthome.core.common,
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.items.dto,
  org.eclipse.smarthome.core.library,

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/PageChangeListener.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/PageChangeListener.java
@@ -266,4 +266,13 @@ public class PageChangeListener implements StateChangeListener {
         }
     }
 
+    public void sendAliveEvent() {
+        ServerAliveEvent aliveEvent = new ServerAliveEvent();
+        aliveEvent.pageId = pageId;
+        aliveEvent.sitemapName = sitemapName;
+        for (SitemapSubscriptionCallback callback : distinctCallbacks) {
+            callback.onEvent(aliveEvent);
+        }
+    }
+
 }

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/ServerAliveEvent.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/ServerAliveEvent.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.io.rest.sitemap.internal;
+
+/**
+ * Event to notify the browser that the sitemap has been changed
+ *
+ * @author Laurent Garnier - Initial Contribution
+ *
+ */
+public class ServerAliveEvent extends SitemapEvent {
+    public final String TYPE = "ALIVE";
+}

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapEventOutput.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapEventOutput.java
@@ -53,9 +53,13 @@ public class SitemapEventOutput extends EventOutput {
             if (sitemapName != null && sitemapName.equals(subscriptions.getSitemapName(subscriptionId))
                     && pageId != null && pageId.equals(subscriptions.getPageId(subscriptionId))) {
                 super.write(chunk);
-                if (logger.isDebugEnabled() && event instanceof SitemapWidgetEvent) {
-                    logger.debug("Sent sitemap event for widget {} to subscription {}.",
-                            ((SitemapWidgetEvent) event).widgetId, subscriptionId);
+                if (logger.isDebugEnabled()) {
+                    if (event instanceof SitemapWidgetEvent) {
+                        logger.debug("Sent sitemap event for widget {} to subscription {}.",
+                                ((SitemapWidgetEvent) event).widgetId, subscriptionId);
+                    } else if (event instanceof ServerAliveEvent) {
+                        logger.debug("Sent alive event to subscription {}.", subscriptionId);
+                    }
                 }
             }
         }

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -239,8 +239,8 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
             @PathParam("sitemapname") @ApiParam(value = "sitemap name") String sitemapname,
             @QueryParam("type") String type, @QueryParam("jsoncallback") @DefaultValue("callback") String callback) {
         final Locale locale = localeService.getLocale(language);
-        logger.debug("Received HTTP GET request from IP {} at '{}' for media type '{}'.",
-                new Object[] { request.getRemoteAddr(), uriInfo.getPath(), type });
+        logger.debug("Received HTTP GET request from IP {} at '{}' for media type '{}'.", request.getRemoteAddr(),
+                uriInfo.getPath(), type);
         Object responseObject = getSitemapBean(sitemapname, uriInfo.getBaseUriBuilder().build(), locale);
         return Response.ok(responseObject).build();
     }

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -133,7 +133,7 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
     UriInfo uriInfo;
 
     @Context
-    private HttpServletRequest request;
+    HttpServletRequest request;
 
     @Context
     private HttpServletResponse response;

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/web-src/smarthome.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/web-src/smarthome.js
@@ -1942,6 +1942,10 @@
 				state,
 				title;
 
+			if (data.TYPE === "ALIVE") {
+				return;
+			}
+
 			if (data.TYPE === "SITEMAP_CHANGED") {
 				var oldLocation = window.location.href;
 				var parts = oldLocation.split("?");


### PR DESCRIPTION
Fixes issue #4809

Signed-off-by: Laurent Garnier <lg.hc@free.fr>

This enhancement introduces a clean job scheduled every 5 minutes that will do 2 actions:
* Send an ALIVE event to all subscribers; if the subscriber is dead, this will trigger an exception on the SSE connection and the subscription will then be released properly.
* Release the subscriptions when the subscription is not attached to a sitemap page. The subscriber has a frame of 30 seconds to attach a page.