### PR TITLE
[Hue] Replaced constant 'SERIAL_NUMBER' by 'Thing.PROPERTY_SERIAL_NUMBER'

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandlerOSGiTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandlerOSGiTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.hue.handler;
 
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
 
@@ -68,7 +69,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
     public void assertThatANewUserIsAddedToConfigIfNotExistingYet() {
         Configuration configuration = new Configuration();
         configuration.put(HOST, DUMMY_HOST);
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
         Bridge bridge = createBridgeThing(configuration);
 
         HueBridgeHandler hueBridgeHandler = getThingHandler(bridge, HueBridgeHandler.class);
@@ -91,7 +92,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
         Configuration configuration = new Configuration();
         configuration.put(HOST, DUMMY_HOST);
         configuration.put(USER_NAME, TEST_USER_NAME);
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
         Bridge bridge = createBridgeThing(configuration);
 
         HueBridgeHandler hueBridgeHandler = getThingHandler(bridge, HueBridgeHandler.class);
@@ -113,7 +114,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
         Configuration configuration = new Configuration();
         configuration.put(HOST, DUMMY_HOST);
         configuration.put(USER_NAME, "notAuthenticatedUser");
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
         Bridge bridge = createBridgeThing(configuration);
 
         HueBridgeHandler hueBridgeHandler = getThingHandler(bridge, HueBridgeHandler.class);
@@ -137,7 +138,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
     public void verifyStatusIfLinkButtonIsNotPressed() {
         Configuration configuration = new Configuration();
         configuration.put(HOST, DUMMY_HOST);
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
         Bridge bridge = createBridgeThing(configuration);
 
         HueBridgeHandler hueBridgeHandler = getThingHandler(bridge, HueBridgeHandler.class);
@@ -161,7 +162,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
     public void verifyStatusIfNewUserCannotBeCreated() {
         Configuration configuration = new Configuration();
         configuration.put(HOST, DUMMY_HOST);
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
         Bridge bridge = createBridgeThing(configuration);
 
         HueBridgeHandler hueBridgeHandler = getThingHandler(bridge, HueBridgeHandler.class);
@@ -185,7 +186,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
     public void verifyOfflineIsSetWithoutBridgeOfflineStatus() {
         Configuration configuration = new Configuration();
         configuration.put(HOST, DUMMY_HOST);
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
         Bridge bridge = createBridgeThing(configuration);
 
         HueBridgeHandler hueBridgeHandler = getThingHandler(bridge, HueBridgeHandler.class);
@@ -201,7 +202,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
     public void assertThatAStatusConfigurationMessageForMissingBridgeIPIsProperlyReturnedIPIsNull() {
         Configuration configuration = new Configuration();
         configuration.put(HOST, null);
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
 
         Bridge bridge = createBridgeThing(configuration);
 
@@ -217,7 +218,7 @@ public class HueBridgeHandlerOSGiTest extends AbstractHueOSGiTest {
     public void assertThatAStatusConfigurationMessageForMissingBridgeIPIsProperlyReturnedIPIsAnEmptyString() {
         Configuration configuration = new Configuration();
         configuration.put(HOST, "");
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
 
         Bridge bridge = createBridgeThing(configuration);
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/internal/HueLightDiscoveryServiceOSGiTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/internal/HueLightDiscoveryServiceOSGiTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.hue.internal;
 
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
@@ -74,7 +75,7 @@ public class HueLightDiscoveryServiceOSGiTest extends AbstractHueOSGiTest {
         Configuration configuration = new Configuration();
         configuration.put(HOST, "1.2.3.4");
         configuration.put(USER_NAME, "testUserName");
-        configuration.put(SERIAL_NUMBER, "testSerialNumber");
+        configuration.put(PROPERTY_SERIAL_NUMBER, "testSerialNumber");
 
         hueBridge = (Bridge) thingRegistry.createThingOfType(BRIDGE_THING_TYPE_UID, BRIDGE_THING_UID, null, "Bridge",
                 configuration);

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/test/HueBridgeDiscoveryParticipantOSGITest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/test/HueBridgeDiscoveryParticipantOSGITest.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.hue.test;
 
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
@@ -101,8 +102,8 @@ public class HueBridgeDiscoveryParticipantOSGITest extends JavaOSGiTest {
         assertThat(result.getThingTypeUID(), is(THING_TYPE_BRIDGE));
         assertThat(result.getBridgeUID(), is(nullValue()));
         assertThat(result.getProperties().get(HOST), is("1.2.3.4"));
-        assertThat(result.getProperties().get(SERIAL_NUMBER), is("serial123"));
-        assertThat(result.getRepresentationProperty(), is(SERIAL_NUMBER));
+        assertThat(result.getProperties().get(PROPERTY_SERIAL_NUMBER), is("serial123"));
+        assertThat(result.getRepresentationProperty(), is(PROPERTY_SERIAL_NUMBER));
     }
 
     @Test

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/HueBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/HueBindingConstants.java
@@ -53,7 +53,6 @@ public class HueBindingConstants {
     // Bridge config properties
     public static final String HOST = "ipAddress";
     public static final String USER_NAME = "userName";
-    public static final String SERIAL_NUMBER = "serialNumber";
     public static final String POLLING_INTERVAL = "pollingInterval";
 
     // Light config properties

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.hue.handler;
 
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
+import static org.eclipse.smarthome.core.thing.Thing.*;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -48,7 +49,6 @@ import org.eclipse.smarthome.config.core.status.ConfigStatusMessage;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.ChannelUID;
-import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
@@ -299,8 +299,8 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
             Config config = fullConfig.getConfig();
             if (config != null) {
                 Map<String, String> properties = editProperties();
-                properties.put(Thing.PROPERTY_SERIAL_NUMBER, config.getMACAddress().replaceAll(":", "").toLowerCase());
-                properties.put(Thing.PROPERTY_FIRMWARE_VERSION, config.getSoftwareVersion());
+                properties.put(PROPERTY_SERIAL_NUMBER, config.getMACAddress().replaceAll(":", "").toLowerCase());
+                properties.put(PROPERTY_FIRMWARE_VERSION, config.getSoftwareVersion());
                 updateProperties(properties);
                 propertiesInitializedSuccessfully = true;
             }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeDiscoveryParticipant.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.hue.internal.discovery;
 
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,10 +54,11 @@ public class HueBridgeDiscoveryParticipant implements UpnpDiscoveryParticipant {
         if (uid != null) {
             Map<String, Object> properties = new HashMap<>(2);
             properties.put(HOST, device.getDetails().getBaseURL().getHost());
-            properties.put(SERIAL_NUMBER, device.getDetails().getSerialNumber());
+            properties.put(PROPERTY_SERIAL_NUMBER, device.getDetails().getSerialNumber());
 
             DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
-                    .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(SERIAL_NUMBER).build();
+                    .withLabel(device.getDetails().getFriendlyName()).withRepresentationProperty(PROPERTY_SERIAL_NUMBER)
+                    .build();
             return result;
         } else {
             return null;

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueBridgeNupnpDiscovery.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.hue.internal.discovery;
 
 import static org.eclipse.smarthome.binding.hue.HueBindingConstants.*;
+import static org.eclipse.smarthome.core.thing.Thing.PROPERTY_SERIAL_NUMBER;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -94,7 +95,8 @@ public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
                 ThingUID uid = new ThingUID(THING_TYPE_BRIDGE, serialNumber);
                 DiscoveryResult result = DiscoveryResultBuilder.create(uid)
                         .withProperties(buildProperties(host, serialNumber))
-                        .withLabel(LABEL_PATTERN.replace("IP", host)).withRepresentationProperty(SERIAL_NUMBER).build();
+                        .withLabel(LABEL_PATTERN.replace("IP", host)).withRepresentationProperty(PROPERTY_SERIAL_NUMBER)
+                        .build();
                 thingDiscovered(result);
             }
         }
@@ -110,7 +112,7 @@ public class HueBridgeNupnpDiscovery extends AbstractDiscoveryService {
     private Map<String, Object> buildProperties(String host, String serialNumber) {
         Map<String, Object> properties = new HashMap<>(2);
         properties.put(HOST, host);
-        properties.put(SERIAL_NUMBER, serialNumber);
+        properties.put(PROPERTY_SERIAL_NUMBER, serialNumber);
         return properties;
     }
 


### PR DESCRIPTION
- Moved this change from #5946 to its own PR

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>