### PR TITLE
5955 improve USB-Serial scanning on startup and configuration change

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
@@ -127,7 +127,7 @@ public class PollingUsbSerialScanner implements UsbSerialDiscovery {
                 logger.debug("Scheduled USB-Serial background discovery every {} seconds",
                         pauseBetweenScans.getSeconds());
             } else {
-                logger.info(
+                logger.debug(
                         "Do not start background scanning, as the configured USB-Serial scanner cannot perform scans on this system");
             }
         }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
@@ -250,18 +250,25 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
                 .getOrDefault(SYSFS_TTY_DEVICES_DIRECTORY_ATTRIBUTE, SYSFS_TTY_DEVICES_DIRECTORY_DEFAULT).toString();
         String newDevDirectory = config.getOrDefault(DEV_DIRECTORY_ATTRIBUTE, DEV_DIRECTORY_DEFAULT).toString();
 
-        if (Objects.equals(sysfsTtyDevicesDirectory, newSysfsTtyDevicesDirectory)
-                && Objects.equals(devDirectory, newDevDirectory)) {
-            logger.debug(
-                    "Skip configuration update, as the new configuration is the same as the current configuration");
-        } else {
+        boolean configurationIsChanged = !(Objects.equals(sysfsTtyDevicesDirectory, newSysfsTtyDevicesDirectory)
+                && Objects.equals(devDirectory, newDevDirectory));
+
+        if (configurationIsChanged) {
             sysfsTtyDevicesDirectory = newSysfsTtyDevicesDirectory;
             devDirectory = newDevDirectory;
+        }
 
-            if (!canPerformScans()) {
-                logger.info(
-                        "Cannot perform scans with this configuration: sysfsTtyDevicesDirectory: {}, devDirectory: {}",
-                        sysfsTtyDevicesDirectory, devDirectory);
+        if (!canPerformScans()) {
+            String logString = String.format(
+                    "Cannot perform scans with this configuration: sysfsTtyDevicesDirectory: {}, devDirectory: {}",
+                    sysfsTtyDevicesDirectory, devDirectory);
+
+            if (configurationIsChanged) {
+                // Warn if the configuration was actively changed
+                logger.warn(logString);
+            } else {
+                // Otherwise, only debug log - so that, in particular, on Non-Linux systems users do not see warning
+                logger.debug(logString);
             }
         }
     }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/SysfsUsbSerialScanner.java
@@ -20,6 +20,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -245,13 +246,23 @@ public class SysfsUsbSerialScanner implements UsbSerialScanner {
     }
 
     private void extractConfiguration(Map<String, Object> config) {
-        sysfsTtyDevicesDirectory = config
+        String newSysfsTtyDevicesDirectory = config
                 .getOrDefault(SYSFS_TTY_DEVICES_DIRECTORY_ATTRIBUTE, SYSFS_TTY_DEVICES_DIRECTORY_DEFAULT).toString();
-        devDirectory = config.getOrDefault(DEV_DIRECTORY_ATTRIBUTE, DEV_DIRECTORY_DEFAULT).toString();
+        String newDevDirectory = config.getOrDefault(DEV_DIRECTORY_ATTRIBUTE, DEV_DIRECTORY_DEFAULT).toString();
 
-        if (!canPerformScans()) {
-            logger.info("Cannot perform scans with this configuration: sysfsTtyDevicesDirectory: {}, devDirectory: {}",
-                    sysfsTtyDevicesDirectory, devDirectory);
+        if (Objects.equals(sysfsTtyDevicesDirectory, newSysfsTtyDevicesDirectory)
+                && Objects.equals(devDirectory, newDevDirectory)) {
+            logger.debug(
+                    "Skip configuration update, as the new configuration is the same as the current configuration");
+        } else {
+            sysfsTtyDevicesDirectory = newSysfsTtyDevicesDirectory;
+            devDirectory = newDevDirectory;
+
+            if (!canPerformScans()) {
+                logger.info(
+                        "Cannot perform scans with this configuration: sysfsTtyDevicesDirectory: {}, devDirectory: {}",
+                        sysfsTtyDevicesDirectory, devDirectory);
+            }
         }
     }
 

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
@@ -80,9 +80,6 @@ public class UsbSerialDiscoveryService extends AbstractDiscoveryService implemen
     protected void activate(@Nullable Map<String, @Nullable Object> configProperties) {
         super.activate(configProperties);
         usbSerialDiscovery.registerDiscoveryListener(this);
-        if (isBackgroundDiscoveryEnabled()) {
-            usbSerialDiscovery.startBackgroundScanning();
-        }
     }
 
     @Modified


### PR DESCRIPTION
Fixes #5955 

* Omits superfluous duplicate call to start the background discovery on activation of the `UsbSerialDiscoveryService`. (If scanning is possible, the duplicate call would simply do nothing - but if scanning is not possible, the corresponding log message was displayed twice.)
* Only updates the configuration of the `SysfsUsbSerialScanner` if it is actually changed. This will also omit duplicate log messages when the same configuration is set twice.
* Reduce log level of message for "no background scanning" in the `PollingUsbSerialScanner` to debug.