### PR TITLE
correctly transfer the listener registration to the new item instance

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/internal/PersistenceManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/src/main/java/org/eclipse/smarthome/core/persistence/internal/PersistenceManagerImpl.java
@@ -420,7 +420,8 @@ public class PersistenceManagerImpl implements PersistenceManager, ItemRegistryC
 
     @Override
     public void updated(Item oldItem, Item item) {
-        // not needed here
+        removed(oldItem);
+        added(item);
     }
 
     /*


### PR DESCRIPTION
Fixes https://github.com/eclipse/smarthome/issues/5991

Signed-off-by: Kai Kreuzer <kai@openhab.org>