### PR TITLE
make module builders available in scripted rules

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/internal/RuleSupportScriptExtension.java
@@ -26,6 +26,10 @@ import org.eclipse.smarthome.automation.Rule;
 import org.eclipse.smarthome.automation.RuleRegistry;
 import org.eclipse.smarthome.automation.Trigger;
 import org.eclipse.smarthome.automation.Visibility;
+import org.eclipse.smarthome.automation.core.util.ActionBuilder;
+import org.eclipse.smarthome.automation.core.util.ConditionBuilder;
+import org.eclipse.smarthome.automation.core.util.ModuleBuilder;
+import org.eclipse.smarthome.automation.core.util.TriggerBuilder;
 import org.eclipse.smarthome.automation.module.script.ScriptExtensionProvider;
 import org.eclipse.smarthome.automation.module.script.rulesupport.shared.RuleSupportRuleRegistryDelegate;
 import org.eclipse.smarthome.automation.module.script.rulesupport.shared.ScriptedAutomationManager;
@@ -76,6 +80,11 @@ public class RuleSupportScriptExtension implements ScriptExtensionProvider {
         staticTypes.put("ConditionHandlerFactory", ScriptedConditionHandlerFactory.class);
         staticTypes.put("TriggerHandlerFactory", ScriptedTriggerHandlerFactory.class);
 
+        staticTypes.put("ModuleBuilder", ModuleBuilder.class);
+        staticTypes.put("ActionBuilder", ActionBuilder.class);
+        staticTypes.put("ConditionBuilder", ConditionBuilder.class);
+        staticTypes.put("TriggerBuilder", TriggerBuilder.class);
+
         staticTypes.put("Configuration", Configuration.class);
         staticTypes.put("Action", Action.class);
         staticTypes.put("Condition", Condition.class);
@@ -92,7 +101,8 @@ public class RuleSupportScriptExtension implements ScriptExtensionProvider {
         types.add(AUTOMATION_MANAGER);
         types.add(RULE_REGISTRY);
 
-        presets.put(RULE_SUPPORT, Arrays.asList("Configuration", "Action", "Condition", "Trigger", "Rule"));
+        presets.put(RULE_SUPPORT, Arrays.asList("Configuration", "Action", "Condition", "Trigger", "Rule",
+                "ModuleBuilder", "ActionBuilder", "ConditionBuilder", "TriggerBuilder"));
         presets.put("RuleSimple", Arrays.asList("SimpleActionHandler", "SimpleConditionHandler", "SimpleTriggerHandler",
                 "SimpleRule", "TriggerType", "ConfigDescriptionParameter", "ModuleType", "ActionType", "Visibility"));
         presets.put("RuleFactories",

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/shared/ScriptedAutomationManager.java
@@ -19,6 +19,7 @@ import org.eclipse.smarthome.automation.Action;
 import org.eclipse.smarthome.automation.Condition;
 import org.eclipse.smarthome.automation.Rule;
 import org.eclipse.smarthome.automation.Trigger;
+import org.eclipse.smarthome.automation.core.util.ActionBuilder;
 import org.eclipse.smarthome.automation.core.util.ModuleBuilder;
 import org.eclipse.smarthome.automation.core.util.RuleBuilder;
 import org.eclipse.smarthome.automation.module.script.rulesupport.internal.ScriptedCustomModuleHandlerFactory;
@@ -164,7 +165,7 @@ public class ScriptedAutomationManager {
             String privId = addPrivateActionHandler(
                     new SimpleRuleActionHandlerDelegate((SimpleRuleActionHandler) element));
 
-            Action scriptedAction = ModuleBuilder.createAction().withId(Integer.toString(moduleIndex++))
+            Action scriptedAction = ActionBuilder.create().withId(Integer.toString(moduleIndex++))
                     .withTypeUID("jsr223.ScriptedAction").withConfiguration(new Configuration()).build();
             scriptedAction.getConfiguration().put("privId", privId);
             actions.add(scriptedAction);

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/shared/simple/SimpleRule.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/shared/simple/SimpleRule.java
@@ -181,7 +181,7 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
 
     @Override
     public List<Condition> getConditions() {
-        return conditions;
+        return conditions == null ? new ArrayList<>() : conditions;
     }
 
     /**
@@ -190,17 +190,17 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
      * @param conditions a list with the conditions that should belong to this {@link Rule}.
      */
     public void setConditions(@Nullable List<Condition> conditions) {
-        this.conditions = conditions == null ? new ArrayList<>() : conditions;
+        this.conditions = conditions;
     }
 
     @Override
     public List<Action> getActions() {
-        return actions;
+        return actions == null ? new ArrayList<>() : actions;
     }
 
     @Override
     public List<Trigger> getTriggers() {
-        return triggers;
+        return triggers == null ? new ArrayList<>() : triggers;
     }
 
     /**
@@ -209,7 +209,7 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
      * @param actions a list with the actions that should belong to this {@link Rule}.
      */
     public void setActions(@Nullable List<Action> actions) {
-        this.actions = actions == null ? new ArrayList<>() : actions;
+        this.actions = actions;
     }
 
     /**
@@ -218,7 +218,7 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
      * @param triggers a list with the triggers that should belong to this {@link Rule}.
      */
     public void setTriggers(@Nullable List<Trigger> triggers) {
-        this.triggers = triggers == null ? new ArrayList<>() : triggers;
+        this.triggers = triggers;
     }
 
     /**

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/shared/simple/SimpleRule.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.rulesupport/src/main/java/org/eclipse/smarthome/automation/module/script/rulesupport/shared/simple/SimpleRule.java
@@ -181,7 +181,7 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
 
     @Override
     public List<Condition> getConditions() {
-        return conditions == null ? new ArrayList<>() : conditions;
+        return conditions == null ? Collections.emptyList() : conditions;
     }
 
     /**
@@ -195,12 +195,12 @@ public abstract class SimpleRule implements Rule, SimpleRuleActionHandler {
 
     @Override
     public List<Action> getActions() {
-        return actions == null ? new ArrayList<>() : actions;
+        return actions == null ? Collections.emptyList() : actions;
     }
 
     @Override
     public List<Trigger> getTriggers() {
-        return triggers == null ? new ArrayList<>() : triggers;
+        return triggers == null ? Collections.emptyList() : triggers;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/eclipse/smarthome/issues/5939

Scripted rules should also use the new module builders and not try to instantiate modules through a constructor.

Signed-off-by: Kai Kreuzer <kai@openhab.org>