### PR TITLE
return collections of interfaces instead of unknown captures

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/Rule.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/src/main/java/org/eclipse/smarthome/automation/Rule.java
@@ -105,21 +105,21 @@ public interface Rule extends Identifiable<String> {
      *
      * @return a list with the conditions that belong to this {@link Rule}.
      */
-    List<? extends Condition> getConditions();
+    List<Condition> getConditions();
 
     /**
      * This method is used to get the actions participating in {@link Rule}.
      *
      * @return a list with the actions that belong to this {@link Rule}.
      */
-    List<? extends Action> getActions();
+    List<Action> getActions();
 
     /**
      * This method is used to get the triggers participating in {@link Rule}.
      *
      * @return a list with the triggers that belong to this {@link Rule}.
      */
-    List<? extends Trigger> getTriggers();
+    List<Trigger> getTriggers();
 
     /**
      * Obtains the modules of the {@link Rule}.


### PR DESCRIPTION
@kaikreuzer 
As written before, I would like to keep the changes as small as possible. You are right, #5911 does not include one logical change because this one could be split out.

Let me ask: Why should we prefer to return `List<? extends Interface>` instead of `List<Interface>`?

I don't see any positive aspect, only negative ones.

Let me give an exampe why I don't think unknown captures help us here - it makes the live just a little bit more difficult (IMHO):

```Java
import java.util.LinkedList;

public class Test {

    interface Base {

    }

    class BaseImpl1 implements Base {

    }

    class BaseImpl2 implements Base {

    }

    void foo() {
        final LinkedList<Base> lst1 = new LinkedList<>();
        final LinkedList<? extends Base> lst2 = new LinkedList<>();

        lst1.add(new BaseImpl1()); // OK
        lst1.add(new BaseImpl2()); // OK

        lst2.add(new BaseImpl1()); // NOK: The method add(capture#1-of ? extends Test.Base) in the type
                                   // LinkedList<capture#1-of ? extends Test.Base> is not applicable for the arguments
                                   // (Test.BaseImpl1)

        lst2.add(new BaseImpl2()); // NOK: The method add(capture#2-of ? extends Test.Base) in the type
                                   // LinkedList<capture#2-of ? extends Test.Base> is not applicable for the arguments
                                   // (Test.BaseImpl2)

        lst1.addAll(lst2); // OK

        lst2.addAll(lst1); // NOK - The method addAll(Collection<? extends capture#4-of ? extends Test.Base>) in the
                           // type LinkedList<capture#4-of ? extends Test.Base> is not applicable for the arguments
                           // (LinkedList<Test.Base>)
    }
}
```

I also don't understand what we want to express here using `List<? extends Interface>` instead of `List<Interface>`.

It is a collection of something that extends an interface. But wouldn't a collection of interface already fit our needs?

Additionally, a generic collection holds one specific type (its template parameter) (and can be filled by that type and its derived ones). Using the `? extends` marker you say I don't know which `Interface` implementation is used. So, assume you add Impl1 and Impl2 to the list then `? extends Interface` have to be evaluate to `Interface` itself, because it needs to be one type that match all its member. As this cannot be resolved by the compiler, it is an unknown capture and it does not know to which sub-class the collection itself is limited.

To let the `Rule` consumers work with the returned lists as good as possible it would prefer to state we return lists of interfaces here.