### PR TITLE
Make project and bundle names more consistent

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.core.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Automation Core
+Bundle-Name: Eclipse SmartHome Automation Core Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.core.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.extension.json/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Activator: org.eclipse.smarthome.automation.internal.sample.json.internal.handler.Activator
 Bundle-ManifestVersion: 2
-Bundle-Name: Automation Sample JSON
+Bundle-Name: Eclipse SmartHome Automation Sample JSON
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.automation.sample.extension.j
  son

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ConfigDescriptionsFragmentTest.fragment;singleton:=
  true

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ConfigDescriptionsFragmentTest.host;singleton:=true
 Bundle-Version: 0.0.1.qualifier

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: LoadingConfigDescriptionsTest.bundle;singleton:=tru
  e

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTest.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: BundleInfoTest.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTestNoAuthor.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTestNoAuthor.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: BundleInfoTestNoAuthor.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Eclipse SmartHome Core
+Bundle-Name: Eclipse SmartHome Core Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.core.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/resources/test-bundle-pool/thingStatusInfoI18nTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/resources/test-bundle-pool/thingStatusInfoI18nTest.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: thingStatusInfoI18nTest.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesI18nTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesI18nTest.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ChannelTypesI18nTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesTest.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ChannelTypesTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ConfigDescriptionsTest.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: SystemChannels.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsInChannelGroups.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsInChannelGroups.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: SystemChannelsInChannelGroups.bundle;singleton:=tru
  e

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: SystemChannelsNoThingTypes.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: SystemChannelsUser.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ThingTypesTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ThingTypesTest.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ThingTypesTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Synthetic Test Bundle
+Bundle-Name: Eclipse SmartHome Synthetic Test Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Network I/O bundle
+Bundle-Name: Eclipse SmartHome Net I/O Bundle Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.net.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mqtt.test/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.smarthome.io.transport.mqtt.test
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Mqtt transport I/O bundle
+Bundle-Name: Eclipse SmartHome MQTT Transport Bundle Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.io.transport.mqtt.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
+++ b/bundles/model/org.eclipse.smarthome.model.persistence.tests/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Persistence Model Tests
+Bundle-Name: Eclipse SmartHome Persistence Model Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.model.persistence.tests
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/storage/org.eclipse.smarthome.storage.json.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.json.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Eclipse SmartHome Json Storage
+Bundle-Name: Eclipse SmartHome Json Storage Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.storage.json.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
+++ b/bundles/storage/org.eclipse.smarthome.storage.mapdb.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Eclipse SmartHome MapDB Storage
+Bundle-Name: Eclipse SmartHome MapDB Storage Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.storage.mapdb.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/test/org.eclipse.smarthome.magic.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Magic Bundle Tests
+Bundle-Name: Eclipse SmartHome Magic Bundle Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.magic.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic.test/pom.xml
@@ -13,7 +13,7 @@
   <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
-  <name>Magic Bundle Tests</name>
+  <name>Eclipse SmartHome Magic Bundle Tests</name>
 
   <build>
     <plugins>

--- a/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Magic Bundle
+Bundle-Name: Eclipse SmartHome Magic Bundle
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.magic;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/bundles/test/org.eclipse.smarthome.magic/pom.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/pom.xml
@@ -13,6 +13,6 @@
   <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
-  <name>Magic Bundle</name>
+  <name>Eclipse SmartHome Magic Bundle</name>
 
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.astro/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-Copyright: Eclipse Public License v1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Astro Binding
+Bundle-Name: Eclipse SmartHome Astro Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.astro;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluegiga.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluegiga.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Bluetooth BlueGiga Binding Tests
+Bundle-Name: Eclipse SmartHome Bluetooth BlueGiga Binding Tests
 Bundle-SymbolicName: 
  org.eclipse.smarthome.binding.bluetooth.bluegiga.test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluegiga/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluegiga/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: BlueGiga Bluetooth Adapter
+Bundle-Name: Eclipse SmartHome BlueGiga Bluetooth Adapter
 Bundle-SymbolicName: org.eclipse.smarthome.binding.bluetooth.bluegiga
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluez/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluez/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: BlueZ Bluetooth Adapter
+Bundle-Name: Eclipse SmartHome BlueZ Bluetooth Adapter
 Bundle-SymbolicName: 
  org.eclipse.smarthome.binding.bluetooth.bluez;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.blukii/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.blukii/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Blukii Binding
+Bundle-Name: Eclipse SmartHome Blukii Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.bluetooth.blukii
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name:  Bluetooth Binding Tests
+Bundle-Name: Eclipse SmartHome Bluetooth Binding Tests
 Bundle-SymbolicName: 
  org.eclipse.smarthome.binding.bluetooth.test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Bluetooth Binding
+Bundle-Name: Eclipse SmartHome Bluetooth Binding
 Bundle-SymbolicName: 
  org.eclipse.smarthome.binding.bluetooth;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: BoseSoundTouch Binding
+Bundle-Name: Eclipse SmartHome BoseSoundTouch Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.bosesoundtouch;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: DigitalSTROM Binding
+Bundle-Name: Eclipse SmartHome DigitalSTROM Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.digitalstrom;singleto
  n:=true

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
-Bundle-Name: Dmx Binding Tests
+Bundle-Name: Eclipse SmartHome DMX Binding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.dmx.test;singleton:=t
  rue

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: DMX Binding
+Bundle-Name: Eclipse SmartHome DMX Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.dmx;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: FSInternetRadio Binding
+Bundle-Name: Eclipse SmartHome FSInternetRadio Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.fsinternetradio;singl
  eton:=true

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-Copyright: Eclipse Public License v2.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Homematic Binding
+Bundle-Name: Eclipse SmartHome Homematic Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.homematic;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.ntp/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: ntp Binding
+Bundle-Name: Eclipse SmartHome NTP Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.ntp;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
-Bundle-Name: OneWire Binding Tests
+Bundle-Name: Eclipse SmartHome OneWire Binding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.onewire.test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
-Bundle-Name: OneWire Binding
+Bundle-Name: Eclipse SmartHome OneWire Binding
 Bundle-SymbolicName: org.eclipse.smarthome.binding.onewire;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier

--- a/extensions/binding/org.eclipse.smarthome.binding.serialbutton/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.serialbutton/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: SerialButton Binding
+Bundle-Name: Eclipse SmartHome SerialButton Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: 
  org.eclipse.smarthome.binding.serialbutton;singleton:=true

--- a/extensions/binding/org.eclipse.smarthome.binding.serialbutton/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.serialbutton/pom.xml
@@ -13,6 +13,6 @@
   <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
-  <name>SerialButton Binding</name>
+  <name>Eclipse SmartHome SerialButton Binding</name>
 
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.sonos/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: Sonos Binding
+Bundle-Name: Eclipse SmartHome Sonos Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.sonos
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: TRÅDFRI Binding Tests
+Bundle-Name: Eclipse SmartHome TRÅDFRI Binding Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri.test;singleto
  n:=true

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri.test/pom.xml
@@ -14,7 +14,7 @@
   <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
-  <name>TRÅDFRI Binding Tests</name>
+  <name>Eclipse SmartHome TRÅDFRI Binding Tests</name>
 
   <build>
     <plugins>

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: TRÅDFRI Binding
+Bundle-Name: Eclipse SmartHome TRÅDFRI Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.tradfri;singleton:=tr
  ue

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/pom.xml
@@ -13,6 +13,6 @@
   <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
-  <name>TRÅDFRI Binding</name>
+  <name>Eclipse SmartHome TRÅDFRI Binding</name>
 
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: WeatherUnderground Binding
+Bundle-Name: Eclipse SmartHome WeatherUnderground Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.binding.weatherunderground;si
  ngleton:=true

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/pom.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/pom.xml
@@ -14,6 +14,6 @@
   <version>0.10.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
-  <name>WeatherUnderground Binding</name>
+  <name>Eclipse SmartHome WeatherUnderground Binding</name>
 
 </project>

--- a/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.yahooweather/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ClassPath: .
 Bundle-ManifestVersion: 2
-Bundle-Name: YahooWeather Binding
+Bundle-Name: Eclipse SmartHome YahooWeather Binding
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: 
  org.eclipse.smarthome.binding.yahooweather;singleton:=true

--- a/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker.test/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: MqttBroker Binding Tests
+Bundle-Name: Eclipse SmartHome MqttBroker Binding Tests
 Bundle-SymbolicName: org.eclipse.smarthome.io.mqttembeddedbroker.test;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier

--- a/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Automatic-Module-Name: org.eclipse.smarthome.io.mqttembeddedbroker
 Bundle-ManifestVersion: 2
-Bundle-Name: Embedded Mqtt Broker
+Bundle-Name: Eclipse SmartHome Embedded Mqtt Broker
 Bundle-SymbolicName: org.eclipse.smarthome.io.mqttembeddedbroker;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the JSonPath Transformation Service
+Bundle-Name: Eclipse SmartHome JSonPath Transformation Service Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.jsonpath.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.map.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Map Transformation Service
+Bundle-Name: Eclipse SmartHome Map Transformation Service Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.map.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the RegEx Transformation Service
+Bundle-Name: Eclipse SmartHome RegEx Transformation Service Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.regex.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Scale Transformation Service
+Bundle-Name: Eclipse SmartHome Scale Transformation Service Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.scale.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the XPath Transformation Service
+Bundle-Name: Eclipse SmartHome XPath Transformation Service Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xpath.test
 Bundle-Vendor: Eclipse.org/SmartHome

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt.test/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Tests for the Xslt Transformation Service
+Bundle-Name: Eclipse SmartHome Xslt Transformation Service Tests
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: org.eclipse.smarthome.transform.xslt.test
 Bundle-Vendor: Eclipse.org/SmartHome


### PR DESCRIPTION
* Add missing "Eclipse SmartHome" prefix to project and bundle names
* Replace "Tests for the" bundle name prefix with "Tests" suffix

Most ESH bundles already follow these naming conventions.