### PR TITLE
Update EmbeddedBrokerServiceImpl.java

### DIFF
--- a/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker/src/main/java/org/eclipse/smarthome/io/mqttembeddedbroker/internal/EmbeddedBrokerServiceImpl.java
+++ b/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker/src/main/java/org/eclipse/smarthome/io/mqttembeddedbroker/internal/EmbeddedBrokerServiceImpl.java
@@ -175,7 +175,7 @@ public class EmbeddedBrokerServiceImpl implements EmbeddedBrokerService, Configu
         Properties properties = new Properties();
 
         // Host and port
-        properties.put(BrokerConstants.HOST_PROPERTY_NAME, "127.0.0.1");
+        properties.put(BrokerConstants.HOST_PROPERTY_NAME, "0.0.0.0");
         int port;
         if (secure) {
             port = (portParam == null) ? port = 8883 : portParam;


### PR DESCRIPTION
Bind the embedded MQTT broker to 0.0.0.0 instead of 127.0.0.1 for external access.
Fixes #5999 

Signed-off-by: David Gräff <david.graeff@web.de>