### PR TITLE
Applied UTF-8 encoding for the consumption of Hue HTTP responses

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HttpClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HttpClient.java
@@ -18,6 +18,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -130,7 +131,7 @@ public class HttpClient {
             }
 
             InputStream in = new BufferedInputStream(conn.getInputStream());
-            String output = IOUtils.toString(in);
+            String output = IOUtils.toString(in, StandardCharsets.UTF_8.name());
             return new Result(output, conn.getResponseCode());
         } finally {
             conn.disconnect();


### PR DESCRIPTION
The Philips Hue mobile application allows the user to assign lamp names in the UTF-8 charset range. For example, a lamp can be named `Hue color lamp küche` (with umlaut character in the name). After testing, it turned out that the pure Hue API response contains correctly encoded lamp name:

```
...
"type": "Extended color light",
"name": "Hue color lamp 2 küche",
"modelid": "LCT010",
"manufacturername": "Philips"
...
```

However, on the binding side, in`org.eclipse.smarthome.binding.hue.internal.HttpClient#doNetwork(String address, String requestMethod, @Nullable String body)` the response content is stringified via doing `IOUtils.toString(responseContentAsStream)`. The consequence is that special characters like umlauts are then represented by questionmark characters, resulting e.g. in a discovery result bearing the name `Hue color lamp k?che`.

The PR fixes this by simply imposing UTF-8 charset for the response content consumption. Tests performed with umlauts and cyrillic letters.