### PR TITLE
Remove unused bundle properties from POM files

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.api/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.api/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation API</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.api</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.api</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.commands/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.commands/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Commands</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.commands</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.commands</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Automation Core Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.core.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.core.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/automation/org.eclipse.smarthome.automation.core/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Core</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.core</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.core</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Automation Event Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.event.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.event.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Automation Integration Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.integration.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.integration.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Automation Core Module Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.module.core.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.module.core.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.core/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.core/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Core Modules</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.module.core</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.module.core</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Timer Modules</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.module.timer</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.module.timer</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.provider.file/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.provider.file/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Provider File</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.provider.file</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.provider.file</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.providers/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.providers/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Providers</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.providers</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.providers</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.java/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Sample Extension Java</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.sample.extension.java</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.sample.extension.java</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Sample JSON</name>
 
-  <properties>
-    <bundle.namespace>org.eclipse.smarthome.automation.sample.extension.json</bundle.namespace>
-    <bunlde.symbolicName>org.eclipse.smarthome.automation.sample.extension.json</bunlde.symbolicName>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Java Demo</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.sample.java.demo</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.sample.java.demo</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Json Demo</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.sample.json.demo</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.sample.json.demo</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Module Type Demo</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.sample.moduletype.demo</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.sample.moduletype.demo</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/pom.xml
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.rest.api/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Automation Sample REST API</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.automation.sample.rest.api</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.automation.sample.rest.api</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/config/org.eclipse.smarthome.config.core.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Configuration Core Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.core.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.core.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/config/org.eclipse.smarthome.config.core/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.core/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Configuration Core</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.core</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.core</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/config/org.eclipse.smarthome.config.discovery.mdns.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.mdns.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Configuration mDNS Discovery Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.discovery.mdns.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.discovery.mdns.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/pom.xml
@@ -11,11 +11,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Configuration Discovery Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.discovery.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.discovery.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test/pom.xml
@@ -11,11 +11,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Configuration USB-Serial Discovery for Linux using sysfs scanning Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.discovery.usbserial.linuxsysfs.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Configuration Discovery UsbSerial Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.discovery.usbserial.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.discovery.usbserial.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/config/org.eclipse.smarthome.config.discovery/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Configuration Discovery</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.discovery</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.discovery</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Configuration Dispatcher Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.dispatch.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.dispatch.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/config/org.eclipse.smarthome.config.dispatch/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.dispatch/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Configuration Dispatcher</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.dispatch</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.dispatch</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Config XML Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.xml.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.xml.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/config/org.eclipse.smarthome.config.xml/pom.xml
+++ b/bundles/config/org.eclipse.smarthome.config.xml/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Configuration XML</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.config.xml</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.config.xml</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core.audio.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/pom.xml
@@ -13,11 +13,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse Smarthome Audio Test</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.audio.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.audio.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/core/org.eclipse.smarthome.core.autoupdate/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.autoupdate/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome AutoUpdate Binding</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.autoupdate</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.autoupdate</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Core Binding XML Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.binding.xml.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.binding.xml.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Core Binding XML</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.binding.xml</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.binding.xml</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core.persistence/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.persistence/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Core Persistence</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.persistence</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.persistence</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core.scheduler/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.scheduler/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Core Scheduler Service</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.scheduler</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.scheduler</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Core Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Thing Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.thing.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.thing.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/pom.xml
@@ -12,11 +12,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Core Thing XML Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.thing.xml.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.thing.xml.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Core Thing XML</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.thing.xml</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.thing.xml</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core.thing/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Thing</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.thing</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.thing</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core.transform.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.transform.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Core Transform Test</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.transform.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.transform.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/core/org.eclipse.smarthome.core.transform/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.transform/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Core Transformation Service</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.transform</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.transform</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core.voice.test/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.voice.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Core Voice Test</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.voice.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.voice.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/core/org.eclipse.smarthome.core.voice/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core.voice/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Core Voice</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core.voice</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core.voice</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/core/org.eclipse.smarthome.core/pom.xml
+++ b/bundles/core/org.eclipse.smarthome.core/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Core</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.core</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.core</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.console.eclipse/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.eclipse/pom.xml
@@ -16,9 +16,4 @@
 
   <name>Eclipse SmartHome Console for OSGi framework Eclipse Equinox</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.console.eclipse</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.console.eclipse</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.console.karaf/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.karaf/pom.xml
@@ -16,11 +16,6 @@
 
   <name>Eclipse SmartHome Console for OSGi runtime Karaf</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.console.karaf</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.console.karaf</bundle.namespace>
-  </properties>
-
   <!-- This dependency is added as long as the bundles are not available in a p2 repo of the target platform. -->
   <dependencies>
     <dependency>

--- a/bundles/io/org.eclipse.smarthome.io.console.rfc147/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console.rfc147/pom.xml
@@ -16,9 +16,4 @@
 
   <name>Eclipse SmartHome Console for OSGi Console RFC 147</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.console.rfc147</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.console.rfc147</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.console/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.console/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Console</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.console</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.console</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.monitor/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Monitor</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.monitor</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.monitor</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.net/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.net/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Network I/O</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.net</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.net</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.rest.core.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core.test/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Eclipse SmartHome IO REST Core Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest.core.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest.core.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Core REST Interface</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest.core</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest.core</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.rest.log/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.log/pom.xml
@@ -16,9 +16,4 @@
 
   <name>Eclipse SmartHome Core REST UI Logging Module</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest.log</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest.log</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap.test/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Eclipse SmartHome Sitemap REST Interface Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest.sitemap.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest.sitemap.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Sitemap REST Interface</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest.sitemap</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest.sitemap</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse.test/pom.xml
@@ -11,11 +11,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome IO SSE Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest.sse.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest.sse.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome SSE Interface</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest.sse</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest.sse</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.rest.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest.test/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Eclipse SmartHome IO REST Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/io/org.eclipse.smarthome.io.rest/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.rest/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome REST Interface</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.rest</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.rest</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.transport.dbus/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.dbus/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome DBus Transport</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.transport.dbus</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.transport.dbus</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome mDNS Service</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.transport.mdns</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.transport.mdns</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Mqtt Transport I/O Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.transport.mqtt.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.transport.mqtt.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome MQTT Transport</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.transport.mqtt</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.transport.mqtt</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp.test/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Eclipse SmartHome IO UPnP Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.transport.upnp.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.transport.upnp.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/io/org.eclipse.smarthome.io.transport.upnp/pom.xml
+++ b/bundles/io/org.eclipse.smarthome.io.transport.upnp/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome UPnP Transport</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.transport.upnp</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.transport.upnp</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.core.test/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Core Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.core.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.core.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.core/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.core/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome Model Core</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.core</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.core</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.item.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.runtime/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Model Items Runtime</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.item.runtime</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.item.runtime</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.item.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item.tests/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Items Model Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.item.tests</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.item.tests</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.item/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.item/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Items</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.item</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.item</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.lazygen/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.lazygen/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Model Lazy Generation</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.lazygen</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.lazygen</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.runtime/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Model Persistence Runtime</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.persistence.runtime</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.persistence.runtime</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Persistence Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.persistence.tests</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.persistence.tests</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.persistence/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.persistence/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Persistence</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.persistence</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.persistence</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Model Rules Runtime</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.rule.runtime</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.rule.runtime</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.rule.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule.tests/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Rules Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.rule.tests</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.rule.tests</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.rule/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.rule/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Rules</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.rule</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.rule</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.script.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.runtime/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Model Script Runtime</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.script.runtime</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.script.runtime</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.script.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script.tests/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Script Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.script.tests</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.script.tests</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.script/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.script/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Script</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.script</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.script</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap.runtime/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Model Sitemap Runtime</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.sitemap.runtime</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.sitemap.runtime</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Model Sitemap</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.sitemap</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.sitemap</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.thing.runtime/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.runtime/pom.xml
@@ -15,8 +15,4 @@
 
   <name>Eclipse SmartHome Thing Model Runtime</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.thing.runtime</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.thing.runtime</bundle.namespace>
-  </properties>
 </project>

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Thing Model Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.thing.tests</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.thing.tests</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/model/org.eclipse.smarthome.model.thing/pom.xml
+++ b/bundles/model/org.eclipse.smarthome.model.thing/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Thing Model</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.model.thing</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.model.thing</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/storage/org.eclipse.smarthome.storage.json.test/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.json.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Storage JSON Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.storage.json.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.storage.json.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/storage/org.eclipse.smarthome.storage.json/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.json/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome JSON Storage</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.storage.json</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.storage.json</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb/pom.xml
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome MapDB Storage</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.storage.mapdb</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.storage.mapdb</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Magic Bundle Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.magic.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.magic</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/test/org.eclipse.smarthome.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Test</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/ui/org.eclipse.smarthome.ui.icon/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome UI Icon Support</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.ui.icon</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.ui.icon</bundle.namespace>
-  </properties>
-
 </project>

--- a/bundles/ui/org.eclipse.smarthome.ui.test/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome UI Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.ui.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.ui.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/bundles/ui/org.eclipse.smarthome.ui/pom.xml
+++ b/bundles/ui/org.eclipse.smarthome.ui/pom.xml
@@ -15,9 +15,4 @@
 
   <name>Eclipse SmartHome UI</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.ui</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.ui</bundle.namespace>
-  </properties>
-
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/pom.xml
@@ -14,9 +14,4 @@
 
   <name>Eclipse SmartHome Astro Binding</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.astro</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.astro</bundle.namespace>
-  </properties>
-
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/pom.xml
@@ -16,9 +16,4 @@
 
   <name>Eclipse SmartHome DigitalSTROM Binding</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.digitalstrom</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.digitalstrom</bundle.namespace>
-  </properties>
-
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/pom.xml
@@ -11,10 +11,6 @@
   <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse Smarthome DMX Binding Tests</name>
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.dmx.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.dmx</bundle.namespace>
-  </properties>
   <build>
     <plugins>
       <plugin>

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio.test/pom.xml
@@ -13,11 +13,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse Smarthome FSInternetRadio Binding Test</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.fsinternetradio.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.fsinternetradio.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/pom.xml
@@ -13,9 +13,4 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Homematic Binding Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.homematic.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.homematic.test</bundle.namespace>
-  </properties>
-
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/pom.xml
@@ -14,10 +14,5 @@
 
   <name>Eclipse SmartHome Homematic Binding</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.homematic</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.homematic</bundle.namespace>
-  </properties>
-
 </project>
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/pom.xml
@@ -13,11 +13,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome hue Binding Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.hue.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.hue.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/pom.xml
@@ -16,9 +16,4 @@
 
   <name>Eclipse SmartHome LIFX Binding</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.lifx</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.lifx</bundle.namespace>
-  </properties>
-
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.test/pom.xml
@@ -14,11 +14,6 @@
 
   <name>Eclipse SmartHome MQTT Binding Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.mqtt.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.mqtt</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/pom.xml
@@ -16,11 +16,6 @@
 
   <name>Eclipse Smarthome OneWire Binding Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.onewire.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.onewire</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/extensions/binding/org.eclipse.smarthome.binding.wemo.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.wemo.test/pom.xml
@@ -13,11 +13,6 @@
   <packaging>eclipse-test-plugin</packaging>
   <name>Eclipse SmartHome Wemo Binding Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.binding.wemo.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.binding.wemo.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/pom.xml
+++ b/extensions/extensionservice/org.eclipse.smarthome.extensionservice.marketplace.test/pom.xml
@@ -13,9 +13,4 @@
 
   <name>Eclipse SmartHome IoT Marketplace Extension Service Test</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.extensionservice.marketplace.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.extensionservice.marketplace.test</bundle.namespace>
-  </properties>
-
 </project>

--- a/extensions/io/org.eclipse.smarthome.io.javasound/pom.xml
+++ b/extensions/io/org.eclipse.smarthome.io.javasound/pom.xml
@@ -13,9 +13,4 @@
 
   <name>Eclipse SmartHome JavaSound I/O</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.io.javasound</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.io.javasound</bundle.namespace>
-  </properties>
-
 </project>

--- a/extensions/ui/org.eclipse.smarthome.ui.classic/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.classic/pom.xml
@@ -13,9 +13,4 @@
 
   <name>Eclipse SmartHome Classic UI</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.ui.classic</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.ui.classic</bundle.namespace>
-  </properties>
-
 </project>

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/pom.xml
@@ -15,11 +15,6 @@
 
 	<name>Eclipse SmartHome Paper UI</name>
 
-	<properties>
-		<bundle.symbolicName>org.eclipse.smarthome.ui.paper</bundle.symbolicName>
-		<bundle.namespace>org.eclipse.smarthome.ui.paper</bundle.namespace>
-	</properties>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/extensions/voice/org.eclipse.smarthome.voice.mactts.test/pom.xml
+++ b/extensions/voice/org.eclipse.smarthome.voice.mactts.test/pom.xml
@@ -15,11 +15,6 @@
 
   <name>Eclipse SmartHome Mac TTS Tests</name>
 
-  <properties>
-    <bundle.symbolicName>org.eclipse.smarthome.voice.mactts.test</bundle.symbolicName>
-    <bundle.namespace>org.eclipse.smarthome.voice.mactts.test</bundle.namespace>
-  </properties>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Removes the unused `bundle.namespace` and `bundle.symbolicName` properties from POM files.

Fixes #6060