### PR TITLE
Add SIUnits to default script scope to allow unit conversions

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Import-Package:
  org.eclipse.smarthome.core.items,
  org.eclipse.smarthome.core.items.events,
  org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.library.unit,
  org.eclipse.smarthome.core.thing,
  org.eclipse.smarthome.core.types,
  org.slf4j

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
@@ -43,7 +43,10 @@ import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.StringListType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.library.unit.ImperialUnits;
+import org.eclipse.smarthome.core.library.unit.MetricPrefix;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
@@ -163,6 +166,9 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
         elements.put("StringType", StringType.class);
 
         elements.put("SIUnits", SIUnits.class);
+        elements.put("ImperialUnits", ImperialUnits.class);
+        elements.put("MetricPrefix", MetricPrefix.class);
+        elements.put("SmartHomeUnits", SmartHomeUnits.class);
 
         // services
         elements.put("items", new ItemRegistryDelegate(itemRegistry));

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
@@ -43,6 +43,7 @@ import org.eclipse.smarthome.core.library.types.StopMoveType;
 import org.eclipse.smarthome.core.library.types.StringListType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
@@ -160,6 +161,8 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
         elements.put("PercentType", PercentType.class);
         elements.put("PointType", PointType.class);
         elements.put("StringType", StringType.class);
+
+        elements.put("SIUnits", SIUnits.class);
 
         // services
         elements.put("items", new ItemRegistryDelegate(itemRegistry));


### PR DESCRIPTION
Since we have added the QuantityType to the script scope it would be nice
to make use of its conversion features, such as `qt.toUnit(SIUnits.CELSIUS)`


Signed-off-by: Stefan Triller <stefan.triller@telekom.de>