### PR TITLE
[homematic] Reduce Bin/XmlRpcServer to specified callback host address

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/server/BinRpcNetworkService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/server/BinRpcNetworkService.java
@@ -47,7 +47,7 @@ public class BinRpcNetworkService implements Runnable {
 
         serverSocket = new ServerSocket();
         serverSocket.setReuseAddress(true);
-        serverSocket.bind(new InetSocketAddress(config.getBinCallbackPort()));
+        serverSocket.bind(new InetSocketAddress(config.getCallbackHost(), config.getBinCallbackPort()));
 
         this.rpcResponseHandler = new RpcResponseHandler<byte[]>(listener) {
 

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/server/XmlRpcServer.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/server/XmlRpcServer.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.binding.homematic.internal.communicator.server;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.InetSocketAddress;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -46,7 +47,7 @@ public class XmlRpcServer implements RpcServer {
     private Server xmlRpcHTTPD;
     private HomematicConfig config;
     private RpcResponseHandler<String> rpcResponseHander;
-    private ResponseHandler jettyResponseHandler = new ResponseHandler();
+    private final ResponseHandler jettyResponseHandler = new ResponseHandler();
 
     public XmlRpcServer(RpcEventListener listener, HomematicConfig config) {
         this.config = config;
@@ -78,7 +79,9 @@ public class XmlRpcServer implements RpcServer {
     public void start() throws IOException {
         logger.debug("Initializing XML-RPC server at port {}", config.getXmlCallbackPort());
 
-        xmlRpcHTTPD = new Server(config.getXmlCallbackPort());
+        InetSocketAddress callbackAddress = new InetSocketAddress(config.getCallbackHost(),
+                config.getXmlCallbackPort());
+        xmlRpcHTTPD = new Server(callbackAddress);
         xmlRpcHTTPD.setHandler(jettyResponseHandler);
 
         try {


### PR DESCRIPTION
Open Server on host specified in the property "callbackHost" instead of
opening it without specification. This will prevent conflicts on machines which provide multiple network interfaces.

Further improvements for stability of the communication between binding and gateway:

* Improved error logging of ConnectionTrackerThread
* Synchronized AbstractHomematicGateway's start/stopServers to prevent starting of new servers while previous operation is still blocking

REMARK:
Actually this change was already in-place on openhab (see https://github.com/openhab/openhab2-addons/commit/357036cb55a746d77e56d5dafd862902590b8df4#diff-34d39d6e0ca3033b15f157f32c370cac),
but it was accidentially not included when moving the binding to the eclipse smarthome project

Signed-off-by: Michael Reitler <michael.reitler@telekom.de>