### PR TITLE
Sort audio sink and source options

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioManagerTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioManagerTest.groovy
@@ -231,6 +231,9 @@ public class AudioManagerTest extends AudioOSGiTest {
                 audioManager.getSource(),
                 is(audioSourceMock)
         assertThat "The source ${audioSourceMock.getId()} was not added to the set of sources",
+                audioManager.getAllSources().contains(audioSourceMock),
+                is(true)
+        assertThat "The source ${audioSourceMock.getId()} was not added to the set of sources",
                 audioManager.getSourceIds().contains(audioSourceMock.getId()),
                 is(true)
         assertThat "The source ${audioSourceMock.getId()} was not added to the set of sources",
@@ -251,6 +254,9 @@ public class AudioManagerTest extends AudioOSGiTest {
         assertThat "The sink ${audioSinkFake.getId()} was not registered",
                 audioManager.getSink(),
                 is(audioSinkFake)
+        assertThat "The sink ${audioSinkFake.getId()} was not added to the set of sinks",
+                audioManager.getAllSinks().contains(audioSinkFake),
+                is(true)
         assertThat "The sink ${audioSinkFake.getId()} was not added to the set of sinks",
                 audioManager.getSinkIds().contains(audioSinkFake.getId()),
                 is(true)

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioManager.java
@@ -25,7 +25,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  * @author Karel Goderis - Initial contribution and API
  * @author Kai Kreuzer - removed unwanted dependencies
  * @author Christoph Weitkamp - Added parameter to adjust the volume
- *
+ * @author Wouter Born - Added methods for getting all sinks and sources
  */
 @NonNullByDefault
 public interface AudioManager {
@@ -143,6 +143,13 @@ public interface AudioManager {
     AudioSource getSource();
 
     /**
+     * Retrieves all audio sources
+     *
+     * @return all audio sources
+     */
+    Set<AudioSource> getAllSources();
+
+    /**
      * Retrieves an AudioSink.
      * If a default name is configured and the service available, this is returned. If no default name is configured,
      * the first available service is returned, if one exists. If no service with the default name is found, null is
@@ -153,6 +160,13 @@ public interface AudioManager {
      */
     @Nullable
     AudioSink getSink();
+
+    /**
+     * Retrieves all audio sinks
+     *
+     * @return all audio sinks
+     */
+    Set<AudioSink> getAllSinks();
 
     /**
      * Retrieves the ids of all sources

--- a/bundles/core/org.eclipse.smarthome.core.voice.test/src/test/java/org/eclipse/smarthome/core/voice/internal/AudioManagerStub.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice.test/src/test/java/org/eclipse/smarthome/core/voice/internal/AudioManagerStub.java
@@ -27,7 +27,7 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  *
  * @author Velin Yordanov - Initial contribution
  * @author Christoph Weitkamp - Added parameter to adjust the volume
- *
+ * @author Wouter Born - Added methods for getting all sinks and sources
  */
 public class AudioManagerStub implements AudioManager {
     private SinkStub sink = new SinkStub();
@@ -39,8 +39,18 @@ public class AudioManagerStub implements AudioManager {
     }
 
     @Override
+    public Set<AudioSource> getAllSources() {
+        return Collections.emptySet();
+    }
+
+    @Override
     public AudioSink getSink() {
         return sink;
+    }
+
+    @Override
+    public Set<AudioSink> getAllSinks() {
+        return Collections.emptySet();
     }
 
     @Override
@@ -122,4 +132,5 @@ public class AudioManagerStub implements AudioManager {
     public Set<String> getSinks(String pattern) {
         return Collections.emptySet();
     }
+
 }


### PR DESCRIPTION
Similar to #6031 this PR sorts the audio source and sink options in the AudioConsoleCommandExtension and AudioManagerImpl.

It will also mark the default audio source and sink with an asterisk, e.g.:

```
openhab> audio sources
* System Microphone (javasound)

openhab> audio sinks
  All amps (chromecast:audiogroup:928bff2a-3d13-4e1b-bdc2-fcefb70483c6)
  Amp 1 (chromecast:audio:7fda5762a13ce62aea8f35e74a0cc9bd)
  Amp 2 (chromecast:audio:176fc3d5dcae6d7fa49c407ed836fe3a)
  Google Home (chromecast:chromecast:9ee48f2e334e85865a2c80a996a84654)
  System Speaker (javasound)
* System Speaker (with mp3 support) (enhancedjavasound)
  TV (chromecast:chromecast:60fb8f54e9f427cf7666dcb17718a6bb)
  Web Audio (webaudio)
```
