### PR TITLE
CNF occurred when using rfc2217

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx.rfc2217/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx.rfc2217/META-INF/MANIFEST.MF
@@ -6,7 +6,8 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.serial.rxtx.rfc2217;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
-Import-Package: gnu.io.rfc2217,
+Import-Package: gnu.io,
+ gnu.io.rfc2217,
  org.apache.commons.net,
  org.apache.commons.net.telnet,
  org.eclipse.jdt.annotation;resolution:=optional,


### PR DESCRIPTION
RxTxSerialPort uses gnu.io package in the constructor -> needs to be imported package in rfc2217

Signed-off-by: Matthias Steigenberger <matthias.steigenberger@gmail.com>