### PR TITLE
Make ChannelGroupType constructor package private

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelGroupTypeXmlResult.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelGroupTypeXmlResult.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 
 import com.thoughtworks.xstream.converters.ConversionException;
@@ -33,12 +34,12 @@ import com.thoughtworks.xstream.converters.ConversionException;
  */
 public class ChannelGroupTypeXmlResult {
 
-    private ChannelGroupTypeUID channelGroupTypeUID;
-    private boolean advanced;
-    private String label;
-    private String description;
-    private String category;
-    private List<ChannelXmlResult> channelTypeReferences;
+    private final ChannelGroupTypeUID channelGroupTypeUID;
+    private final boolean advanced;
+    private final String label;
+    private final String description;
+    private final String category;
+    private final List<ChannelXmlResult> channelTypeReferences;
 
     public ChannelGroupTypeXmlResult(ChannelGroupTypeUID channelGroupTypeUID, boolean advanced, String label,
             String description, String category, List<ChannelXmlResult> channelTypeReferences) {
@@ -71,8 +72,9 @@ public class ChannelGroupTypeXmlResult {
     }
 
     public ChannelGroupType toChannelGroupType() throws ConversionException {
-        ChannelGroupType channelGroupType = new ChannelGroupType(this.channelGroupTypeUID, this.advanced, this.label,
-                this.description, this.category, toChannelDefinitions(this.channelTypeReferences));
+        ChannelGroupType channelGroupType = ChannelGroupTypeBuilder.instance(this.channelGroupTypeUID, this.label)
+                .isAdvanced(this.advanced).withDescription(this.description).withCategory(this.category)
+                .withChannelDefinitions(toChannelDefinitions(this.channelTypeReferences)).build();
 
         return channelGroupType;
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelGroupType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelGroupType.java
@@ -77,8 +77,8 @@ public class ChannelGroupType extends AbstractDescriptionType {
      *            (could be null or empty)
      * @throws IllegalArgumentException if the UID is null, or the label is null or empty
      */
-    public ChannelGroupType(ChannelGroupTypeUID uid, boolean advanced, String label, String description,
-            String category, List<ChannelDefinition> channelDefinitions) throws IllegalArgumentException {
+    ChannelGroupType(ChannelGroupTypeUID uid, boolean advanced, String label, String description, String category,
+            List<ChannelDefinition> channelDefinitions) throws IllegalArgumentException {
         super(uid, label, description);
 
         this.advanced = advanced;

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/TestHueChannelTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/TestHueChannelTypeProvider.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider;
@@ -58,10 +59,12 @@ public class TestHueChannelTypeProvider implements ChannelTypeProvider {
                     new URI("Xhue", "XLCT001:Xcolor_temperature", null));
             channelTypes = Arrays.asList(ctColor, ctColorTemperature, ctColorX, ctColorTemperatureX);
 
-            ChannelGroupType groupX = new ChannelGroupType(GROUP_CHANNEL_GROUP_TYPE_UID, false, "Channel Group",
-                    "Channel Group", null,
-                    Arrays.asList(new ChannelDefinition("foo", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID),
-                            new ChannelDefinition("bar", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID)));
+            ChannelGroupType groupX = ChannelGroupTypeBuilder.instance(GROUP_CHANNEL_GROUP_TYPE_UID, "Channel Group")
+                    .isAdvanced(false).withDescription("Channel Group")
+                    .withChannelDefinitions(Arrays.asList(
+                            new ChannelDefinition("foo", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID),
+                            new ChannelDefinition("bar", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID)))
+                    .build();
             channelGroupTypes = Arrays.asList(groupX);
 
         } catch (Exception willNeverBeThrown) {

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/TestHueChannelTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/TestHueChannelTypeProvider.java
@@ -60,7 +60,7 @@ public class TestHueChannelTypeProvider implements ChannelTypeProvider {
             channelTypes = Arrays.asList(ctColor, ctColorTemperature, ctColorX, ctColorTemperatureX);
 
             ChannelGroupType groupX = ChannelGroupTypeBuilder.instance(GROUP_CHANNEL_GROUP_TYPE_UID, "Channel Group")
-                    .isAdvanced(false).withDescription("Channel Group")
+                    .withDescription("Channel Group")
                     .withChannelDefinitions(Arrays.asList(
                             new ChannelDefinition("foo", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID),
                             new ChannelDefinition("bar", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID)))

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -163,7 +163,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                     if (groupType == null || device.isGatewayExtras()) {
                         String groupLabel = String.format("%s",
                                 WordUtils.capitalizeFully(StringUtils.replace(channel.getType(), "_", " ")));
-                        groupType = ChannelGroupTypeBuilder.instance(groupTypeUID, groupLabel).isAdvanced(false)
+                        groupType = ChannelGroupTypeBuilder.instance(groupTypeUID, groupLabel)
                                 .withChannelDefinitions(channelDefinitions).build();
                         channelTypeProvider.addChannelGroupType(groupType);
                         groupTypes.add(groupType);
@@ -349,8 +349,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
 
     private URI getConfigDescriptionURI(HmDevice device) {
         try {
-            return new URI(
-                    String.format("%s:%s", CONFIG_DESCRIPTION_URI_THING_PREFIX, UidUtils.generateThingTypeUID(device)));
+            return new URI(String.format("%s:%s", CONFIG_DESCRIPTION_URI_THING_PREFIX, UidUtils.generateThingTypeUID(device)));
         } catch (URISyntaxException ex) {
             logger.warn("Can't create configDescriptionURI for device type {}", device.getType());
             return null;

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -44,6 +44,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelKind;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
@@ -73,7 +74,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
     private HomematicThingTypeProvider thingTypeProvider;
     private HomematicChannelTypeProvider channelTypeProvider;
     private HomematicConfigDescriptionProvider configDescriptionProvider;
-    private Map<String, Set<String>> firmwaresByType = new HashMap<String, Set<String>>();
+    private final Map<String, Set<String>> firmwaresByType = new HashMap<String, Set<String>>();
 
     private static final String[] STATUS_DATAPOINT_NAMES = new String[] { DATAPOINT_NAME_UNREACH,
             DATAPOINT_NAME_CONFIG_PENDING, DATAPOINT_NAME_DEVICE_IN_BOOTLOADER, DATAPOINT_NAME_UPDATE_PENDING };
@@ -128,7 +129,7 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
         if (thingTypeProvider != null) {
             ThingTypeUID thingTypeUID = UidUtils.generateThingTypeUID(device);
             ThingType tt = thingTypeProvider.getInternalThingType(thingTypeUID);
-            
+
             if (tt == null || device.isGatewayExtras()) {
                 logger.debug("Generating ThingType for device '{}' with {} datapoints", device.getType(),
                         device.getDatapointCount());
@@ -162,8 +163,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                     if (groupType == null || device.isGatewayExtras()) {
                         String groupLabel = String.format("%s",
                                 WordUtils.capitalizeFully(StringUtils.replace(channel.getType(), "_", " ")));
-                        groupType = new ChannelGroupType(groupTypeUID, false, groupLabel, null, null,
-                                channelDefinitions);
+                        groupType = ChannelGroupTypeBuilder.instance(groupTypeUID, groupLabel).isAdvanced(false)
+                                .withChannelDefinitions(channelDefinitions).build();
                         channelTypeProvider.addChannelGroupType(groupType);
                         groupTypes.add(groupType);
                     }
@@ -341,14 +342,15 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                 }
             }
         }
-        
+
         configDescriptionProvider.addConfigDescription(new ConfigDescription(configDescriptionURI, parms, groups));
 
     }
 
     private URI getConfigDescriptionURI(HmDevice device) {
         try {
-            return new URI(String.format("%s:%s", CONFIG_DESCRIPTION_URI_THING_PREFIX, UidUtils.generateThingTypeUID(device)));
+            return new URI(
+                    String.format("%s:%s", CONFIG_DESCRIPTION_URI_THING_PREFIX, UidUtils.generateThingTypeUID(device)));
         } catch (URISyntaxException ex) {
             logger.warn("Can't create configDescriptionURI for device type {}", device.getType());
             return null;


### PR DESCRIPTION
This change is API breaking, the builder should be used instead.

ESH (I fixed the few occurrences) and the openHAB repositories are not affected by this change, I have
verified that.

See https://github.com/eclipse/smarthome/pull/5916#issuecomment-405345491

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>