### PR TITLE
Adjust the AudioConsoleTest to changes in the AudioConsole

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioConsoleTest.groovy
+++ b/bundles/core/org.eclipse.smarthome.core.audio.test/src/test/groovy/org/eclipse/smarthome/core/audio/test/AudioConsoleTest.groovy
@@ -34,7 +34,7 @@ public class AudioConsoleTest extends AudioOSGiTest {
 
     private def consoleOutput
     private def consoleMock = [println: {String s -> consoleOutput = s}] as Console
-    
+
     private def testTimeout = 1;
 
     @Before
@@ -82,8 +82,8 @@ public class AudioConsoleTest extends AudioOSGiTest {
 
         waitForAssert({
             assertThat "The given volume was invalid",
-                consoleOutput,
-                is(null)
+                    consoleOutput,
+                    is(null)
         })
     }
 
@@ -129,7 +129,7 @@ public class AudioConsoleTest extends AudioOSGiTest {
         waitForAssert({
             assertThat "The listed sink was not as expected",
                     consoleOutput,
-                    is(audioSinkFake.getId())
+                    is(String.format("* %s %s", audioSinkFake.getId(), audioSinkFake.getLabel(null)))
         })
     }
 
@@ -143,13 +143,13 @@ public class AudioConsoleTest extends AudioOSGiTest {
         waitForAssert({
             assertThat "The listed source was not as expected",
                     consoleOutput,
-                    is(audioSourceMock.getId())
+                    is(String.format("* %s %s", audioSourceMock.getId(), audioSourceMock.getLabel(null)))
         })
     }
 
     protected AudioConsoleCommandExtension getAudioConsoleCommandExtension(){
         audioConsoleCommandExtension = getService(ConsoleCommandExtension, AudioConsoleCommandExtension)
-        
+
         assertThat "Could not get AudioConsoleCommandExtension",
                 audioConsoleCommandExtension,
                 is(notNullValue())


### PR DESCRIPTION
In #6043, the AudioConsoleCommandExtension was modified to sort the output. This also changed the formatting of the output slightly, which isn't reflected in two tests.

This did not pop up in the CI build since the waitForAssert method is currently broken (and will be repaired in #5992).

Signed-off-by: Florian Stolte <fstolte@itemis.de>