### PR TITLE
automation: use separate builders and don't use setters.

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/src/test/java/org/eclipse/smarthome/automation/core/internal/ReferenceResolverUtilTest.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/src/test/java/org/eclipse/smarthome/automation/core/internal/ReferenceResolverUtilTest.java
@@ -91,17 +91,18 @@ public class ReferenceResolverUtilTest {
     @Test
     public void testModuleConfigurationResolving() {
         // test trigger configuration.
-        Module trigger = ModuleBuilder.createTrigger().withConfiguration(new Configuration(moduleConfiguration))
-                .build();
+        Module trigger = ModuleBuilder.createTrigger().withId("id1").withTypeUID("typeUID1")
+                .withConfiguration(new Configuration(moduleConfiguration)).build();
         ReferenceResolver.updateConfiguration(trigger.getConfiguration(), context, logger);
         Assert.assertEquals(trigger.getConfiguration(), new Configuration(expectedModuleConfiguration));
         // test condition configuration.
-        Module condition = ModuleBuilder.createCondition().withConfiguration(new Configuration(moduleConfiguration))
-                .build();
+        Module condition = ModuleBuilder.createCondition().withId("id2").withTypeUID("typeUID2")
+                .withConfiguration(new Configuration(moduleConfiguration)).build();
         ReferenceResolver.updateConfiguration(condition.getConfiguration(), context, logger);
         Assert.assertEquals(condition.getConfiguration(), new Configuration(expectedModuleConfiguration));
         // test action configuration.
-        Module action = ModuleBuilder.createAction().withConfiguration(new Configuration(moduleConfiguration)).build();
+        Module action = ModuleBuilder.createAction().withId("id3").withTypeUID("typeUID3")
+                .withConfiguration(new Configuration(moduleConfiguration)).build();
         ReferenceResolver.updateConfiguration(action.getConfiguration(), context, logger);
         Assert.assertEquals(action.getConfiguration(), new Configuration(expectedModuleConfiguration));
     }
@@ -109,11 +110,13 @@ public class ReferenceResolverUtilTest {
     @Test
     public void testModuleInputResolving() {
         // test Composite child ModuleImpl(condition) context
-        Module condition = ModuleBuilder.createCondition().withInputs(compositeChildModuleInputsReferences).build();
+        Module condition = ModuleBuilder.createCondition().withId("id1").withTypeUID("typeUID1")
+                .withInputs(compositeChildModuleInputsReferences).build();
         Map<String, Object> conditionContext = ReferenceResolver.getCompositeChildContext(condition, context);
         Assert.assertEquals(conditionContext, expectedCompositeChildModuleContext);
         // test Composite child ModuleImpl(action) context
-        Module action = ModuleBuilder.createAction().withInputs(compositeChildModuleInputsReferences).build();
+        Module action = ModuleBuilder.createAction().withId("id2").withTypeUID("typeUID2")
+                .withInputs(compositeChildModuleInputsReferences).build();
         Map<String, Object> actionContext = ReferenceResolver.getCompositeChildContext(action, context);
         Assert.assertEquals(actionContext, expectedCompositeChildModuleContext);
     }

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/ActionImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/ActionImpl.java
@@ -35,36 +35,24 @@ import org.eclipse.smarthome.config.core.Configuration;
 @NonNullByDefault
 public class ActionImpl extends ModuleImpl implements Action {
 
-    @Nullable
-    private ActionHandler actionHandler;
+    private @Nullable ActionHandler actionHandler;
     private Set<Connection> connections = Collections.emptySet();
     private Map<String, String> inputs = Collections.emptyMap();
-
-    public ActionImpl() {
-    }
-
-    /**
-     * Utility constructor creating copy of passed action.
-     *
-     * @param action another action which is uses as base of created
-     */
-    public ActionImpl(final Action action) {
-        this(action.getId(), action.getTypeUID(), action.getConfiguration(), action.getInputs());
-        setLabel(action.getLabel());
-        setDescription(action.getDescription());
-    }
 
     /**
      * Constructor of Action object.
      *
-     * @param UID           action unique id.
-     * @param typeUID       module type unique id.
+     * @param UID action unique id.
+     * @param typeUID module type unique id.
      * @param configuration map of configuration values.
-     * @param inputs        set of connections to other modules (triggers and other actions).
+     * @param label the label
+     * @param description description
+     * @param inputs set of connections to other modules (triggers and other actions).
      */
-    public ActionImpl(String UID, String typeUID, Configuration configuration, @Nullable Map<String, String> inputs) {
-        super(UID, typeUID, configuration);
-        setInputs(inputs);
+    public ActionImpl(String UID, String typeUID, @Nullable Configuration configuration, @Nullable String label,
+            @Nullable String description, @Nullable Map<String, String> inputs) {
+        super(UID, typeUID, configuration, label, description);
+        this.inputs = inputs == null ? Collections.emptyMap() : Collections.unmodifiableMap(inputs);
     }
 
     /**

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/ConditionImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/ConditionImpl.java
@@ -35,30 +35,22 @@ public class ConditionImpl extends ModuleImpl implements Condition {
 
     private Map<String, String> inputs = Collections.emptyMap();
     private Set<Connection> connections = Collections.emptySet();
-
-    @Nullable
-    private ConditionHandler conditionHandler;
-
-    public ConditionImpl() {
-    }
-
-    public ConditionImpl(Condition condition) {
-        this(condition.getId(), condition.getTypeUID(), condition.getConfiguration(), condition.getInputs());
-        setLabel(condition.getLabel());
-        setDescription(condition.getDescription());
-    }
+    private @Nullable ConditionHandler conditionHandler;
 
     /**
      * Constructor of {@link Condition} module object.
      *
-     * @param id            id of the module.
-     * @param typeUID       unique module type id.
+     * @param id id of the module.
+     * @param typeUID unique module type id.
      * @param configuration configuration values of the {@link Condition} module.
-     * @param inputs        set of {@link Input}s used by this module.
+     * @param label the label
+     * @param description description
+     * @param inputs set of {@link Input}s used by this module.
      */
-    public ConditionImpl(String id, String typeUID, Configuration configuration, Map<String, String> inputs) {
-        super(id, typeUID, configuration);
-        setInputs(inputs);
+    public ConditionImpl(String id, String typeUID, @Nullable Configuration configuration, @Nullable String label,
+            @Nullable String description, @Nullable Map<String, String> inputs) {
+        super(id, typeUID, configuration, label, description);
+        this.inputs = inputs == null ? Collections.emptyMap() : Collections.unmodifiableMap(inputs);
     }
 
     /**

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/ModuleImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/ModuleImpl.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.automation.core.internal;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.automation.Module;
 import org.eclipse.smarthome.automation.Rule;
 import org.eclipse.smarthome.automation.type.Input;
@@ -69,18 +70,19 @@ public abstract class ModuleImpl implements Module {
     /**
      * Constructor of the module.
      *
-     * @param id            the module id.
-     * @param typeUID       unique id of the module type.
+     * @param id the module id.
+     * @param typeUID unique id of the module type.
      * @param configuration configuration values of the module.
+     * @param label the label
+     * @param description the description
      */
-    public ModuleImpl(String id, String typeUID, Configuration configuration) {
+    public ModuleImpl(String id, String typeUID, @Nullable Configuration configuration, @Nullable String label,
+            @Nullable String description) {
         this.id = id;
         this.type = typeUID;
-        setConfiguration(configuration);
-    }
-
-    public ModuleImpl() {
-        setConfiguration(null);
+        this.configuration = configuration == null ? new Configuration() : configuration;
+        this.label = label;
+        this.description = description;
     }
 
     @Override

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleImpl.java
@@ -63,8 +63,8 @@ public class RuleImpl implements Rule {
 
     /**
      * Constructor for creating an empty {@link Rule} with a specified rule identifier.
-     * When {@code null} is passed for the {@code uid} parameter, the {@link Rule}'s identifier will
-     * be randomly generated.
+     * When {@code null} is passed for the {@code uid} parameter, the {@link Rule}'s identifier will be randomly
+     * generated.
      *
      * @param uid the rule's identifier, or {@code null} if a random identifier should be generated.
      */
@@ -76,36 +76,22 @@ public class RuleImpl implements Rule {
      * Utility constructor for creating a {@link Rule} from a set of modules, or from a template.
      * When {@code null} is passed for the {@code uid} parameter, the {@link Rule}'s identifier will be randomly
      * generated.
-     * }
-     * 
-     * /**
-     * Utility constructor for creating a {@link Rule} from a set of modules, or from a template.
-     * When {@code null} is passed for the {@code uid} parameter, the {@link Rule}'s identifier will be randomly
-     * generated.
      *
-     * @param uid the {@link Rule}'s identifier, or {@code null} if a random identifier should be
-     *            generated.
+     * @param uid the {@link Rule}'s identifier, or {@code null} if a random identifier should be generated.
      * @param name the rule's name
      * @param description the rule's description
      * @param tags the tags
-     * @param triggers the {@link Rule}'s triggers list, or {@code null} if the {@link Rule} should
-     *            have no
-     *            triggers or
+     * @param triggers the {@link Rule}'s triggers list, or {@code null} if the {@link Rule} should have no triggers or
      *            will be created from a template.
-     * @param conditions the {@link Rule}'s conditions list, or {@code null} if the {@link Rule} should
-     *            have no
+     * @param conditions the {@link Rule}'s conditions list, or {@code null} if the {@link Rule} should have no
      *            conditions, or will be created from a template.
-     * @param actions the {@link Rule}'s actions list, or {@code null} if the {@link Rule} should
-     *            have no
-     *            actions, or will be created from a template.
+     * @param actions the {@link Rule}'s actions list, or {@code null} if the {@link Rule} should have no actions, or
+     *            will be created from a template.
      * @param configDescriptions metadata describing the configuration of the {@link Rule}.
      * @param configuration the values that will configure the modules of the {@link Rule}.
      * @param templateUID the {@link RuleTemplate} identifier of the template that will be used by the
-     *            {@link RuleRegistry} to validate the {@link Rule}'s configuration, as well as to
-     *            create and
-     *            configure
-     *            the {@link Rule}'s modules, or null if the {@link Rule} should not be created
-     *            from a template.
+     *            {@link RuleRegistry} to validate the {@link Rule}'s configuration, as well as to create and configure
+     *            the {@link Rule}'s modules, or null if the {@link Rule} should not be created from a template.
      * @param visibility the {@link Rule}'s visibility
      */
     public RuleImpl(@Nullable String uid, final @Nullable String name, final @Nullable String description,
@@ -142,10 +128,9 @@ public class RuleImpl implements Rule {
     }
 
     /**
-     * This method is used to specify the {@link RuleTemplate} identifier of the template that will be used to
-     * by the {@link RuleRegistry} to resolve the {@link RuleImpl}: to validate the {@link RuleImpl}'s configuration, as
-     * well as
-     * to create and configure the {@link RuleImpl}'s modules.
+     * This method is used to specify the {@link RuleTemplate} identifier of the template that will be used to by the
+     * {@link RuleRegistry} to resolve the {@link RuleImpl}: to validate the {@link RuleImpl}'s configuration, as well
+     * as to create and configure the {@link RuleImpl}'s modules.
      */
     public void setTemplateUID(@Nullable String templateUID) {
         this.templateUID = templateUID;
@@ -230,8 +215,8 @@ public class RuleImpl implements Rule {
     }
 
     /**
-     * This method is used to describe with {@link ConfigDescriptionParameter}s
-     * the meta info for configuration properties of the {@link RuleImpl}.
+     * This method is used to describe with {@link ConfigDescriptionParameter}s the meta info for configuration
+     * properties of the {@link RuleImpl}.
      */
     public void setConfigurationDescriptions(@Nullable List<ConfigDescriptionParameter> configDescriptions) {
         this.configDescriptions = configDescriptions == null ? Collections.emptyList()

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.automation.core.internal;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -45,92 +46,88 @@ import org.eclipse.smarthome.config.core.Configuration;
 @NonNullByDefault
 public class RuleImpl implements Rule {
 
-    @NonNullByDefault({})
-    private List<Trigger> triggers;
-    @NonNullByDefault({})
-    private List<Condition> conditions;
-    @NonNullByDefault({})
-    private List<Action> actions;
-    @NonNullByDefault({})
-    private Configuration configuration;
-    @NonNullByDefault({})
-    private List<ConfigDescriptionParameter> configDescriptions;
-    @Nullable
-    private String templateUID;
-    @NonNullByDefault({})
-    private String uid;
-    @Nullable
-    private String name;
-    @NonNullByDefault({})
-    private Set<String> tags;
-    @NonNullByDefault({})
-    private Visibility visibility;
-    @Nullable
-    private String description;
+    protected @NonNullByDefault({}) List<Trigger> triggers;
+    protected @NonNullByDefault({}) List<Condition> conditions;
+    protected @NonNullByDefault({}) List<Action> actions;
+    protected @NonNullByDefault({}) Configuration configuration;
+    protected @NonNullByDefault({}) List<ConfigDescriptionParameter> configDescriptions;
+    protected @Nullable String templateUID;
+    protected @NonNullByDefault({}) String uid;
+    protected @Nullable String name;
+    protected @NonNullByDefault({}) Set<String> tags;
+    protected @NonNullByDefault({}) Visibility visibility;
+    protected @Nullable String description;
 
     private transient volatile RuleStatusInfo status = new RuleStatusInfo(RuleStatus.UNINITIALIZED,
             RuleStatusDetail.NONE);
 
     /**
-     * Package protected default constructor to allow reflective instantiation.
-     *
-     * !!! DO NOT REMOVE - Gson needs it !!!
-     */
-    RuleImpl() {
-    }
-
-    /**
-     * Constructor for creating an empty {@link RuleImpl} with a specified rule identifier.
-     * When {@code null} is passed for the {@code uid} parameter, the {@link RuleImpl}'s identifier will
+     * Constructor for creating an empty {@link Rule} with a specified rule identifier.
+     * When {@code null} is passed for the {@code uid} parameter, the {@link Rule}'s identifier will
      * be randomly generated.
      *
      * @param uid the rule's identifier, or {@code null} if a random identifier should be generated.
      */
     public RuleImpl(@Nullable String uid) {
-        this(uid, null, null, null, null, null, null, null);
+        this(uid, null, null, null, null, null, null, null, null, null, null);
     }
 
     /**
-     * Utility constructor for creating a {@link RuleImpl} from a set of modules, or from a template.
-     * When {@code null} is passed for the {@code uid} parameter, the {@link RuleImpl}'s identifier will be randomly
+     * Utility constructor for creating a {@link Rule} from a set of modules, or from a template.
+     * When {@code null} is passed for the {@code uid} parameter, the {@link Rule}'s identifier will be randomly
+     * generated.
+     * }
+     * 
+     * /**
+     * Utility constructor for creating a {@link Rule} from a set of modules, or from a template.
+     * When {@code null} is passed for the {@code uid} parameter, the {@link Rule}'s identifier will be randomly
      * generated.
      *
-     * @param uid                the {@link RuleImpl}'s identifier, or {@code null} if a random identifier should be
-     *                           generated.
-     * @param triggers           the {@link RuleImpl}'s triggers list, or {@code null} if the {@link RuleImpl} should
-     *                           have no
-     *                           triggers or
-     *                           will be created from a template.
-     * @param conditions         the {@link RuleImpl}'s conditions list, or {@code null} if the {@link RuleImpl} should
-     *                           have no
-     *                           conditions, or will be created from a template.
-     * @param actions            the {@link RuleImpl}'s actions list, or {@code null} if the {@link RuleImpl} should
-     *                           have no
-     *                           actions, or will be created from a template.
-     * @param configDescriptions metadata describing the configuration of the {@link RuleImpl}.
-     * @param configuration      the values that will configure the modules of the {@link RuleImpl}.
-     * @param templateUID        the {@link RuleTemplate} identifier of the template that will be used by the
-     *                           {@link RuleRegistry} to validate the {@link RuleImpl}'s configuration, as well as to
-     *                           create and
-     *                           configure
-     *                           the {@link RuleImpl}'s modules, or null if the {@link RuleImpl} should not be created
-     *                           from a template.
-     * @param visibility         the {@link RuleImpl}'s visibility
+     * @param uid the {@link Rule}'s identifier, or {@code null} if a random identifier should be
+     *            generated.
+     * @param name the rule's name
+     * @param description the rule's description
+     * @param tags the tags
+     * @param triggers the {@link Rule}'s triggers list, or {@code null} if the {@link Rule} should
+     *            have no
+     *            triggers or
+     *            will be created from a template.
+     * @param conditions the {@link Rule}'s conditions list, or {@code null} if the {@link Rule} should
+     *            have no
+     *            conditions, or will be created from a template.
+     * @param actions the {@link Rule}'s actions list, or {@code null} if the {@link Rule} should
+     *            have no
+     *            actions, or will be created from a template.
+     * @param configDescriptions metadata describing the configuration of the {@link Rule}.
+     * @param configuration the values that will configure the modules of the {@link Rule}.
+     * @param templateUID the {@link RuleTemplate} identifier of the template that will be used by the
+     *            {@link RuleRegistry} to validate the {@link Rule}'s configuration, as well as to
+     *            create and
+     *            configure
+     *            the {@link Rule}'s modules, or null if the {@link Rule} should not be created
+     *            from a template.
+     * @param visibility the {@link Rule}'s visibility
      */
-    public RuleImpl(@Nullable String uid, @Nullable List<Trigger> triggers, @Nullable List<Condition> conditions,
+    public RuleImpl(@Nullable String uid, final @Nullable String name, final @Nullable String description,
+            final @Nullable Set<String> tags, @Nullable List<Trigger> triggers, @Nullable List<Condition> conditions,
             @Nullable List<Action> actions, @Nullable List<ConfigDescriptionParameter> configDescriptions,
             @Nullable Configuration configuration, @Nullable String templateUID, @Nullable Visibility visibility) {
         this.uid = uid == null ? UUID.randomUUID().toString() : uid;
-        this.triggers = triggers == null ? Collections.emptyList() : Collections.unmodifiableList(triggers);
-        this.conditions = conditions == null ? Collections.emptyList() : Collections.unmodifiableList(conditions);
-        this.actions = actions == null ? Collections.emptyList() : Collections.unmodifiableList(actions);
+        this.name = name;
+        this.description = description;
+        this.tags = tags == null ? Collections.emptySet() : Collections.unmodifiableSet(new HashSet<>(tags));
+        this.triggers = triggers == null ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(triggers));
+        this.conditions = conditions == null ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(conditions));
+        this.actions = actions == null ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(actions));
         this.configDescriptions = configDescriptions == null ? Collections.emptyList()
-                : Collections.unmodifiableList(configDescriptions);
+                : Collections.unmodifiableList(new ArrayList<>(configDescriptions));
         this.configuration = configuration == null ? new Configuration()
                 : new Configuration(configuration.getProperties());
-        setTemplateUID(templateUID);
+        this.templateUID = templateUID;
         this.visibility = visibility == null ? Visibility.VISIBLE : visibility;
-        tags = Collections.emptySet();
     }
 
     @Override

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/TriggerImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/TriggerImpl.java
@@ -26,20 +26,11 @@ import org.eclipse.smarthome.config.core.Configuration;
 @NonNullByDefault
 public class TriggerImpl extends ModuleImpl implements Trigger {
 
-    @Nullable
-    private TriggerHandler triggerHandler;
+    private @Nullable TriggerHandler triggerHandler;
 
-    public TriggerImpl() {
-    }
-
-    public TriggerImpl(String id, String typeUID, Configuration configuration) {
-        super(id, typeUID, configuration);
-    }
-
-    public TriggerImpl(Trigger trigger) {
-        super(trigger.getId(), trigger.getTypeUID(), trigger.getConfiguration());
-        setLabel(trigger.getLabel());
-        setDescription(trigger.getDescription());
+    public TriggerImpl(String id, String typeUID, @Nullable Configuration configuration, @Nullable String label,
+            @Nullable String description) {
+        super(id, typeUID, configuration, label, description);
     }
 
     /**

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/ActionBuilder.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/ActionBuilder.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.automation.core.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.automation.Action;
+import org.eclipse.smarthome.automation.core.internal.ActionImpl;
+
+/**
+ * This class allows the easy construction of an {@link Action} instance using the builder pattern.
+ *
+ * @author Markus Rathgeb - Initial contribution and API
+ */
+@NonNullByDefault
+public class ActionBuilder extends ModuleBuilder<ActionBuilder, Action> {
+
+    private @Nullable Map<String, String> inputs;
+
+    protected ActionBuilder() {
+        super();
+    }
+
+    protected ActionBuilder(final Action action) {
+        super(action);
+        this.inputs = action.getInputs();
+    }
+
+    public static ActionBuilder create() {
+        return new ActionBuilder();
+    }
+
+    public static ActionBuilder create(final Action action) {
+        return new ActionBuilder(action);
+    }
+
+    public ActionBuilder withInputs(@Nullable Map<String, String> inputs) {
+        this.inputs = inputs != null ? Collections.unmodifiableMap(new HashMap<>(inputs)) : null;
+        return this;
+    }
+
+    @Override
+    public Action build() {
+        return new ActionImpl(getId(), getTypeUID(), configuration, label, description, inputs);
+    }
+
+}

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/ConditionBuilder.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/ConditionBuilder.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.automation.core.util;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.automation.Condition;
+import org.eclipse.smarthome.automation.core.internal.ConditionImpl;
+
+/**
+ * This class allows the easy construction of a {@link Condition} instance using the builder pattern.
+ *
+ * @author Markus Rathgeb - Initial contribution and API
+ */
+@NonNullByDefault
+public class ConditionBuilder extends ModuleBuilder<ConditionBuilder, Condition> {
+
+    private @Nullable Map<String, String> inputs;
+
+    protected ConditionBuilder() {
+        super();
+    }
+
+    protected ConditionBuilder(final Condition condition) {
+        super(condition);
+        this.inputs = condition.getInputs();
+    }
+
+    public static ConditionBuilder create() {
+        return new ConditionBuilder();
+    }
+
+    public static ConditionBuilder create(final Condition condition) {
+        return new ConditionBuilder(condition);
+    }
+
+    public ConditionBuilder withInputs(@Nullable Map<String, String> inputs) {
+        this.inputs = inputs != null ? Collections.unmodifiableMap(new HashMap<>(inputs)) : null;
+        return this;
+    }
+
+    @Override
+    public Condition build() {
+        return new ConditionImpl(getId(), getTypeUID(), configuration, label, description, inputs);
+    }
+
+}

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/ConfigurationNormalizer.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/ConfigurationNormalizer.java
@@ -19,8 +19,6 @@ import java.util.Map.Entry;
 
 import org.eclipse.smarthome.automation.Module;
 import org.eclipse.smarthome.automation.RuleRegistry;
-import org.eclipse.smarthome.automation.core.internal.ModuleImpl;
-import org.eclipse.smarthome.automation.core.internal.RuleImpl;
 import org.eclipse.smarthome.automation.type.ModuleType;
 import org.eclipse.smarthome.automation.type.ModuleTypeRegistry;
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter;

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/RuleBuilder.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/RuleBuilder.java
@@ -14,7 +14,9 @@ package org.eclipse.smarthome.automation.core.util;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -52,15 +54,15 @@ public class RuleBuilder {
     private @Nullable String description;
 
     protected RuleBuilder(Rule rule) {
-        this.triggers = rule.getTriggers();
-        this.conditions = rule.getConditions();
-        this.actions = rule.getActions();
+        this.triggers = new LinkedList<>(rule.getTriggers());
+        this.conditions = new LinkedList<>(rule.getConditions());
+        this.actions = new LinkedList<>(rule.getActions());
         this.configuration = rule.getConfiguration();
-        this.configDescriptions = rule.getConfigurationDescriptions();
+        this.configDescriptions = new LinkedList<>(rule.getConfigurationDescriptions());
         this.templateUID = rule.getTemplateUID();
         this.uid = rule.getUID();
         this.name = rule.getName();
-        this.tags = rule.getTags();
+        this.tags = new HashSet<>(rule.getTags());
         this.visibility = rule.getVisibility();
         this.description = rule.getDescription();
     }
@@ -150,7 +152,7 @@ public class RuleBuilder {
     }
 
     public RuleBuilder withTags(@Nullable Set<String> tags) {
-        this.tags = tags;
+        this.tags = tags != null ? new HashSet<>(tags) : Collections.emptySet();
         return this;
     }
 
@@ -160,7 +162,7 @@ public class RuleBuilder {
     }
 
     public RuleBuilder withConfigurationDescriptions(@Nullable List<ConfigDescriptionParameter> configDescs) {
-        this.configDescriptions = configDescs;
+        this.configDescriptions = configDescs != null ? new LinkedList<>(configDescs) : Collections.emptyList();
         return this;
     }
 

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/RuleBuilder.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/RuleBuilder.java
@@ -39,14 +39,34 @@ import org.eclipse.smarthome.config.core.Configuration;
 @NonNullByDefault
 public class RuleBuilder {
 
-    private final RuleImpl rule;
+    private @NonNullByDefault({}) List<Trigger> triggers;
+    private @NonNullByDefault({}) List<Condition> conditions;
+    private @NonNullByDefault({}) List<Action> actions;
+    private @NonNullByDefault({}) Configuration configuration;
+    private @NonNullByDefault({}) List<ConfigDescriptionParameter> configDescriptions;
+    private @Nullable String templateUID;
+    private @NonNullByDefault({}) final String uid;
+    private @Nullable String name;
+    private @NonNullByDefault({}) Set<String> tags;
+    private @NonNullByDefault({}) Visibility visibility;
+    private @Nullable String description;
 
-    protected RuleBuilder(RuleImpl rule) {
-        this.rule = rule;
+    protected RuleBuilder(Rule rule) {
+        this.triggers = rule.getTriggers();
+        this.conditions = rule.getConditions();
+        this.actions = rule.getActions();
+        this.configuration = rule.getConfiguration();
+        this.configDescriptions = rule.getConfigurationDescriptions();
+        this.templateUID = rule.getTemplateUID();
+        this.uid = rule.getUID();
+        this.name = rule.getName();
+        this.tags = rule.getTags();
+        this.visibility = rule.getVisibility();
+        this.description = rule.getDescription();
     }
 
     public static RuleBuilder create(String ruleId) {
-        RuleImpl rule = new RuleImpl(ruleId);
+        Rule rule = new RuleImpl(ruleId);
         return new RuleBuilder(rule);
     }
 
@@ -66,22 +86,22 @@ public class RuleBuilder {
     }
 
     public RuleBuilder withName(@Nullable String name) {
-        this.rule.setName(name);
+        this.name = name;
         return this;
     }
 
     public RuleBuilder withDescription(@Nullable String description) {
-        this.rule.setDescription(description);
+        this.description = description;
         return this;
     }
 
     public RuleBuilder withTemplateUID(@Nullable String uid) {
-        this.rule.setTemplateUID(uid);
+        this.templateUID = uid;
         return this;
     }
 
     public RuleBuilder withVisibility(@Nullable Visibility visibility) {
-        this.rule.setVisibility(visibility);
+        this.visibility = visibility;
         return this;
     }
 
@@ -92,8 +112,8 @@ public class RuleBuilder {
     public RuleBuilder withTriggers(@Nullable List<? extends Trigger> triggers) {
         if (triggers != null) {
             ArrayList<Trigger> triggerList = new ArrayList<>(triggers.size());
-            triggers.forEach(t -> triggerList.add(ModuleBuilder.createTrigger(t).build()));
-            this.rule.setTriggers(triggerList);
+            triggers.forEach(t -> triggerList.add(TriggerBuilder.create(t).build()));
+            this.triggers = triggerList;
         }
         return this;
     }
@@ -105,8 +125,8 @@ public class RuleBuilder {
     public RuleBuilder withConditions(@Nullable List<? extends Condition> conditions) {
         if (conditions != null) {
             ArrayList<Condition> conditionList = new ArrayList<>(conditions.size());
-            conditions.forEach(c -> conditionList.add(ModuleBuilder.createCondition(c).build()));
-            this.rule.setConditions(conditionList);
+            conditions.forEach(c -> conditionList.add(ConditionBuilder.create(c).build()));
+            this.conditions = conditionList;
         }
         return this;
     }
@@ -118,8 +138,8 @@ public class RuleBuilder {
     public RuleBuilder withActions(@Nullable List<? extends Action> actions) {
         if (actions != null) {
             ArrayList<Action> actionList = new ArrayList<>(actions.size());
-            actions.forEach(a -> actionList.add(ModuleBuilder.createAction(a).build()));
-            this.rule.setActions(actionList);
+            actions.forEach(a -> actionList.add(ActionBuilder.create(a).build()));
+            this.actions = actionList;
         }
         return this;
     }
@@ -130,22 +150,23 @@ public class RuleBuilder {
     }
 
     public RuleBuilder withTags(@Nullable Set<String> tags) {
-        this.rule.setTags(tags);
+        this.tags = tags;
         return this;
     }
 
     public RuleBuilder withConfiguration(@Nullable Configuration ruleConfiguration) {
-        this.rule.setConfiguration(ruleConfiguration);
+        this.configuration = ruleConfiguration;
         return this;
     }
 
     public RuleBuilder withConfigurationDescriptions(@Nullable List<ConfigDescriptionParameter> configDescs) {
-        this.rule.setConfigurationDescriptions(configDescs);
+        this.configDescriptions = configDescs;
         return this;
     }
 
     public Rule build() {
-        return this.rule;
+        return new RuleImpl(uid, name, description, tags, triggers, conditions, actions, configDescriptions,
+                configuration, templateUID, visibility);
     }
 
 }

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/TriggerBuilder.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/TriggerBuilder.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.automation.core.util;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.automation.Trigger;
+import org.eclipse.smarthome.automation.core.internal.TriggerImpl;
+
+/**
+ * This class allows the easy construction of a {@link Trigger} instance using the builder pattern.
+ *
+ * @author Markus Rathgeb - Initial contribution and API
+ */
+@NonNullByDefault
+public class TriggerBuilder extends ModuleBuilder<TriggerBuilder, Trigger> {
+
+    protected TriggerBuilder() {
+        super();
+    }
+
+    protected TriggerBuilder(final Trigger condition) {
+        super(condition);
+    }
+
+    public static TriggerBuilder create() {
+        return new TriggerBuilder();
+    }
+
+    public static TriggerBuilder create(final Trigger trigger) {
+        return new TriggerBuilder(trigger);
+    }
+
+    @Override
+    public Trigger build() {
+        return new TriggerImpl(getId(), getTypeUID(), configuration, label, description);
+    }
+
+}


### PR DESCRIPTION
As we are using builders we should not rely on setters methods of the
build objects but build objects if the "build" method is called.

This allow us to remove setters on the respective objects that are only
intended to be used at build time.