### PR TITLE
PaperUI: Refactor+Simplify Item options

### DIFF
--- a/extensions/ui/org.eclipse.smarthome.ui.paper/tests/configService.test.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/tests/configService.test.js
@@ -10,13 +10,15 @@ describe('factory configService', function() {
         expect(configService).toBeDefined();
     });
     describe('tests for Rendering model', function() {
-        var $httpBackend
-        var restConfig
-        var itemRepository
+        var $httpBackend;
+        var restConfig;
+        var itemRepository;
+        var $q;
         beforeEach(inject(function($injector, $rootScope, thingService) {
             $httpBackend = $injector.get('$httpBackend');
             restConfig = $injector.get('restConfig');
             itemRepository = $injector.get('itemRepository');
+            $q = $injector.get('$q');
         }));
         it('should accept empty config parameters', function() {
             var params = configService.getRenderingModel();
@@ -84,15 +86,21 @@ describe('factory configService', function() {
                 label : 'contact item'
             }]
             
-            spyOn(itemRepository, 'getAll').and.callFake(function(callback) {
-                callback(items)
-            });
+            var deferred = $q.defer();
+            var prom = deferred.promise;
+
+            spyOn(itemRepository, 'getAll').and.returnValue(prom);
             
             var params = configService.getRenderingModel(inputParams);
-            expect(params[0].parameters[0].element).toEqual("select");
-            expect(params[0].parameters[0].options.length).toEqual(1);
-            expect(params[0].parameters[0].options[0]).toBeDefined();
-            expect(params[0].parameters[0].options[0].label).toEqual('number item');
+            prom.then(function() {
+                expect(params[0].parameters[0].element).toEqual("select");
+                expect(params[0].parameters[0].options.length).toEqual(1);
+                expect(params[0].parameters[0].options[0]).toBeDefined();
+                expect(params[0].parameters[0].options[0].label).toEqual('number item');
+            })
+
+            deferred.resolve(items);
+
         });
         it('should return date widget for context DATE type=Text', function() {
             var inputParams = [ {

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/services.js
@@ -158,6 +158,10 @@ angular.module('PaperUI.services', [ 'PaperUI.services.repositories', 'PaperUI.c
                 return false;
         }
 
+        if (context === "ITEM") {
+            getItemOptions(parameter);
+        }
+
         if (context === "RULE") {
             parameter.options = parameter.options ? parameter.options : [];
             ruleRepository.getAll(function(rules) {
@@ -266,27 +270,11 @@ angular.module('PaperUI.services', [ 'PaperUI.services.repositories', 'PaperUI.c
         return configParameters;
     }
 
-    var getItemConfigs = function(configParams) {
-        var configParameters = configParams;
-        var parameterItems = []
-        angular.forEach(configParameters, function(configParameter) {
-            parameterItems = parameterItems.concat($.grep(configParameter.parameters, function(value) {
-                return value.context && value.context.toUpperCase() == 'ITEM';
-            }));
-        })
-        if (parameterItems.length > 0) {
-            itemRepository.getAll(function(items) {
-                angular.forEach(configParameters, function(configParameter) {
-                    angular.forEach(configParameter.parameters, function(parameter) {
-                        if (parameter.context && parameter.context.toUpperCase() === 'ITEM') {
-                            var filteredItems = filterByAttributes(items, parameter.filterCriteria);
-                            parameter.options = $filter('orderBy')(filteredItems, 'label');
-                        }
-                    })
-                })
-            });
-        }
-        return configParameters;
+    var getItemOptions = function(parameter) {
+        return itemRepository.getAll().then(function(items) {
+            var filteredItems = filterByAttributes(items, parameter.filterCriteria);
+            parameter.options = $filter('orderBy')(filteredItems, 'label');
+        });
     }
 
     var filterByAttributes = function(arr, filters) {
@@ -387,7 +375,6 @@ angular.module('PaperUI.services', [ 'PaperUI.services.repositories', 'PaperUI.c
                 }
                 renderingGroups.push(group);
             });
-            renderingGroups = getItemConfigs(renderingGroups)
             return getChannelsConfig(renderingGroups);
         },
 


### PR DESCRIPTION
Removed the traversing of all parameter groups while filling the item options of just one parameter.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>