### PR TITLE
[Hue] Added support for bulbs using CIE XY colormode only

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
@@ -24,7 +24,6 @@
         <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <environments combine.self="override"></environments>
           <dependency-resolution>
             <extraRequirements>
               <requirement>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandlerTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 
 import org.eclipse.smarthome.binding.hue.internal.FullConfig;
 import org.eclipse.smarthome.binding.hue.internal.FullLight;
+import org.eclipse.smarthome.binding.hue.internal.State.ColorMode;
 import org.eclipse.smarthome.binding.hue.internal.StateUpdate;
 import org.eclipse.smarthome.binding.hue.test.HueLightState;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -52,6 +53,7 @@ import com.google.gson.JsonParser;
  * @author Andre Fuechsel - modified tests after introducing the generic thing types
  * @author Denis Dudnik - switched to internally integrated source of Jue library
  * @author Simon Kaufmann - migrated to plain Java test
+ * @author Christoph Weitkamp - Added support for bulbs using CIE XY colormode only
  */
 public class HueLightHandlerTest {
 
@@ -193,6 +195,24 @@ public class HueLightHandlerTest {
     public void assertCommandForColorChannelWhite() {
         String expectedReply = "{\"bri\" : 254, \"sat\" : 0, \"hue\" : 0}";
         assertSendCommandForColor(HSBType.WHITE, new HueLightState(), expectedReply);
+    }
+
+    @Test
+    public void assertXYCommandForColorChannelBlack() {
+        String expectedReply = "{\"on\" : false}";
+        assertSendCommandForColor(HSBType.BLACK, new HueLightState().colormode(ColorMode.XY), expectedReply);
+    }
+
+    @Test
+    public void assertXYCommandForColorChannelWhite() {
+        String expectedReply = "{\"xy\" : [ 0.31271592 , 0.32900152 ]}";
+        assertSendCommandForColor(HSBType.WHITE, new HueLightState().colormode(ColorMode.XY), expectedReply);
+    }
+
+    @Test
+    public void assertXYCommandForColorChannelColorful() {
+        String expectedReply = "{\"xy\" : [ 0.16969365 , 0.12379659 ]}";
+        assertSendCommandForColor(new HSBType("220,90,50"), new HueLightState().colormode(ColorMode.XY), expectedReply);
     }
 
     @Test

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/test/HueLightState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/test/HueLightState.java
@@ -12,12 +12,15 @@
  */
 package org.eclipse.smarthome.binding.hue.test;
 
+import org.eclipse.smarthome.binding.hue.internal.State.ColorMode;
+
 /**
  * Builder for the current state of a hue light.
  *
  * @author Dominic Lerbs - Initial contribution
  * @author Markus Mazurczak - Added possibility to set modelId to "PAR16 50 TW" to test osram workaround
  * @author Markus Rathgeb - migrated to plain Java test
+ * @author Christoph Weitkamp - Added support for bulbs using CIE XY colormode only
  */
 public class HueLightState {
 
@@ -28,6 +31,7 @@ public class HueLightState {
     boolean isOn = true;
     String alert = "none";
     String effect = "none";
+    String colorMode = "hs";
     String model = "LCT001";
 
     public HueLightState() {
@@ -72,6 +76,11 @@ public class HueLightState {
         return this;
     }
 
+    public HueLightState colormode(ColorMode colorMode) {
+        this.colorMode = colorMode.toString();
+        return this;
+    }
+
     @Override
     public String toString() {
         return "" + //
@@ -90,7 +99,7 @@ public class HueLightState {
                 "        \"ct\": " + colorTemperature + "," + //
                 "        \"alert\": \"" + alert + "\"," + //
                 "        \"effect\": \"" + effect + "\"," + //
-                "        \"colormode\": \"hs\"," + //
+                "        \"colormode\": \"" + colorMode + "\"," + //
                 "        \"reachable\": true" + //
                 "      }," + //
                 "      \"type\": \"Extended color light\"," + //

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * {@link HueLightHandler} is the handler for a hue light. It uses the {@link HueClient} to execute the actual
  * command.
  *
- * @author Dennis Nobel - Initial contribution of hue binding
+ * @author Dennis Nobel - Initial contribution
  * @author Oliver Libutzki
  * @author Kai Kreuzer - stabilized code
  * @author Andre Fuechsel - implemented switch off when brightness == 0, changed to support generic thing types, changed
@@ -64,7 +64,7 @@ import org.slf4j.LoggerFactory;
  *         bulbs
  * @author Yordan Zhelev - added alert and effect functions
  * @author Denis Dudnik - switched to internally integrated source of Jue library
- *
+ * @author Christoph Weitkamp - Added support for bulbs using CIE XY colormode only
  */
 @NonNullByDefault
 public class HueLightHandler extends BaseThingHandler implements LightStatusListener {
@@ -243,7 +243,7 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
                     if (hsbCommand.getBrightness().intValue() == 0) {
                         lightState = LightStateConverter.toOnOffLightState(OnOffType.OFF);
                     } else {
-                        lightState = LightStateConverter.toColorLightState(hsbCommand);
+                        lightState = LightStateConverter.toColorLightState(hsbCommand, light.getState());
                     }
                 } else if (command instanceof PercentType) {
                     lightState = LightStateConverter.toBrightnessLightState((PercentType) command);

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
@@ -75,12 +75,7 @@ public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
 
     @Override
     protected void startScan() {
-        scheduler.schedule(new Runnable() {
-            @Override
-            public void run() {
-                discoverHueBridges();
-            }
-        }, 0, TimeUnit.SECONDS);
+        scheduler.schedule(this::discoverHueBridges, 0, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
- Added support for bulbs using CIE XY colormode only

Addresses #4939 

Beta version: [org.eclipse.smarthome.binding.hue-0.10.0-SNAPSHOT.jar.zip](https://github.com/eclipse/smarthome/files/2216051/org.eclipse.smarthome.binding.hue-0.10.0-SNAPSHOT.jar.zip)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>