### PR TITLE
WIP: Add tags to SystemChannelTypes

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -44,6 +44,7 @@ Import-Package:
  org.eclipse.smarthome.core.items.events,
  org.eclipse.smarthome.core.library,
  org.eclipse.smarthome.core.library.items,
+ org.eclipse.smarthome.core.library.tags,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.library.unit,
  org.eclipse.smarthome.core.service,

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.tags.SystemTags;
 import org.eclipse.smarthome.core.thing.i18n.ThingTypeI18nLocalizationService;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
@@ -70,7 +71,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
                     Arrays.asList(new StateOption("0", "no signal"), new StateOption("1", "weak"),
                             new StateOption("2", "average"), new StateOption("3", "good"),
                             new StateOption("4", "excellent"))))
-            .build();
+            .withTags(Arrays.asList(SystemTags.CAP_MEASUREMENT)).build();
 
     /**
      * Low battery default system wide {@link ChannelType}. Represents a low battery warning with possible values
@@ -80,7 +81,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .state(new ChannelTypeUID(BINDING_ID, "low-battery"), "Low Battery", "Switch").withCategory("Battery")
             .withStateDescription(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription())
-            .build();
+            .withTags(Arrays.asList(SystemTags.CAP_LOW_BATTERY, SystemTags.CAP_SWITCHABLE)).build();
 
     /**
      * Battery level default system wide {@link ChannelType}. Represents the battery level as a percentage.
@@ -89,7 +90,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .state(new ChannelTypeUID(BINDING_ID, "battery-level"), "Battery Level", "Number").withCategory("Battery")
             .withStateDescription(
                     new StateDescription(BigDecimal.ZERO, new BigDecimal(100), BigDecimal.ONE, "%.0f %%", true, null))
-            .build();
+            .withTags(Arrays.asList(SystemTags.PROP_VOLTAGE, SystemTags.CAP_MEASUREMENT)).build();
 
     /**
      * System wide trigger {@link ChannelType} without event options.
@@ -136,7 +137,8 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      */
     public static final ChannelType SYSTEM_POWER = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "power"), "Power", "Switch")
-            .withDescription("Device is operable when channel has state ON").build();
+            .withDescription("Device is operable when channel has state ON")
+            .withTags(Arrays.asList(SystemTags.PROP_POWER, SystemTags.CAP_SWITCHABLE)).build();
 
     /**
      * Location: default system wide {@link ChannelType} which displays a location
@@ -151,9 +153,10 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      */
     public static final ChannelType SYSTEM_MOTION = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "motion"), "Motion", "Switch")
-            .withDescription("Motion detected by the device").withCategory("Motion").withStateDescription(
+            .withDescription("Motion detected by the device").withCategory("Motion")
+            .withStateDescription(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription())
-            .build();
+            .withTags(Arrays.asList(SystemTags.CAP_SWITCHABLE)).build();
 
     /**
      * Brightness: default system wide {@link ChannelType} which allows changing the brightness from 0-100%
@@ -162,13 +165,15 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .state(new ChannelTypeUID(BINDING_ID, "brightness"), "Brightness", "Dimmer")
             .withStateDescription(
                     new StateDescription(BigDecimal.ZERO, new BigDecimal(100), null, "%d %%", false, null))
-            .withCategory("Light").build();
+            .withCategory("Light")
+            .withTags(Arrays.asList(SystemTags.PROP_LIGHT, SystemTags.PUR_LIGHTING, SystemTags.CAP_DIMMABLE)).build();
 
     /**
      * Color: default system wide {@link ChannelType} which allows changing the color
      */
     public static final ChannelType SYSTEM_COLOR = ChannelTypeBuilder
-            .state(new ChannelTypeUID(BINDING_ID, "color"), "Color", "Color").withCategory("ColorLight").build();
+            .state(new ChannelTypeUID(BINDING_ID, "color"), "Color", "Color").withCategory("ColorLight")
+            .withTags(Arrays.asList(SystemTags.PROP_LIGHT, SystemTags.PUR_LIGHTING, SystemTags.CAP_COLOR)).build();
 
     /**
      * Color-temperature: default system wide {@link ChannelType} which allows changing the color temperature
@@ -176,7 +181,9 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
     public static final ChannelType SYSTEM_COLOR_TEMPERATURE = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "color-temperature"), "Color Temperature", "Dimmer")
             .withStateDescription(new StateDescription(BigDecimal.ZERO, new BigDecimal(100), null, "%d", false, null))
-            .withCategory("ColorLight").build();
+            .withCategory("ColorLight")
+            .withTags(Arrays.asList(SystemTags.PROP_LIGHT, SystemTags.PUR_LIGHTING, SystemTags.CAP_COLOR_TEMPERATURE))
+            .build();
 
     // media channels
 
@@ -188,21 +195,24 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .withDescription("Change the sound volume of a device")
             .withStateDescription(
                     new StateDescription(BigDecimal.ZERO, new BigDecimal(100), null, "%d %%", false, null))
-            .withCategory("SoundVolume").build();
+            .withCategory("SoundVolume")
+            .withTags(Arrays.asList(SystemTags.PROP_NOISE, SystemTags.CAP_DIMMABLE, SystemTags.CAP_VOLUME)).build();
 
     /**
      * Mute: default system wide {@link ChannelType} which allows muting and un-muting audio
      */
     public static final ChannelType SYSTEM_MUTE = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "mute"), "Mute", "Switch").withDescription("Mute audio of the device")
-            .withCategory("SoundVolume").build();
+            .withCategory("SoundVolume").withTags(Arrays.asList(SystemTags.PROP_NOISE, SystemTags.CAP_SWITCHABLE))
+            .build();
 
     /**
      * Media-control: system wide {@link ChannelType} which controls a media player
      */
     public static final ChannelType SYSTEM_MEDIA_CONTROL = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "media-control"), "Media Control", "Player")
-            .withCategory("MediaControl").build();
+            .withCategory("MediaControl").withTags(Arrays.asList(SystemTags.PROP_NOISE, SystemTags.CAP_CONTROL))
+            .build();
 
     /**
      * Media-title: default system wide {@link ChannelType} which displays the title of a (played) song
@@ -232,7 +242,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .withCategory("Wind")
             .withStateDescription(
                     new StateDescription(BigDecimal.ZERO, new BigDecimal(360), null, "%.0f %unit%", true, null))
-            .build();
+            .withTags(Arrays.asList(SystemTags.PROP_WIND, SystemTags.CAP_MEASUREMENT)).build();
 
     /**
      * Wind-speed: system wide {@link ChannelType} which shows the wind speed
@@ -241,7 +251,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .state(new ChannelTypeUID(BINDING_ID, "wind-speed"), "Wind Speed", "Number:Speed").withCategory("Wind")
             .withStateDescription(StateDescriptionFragmentBuilder.create().withReadOnly(true).withPattern("%.1f %unit%")
                     .build().toStateDescription())
-            .build();
+            .withTags(Arrays.asList(SystemTags.PROP_WIND, SystemTags.CAP_MEASUREMENT)).build();
 
     /**
      * Outdoor-temperature: system wide {@link ChannelType} which shows the outdoor temperature
@@ -249,9 +259,10 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
     public static final ChannelType SYSTEM_OUTDOOR_TEMPERATURE = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "outdoor-temperature"), "Current Outdoor Temperature",
                     "Number:Temperature")
-            .withCategory("Temperature").withStateDescription(StateDescriptionFragmentBuilder.create()
-                    .withReadOnly(true).withPattern("%.1f %unit%").build().toStateDescription())
-            .build();
+            .withCategory("Temperature")
+            .withStateDescription(StateDescriptionFragmentBuilder.create().withReadOnly(true).withPattern("%.1f %unit%")
+                    .build().toStateDescription())
+            .withTags(Arrays.asList(SystemTags.PROP_TEMPERATURE, SystemTags.CAP_MEASUREMENT)).build();
 
     /**
      * Atmospheric-humidity: system wide {@link ChannelType} which shows the atmospheric humidity
@@ -259,18 +270,20 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
     public static final ChannelType SYSTEM_ATMOSPHERIC_HUMIDITY = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "atmospheric-humidity"), "Atmospheric Humidity",
                     "Number:Dimensionless")
-            .withCategory("Humidity").withStateDescription(StateDescriptionFragmentBuilder.create().withReadOnly(true)
-                    .withPattern("%.0f %%").build().toStateDescription())
-            .build();
+            .withCategory("Humidity")
+            .withStateDescription(StateDescriptionFragmentBuilder.create().withReadOnly(true).withPattern("%.0f %%")
+                    .build().toStateDescription())
+            .withTags(Arrays.asList(SystemTags.PROP_HUMIDITY, SystemTags.CAP_MEASUREMENT)).build();
 
     /**
      * Barometric-pressure: system wide {@link ChannelType} which shows the barometric pressure
      */
     public static final ChannelType SYSTEM_BAROMETRIC_PRESSURE = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "barometric-pressure"), "Barometric Pressure", "Number:Pressure")
-            .withCategory("Pressure").withStateDescription(StateDescriptionFragmentBuilder.create().withReadOnly(true)
-                    .withPattern("%.3f %unit%").build().toStateDescription())
-            .build();
+            .withCategory("Pressure")
+            .withStateDescription(StateDescriptionFragmentBuilder.create().withReadOnly(true).withPattern("%.3f %unit%")
+                    .build().toStateDescription())
+            .withTags(Arrays.asList(SystemTags.PROP_PRESSURE, SystemTags.CAP_MEASUREMENT)).build();
 
     private static class LocalizedChannelTypeKey {
         public final String locale;

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
@@ -81,7 +81,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .state(new ChannelTypeUID(BINDING_ID, "low-battery"), "Low Battery", "Switch").withCategory("Battery")
             .withStateDescription(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription())
-            .withTags(Arrays.asList(SystemTags.CAP_LOW_BATTERY, SystemTags.CAP_SWITCHABLE)).build();
+            .withTags(Arrays.asList(SystemTags.CAP_LOW_BATTERY, SystemTags.CAP_MEASUREMENT)).build();
 
     /**
      * Battery level default system wide {@link ChannelType}. Represents the battery level as a percentage.
@@ -156,7 +156,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .withDescription("Motion detected by the device").withCategory("Motion")
             .withStateDescription(
                     StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription())
-            .withTags(Arrays.asList(SystemTags.CAP_SWITCHABLE)).build();
+            .withTags(Arrays.asList(SystemTags.CAP_MEASUREMENT, SystemTags.PROP_PRESENCE)).build();
 
     /**
      * Brightness: default system wide {@link ChannelType} which allows changing the brightness from 0-100%
@@ -195,15 +195,14 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             .withDescription("Change the sound volume of a device")
             .withStateDescription(
                     new StateDescription(BigDecimal.ZERO, new BigDecimal(100), null, "%d %%", false, null))
-            .withCategory("SoundVolume")
-            .withTags(Arrays.asList(SystemTags.PROP_NOISE, SystemTags.CAP_DIMMABLE, SystemTags.CAP_VOLUME)).build();
+            .withCategory("SoundVolume").withTags(Arrays.asList(SystemTags.CAP_VOLUME)).build();
 
     /**
      * Mute: default system wide {@link ChannelType} which allows muting and un-muting audio
      */
     public static final ChannelType SYSTEM_MUTE = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "mute"), "Mute", "Switch").withDescription("Mute audio of the device")
-            .withCategory("SoundVolume").withTags(Arrays.asList(SystemTags.PROP_NOISE, SystemTags.CAP_SWITCHABLE))
+            .withCategory("SoundVolume").withTags(Arrays.asList(SystemTags.CAP_VOLUME, SystemTags.CAP_SWITCHABLE))
             .build();
 
     /**
@@ -211,8 +210,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
      */
     public static final ChannelType SYSTEM_MEDIA_CONTROL = ChannelTypeBuilder
             .state(new ChannelTypeUID(BINDING_ID, "media-control"), "Media Control", "Player")
-            .withCategory("MediaControl").withTags(Arrays.asList(SystemTags.PROP_NOISE, SystemTags.CAP_CONTROL))
-            .build();
+            .withCategory("MediaControl").withTags(Arrays.asList(SystemTags.CAP_CONTROL)).build();
 
     /**
      * Media-title: default system wide {@link ChannelType} which displays the title of a (played) song

--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -24,6 +24,7 @@ Export-Package:
  org.eclipse.smarthome.core.library,
  org.eclipse.smarthome.core.library.dimension,
  org.eclipse.smarthome.core.library.items,
+ org.eclipse.smarthome.core.library.tags,
  org.eclipse.smarthome.core.library.types,
  org.eclipse.smarthome.core.library.unit,
  org.eclipse.smarthome.core.net,

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/tags/SystemTags.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/tags/SystemTags.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.library.tags;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * System-wide semantic tags
+ *
+ * @author Stefan Triller - Initial Contribution
+ *
+ */
+@NonNullByDefault
+public class SystemTags {
+
+    public static final String TAG_KIND_DELIMITER = ":";
+
+    private static enum Kind {
+        Object,
+        Location,
+        Property,
+        Purpose,
+        Capability;
+    }
+
+    public static final String LOC_HOME = Kind.Location + TAG_KIND_DELIMITER + "Home";
+    public static final String LOC_WORK = Kind.Location + TAG_KIND_DELIMITER + "Work";
+
+    public static final String PROP_TEMPERATURE = Kind.Property + TAG_KIND_DELIMITER + "Temperature";
+    public static final String PROP_LIGHT = Kind.Property + TAG_KIND_DELIMITER + "Light";
+    public static final String PROP_HUMIDITY = Kind.Property + TAG_KIND_DELIMITER + "Humidity";
+    public static final String PROP_PRESSURE = Kind.Property + TAG_KIND_DELIMITER + "Pressure";
+    public static final String PROP_SMOKE = Kind.Property + TAG_KIND_DELIMITER + "Smoke";
+    public static final String PROP_NOISE = Kind.Property + TAG_KIND_DELIMITER + "Noise";
+    public static final String PROP_RAIN = Kind.Property + TAG_KIND_DELIMITER + "Rain";
+    public static final String PROP_WIND = Kind.Property + TAG_KIND_DELIMITER + "Wind";
+    public static final String PROP_WATER = Kind.Property + TAG_KIND_DELIMITER + "Water";
+    public static final String PROP_CO2 = Kind.Property + TAG_KIND_DELIMITER + "CO2";
+    public static final String PROP_CO = Kind.Property + TAG_KIND_DELIMITER + "CO";
+    public static final String PROP_ENERGY = Kind.Property + TAG_KIND_DELIMITER + "Energy";
+    public static final String PROP_POWER = Kind.Property + TAG_KIND_DELIMITER + "Power";
+    public static final String PROP_VOLTAGE = Kind.Property + TAG_KIND_DELIMITER + "Voltage";
+    public static final String PROP_CURRENT = Kind.Property + TAG_KIND_DELIMITER + "Current";
+    public static final String PROP_FREQUENCY = Kind.Property + TAG_KIND_DELIMITER + "Frequency";
+    public static final String PROP_GAS = Kind.Property + TAG_KIND_DELIMITER + "Gas";
+    public static final String PROP_OIL = Kind.Property + TAG_KIND_DELIMITER + "Oil";
+
+    public static final String PUR_ALARM = Kind.Purpose + TAG_KIND_DELIMITER + "Alarm";
+    public static final String PUR_ALARM_FIRE = PUR_ALARM + TAG_KIND_DELIMITER + "Fire";
+    public static final String PUR_ALARM_LEAKAGE = PUR_ALARM + TAG_KIND_DELIMITER + "Leakage";
+    public static final String PUR_ALARM_INTRUSION = PUR_ALARM + TAG_KIND_DELIMITER + "Intrusion";
+    public static final String PUR_ALARM_CO = PUR_ALARM + TAG_KIND_DELIMITER + "CO";
+    public static final String PUR_LIGHTING = Kind.Purpose + TAG_KIND_DELIMITER + "Lighting";
+    public static final String PUR_LIGHTING_ILLUMINATION = PUR_LIGHTING + TAG_KIND_DELIMITER + "Illumination";
+    public static final String PUR_LIGHTING_AMBIENCE = PUR_LIGHTING + TAG_KIND_DELIMITER + "Ambience";
+    public static final String PUR_LIGHTING_NIGHT = PUR_LIGHTING + TAG_KIND_DELIMITER + "Night";
+    public static final String PUR_HEATING = Kind.Purpose + TAG_KIND_DELIMITER + "Heating";
+    public static final String PUR_COOLING = Kind.Purpose + TAG_KIND_DELIMITER + "Cooling";
+
+    public static final String CAP_MEASUREMENT = Kind.Capability + TAG_KIND_DELIMITER + "Measurement";
+    public static final String CAP_CONTROL = Kind.Capability + TAG_KIND_DELIMITER + "Control";
+    public static final String CAP_SWITCHABLE = Kind.Capability + TAG_KIND_DELIMITER + "Switchable";
+    public static final String CAP_DIMMABLE = Kind.Capability + TAG_KIND_DELIMITER + "Dimmable";
+    public static final String CAP_COLOR = Kind.Capability + TAG_KIND_DELIMITER + "Color";
+    public static final String CAP_COLOR_TEMPERATURE = Kind.Capability + TAG_KIND_DELIMITER + "ColorTemperature";
+    public static final String CAP_LOW_BATTERY = Kind.Capability + TAG_KIND_DELIMITER + "LowBattery";
+    public static final String CAP_OPENSTATE = Kind.Capability + TAG_KIND_DELIMITER + "OpenState";
+    public static final String CAP_TAMPERED = Kind.Capability + TAG_KIND_DELIMITER + "Tampered";
+    public static final String CAP_OPEN_LEVEL = Kind.Capability + TAG_KIND_DELIMITER + "OpenLevel";
+    public static final String CAP_TILT = Kind.Capability + TAG_KIND_DELIMITER + "Tilt";
+    public static final String CAP_VOLUME = Kind.Capability + TAG_KIND_DELIMITER + "Volume";
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/tags/SystemTags.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/tags/SystemTags.java
@@ -54,6 +54,7 @@ public class SystemTags {
     public static final String PROP_FREQUENCY = Kind.Property + TAG_KIND_DELIMITER + "Frequency";
     public static final String PROP_GAS = Kind.Property + TAG_KIND_DELIMITER + "Gas";
     public static final String PROP_OIL = Kind.Property + TAG_KIND_DELIMITER + "Oil";
+    public static final String PROP_PRESENCE = Kind.Property + TAG_KIND_DELIMITER + "Presence";
 
     public static final String PUR_ALARM = Kind.Purpose + TAG_KIND_DELIMITER + "Alarm";
     public static final String PUR_ALARM_FIRE = PUR_ALARM + TAG_KIND_DELIMITER + "Fire";
@@ -66,6 +67,9 @@ public class SystemTags {
     public static final String PUR_LIGHTING_NIGHT = PUR_LIGHTING + TAG_KIND_DELIMITER + "Night";
     public static final String PUR_HEATING = Kind.Purpose + TAG_KIND_DELIMITER + "Heating";
     public static final String PUR_COOLING = Kind.Purpose + TAG_KIND_DELIMITER + "Cooling";
+    public static final String PUR_PRESENCE = Kind.Purpose + TAG_KIND_DELIMITER + "Presence";
+    public static final String PUR_PRESENCE_AWAY = PUR_PRESENCE + TAG_KIND_DELIMITER + "Away";
+    public static final String PUR_PRESENCE_HOME = PUR_PRESENCE + TAG_KIND_DELIMITER + "AtHome";
 
     public static final String CAP_MEASUREMENT = Kind.Capability + TAG_KIND_DELIMITER + "Measurement";
     public static final String CAP_CONTROL = Kind.Capability + TAG_KIND_DELIMITER + "Control";


### PR DESCRIPTION
This PR is meant for discussing the tags for the default SystemChannelTypes
as stated in the wiki:

https://github.com/eclipse/smarthome/wiki/Semantic-Tag-Library

Also the location (and name) for the "SystemTags" class is open for
discussion.

The idea is to have hierarchical tags, so "Purpose:Alarm:Fire" can also
be retrieved by looking for all alarms, i.e "Purpose:Alarm".

Once we have agreed on the tags, I will adjust the tests for the channels
and add them to this PR.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>