### PR TITLE
[core] Provide preconfigured ChannelBuilder to allow editing an existing channel

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
@@ -23,7 +23,6 @@
         <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
-          <environments combine.self="override"></environments>
           <dependency-resolution>
             <extraRequirements>
               <requirement>

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -64,6 +64,7 @@ import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelKind;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.thing.type.ThingType;
@@ -230,6 +231,44 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         assertThat(channel.getAcceptedItemType(), is("Switch"));
         assertThat(channel.getDefaultTags().size(), is(1));
         assertThat(channel.getDefaultTags().iterator().next(), is("Test Tag"));
+    }
+
+    @Test
+    public void testEditChannelBuilder() throws Exception {
+        registerThingTypeProvider();
+        registerChannelTypeProvider();
+        AtomicReference<ThingHandlerCallback> thc = new AtomicReference<>();
+        ThingHandlerFactory thingHandlerFactory = new BaseThingHandlerFactory() {
+            @Override
+            public boolean supportsThingType(@NonNull ThingTypeUID thingTypeUID) {
+                return true;
+            }
+
+            @Override
+            protected @Nullable ThingHandler createHandler(@NonNull Thing thing) {
+                ThingHandler mockHandler = mock(ThingHandler.class);
+                doAnswer(a -> {
+                    thc.set((ThingHandlerCallback) a.getArguments()[0]);
+                    return null;
+                }).when(mockHandler).setCallback(any(ThingHandlerCallback.class));
+                when(mockHandler.getThing()).thenReturn(THING);
+                return mockHandler;
+            }
+        };
+        registerService(thingHandlerFactory, ThingHandlerFactory.class.getName());
+        new Thread((Runnable) () -> managedThingProvider.add(THING)).start();
+
+        waitForAssert(() -> {
+            assertNotNull(thc.get());
+        });
+
+        ChannelBuilder channelBuilder = thc.get().editChannelBuilder(THING, CHANNEL_UID);
+        Channel channel = channelBuilder.build();
+
+        assertNull(channel.getLabel());
+        assertNull(channel.getDescription());
+        assertEquals("Switch", channel.getAcceptedItemType());
+        assertEquals(CHANNEL_TYPE_UID, channel.getChannelTypeUID());
     }
 
     @Test
@@ -532,9 +571,9 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     }
 
     private void registerChannelTypeProvider() throws Exception {
-        ChannelType channelType = new ChannelType(CHANNEL_TYPE_UID, false, "Switch", ChannelKind.STATE, "Test Label",
-                "Test Description", "Test Category", Collections.singleton("Test Tag"), null, null,
-                new URI("test:channel"));
+        ChannelType channelType = ChannelTypeBuilder.state(CHANNEL_TYPE_UID, "Test Label", "Switch")
+                .withDescription("Test Description").withCategory("Test Category").withTag("Test Tag")
+                .withConfigDescriptionURI(new URI("test:channel")).build();
 
         ChannelTypeProvider mockChannelTypeProvider = mock(ChannelTypeProvider.class);
         when(mockChannelTypeProvider.getChannelType(eq(CHANNEL_TYPE_UID), any())).thenReturn(channelType);

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -262,7 +262,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
             assertNotNull(thc.get());
         });
 
-        ChannelBuilder channelBuilder = thc.get().editChannelBuilder(THING, CHANNEL_UID);
+        ChannelBuilder channelBuilder = thc.get().editChannel(THING, CHANNEL_UID);
         Channel channel = channelBuilder.build();
 
         assertNull(channel.getLabel());

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
@@ -125,7 +125,7 @@ public interface ThingHandlerCallback {
      * @return a preconfigured ChannelBuilder
      * @throw {@link IllegalArgumentException} if no channel with the given UID exists for the given thing
      */
-    ChannelBuilder editChannelBuilder(Thing thing, ChannelUID channelUID);
+    ChannelBuilder editChannel(Thing thing, ChannelUID channelUID);
 
     /**
      * Returns whether at least one item is linked for the given UID of the channel.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
@@ -106,7 +106,7 @@ public interface ThingHandlerCallback {
     void channelTriggered(Thing thing, ChannelUID channelUID, String event);
 
     /**
-     * Create a {@link ChannelBuilder} which is preconfigured with values from the given channel type.
+     * Creates a {@link ChannelBuilder} which is preconfigured with values from the given channel type.
      *
      * @param channelUID the UID of the channel to be created
      * @param channelTypeUID the channel type UID for which the channel should be created
@@ -114,6 +114,18 @@ public interface ThingHandlerCallback {
      * @throw {@link IllegalArgumentException} if the referenced channel type is not known
      */
     ChannelBuilder createChannelBuilder(ChannelUID channelUID, ChannelTypeUID channelTypeUID);
+
+    /**
+     * Creates a {@link ChannelBuilder} which is preconfigured with values from the given channel and allows to modify
+     * it. The methods {@link BaseThingHandler#editThing(Thing)} and {@link BaseThingHandler#updateThing(Thing)} must be
+     * called to persist the changes.
+     *
+     * @param thing thing (must not be null)
+     * @param channelUID the UID of the channel to be edited
+     * @return a preconfigured ChannelBuilder
+     * @throw {@link IllegalArgumentException} if no channel with the given UID exists for the given thing
+     */
+    ChannelBuilder editChannelBuilder(Thing thing, ChannelUID channelUID);
 
     /**
      * Returns whether at least one item is linked for the given UID of the channel.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -286,7 +286,7 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
         };
 
         @Override
-        public ChannelBuilder editChannelBuilder(Thing thing, ChannelUID channelUID) {
+        public ChannelBuilder editChannel(Thing thing, ChannelUID channelUID) {
             Channel channel = thing.getChannel(channelUID.getId());
             if (channel == null) {
                 throw new IllegalArgumentException(

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -286,6 +286,16 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
         };
 
         @Override
+        public ChannelBuilder editChannelBuilder(Thing thing, ChannelUID channelUID) {
+            Channel channel = thing.getChannel(channelUID.getId());
+            if (channel == null) {
+                throw new IllegalArgumentException(
+                        "Channel " + channelUID + "does not exist for thing " + thing.getUID());
+            }
+            return ChannelBuilder.create(channel);
+        }
+
+        @Override
         public boolean isChannelLinked(ChannelUID channelUID) {
             return !itemChannelLinkRegistry.getLinks(channelUID).isEmpty();
         }


### PR DESCRIPTION
- Provide preconfigured ChannelBuilder to allow editing an existing Channel

Follow-up PR for #5959.

Example to edit the properties of a channel (assumption `channelUID` is given):
```java
    ThingHandlerCallback callback = getCallback();
    if (callback != null) {
        Channel channel = callback.editChannelBuilder(getThing(), channelUID).withProperties(Collections.singletonMap("key1", "value1")).build();
        updateThing(editThing().withoutChannel(channelUID).withChannel(channel).build());
    }
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>