### PR TITLE
Automation: Resolve variables in lists for RuleTemplate

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/ReferenceResolver.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/util/ReferenceResolver.java
@@ -43,12 +43,10 @@ import org.slf4j.Logger;
  * </li>
  * </ul>
  *
- * ModuleImpl 'A' Configuration properties can have references to either CompositeModule Configuration properties or
- * RuleImpl
+ * ModuleImpl 'A' Configuration properties can have references to either CompositeModule Configuration properties or RuleImpl
  * Configuration properties depending where ModuleImpl 'A' is placed.
  * <br/>
- * Note. If ModuleImpl 'A' is child of CompositeModule - it cannot have direct configuration references to the RuleImpl
- * that is
+ * Note. If ModuleImpl 'A' is child of CompositeModule - it cannot have direct configuration references to the RuleImpl that is
  * holding the CompositeModule.
  * <ul>
  * <li>


### PR DESCRIPTION
If a module has a configuration whose parameter is a list like

```
"configuration": {
          "param": ["${var1}", "${var2}"]
        }
```

all variables should be resolved.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>