### PR TITLE
SystemOffsetProfile should not try to adjust UndefType values

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfile.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/SystemOffsetProfile.java
@@ -108,6 +108,11 @@ public class SystemOffsetProfile implements StateProfile {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private Type applyOffset(Type state, boolean towardsItem) {
+        if (state instanceof UnDefType) {
+            // we cannot adjust undef or null values, thus we simply return them without reporting an error or warning
+            return state;
+        }
+
         QuantityType finalOffset = offset;
         if (finalOffset == null) {
             logger.warn(


### PR DESCRIPTION
Fixes nonsense warnings in the log file like:

2018-07-17 06:48:26.482 [WARN ] [nternal.profiles.SystemOffsetProfile] - Offset '0.08' cannot be applied to the incompatible state 'UNDEF' sent from the binding. Returning original state.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>