### PR TITLE
StateProfileType and TriggerProfileType should only return unmodifiable collections

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/StateProfileTypeImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/StateProfileTypeImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
@@ -36,8 +37,8 @@ public class StateProfileTypeImpl implements StateProfileType {
             Collection<String> supportedItemTypesOfChannel) {
         this.profileTypeUID = profileTypeUID;
         this.label = label;
-        this.supportedItemTypes = supportedItemTypes;
-        this.supportedItemTypesOfChannel = supportedItemTypesOfChannel;
+        this.supportedItemTypes = Collections.unmodifiableCollection(supportedItemTypes);
+        this.supportedItemTypesOfChannel = Collections.unmodifiableCollection(supportedItemTypesOfChannel);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/TriggerProfileTypeImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/profiles/TriggerProfileTypeImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.core.thing.internal.profiles;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.profiles.ProfileTypeUID;
@@ -37,8 +38,8 @@ public class TriggerProfileTypeImpl implements TriggerProfileType {
             Collection<ChannelTypeUID> supportedChannelTypeUIDs) {
         this.profileTypeUID = profileTypeUID;
         this.label = label;
-        this.supportedItemTypes = supportedItemTypes;
-        this.supportedChannelTypeUIDs = supportedChannelTypeUIDs;
+        this.supportedItemTypes = Collections.unmodifiableCollection(supportedItemTypes);
+        this.supportedChannelTypeUIDs = Collections.unmodifiableCollection(supportedChannelTypeUIDs);
     }
 
     @Override


### PR DESCRIPTION
Follow up to https://github.com/eclipse/smarthome/pull/6019#discussion_r209860055

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>