### PR TITLE
[homematic] Feature - Enable configuration of device parameters

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/parser/ListDevicesParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/parser/ListDevicesParser.java
@@ -54,8 +54,10 @@ public class ListDevicesParser extends CommonRpcParser<Object[], Collection<HmDe
                 String id = toString(data.get("ID"));
                 String firmware = toString(data.get("FIRMWARE"));
 
-                devices.put(address,
-                        new HmDevice(address, hmInterface, type, config.getGatewayInfo().getId(), id, firmware));
+                HmDevice device = new HmDevice(address, hmInterface, type, config.getGatewayInfo().getId(), id,
+                        firmware);
+                device.addChannel(new HmChannel(type, -1));
+                devices.put(address, device);
             } else {
                 // channel
                 String deviceAddress = getSanitizedAddress(data.get("PARENT"));


### PR DESCRIPTION
### Motivation
I want to be able to configure my homematic devices through ESH. All configuration options that are offered by a device should be available to me.

### Context
The information exchange between a homematic gateway and the binding is done via parameters. For homematic devices, some parameters are mapped to ESH channels, while others are mapped to configuration parameters of the corresponding thing.

On homematic side, most parameters of a device are structured in so-called channels, which are identified by the device address followed by a number. However, some parameters belong directly to the device, not to a channel. Currently, these parameters are not handled by the binding. One example for such a parameter is the "Button Lock" of a hm thermostat which allows to enable/disable the button lock on the device.

### Contribution
This PR makes the parameters of a HmDevice that do not belong to one of its HmChannels available to the binding. These parameters, which were previously ignored by the binding, are now treated as parameters of the non-existing HmChannel with number "-1". This is accomplished by a mapping that is done in the RpcClient when sending/receiving values for these parameters. The reason for this approach is that it requires only very few changes to the binding. Once mapped to a HmChannel, the parameters are automatically handled correctly throughout the binding.

Signed-off-by: Florian Stolte <fstolte@itemis.de>