### PR TITLE
[Homematic Binding] Changes for Thing Types and Homegear prefix

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/README.md
@@ -189,6 +189,7 @@ Bridge homematic:bridge:ccu [ gatewayAddress="..." ]
 
 The first parameter after Thing is the device type, the second the serial number.
 If you are using Homegear, you have to add the prefix ```HG-``` for each type.
+The prefix ```HG-```is needed for Things and Items but not Types.
 This is necessary, because the Homegear devices supports more datapoints than Homematic devices.
 
 ```java
@@ -211,18 +212,29 @@ The receiveDelay is handy for dimmers and rollershutters for example.
 If you have a slider in a UI and you move this slider to a new position, it jumps around because the gateway sends multiple events with different positions until the final has been reached.
 If you set the ```receiveDelay``` to some seconds, these events are filtered out and only the last position is distributed to the binding.
 The disadvantage is of course, that all events for this channel are delayed.
+*The channel configs are optional*
 
 ```java
   Thing HM-LC-Dim1T-Pl-2    JEQ0999999 "Name"  @  "Location" {
       Channels:
-          Type HM-LC-Dim1T-Pl-2_1_level : 1#LEVEL [
+          Type HM-LC-Dim1T-Pl-2_1_LEVEL : 1#LEVEL [
               delay = 0,
               receiveDelay = 4
           ]
   }
 ```
 
-The Type is the device type, channel number and lowercase channel name separated with a underscore.
+The Type is the device type, channel number and uppercase channel name separated with a underscore.
+If you are using Homegear, the ```HG-``` prefix is not needed for the Type.
+
+Example without channel configs
+
+```java
+  Thing HM-LC-Dim1T-Pl-2    JEQ0999999 "Name"  @  "Location" {
+      Channels:
+          Type HM-LC-Dim1T-Pl-2_1_LEVEL : 1#LEVEL
+  }
+```
 
 ### Items
 


### PR DESCRIPTION
- Added a more clear description when the `HG-` prefix for Homegear is needed
- Added information that channel configs are optional
- Changed the description from lowercase to uppercase for Thing Types
-> See: https://community.openhab.org/t/solved-homematic-channel-type-couldn-t-be-resolved/47950/5

When adding the Thing Type in lowercase the logviewer says:
`Channel type homematic:HM-LC-Dim1T-Pl-2_1_level could not be resolved.`
It´s only working when the Thing Type is added in uppercase.