### PR TITLE
Extend console thing command so that more detailed information about things can be displayed

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/console/ThingConsoleCommandExtension.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/console/ThingConsoleCommandExtension.java
@@ -214,9 +214,9 @@ public class ThingConsoleCommandExtension extends AbstractConsoleCommandExtensio
         console.println("");
 
         if (thing.getConfiguration().getProperties().isEmpty()) {
-            console.println("No configuration properties");
+            console.println("No configuration parameters");
         } else {
-            console.println("Configuration properties:");
+            console.println("Configuration parameters:");
             for (Map.Entry<String, Object> entry : thing.getConfiguration().getProperties().entrySet()) {
                 console.println("\t" + entry.getKey() + " : " + entry.getValue());
             }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/console/ThingConsoleCommandExtension.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/console/ThingConsoleCommandExtension.java
@@ -12,12 +12,18 @@
  */
 package org.eclipse.smarthome.core.thing.internal.console;
 
+import static java.util.Arrays.asList;
+
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.smarthome.core.events.EventPublisher;
 import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ManagedThingProvider;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -38,11 +44,14 @@ import org.osgi.service.component.annotations.Reference;
  * @author Dennis Nobel - Initial contribution
  * @author Thomas Höfer - Added localization of thing status
  * @author Stefan Triller - Added trigger channel command
+ * @author Henning Sudbrock - Added show command
  */
 @Component(immediate = true, service = ConsoleCommandExtension.class)
 public class ThingConsoleCommandExtension extends AbstractConsoleCommandExtension {
 
+    private static final String CMD_THINGS = "things";
     private static final String SUBCMD_LIST = "list";
+    private static final String SUBCMD_SHOW = "show";
     private static final String SUBCMD_CLEAR = "clear";
     private static final String SUBCMD_REMOVE = "remove";
     private static final String SUBCMD_TRIGGER = "trigger";
@@ -53,7 +62,7 @@ public class ThingConsoleCommandExtension extends AbstractConsoleCommandExtensio
     private EventPublisher eventPublisher;
 
     public ThingConsoleCommandExtension() {
-        super("things", "Access your thing registry.");
+        super(CMD_THINGS, "Access your thing registry.");
     }
 
     @Override
@@ -64,6 +73,9 @@ public class ThingConsoleCommandExtension extends AbstractConsoleCommandExtensio
             switch (subCommand) {
                 case SUBCMD_LIST:
                     printThings(console, things);
+                    return;
+                case SUBCMD_SHOW:
+                    printThingsDetails(console, asList(args).subList(1, args.length));
                     return;
                 case SUBCMD_CLEAR:
                     removeAllThings(console, things);
@@ -117,6 +129,8 @@ public class ThingConsoleCommandExtension extends AbstractConsoleCommandExtensio
     @Override
     public List<String> getUsages() {
         return Arrays.asList(new String[] { buildCommandUsage(SUBCMD_LIST, "lists all things"),
+                buildCommandUsage(SUBCMD_SHOW + " <thingUID>*",
+                        "show details about one or more things; show details for all things if no thingUID provided"),
                 buildCommandUsage(SUBCMD_CLEAR, "removes all managed things"),
                 buildCommandUsage(SUBCMD_REMOVE + " <thingUID>", "removes a thing"),
                 buildCommandUsage(SUBCMD_TRIGGER + " <channelUID> [<event>]",
@@ -137,6 +151,94 @@ public class ThingConsoleCommandExtension extends AbstractConsoleCommandExtensio
 
             console.println(String.format("%s (Type=%s, Status=%s, Label=%s, Bridge=%s)", id, thingType, status, label,
                     bridgeUID));
+        }
+    }
+
+    private void printThingsDetails(Console console, List<String> thingUIDStrings) {
+        Collection<Thing> things;
+
+        if (thingUIDStrings.isEmpty()) {
+            things = thingRegistry.getAll();
+        } else {
+            things = new ArrayList<>();
+            for (String thingUIDString : thingUIDStrings) {
+                ThingUID thingUID;
+                try {
+                    thingUID = new ThingUID(thingUIDString);
+                } catch (IllegalArgumentException e) {
+                    console.println("This is not a valid thing UID: " + thingUIDString);
+                    return;
+                }
+
+                Thing thing = thingRegistry.get(thingUID);
+                if (thing == null) {
+                    console.println("Could not find thing with UID " + thingUID);
+                    return;
+                }
+                things.add(thing);
+            }
+        }
+
+        printThingsDetails(console, things);
+    }
+
+    private void printThingsDetails(Console console, Collection<Thing> things) {
+        for (Iterator<Thing> iter = things.iterator(); iter.hasNext();) {
+            printThingDetails(console, iter.next());
+            if (iter.hasNext()) {
+                console.println("");
+                console.println("--- --- --- --- ---");
+                console.println("");
+            }
+        }
+    }
+
+    private void printThingDetails(Console console, Thing thing) {
+        console.println("UID: " + thing.getUID());
+        console.println("Type: " + thing.getThingTypeUID());
+        console.println("Label: " + thing.getLabel());
+        console.println("Status: " + thingStatusInfoI18nLocalizationService.getLocalizedThingStatusInfo(thing, null));
+        if (thing.getBridgeUID() != null) {
+            console.println("Bridge: " + thing.getBridgeUID());
+        }
+        console.println("");
+
+        if (thing.getProperties().isEmpty()) {
+            console.println("No properties");
+        } else {
+            console.println("Properties:");
+            for (Map.Entry<String, String> entry : thing.getProperties().entrySet()) {
+                console.println("\t" + entry.getKey() + " : " + entry.getValue());
+            }
+        }
+        console.println("");
+
+        if (thing.getConfiguration().getProperties().isEmpty()) {
+            console.println("No configuration properties");
+        } else {
+            console.println("Configuration properties:");
+            for (Map.Entry<String, Object> entry : thing.getConfiguration().getProperties().entrySet()) {
+                console.println("\t" + entry.getKey() + " : " + entry.getValue());
+            }
+        }
+        console.println("");
+
+        if (thing.getChannels().isEmpty()) {
+            console.println("No channels");
+        } else {
+            console.println("Channels:");
+            for (Iterator<Channel> iter = thing.getChannels().iterator(); iter.hasNext();) {
+                Channel channel = iter.next();
+                console.println("\tID: " + channel.getUID().getId());
+                console.println("\tLabel: " + channel.getLabel());
+                console.println("\tType: " + channel.getChannelTypeUID());
+                if (channel.getDescription() != null) {
+                    console.println("\tDescription: " + channel.getDescription());
+                }
+                if (iter.hasNext()) {
+                    console.println("");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR extends the console `thing` command with a new sub command for displaying more detailed information about one or more things.

*Motivation*
Motivation for this command is that, currently, while the console `thing` command permits to list all available things, only rather basic information is displayed about each thing. 

Example:
```
zigbee:coordinator_ember:0138143B (Type=Bridge, Status=ONLINE, Label=BV 2010/10 (ZigBee USB dongle), Bridge=null)
yahooweather:weather:berlin (Type=Thing, Status=ONLINE, Label=Weather Information, Bridge=null)
astro:sun:home (Type=Thing, Status=ONLINE, Label=Astro sun data, Bridge=null)
astro:moon:home (Type=Thing, Status=ONLINE, Label=Astro moon data, Bridge=null)
```

If one wants more information about a thing (like, e.g., properties, config properties, channels), one can of course make a REST call, but the output is JSON, intended to be read by a machine. Moreover, when one works in the console (what I do a lot) one would have to switch to another tool to get this information.

*The new command*
This PR adds a new console command `show`, which prints a more detailed description of the things specified by console command arguments:
* If no arguments are specified, a detailed description is printed for all things
* Otherwise, every argument is interpreted as a thing UID, and the detailed description is printed for all those things.

Here is a sample output for an NTP thing:

```
UID: ntp:ntp:demo
Type: ntp:ntp
Label: NTP Server
Status: ONLINE

No properties

Configuration properties:
	hostname : nl.pool.ntp.org
	serverPort : 123
	refreshInterval : 60
	refreshNtp : 30

Channels:
	ID: dateTime
	Label: Date
	Type: ntp:dateTime-channel
	Description: NTP refreshed date & time

	ID: string
	Label: Date
	Type: ntp:string-channel
	Description: NTP refreshed date & time
```

And here is the sample output for a thing provided by the ZigBee binding for a ZigBee device:

```

UID: zigbee:device:0138143B:000d6f000e36aae0
Type: zigbee:device
Label: CentraLite 3200-de
Status: ONLINE
Bridge: zigbee:coordinator_ember:0138143B
 
Properties:
	zigbee_logicaltype : ROUTER
	zigbee_powerlevel : FULL
	modelId : 3200-de
	zigbee_networkaddress : 38295
	zigbee_powersource : MAINS
	zigbee_stkversion : 0
	zigbee_datecode : ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
	zigbee_zclversion : 1
	zigbee_routes : []
	zigbee_lastupdate :
	vendor : CentraLite
	zigbee_powermode : RECEIVER_ON_IDLE
	zigbee_powersources : [MAINS]
	hardwareVersion : 3
	firmwareVersion : 30045310
	zigbee_neighbors : [{"joining":"UNKNOWN","address":"0","depth":"0","lqi":"255","macaddress":"000D6F000DCFA37F"},{"joining":"UNKNOWN","address":"60767","depth":"15","lqi":"255","macaddress":"00124B00028A1B7D"}]
	zigbee_devices : []
 
Configuration properties:
	zigbee_macaddress : 000D6F000E36AAE0
 
Channels:
	ID: 000D6F000E36AAE0_1_electrical_rmscurrent
	Label: Current
	Type: zigbee:electrical_rmscurrent
 
	ID: 000D6F000E36AAE0_1_electrical_rmsvoltage
	Label: Voltage
	Type: zigbee:electrical_rmsvoltage
 
	ID: 000D6F000E36AAE0_1_electrical_activepower
	Label: Total Active Power
	Type: zigbee:electrical_activepower
 
	ID: 000D6F000E36AAE0_1_switch_onoff
	Label: Switch
	Type: zigbee:switch_onoff
```