### PR TITLE
Temporarily disable failing DMX Tests

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/DmxBridgeHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/DmxBridgeHandlerTest.java
@@ -39,6 +39,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.test.java.JavaTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -122,11 +123,13 @@ public class DmxBridgeHandlerTest extends JavaTest {
         waitForAssert(() -> assertEquals(ThingStatus.ONLINE, bridge.getStatusInfo().getStatus()));
     }
 
+    @Ignore("https://github.com/eclipse/smarthome/issues/6015#issuecomment-411313627")
     @Test
     public void assertSendDmxDataIsCalled() {
         Mockito.verify(bridgeHandler, after(500).atLeast(9)).sendDmxData();
     }
 
+    @Ignore("https://github.com/eclipse/smarthome/issues/6015")
     @Test
     public void assertMuteChannelMutesOutput() {
         bridgeHandler.handleCommand(CHANNEL_UID_MUTE, OnOffType.ON);


### PR DESCRIPTION
They seem to be pretty timing related and fail quite often, see
https://github.com/eclipse/smarthome/issues/6015

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>