### PR TITLE
[homematic] Add a config parameter for factory reset on thing deletion

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/ESH-INF/thing/bridge.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/ESH-INF/thing/bridge.xml
@@ -99,7 +99,13 @@
 			</parameter>
 			<parameter name="unpairOnDeletion" type="boolean">
 				<label>Unpair Devices on Deletion</label>
-				<description>If set to true, devices are unpaired from the gateway when their corresponding things are removed</description>
+				<description>If set to true, devices are unpaired from the gateway when their corresponding things are removed. The option "factoryResetOnDeletion" also unpairs a device, so in order to avoid unpairing on deletion, both options need to be set to false!</description>
+				<advanced>true</advanced>
+				<default>false</default>
+			</parameter>
+			<parameter name="factoryResetOnDeletion" type="boolean">
+				<label>Factory Reset Devices on Deletion</label>
+				<description>If set to true, devices are factory reset when their corresponding things are removed. Due to the factory reset, the device will also be unpaired from the gateway, even if "unpairOnDeletion" is set to false!</description>
 				<advanced>true</advanced>
 				<default>false</default>
 			</parameter>

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/README.md
@@ -141,7 +141,12 @@ The port number of the CUxD daemon (default = 8701)
 Time in seconds that the controller will be in install mode when a device discovery is initiated (default = 60)
 
 -   **unpairOnDeletion**
-If true, devices are automatically unpaired from a gateway when the corresponding thing is deleted (default = false)
+If set to true, devices are automatically unpaired from the gateway when their corresponding things are deleted.
+**Warning!** The option "factoryResetOnDeletion" also unpairs a device, so in order to avoid unpairing on deletion completely, both options need to be set to false! (default = false)
+
+-   **factoryResetOnDeletion**
+If set to true, devices are automatically factory reset when their corresponding things are removed.
+Due to the factory reset, the device will also be unpaired from the gateway, even if "unpairOnDeletion" is set to false! (default = false)
 
 The syntax for a bridge is:
 

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicThingHandler.java
@@ -518,8 +518,8 @@ public class HomematicThingHandler extends BaseThingHandler {
         }
 
         final HomematicConfig config = bridge.getConfiguration().as(HomematicConfig.class);
-        final boolean unpairOnDeletion = config.isUnpairOnDeletion() || config.isFactoryResetOnDeletion();
         final boolean factoryResetOnDeletion = config.isFactoryResetOnDeletion();
+        final boolean unpairOnDeletion = factoryResetOnDeletion || config.isUnpairOnDeletion();
 
         if (unpairOnDeletion) {
             deviceDeletionPending = true;

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/common/HomematicConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/common/HomematicConfig.java
@@ -56,6 +56,7 @@ public class HomematicConfig {
     private int installModeDuration = DEFAULT_INSTALL_MODE_DURATION;
     private long discoveryTimeToLive = -1;
     private boolean unpairOnDeletion = false;
+    private boolean factoryResetOnDeletion = false;
 
     private HmGatewayInfo gatewayInfo;
 
@@ -232,6 +233,25 @@ public class HomematicConfig {
      */
     public void setUnpairOnDeletion(boolean unpairOnDeletion) {
         this.unpairOnDeletion = unpairOnDeletion;
+    }
+
+    /**
+     * Returns if devices are factory reset when their corresponding things are removed
+     * 
+     * @return <i>true</i> if devices are factory reset when their corresponding things are removed
+     */
+    public boolean isFactoryResetOnDeletion() {
+        return factoryResetOnDeletion;
+    }
+
+    /**
+     * Sets factoryResetOnDeletion
+     * 
+     * @param factoryResetOnDeletion if set to <i>true</i>, devices are factory reset when their corresponding things
+     *            are removed
+     */
+    public void setFactoryResetOnDeletion(boolean factoryResetOnDeletion) {
+        this.factoryResetOnDeletion = factoryResetOnDeletion;
     }
 
     /**


### PR DESCRIPTION
Introduces the bridge config parameter "factoryResetOnDeletion" to the HomeMatic binding. This parameter allows to automatically perform a factory reset + unpairing when a thing for a device is deleted.

Addresses issue #5997

Signed-off-by: Florian Stolte <fstolte@itemis.de>