### PR TITLE
Fix CCE in mDNS client

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 
 import javax.jmdns.JmDNS;
 import javax.jmdns.ServiceInfo;
@@ -40,10 +38,7 @@ import org.eclipse.smarthome.io.transport.mdns.ServiceDescription;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,9 +53,9 @@ import org.slf4j.LoggerFactory;
 public class MDNSClientImpl implements MDNSClient, NetworkAddressChangeListener {
     private final Logger logger = LoggerFactory.getLogger(MDNSClientImpl.class);
 
-    private final ConcurrentMap<InetAddress, JmDNS> jmdnsInstances = new ConcurrentHashMap<>();
+    private final Map<InetAddress, JmDNS> jmdnsInstances = new ConcurrentHashMap<>();
 
-    private final ConcurrentSkipListSet<ServiceDescription> activeServices = new ConcurrentSkipListSet<>();
+    private final Set<ServiceDescription> activeServices = ConcurrentHashMap.newKeySet();
 
     private NetworkAddressService networkAddressService;
 
@@ -186,7 +181,6 @@ public class MDNSClientImpl implements MDNSClient, NetworkAddressChangeListener 
             instance.registerService(serviceInfo);
         }
     }
-
 
     @Override
     public void unregisterService(ServiceDescription description) {


### PR DESCRIPTION
This fixes and issue introduced by #6005, leading to the following CCE:

```
Exception in thread "pool-38-thread-1" java.lang.ClassCastException: org.eclipse.smarthome.io.transport.mdns.ServiceDescription cannot be cast to java.lang.Comparable
        at java.util.concurrent.ConcurrentSkipListMap.cpr(ConcurrentSkipListMap.java:655)
        at java.util.concurrent.ConcurrentSkipListMap.doPut(ConcurrentSkipListMap.java:835)
        at java.util.concurrent.ConcurrentSkipListMap.putIfAbsent(ConcurrentSkipListMap.java:1962)
        at java.util.concurrent.ConcurrentSkipListSet.add(ConcurrentSkipListSet.java:241)
        at org.eclipse.smarthome.io.transport.mdns.internal.MDNSClientImpl.registerService(MDNSClientImpl.java:175)
    ...
```

This was because `ConcurrentSkipListSet` expects `Comparable` content, but `ServiceDescription` isn't. I don't see why that would have been required, so I changed it to a more relaxed concurrent set implementation.

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>