### PR TITLE
Fixed network-address context

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTest.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTest.bundle/ESH-INF/thing/thing-types.xml
@@ -10,7 +10,7 @@
 
 		<config-description>
 			<parameter name="ip" type="text">
-				<context>network_address</context>
+				<context>network-address</context>
 				<label>Network Address</label>
 				<description>Network address of the hue bridge.</description>
 				<required>true</required>

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTestNoAuthor.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTestNoAuthor.bundle/ESH-INF/thing/thing-types.xml
@@ -10,7 +10,7 @@
 
 		<config-description>
 			<parameter name="ip" type="text">
-				<context>network_address</context>
+				<context>network-address</context>
 				<label>Network Address</label>
 				<description>Network address of the hue bridge.</description>
 				<required>true</required>

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/ESH-INF/config/bridgeConfig.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/ESH-INF/config/bridgeConfig.xml
@@ -20,7 +20,7 @@
 			<required>false</required>
 		</parameter><!--ipAddress -->
 		<parameter name="dSSAddress" type="text" groupName="connection">
-			<context>network_address</context>
+			<context>network-address</context>
 			<label>@text/dss_param_ip_address_label</label>
 			<description>@text/dss_param_ip_address_desc</description>
 			<required>true</required>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/ESH-INF/thing/thing-types.xml
@@ -26,7 +26,7 @@
 
 		<config-description>
 			<parameter name="ip" type="text" required="true">
-				<context>network_address</context>
+				<context>network-address</context>
 				<label>Network Address</label>
 				<description>The IP address (name or numeric) of the internet radio.</description>
 			</parameter>

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/ESH-INF/thing/bridge.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/ESH-INF/thing/bridge.xml
@@ -16,7 +16,7 @@
 
 		<config-description>
 			<parameter name="gatewayAddress" type="text" required="true">
-				<context>network_address</context>
+				<context>network-address</context>
 				<label>Gateway Address</label>
 				<description>Network address of the Homematic gateway</description>
 			</parameter>
@@ -32,7 +32,7 @@
 				</options>
 			</parameter>
 			<parameter name="callbackHost" type="text">
-				<context>network_address</context>
+				<context>network-address</context>
 				<label>Callback Network Address</label>
 				<description>Callback network address of the ESH runtime, default is auto-discovery</description>
 			</parameter>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/bridge.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/bridge.xml
@@ -15,7 +15,7 @@
 
 		<config-description>
 			<parameter name="ipAddress" type="text">
-				<context>network_address</context>
+				<context>network-address</context>
 				<label>Network Address</label>
 				<description>Network address of the hue bridge.</description>
 				<required>true</required>

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/ESH-INF/thing/thing-types.xml
@@ -13,7 +13,7 @@
 		</channels>
 		<config-description>
 			<parameter name="hostname" type="text" required="true">
-				<context>network_address</context>
+				<context>network-address</context>
 				<label>Hostname</label>
 				<description>The NTP server hostname.</description>
 				<default>0.pool.ntp.org</default>


### PR DESCRIPTION
For some reason, a wrong spelling of the context has spread over our code base - let's fix it to match the documentation.

Signed-off-by: Kai Kreuzer <kai@openhab.org>