### PR TITLE
Fix license header

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.test/src/test/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryServiceTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.test/src/test/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryServiceTest.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.smarthome.config.discovery.usbserial.internal;
 
 import static java.util.Arrays.asList;

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactoryTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactoryTest.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.smarthome.core.thing.firmware;
 
 import static org.hamcrest.CoreMatchers.*;

--- a/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericMetadataProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.item/src/org/eclipse/smarthome/model/item/internal/GenericMetadataProvider.java
@@ -1,9 +1,14 @@
 /**
- * Copyright (c) 2014-2017 by the respective copyright holders.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.smarthome.model.item.internal;
 

--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/AsyncResultWrapper.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/AsyncResultWrapper.java
@@ -9,11 +9,12 @@
  * http://www.eclipse.org/legal/epl-2.0
  *
  * SPDX-License-Identifier: EPL-2.0
- *
- * @author Tanya Georgieva - Refactor the groovy file to java
  */
 package org.eclipse.smarthome.test;
 
+/**
+ * @author Tanya Georgieva - Refactor the groovy file to java
+ */
 public class AsyncResultWrapper<T> {
     private T wrappedObject;
     private boolean isSet = false;

--- a/features/karaf/esh-core/src/main/feature/feature.xml
+++ b/features/karaf/esh-core/src/main/feature/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">

--- a/features/karaf/esh-ext/src/main/feature/feature.xml
+++ b/features/karaf/esh-ext/src/main/feature/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">

--- a/features/karaf/esh-tp/src/main/feature/feature.xml
+++ b/features/karaf/esh-tp/src/main/feature/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <features name="${project.artifactId}-${project.version}" xmlns="http://karaf.apache.org/xmlns/features/v1.4.0">

--- a/features/org.eclipse.smarthome.feature.runtime.automation/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.automation/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature

--- a/features/org.eclipse.smarthome.feature.runtime.binding/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.binding/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature

--- a/features/org.eclipse.smarthome.feature.runtime.console.equinox/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.equinox/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature

--- a/features/org.eclipse.smarthome.feature.runtime.console.rfc147/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.console.rfc147/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature

--- a/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.core/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature

--- a/features/org.eclipse.smarthome.feature.runtime.model/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.model/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature

--- a/features/org.eclipse.smarthome.feature.runtime.rest/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.rest/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature

--- a/features/org.eclipse.smarthome.feature.runtime.ui/feature.xml
+++ b/features/org.eclipse.smarthome.feature.runtime.ui/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature

--- a/features/org.eclipse.smarthome.feature.test/feature.xml
+++ b/features/org.eclipse.smarthome.feature.test/feature.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+	Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
 
-    See the NOTICE file(s) distributed with this work for additional
-    information regarding copyright ownership.
+	See the NOTICE file(s) distributed with this work for additional
+	information regarding copyright ownership.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <feature


### PR DESCRIPTION
Fix licenses as stated in the documentation using the `mvn license:format` command.

There are four different changes / commits:

* add missing license headers:
Shouldn't missing license headers be detected by SAT?

* fix old license header:
Shouldn't the date be checked by SAT, too (as it is part of the license header)?

* author should not be part of the license header:
Shouldn't this violate the regular expression of the SAT check and so be detected?

* fix format of license header of feature XML files:
Is the indentation changed by e.g. the Eclipse IDE? Shouldn't we keep the one that is set by the `mvn license:format` command as this one is used to update the license every year, too.