### PR TITLE
Add Automatic-Module-Name entry to archetype manifests

### DIFF
--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: ${artifactId}
 Bundle-ManifestVersion: 2
 Bundle-Name: ${bindingIdCamelCase} Binding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Automatic-Module-Name: ${artifactId}
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2


### PR DESCRIPTION
See also https://github.com/eclipse/smarthome/issues/5822.