### PR TITLE
Automation: I/O connection supports HashMaps

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/ConnectionValidator.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/ConnectionValidator.java
@@ -256,6 +256,14 @@ public class ConnectionValidator {
         String outputName = connection.getOutputName();
         if (outputs != null && !outputs.isEmpty()) {
             for (Output output : outputs) {
+                if (outputName.matches(output.getName() + "\\.*[a-zA-Z0-9_]+$")) {
+                    String dataStructure = outputName.split("\\.")[0];
+                    if (output.getName().equals(dataStructure)) {
+                        // we are referencing a value inside an existing data structure of the output and will not check
+                        // if the property inside of it really exists, so the connection will be treated as valid
+                        return;
+                    }
+                }
                 if (output.getName().equals(outputName)) {
                     if (input.getType().equals("*")) {
                         return;

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleEngineImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/RuleEngineImpl.java
@@ -1123,9 +1123,27 @@ public class RuleEngineImpl implements RuleManager, RegistryChangeListener<Modul
             for (Connection c : connections) {
                 String outputModuleId = c.getOuputModuleId();
                 if (outputModuleId != null) {
-                    sb.append(outputModuleId).append(OUTPUT_SEPARATOR).append(c.getOutputName());
-                    context.put(c.getInputName(), context.get(sb.toString()));
-                    sb.setLength(0);
+                    String outputName = c.getOutputName();
+                    sb.append(outputModuleId).append(OUTPUT_SEPARATOR);
+                    // if the outputName contains a dot we assume its a hashmap and retrieve the value after the dot
+                    if (outputName != null && outputName.contains(".")) {
+                        String[] parts = outputName.split("\\.");
+                        sb.append(parts[0]);
+                        Object dataStructure = context.get(sb.toString());
+                        if (dataStructure instanceof HashMap) {
+                            @SuppressWarnings("rawtypes")
+                            HashMap hm = (HashMap) dataStructure;
+                            Object val = hm.get(parts[1]);
+                            if (val != null) {
+                                context.put(c.getInputName(), val);
+                            }
+                        }
+                        sb.setLength(0);
+                    } else {
+                        sb.append(outputName);
+                        context.put(c.getInputName(), context.get(sb.toString()));
+                        sb.setLength(0);
+                    }
                 } else {
                     // get reference from context
                     String ref = c.getOutputName();


### PR DESCRIPTION
Automation modules support input and output values and their names and/or
types have to match in order to be a valid connection between two modules.

With this PR it is possible that one module returns a HashMap of values
and a follow-up modul fetches certain values out of this map. This allows
for creating modules with a dynamic amount of outputs.

For example an action reference the values of a trigger's output called
"itemStates" as follows:

```
"inputs" : {
	"stateItemA" : "MyTrigger.itemStates.ItemA",
	"stateItemB" : "MyTrigger.itemStates.ItemB"
}
```

Where "itemStates" is the HashMap and "ItemA" and "ItemB" are the keys.
Input variable "stateItemA" will be whichever value is the result of the
call `itemStates.get("ItemA")`.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>