### PR TITLE
Add getSupportedItemTypesOfChannel method to StateProfileType

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/StateProfileTypeImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/StateProfileTypeImpl.java
@@ -30,11 +30,14 @@ public class StateProfileTypeImpl implements StateProfileType {
     private final ProfileTypeUID profileTypeUID;
     private final String label;
     private final Collection<String> supportedItemTypes;
+    private final Collection<String> supportedItemTypesOfChannel;
 
-    public StateProfileTypeImpl(ProfileTypeUID profileTypeUID, String label, Collection<String> supportedItemTypes) {
+    public StateProfileTypeImpl(ProfileTypeUID profileTypeUID, String label, Collection<String> supportedItemTypes,
+            Collection<String> supportedItemTypesOfChannel) {
         this.profileTypeUID = profileTypeUID;
         this.label = label;
         this.supportedItemTypes = supportedItemTypes;
+        this.supportedItemTypesOfChannel = supportedItemTypesOfChannel;
     }
 
     @Override
@@ -50,6 +53,11 @@ public class StateProfileTypeImpl implements StateProfileType {
     @Override
     public String getLabel() {
         return label;
+    }
+
+    @Override
+    public Collection<String> getSupportedItemTypesOfChannel() {
+        return supportedItemTypesOfChannel;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/TriggerProfileTypeImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/TriggerProfileTypeImpl.java
@@ -26,19 +26,39 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
  *
  */
 @NonNullByDefault
-public class TriggerProfileTypeImpl extends StateProfileTypeImpl implements TriggerProfileType {
+public class TriggerProfileTypeImpl implements TriggerProfileType {
 
+    private final ProfileTypeUID profileTypeUID;
     private final Collection<ChannelTypeUID> supportedChannelTypeUIDs;
+    private final String label;
+    private final Collection<String> supportedItemTypes;
 
     public TriggerProfileTypeImpl(ProfileTypeUID profileTypeUID, String label, Collection<String> supportedItemTypes,
             Collection<ChannelTypeUID> supportedChannelTypeUIDs) {
-        super(profileTypeUID, label, supportedItemTypes);
+        this.profileTypeUID = profileTypeUID;
+        this.label = label;
+        this.supportedItemTypes = supportedItemTypes;
         this.supportedChannelTypeUIDs = supportedChannelTypeUIDs;
     }
 
     @Override
     public Collection<ChannelTypeUID> getSupportedChannelTypeUIDs() {
         return supportedChannelTypeUIDs;
+    }
+
+    @Override
+    public Collection<String> getSupportedItemTypes() {
+        return supportedItemTypes;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+
+    @Override
+    public ProfileTypeUID getUID() {
+        return profileTypeUID;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeBuilder.java
@@ -36,12 +36,13 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
     @FunctionalInterface
     private interface ProfileTypeFactory<T extends ProfileType> {
         T create(ProfileTypeUID profileTypeUID, String label, Collection<String> supportedItemTypes,
-                Collection<ChannelTypeUID> supportedChannelTypeUIDs);
+                Collection<String> supportedItemTypesOfChannel, Collection<ChannelTypeUID> supportedChannelTypeUIDs);
     }
 
     private final ProfileTypeFactory<T> profileTypeFactory;
     private final ProfileTypeUID profileTypeUID;
     private final Collection<String> supportedItemTypes = new HashSet<>();
+    private final Collection<String> supportedItemTypesOfChannel = new HashSet<>();
     private final Collection<ChannelTypeUID> supportedChannelTypeUIDs = new HashSet<>();
     private final String label;
 
@@ -60,9 +61,9 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
      */
     public static ProfileTypeBuilder<StateProfileType> newState(ProfileTypeUID profileTypeUID, String label) {
         return new ProfileTypeBuilder<>(profileTypeUID, label,
-                (leProfileTypeUID, leLabel, leSupportedItemTypes,
+                (leProfileTypeUID, leLabel, leSupportedItemTypes, leSupportedItemTypesOfChannel,
                         leSupportedChannelTypeUIDs) -> new StateProfileTypeImpl(leProfileTypeUID, leLabel,
-                                leSupportedItemTypes));
+                                leSupportedItemTypes, leSupportedItemTypesOfChannel));
     }
 
     /**
@@ -74,7 +75,7 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
      */
     public static ProfileTypeBuilder<TriggerProfileType> newTrigger(ProfileTypeUID profileTypeUID, String label) {
         return new ProfileTypeBuilder<>(profileTypeUID, label,
-                (leProfileTypeUID, leLabel, leSupportedItemTypes,
+                (leProfileTypeUID, leLabel, leSupportedItemTypes, supportedItemTypesOfChannel,
                         leSupportedChannelTypeUIDs) -> new TriggerProfileTypeImpl(leProfileTypeUID, leLabel,
                                 leSupportedItemTypes, leSupportedChannelTypeUIDs));
     }
@@ -126,10 +127,11 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
     /**
      * Create a profile type instance with the previously given parameters.
      *
-     * @return the according subtype of
+     * @return the according subtype of {@link ProfileType}
      */
     public T build() {
-        return profileTypeFactory.create(profileTypeUID, label, supportedItemTypes, supportedChannelTypeUIDs);
+        return profileTypeFactory.create(profileTypeUID, label, supportedItemTypes, supportedItemTypesOfChannel,
+                supportedChannelTypeUIDs);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/ProfileTypeBuilder.java
@@ -75,7 +75,7 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
      */
     public static ProfileTypeBuilder<TriggerProfileType> newTrigger(ProfileTypeUID profileTypeUID, String label) {
         return new ProfileTypeBuilder<>(profileTypeUID, label,
-                (leProfileTypeUID, leLabel, leSupportedItemTypes, supportedItemTypesOfChannel,
+                (leProfileTypeUID, leLabel, leSupportedItemTypes, leSupportedItemTypesOfChannel,
                         leSupportedChannelTypeUIDs) -> new TriggerProfileTypeImpl(leProfileTypeUID, leLabel,
                                 leSupportedItemTypes, leSupportedChannelTypeUIDs));
     }
@@ -121,6 +121,28 @@ public final class ProfileTypeBuilder<T extends ProfileType> {
      */
     public ProfileTypeBuilder<T> withSupportedChannelTypeUIDs(Collection<ChannelTypeUID> channelTypeUIDs) {
         supportedChannelTypeUIDs.addAll(channelTypeUIDs);
+        return this;
+    }
+
+    /**
+     * Declare that channels with these item type(s) are compatible with profiles of this type.
+     *
+     * @param supportedItemTypesOfChannel item types on channel to which this profile type is compatible with
+     * @return the builder itself
+     */
+    public ProfileTypeBuilder<T> withSupportedItemTypesOfChannel(String... supportedItemTypesOfChannel) {
+        this.supportedItemTypesOfChannel.addAll(Arrays.asList(supportedItemTypesOfChannel));
+        return this;
+    }
+
+    /**
+     * Declare that channels with these item type(s) are compatible with profiles of this type.
+     *
+     * @param supportedItemTypesOfChannel item types on channel to which this profile type is compatible with
+     * @return the builder itself
+     */
+    public ProfileTypeBuilder<T> withSupportedItemTypesOfChannel(Collection<String> supportedItemTypesOfChannel) {
+        this.supportedItemTypesOfChannel.addAll(supportedItemTypesOfChannel);
         return this;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/StateProfileType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/StateProfileType.java
@@ -29,7 +29,7 @@ public interface StateProfileType extends ProfileType {
     /**
      * Get a collection of ItemType names that a Channel needs to support in order to able to use this ProfileType
      *
-     * @return a collection of ItemType names
+     * @return a collection of supported ItemType names (an empty list means ALL types are supported)
      */
     Collection<String> getSupportedItemTypesOfChannel();
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/StateProfileType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/StateProfileType.java
@@ -12,15 +12,25 @@
  */
 package org.eclipse.smarthome.core.thing.profiles;
 
+import java.util.Collection;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 
 /**
  * Describes a {@link StateProfile} type.
  *
  * @author Simon Kaufmann - initial contribution and API.
+ * @author Stefan Triller - added getSupportedItemTypesOfChannel method
  *
  */
 @NonNullByDefault
 public interface StateProfileType extends ProfileType {
+
+    /**
+     * Get a collection of ItemType names that a Channel needs to support in order to able to use this ProfileType
+     *
+     * @return a collection of ItemType names
+     */
+    Collection<String> getSupportedItemTypesOfChannel();
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -36,8 +36,9 @@ public interface SystemProfiles {
 
     StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
 
-    StateProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset").withSupportedItemTypes("Number")
-            .withSupportedItemTypesOfChannel("Number").build();
+    StateProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset")
+            .withSupportedItemTypes(CoreItemFactory.NUMBER).withSupportedItemTypesOfChannel(CoreItemFactory.NUMBER)
+            .build();
 
     TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle")

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/profiles/SystemProfiles.java
@@ -37,7 +37,7 @@ public interface SystemProfiles {
     StateProfileType FOLLOW_TYPE = ProfileTypeBuilder.newState(FOLLOW, "Follow").build();
 
     StateProfileType OFFSET_TYPE = ProfileTypeBuilder.newState(OFFSET, "Offset").withSupportedItemTypes("Number")
-            .build();
+            .withSupportedItemTypesOfChannel("Number").build();
 
     TriggerProfileType RAWBUTTON_TOGGLE_SWITCH_TYPE = ProfileTypeBuilder
             .newTrigger(RAWBUTTON_TOGGLE_SWITCH, "Raw Button Toggle")


### PR DESCRIPTION
This method is necessary to query whether a StateProfileType is applicable
to a certain ChannelType with its supportedItemTypes.

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>