### PR TITLE
Rework AudioManager interface and usage

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.media/src/main/java/org/eclipse/smarthome/automation/module/media/internal/MediaActionTypeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.media/src/main/java/org/eclipse/smarthome/automation/module/media/internal/MediaActionTypeProvider.java
@@ -130,9 +130,8 @@ public class MediaActionTypeProvider implements ModuleTypeProvider {
     private List<ParameterOption> getSinkOptions(Locale locale) {
         List<ParameterOption> options = new ArrayList<>();
 
-        for (String sinkId : audioManager.getSinkIds()) {
-            AudioSink sink = audioManager.getSink(sinkId);
-            options.add(new ParameterOption(sinkId, sink.getLabel(locale)));
+        for (AudioSink sink : audioManager.getAllSinks()) {
+            options.add(new ParameterOption(sink.getId(), sink.getLabel(locale)));
         }
         return options;
     }

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioManagerTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioManagerTest.groovy
@@ -234,9 +234,6 @@ public class AudioManagerTest extends AudioOSGiTest {
                 audioManager.getAllSources().contains(audioSourceMock),
                 is(true)
         assertThat "The source ${audioSourceMock.getId()} was not added to the set of sources",
-                audioManager.getSourceIds().contains(audioSourceMock.getId()),
-                is(true)
-        assertThat "The source ${audioSourceMock.getId()} was not added to the set of sources",
                 audioManager.getSourceIds(audioSourceMock.getId()).contains(audioSourceMock.getId()),
                 is(true)
     }
@@ -258,10 +255,7 @@ public class AudioManagerTest extends AudioOSGiTest {
                 audioManager.getAllSinks().contains(audioSinkFake),
                 is(true)
         assertThat "The sink ${audioSinkFake.getId()} was not added to the set of sinks",
-                audioManager.getSinkIds().contains(audioSinkFake.getId()),
-                is(true)
-        assertThat "The sink ${audioSinkFake.getId()} was not added to the set of sinks",
-                audioManager.getSinks(audioSinkFake.getId()).contains(audioSinkFake.getId()),
+                audioManager.getSinkIds(audioSinkFake.getId()).contains(audioSinkFake.getId()),
                 is(true)
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/AudioManager.java
@@ -80,20 +80,20 @@ public interface AudioManager {
      * Plays an audio file from the "sounds" folder using the given audio sink.
      *
      * @param fileName The file from the "sounds" folder
-     * @param sink The id of the audio sink to use or null for the default
+     * @param sinkId The id of the audio sink to use or null for the default
      * @throws AudioException in case the file does not exist or cannot be opened
      */
-    void playFile(String fileName, @Nullable String sink) throws AudioException;
+    void playFile(String fileName, @Nullable String sinkId) throws AudioException;
 
     /**
      * Plays an audio file with the given volume from the "sounds" folder using the given audio sink.
      *
      * @param fileName The file from the "sounds" folder
-     * @param sink The id of the audio sink to use or null for the default
+     * @param sinkId The id of the audio sink to use or null for the default
      * @param volume The volume to be used or null if the default notification volume should be used
      * @throws AudioException in case the file does not exist or cannot be opened
      */
-    void playFile(String fileName, @Nullable String sink, @Nullable PercentType volume) throws AudioException;
+    void playFile(String fileName, @Nullable String sinkId, @Nullable PercentType volume) throws AudioException;
 
     /**
      * Stream audio from the passed url using the default audio sink.
@@ -169,20 +169,6 @@ public interface AudioManager {
     Set<AudioSink> getAllSinks();
 
     /**
-     * Retrieves the ids of all sources
-     *
-     * @return ids of all sources
-     */
-    Set<String> getSourceIds();
-
-    /**
-     * Retrieves the ids of all sinks
-     *
-     * @return ids of all sources
-     */
-    Set<String> getSinkIds();
-
-    /**
      * Get a list of source ids that match a given pattern
      *
      * @param pattern pattern to search, can include `*` and `?` placeholders
@@ -205,6 +191,6 @@ public interface AudioManager {
      * @param pattern pattern to search, can include `*` and `?` placeholders
      * @return ids of matching sinks
      */
-    Set<String> getSinks(String pattern);
+    Set<String> getSinkIds(String pattern);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioConsoleCommandExtension.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioConsoleCommandExtension.java
@@ -155,9 +155,9 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
 
     }
 
-    private void playOnSinks(String sinkIds, String fileName, PercentType volume, Console console) {
-        for (String sink : audioManager.getSinks(sinkIds)) {
-            playOnSink(sink, fileName, volume, console);
+    private void playOnSinks(String pattern, String fileName, PercentType volume, Console console) {
+        for (String sinkId : audioManager.getSinkIds(pattern)) {
+            playOnSink(sinkId, fileName, volume, console);
         }
     }
 
@@ -182,9 +182,9 @@ public class AudioConsoleCommandExtension extends AbstractConsoleCommandExtensio
         }
     }
 
-    private void streamOnSinks(String sinkIds, String url, Console console) {
-        for (String sink : audioManager.getSinks(sinkIds)) {
-            streamOnSink(sink, url, console);
+    private void streamOnSinks(String pattern, String url, Console console) {
+        for (String sinkId : audioManager.getSinkIds(pattern)) {
+            streamOnSink(sinkId, url, console);
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.audio/src/main/java/org/eclipse/smarthome/core/audio/internal/AudioManagerImpl.java
@@ -167,18 +167,18 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
     }
 
     @Override
-    public void playFile(String fileName, String sink) throws AudioException {
-        playFile(fileName, sink, null);
+    public void playFile(String fileName, String sinkId) throws AudioException {
+        playFile(fileName, sinkId, null);
     }
 
     @Override
-    public void playFile(String fileName, String sink, PercentType volume) throws AudioException {
+    public void playFile(String fileName, String sinkId, PercentType volume) throws AudioException {
         Objects.requireNonNull(fileName, "File cannot be played as fileName is null.");
 
         File file = new File(
                 ConfigConstants.getConfigFolder() + File.separator + SOUND_DIR + File.separator + fileName);
         FileAudioStream is = new FileAudioStream(file);
-        play(is, sink, volume);
+        play(is, sinkId, volume);
     }
 
     @Override
@@ -254,16 +254,6 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
     }
 
     @Override
-    public Set<String> getSourceIds() {
-        return new HashSet<>(audioSources.keySet());
-    }
-
-    @Override
-    public Set<String> getSinkIds() {
-        return new HashSet<>(audioSinks.keySet());
-    }
-
-    @Override
     public Set<String> getSourceIds(String pattern) {
         String regex = pattern.replace("?", ".?").replace("*", ".*?");
         Set<String> matchedSources = new HashSet<>();
@@ -283,17 +273,17 @@ public class AudioManagerImpl implements AudioManager, ConfigOptionProvider {
     }
 
     @Override
-    public Set<String> getSinks(String pattern) {
+    public Set<String> getSinkIds(String pattern) {
         String regex = pattern.replace("?", ".?").replace("*", ".*?");
-        Set<String> matchedSinks = new HashSet<>();
+        Set<String> matchedSinkIds = new HashSet<>();
 
-        for (String aSink : audioSinks.keySet()) {
-            if (aSink.matches(regex)) {
-                matchedSinks.add(aSink);
+        for (String sinkId : audioSinks.keySet()) {
+            if (sinkId.matches(regex)) {
+                matchedSinkIds.add(sinkId);
             }
         }
 
-        return matchedSinks;
+        return matchedSinkIds;
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.voice.test/src/test/java/org/eclipse/smarthome/core/voice/internal/AudioManagerStub.java
+++ b/bundles/core/org.eclipse.smarthome.core.voice.test/src/test/java/org/eclipse/smarthome/core/voice/internal/AudioManagerStub.java
@@ -79,12 +79,12 @@ public class AudioManagerStub implements AudioManager {
     }
 
     @Override
-    public void playFile(String fileName, String sink) throws AudioException {
+    public void playFile(String fileName, String sinkId) throws AudioException {
 
     }
 
     @Override
-    public void playFile(String fileName, String sink, PercentType volume) throws AudioException {
+    public void playFile(String fileName, String sinkId, PercentType volume) throws AudioException {
 
     }
 
@@ -109,16 +109,6 @@ public class AudioManagerStub implements AudioManager {
     }
 
     @Override
-    public Set<String> getSourceIds() {
-        return Collections.emptySet();
-    }
-
-    @Override
-    public Set<String> getSinkIds() {
-        return Collections.emptySet();
-    }
-
-    @Override
     public Set<String> getSourceIds(String pattern) {
         return Collections.emptySet();
     }
@@ -129,7 +119,7 @@ public class AudioManagerStub implements AudioManager {
     }
 
     @Override
-    public Set<String> getSinks(String pattern) {
+    public Set<String> getSinkIds(String pattern) {
         return Collections.emptySet();
     }
 


### PR DESCRIPTION
* Removes the `getSinkIds` and `getSourceIds` methods from the AudioManager interface because the same data (and more) can be obtained with the `getAllSinks` and `getAllSources` methods that were added in #6043
* Renames the `getSinks(String pattern)` method to `getSinkIds` so it is more consistent with its result and the `getSourceIds(String pattern)` on the AudioManager interface
* Adds an Id suffix to variables and parameters that contain sink or source identifiers