### PR TITLE
Add reference to original source for Bluegiga library

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluegiga/NOTICE
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluegiga/NOTICE
@@ -12,6 +12,11 @@ https://www.eclipse.org/legal/epl-2.0/.
 
 https://github.com/eclipse/smarthome
 
+Some code of this bundle originates from the Z-Smart Systems Bluegiga Java Library,
+the source of which can be found at -:
+
+https://github.com/zsmartsystems/com.zsmartsystems.bluetooth.bluegiga
+
 == Copyright Holders
 
 See the NOTICE file distributed with the source code at


### PR DESCRIPTION
Add reference to original Bluegiga library source, as discussed previously [here](https://github.com/eclipse/smarthome/pull/5885#issuecomment-405120263).

Signed-off-by: Chris Jackson <chris@cd-jackson.com>