### PR TITLE
Fixed spelling in StateDescription.java

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/StateDescription.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/types/StateDescription.java
@@ -107,7 +107,7 @@ public class StateDescription {
     /**
      * Returns a list of predefined states with their label.
      *
-     * @return ist of predefined states with their label
+     * @return a list of predefined states with their label
      */
     public List<StateOption> getOptions() {
         return options;


### PR DESCRIPTION
- Moved this fix from #5694 to own PR

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>