### PR TITLE
RuleEngine: ItemCommandAction: Use input for commands to allow module chaining

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/ItemActions.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/ItemActions.json
@@ -17,7 +17,7 @@
          "name":"command",
          "type":"TEXT",
          "label":"Command",
-         "description":"the command to be sent",
+         "description":"the default command to be sent if none is passed as an input value",
          "required":true,
          "limitToOptions":false,
          "options":[
@@ -52,8 +52,8 @@
       {
         "name":"command",
         "type":"org.eclipse.smarthome.core.types.Command",
-        "label":"Command to send",
-        "description":"Command that will be send to the Item if none is specified in the configuration."
+        "label":"Command",
+        "description":"command that will be sent to the item."
       }
      ]
     }

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/ItemActions.json
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/ESH-INF/automation/moduletypes/ItemActions.json
@@ -47,6 +47,14 @@
             }
           ]
       }
+     ],
+     "inputs":[
+      {
+        "name":"command",
+        "type":"org.eclipse.smarthome.core.types.Command",
+        "label":"Command to send",
+        "description":"Command that will be send to the Item if none is specified in the configuration."
+      }
      ]
     }
    ]

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemCommandActionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemCommandActionHandler.java
@@ -107,18 +107,16 @@ public class ItemCommandActionHandler extends BaseModuleHandler<Action> implemen
         if (itemName != null && eventPublisher != null && itemRegistry != null) {
             try {
                 Item item = itemRegistry.getItem(itemName);
+
                 Command commandObj = null;
-                if (command != null) {
-                    commandObj = TypeParser.parseCommand(item.getAcceptedCommandTypes(), command);
-                } else {
-                    Object cmd = inputs.get(COMMAND);
-                    if (cmd instanceof Command) {
-                        if (item.getAcceptedCommandTypes().contains(cmd.getClass())) {
-                            commandObj = (Command) cmd;
-                        }
-                    } else {
-                        logger.warn("Passed input for '{}' is not of type 'Command'", COMMAND);
+                Object cmd = inputs.get(COMMAND);
+
+                if (cmd instanceof Command) {
+                    if (item.getAcceptedCommandTypes().contains(cmd.getClass())) {
+                        commandObj = (Command) cmd;
                     }
+                } else {
+                    commandObj = TypeParser.parseCommand(item.getAcceptedCommandTypes(), command);
                 }
                 if (commandObj != null) {
                     ItemCommandEvent itemCommandEvent = ItemEventFactory.createCommandEvent(itemName, commandObj);

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemCommandActionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemCommandActionHandler.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Benedikt Niehues - Initial contribution and API
  * @author Kai Kreuzer - refactored and simplified customized module handling
- * @author Stefan Triller - if config command is not set, use command from input variables
+ * @author Stefan Triller - use command from input first and if not set, use command from configuration
  *
  */
 public class ItemCommandActionHandler extends BaseModuleHandler<Action> implements ActionHandler {

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemCommandActionHandler.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/src/main/java/org/eclipse/smarthome/automation/module/core/handler/ItemCommandActionHandler.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Benedikt Niehues - Initial contribution and API
  * @author Kai Kreuzer - refactored and simplified customized module handling
+ * @author Stefan Triller - if config command is not set, use command from input variables
  *
  */
 public class ItemCommandActionHandler extends BaseModuleHandler<Action> implements ActionHandler {
@@ -102,10 +103,23 @@ public class ItemCommandActionHandler extends BaseModuleHandler<Action> implemen
     public Map<String, Object> execute(Map<String, Object> inputs) {
         String itemName = (String) module.getConfiguration().get(ITEM_NAME);
         String command = (String) module.getConfiguration().get(COMMAND);
-        if (itemName != null && command != null && eventPublisher != null && itemRegistry != null) {
+
+        if (itemName != null && eventPublisher != null && itemRegistry != null) {
             try {
                 Item item = itemRegistry.getItem(itemName);
-                Command commandObj = TypeParser.parseCommand(item.getAcceptedCommandTypes(), command);
+                Command commandObj = null;
+                if (command != null) {
+                    commandObj = TypeParser.parseCommand(item.getAcceptedCommandTypes(), command);
+                } else {
+                    Object cmd = inputs.get(COMMAND);
+                    if (cmd instanceof Command) {
+                        if (item.getAcceptedCommandTypes().contains(cmd.getClass())) {
+                            commandObj = (Command) cmd;
+                        }
+                    } else {
+                        logger.warn("Passed input for '{}' is not of type 'Command'", COMMAND);
+                    }
+                }
                 if (commandObj != null) {
                     ItemCommandEvent itemCommandEvent = ItemEventFactory.createCommandEvent(itemName, commandObj);
                     logger.debug("Executing ItemCommandAction on Item {} with Command {}",


### PR DESCRIPTION
If the ItemCommandAction should be used to post the outcome of a previous
action to an item, it can now retrieve the command as an input value.

Before this PR the ItemCommandAction could only have one command specified
in its configuration.


Signed-off-by: Stefan Triller <stefan.triller@telekom.de>