### PR TITLE
Fix thread names for the USB-Serial scanning on Linux (use name, not namePrefix)

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/linuxsysfs/internal/PollingUsbSerialScanner.java
@@ -82,7 +82,7 @@ public class PollingUsbSerialScanner implements UsbSerialDiscovery {
         }
 
         scheduler = Executors.newSingleThreadScheduledExecutor(
-                ThreadFactoryBuilder.create().withNamePrefix(THREAD_NAME).withDaemonThreads(true).build());
+                ThreadFactoryBuilder.create().withName(THREAD_NAME).withDaemonThreads(true).build());
     }
 
     @Deactivate


### PR DESCRIPTION
This small issue slipped through when I introduced using a `ThreadFactoryBuilder` for the polling thread of the USB-Serial discovery.

* Before this change: Uses the `withNamePrefix` builder method, resulting in thread names like `usb-serial-discovery-linux-sysfs-pool-5-thread-1`.
* After this change: Uses the `withName` builder method, resulting in the correct thread names like `ESH-usb-serial-discovery-linux-sysfs-1`.