### PR TITLE
Streamline macOS TTS feature, bundle and POM names

### DIFF
--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Eclipse SmartHome Mac TTS Tests
+Bundle-Name: Eclipse SmartHome macOS Text-to-Speech Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.voice.mactts.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/pom.xml
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/pom.xml
@@ -13,7 +13,7 @@
 
   <packaging>eclipse-test-plugin</packaging>
 
-  <name>Eclipse SmartHome Mac TTS Tests</name>
+  <name>Eclipse SmartHome macOS Text-to-Speech Tests</name>
 
   <properties>
     <bundle.symbolicName>org.eclipse.smarthome.voice.mactts.test</bundle.symbolicName>

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: macOS Text-to-Speech
+Bundle-Name: Eclipse SmartHome macOS Text-to-Speech
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.voice.mactts;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts/pom.xml
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts/pom.xml
@@ -14,6 +14,6 @@
   <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
-  <name>Eclipse SmartHome MacOS TTS</name>
+  <name>Eclipse SmartHome macOS Text-to-Speech</name>
 
 </project>

--- a/features/karaf/esh-ext/src/main/feature/feature.xml
+++ b/features/karaf/esh-ext/src/main/feature/feature.xml
@@ -247,7 +247,7 @@
     <bundle>mvn:org.eclipse.smarthome.io/org.eclipse.smarthome.io.webaudio/${project.version}</bundle>
   </feature>
 
-  <feature name="esh-voice-mactts" description="MacOS Text-to-Speech" version="${project.version}">
+  <feature name="esh-voice-mactts" description="macOS Text-to-Speech" version="${project.version}">
     <feature>esh-base</feature>
     <bundle>mvn:org.eclipse.smarthome.voice/org.eclipse.smarthome.voice.mactts/${project.version}</bundle>
   </feature>


### PR DESCRIPTION
Consistently use the same name for the macOS TTS voice addon as:

* feature description
* bundle name
* POM project name

I.e. similar to what is also done for bindings (see also https://github.com/openhab/openhab2-addons/pull/3838).

I see it is common for ESH projects to add a "Eclipse SmartHome" prefix to the bundle and POM project names. Although that is also not consistently used. ;-)

This also replaces some remaining occurences of "MacOS" with "macOS" that were overlooked in https://github.com/eclipse/smarthome/pull/5737.