### PR TITLE
[Tradfri] Supress 'old firmware' warning if firmware property is not set

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
@@ -108,12 +108,16 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
                 establishConnection();
             }
         } else {
-            if (isOldFirmware()) {
-                /*
-                 * older firmware - fall back to authentication with security code
-                 * in this case the Thing configuration will not be persisted
-                 */
-                logger.warn("Gateway with old firmware - please consider upgrading to the latest version.");
+            String currentFirmware = thing.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION);
+            if (isNullOrEmpty(currentFirmware)
+                    || MIN_SUPPORTED_VERSION.compareTo(new TradfriVersion(currentFirmware)) > 0) {
+                // older firmware - fall back to authentication with security code
+                // in this case the Thing configuration will not be persisted
+                if (!isNullOrEmpty(currentFirmware)) {
+                    // show warning only if we already have set the firmware property
+                    logger.warn("Gateway with old firmware '{}' - please consider upgrading to the latest version.",
+                            currentFirmware);
+                }
 
                 Configuration editedConfig = editConfiguration();
                 editedConfig.put(TradfriBindingConstants.GATEWAY_CONFIG_IDENTITY, "");
@@ -360,16 +364,6 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
 
     private boolean isNullOrEmpty(String string) {
         return string == null || string.isEmpty();
-    }
-
-    /**
-     * Checks current firmware in the thing properties and compares it with the value of {@link #MIN_SUPPORTED_VERSION}
-     *
-     * @return true if current firmware is older than {@value #MIN_SUPPORTED_VERSION}
-     */
-    private boolean isOldFirmware() {
-        String currentFirmware = thing.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION);
-        return currentFirmware == null || MIN_SUPPORTED_VERSION.compareTo(new TradfriVersion(currentFirmware)) > 0;
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java
@@ -255,13 +255,13 @@ public class TradfriGatewayHandler extends BaseBridgeHandler implements CoapCall
             scanJob.cancel(true);
             scanJob = null;
         }
-        if (deviceClient != null) {
-            deviceClient.shutdown();
-            deviceClient = null;
-        }
         if (endPoint != null) {
             endPoint.destroy();
             endPoint = null;
+        }
+        if (deviceClient != null) {
+            deviceClient.shutdown();
+            deviceClient = null;
         }
         super.dispose();
     }


### PR DESCRIPTION
- Supress 'old firmware' warning if firmware property is not set

Closes #5765

I additionally changed the order of destroying the endpoint before shutting down the client. This maybe is a fix for #6065. We use this order to receive a pre-shared key and that method does not fail:

https://github.com/eclipse/smarthome/blob/b39fe45be22b7290269f1959803e49fda91cdb6a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/handler/TradfriGatewayHandler.java#L195-L196

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>