### PR TITLE
[homematic] Save updated config parameters in thing configuration

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicThingHandler.java
@@ -456,15 +456,15 @@ public class HomematicThingHandler extends BaseThingHandler {
     @Override
     public void handleConfigurationUpdate(Map<String, Object> configurationParameters)
             throws ConfigValidationException {
-        validateConfigurationParameters(configurationParameters);
+        super.handleConfigurationUpdate(configurationParameters);
 
         try {
             HomematicGateway gateway = getHomematicGateway();
             HmDevice device = gateway.getDevice(UidUtils.getHomematicAddress(getThing()));
 
-            for (Entry<String, Object> configurationParmeter : configurationParameters.entrySet()) {
-                String key = configurationParmeter.getKey();
-                Object newValue = configurationParmeter.getValue();
+            for (Entry<String, Object> configurationParameter : configurationParameters.entrySet()) {
+                String key = configurationParameter.getKey();
+                Object newValue = configurationParameter.getValue();
 
                 if (key.startsWith("HMP_")) {
                     key = StringUtils.removeStart(key, "HMP_");


### PR DESCRIPTION
- when handling a configuration update for a homematic thing, the
configuration is now also updated in the thing (instead of only updating
the config of the actual homematic device)
- fixed a typo

Signed-off-by: Florian Stolte <fstolte@itemis.de>