### PR TITLE
Do not use NetworkAddressChangeListener as an OSGi service, but as a callback of NetworkAddressService

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.upnp/src/main/java/org/eclipse/smarthome/config/discovery/upnp/internal/UpnpDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.upnp/src/main/java/org/eclipse/smarthome/config/discovery/upnp/internal/UpnpDiscoveryService.java
@@ -19,13 +19,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.config.discovery.upnp.UpnpDiscoveryParticipant;
 import org.eclipse.smarthome.core.net.CidrAddress;
 import org.eclipse.smarthome.core.net.NetworkAddressChangeListener;
+import org.eclipse.smarthome.core.net.NetworkAddressService;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.jupnp.UpnpService;
@@ -52,8 +52,9 @@ import org.slf4j.LoggerFactory;
  * @author Tim Roberts - Added primary address change
  *
  */
-@Component(immediate = true, service = { DiscoveryService.class, NetworkAddressChangeListener.class }, configurationPid = "discovery.upnp")
-public class UpnpDiscoveryService extends AbstractDiscoveryService implements RegistryListener, NetworkAddressChangeListener {
+@Component(immediate = true, service = DiscoveryService.class, configurationPid = "discovery.upnp")
+public class UpnpDiscoveryService extends AbstractDiscoveryService
+        implements RegistryListener, NetworkAddressChangeListener {
 
     private final Logger logger = LoggerFactory.getLogger(UpnpDiscoveryService.class);
 
@@ -87,6 +88,15 @@ public class UpnpDiscoveryService extends AbstractDiscoveryService implements Re
 
     protected void unsetUpnpService(UpnpService upnpService) {
         this.upnpService = null;
+    }
+
+    @Reference
+    protected void setNetworkAddressService(NetworkAddressService networkAddressService) {
+        networkAddressService.addNetworkAddressChangeListener(this);
+    }
+
+    protected void unsetNetworkAddressService(NetworkAddressService networkAddressService) {
+        networkAddressService.removeNetworkAddressChangeListener(this);
     }
 
     @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetUtil.java
@@ -93,7 +93,8 @@ public class NetUtil implements NetworkAddressService {
     private @NonNullByDefault({}) SafeCaller safeCaller;
 
     @Activate
-    protected void activate(Map<String, @Nullable Object> props) {
+    protected void activate(Map<String, Object> props) {
+        lastKnownInterfaceAddresses = Collections.emptyList();
         modified(props);
     }
 
@@ -108,7 +109,7 @@ public class NetUtil implements NetworkAddressService {
     }
 
     @Modified
-    public synchronized void modified(Map<String, @Nullable Object> config) {
+    public synchronized void modified(Map<String, Object> config) {
         String primaryAddressConf = (String) config.get(PRIMARY_ADDRESS);
         String oldPrimaryAddress = primaryAddress;
         if (primaryAddressConf == null || primaryAddressConf.isEmpty() || !isValidIPConfig(primaryAddressConf)) {
@@ -632,8 +633,10 @@ public class NetUtil implements NetworkAddressService {
         }
     }
 
-    private boolean getConfigParameter(Map<String, @Nullable Object> parameters, String parameter,
-            boolean defaultValue) {
+    private boolean getConfigParameter(Map<String, Object> parameters, String parameter, boolean defaultValue) {
+        if (parameters == null) {
+            return defaultValue;
+        }
         Object value = parameters.get(parameter);
         if (value == null) {
             return defaultValue;

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressChangeListener.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressChangeListener.java
@@ -20,8 +20,7 @@ import org.eclipse.jdt.annotation.Nullable;
 /**
  * This is an interface for listeners who wants to be notified for the change of network address.
  * There are only network address adds, and removes; it makes no effort to correlate
- * which existing network is changed. Listeners should register themselves
- * with this interface as a service.
+ * which existing network is changed. Listeners should register themselves at the {@link NetworkAddressService}.
  *
  * @see NetUtil
  *

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/net/NetworkAddressService.java
@@ -42,19 +42,33 @@ public interface NetworkAddressService {
      */
     @Nullable
     String getConfiguredBroadcastAddress();
-    
+
     /**
      * Use only one address per interface and family (IPv4 and IPv6). If set listeners should bind only to one address
      * per interface and family.
-     * 
+     *
      * @return use only one address per interface and family
      */
     boolean isUseOnlyOneAddress();
-    
+
     /**
      * Use IPv6. If not set, IPv6 addresses should be completely ignored by listeners.
-     * 
+     *
      * @return use IPv6
      */
     boolean isUseIPv6();
+
+    /**
+     * Adds a {@link NetworkAddressChangeListener} that is notified about changes.
+     *
+     * @param listener The listener
+     */
+    public void addNetworkAddressChangeListener(NetworkAddressChangeListener listener);
+
+    /**
+     * Removes a {@link NetworkAddressChangeListener} so that it is no longer notified about changes.
+     *
+     * @param listener The listener
+     */
+    public void removeNetworkAddressChangeListener(NetworkAddressChangeListener listener);
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.mdns/src/main/java/org/eclipse/smarthome/io/transport/mdns/internal/MDNSClientImpl.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  * @author Gary Tse - Add NetworkAddressChangeListener to handle interface changes
  *
  */
-@Component(immediate = true)
+@Component(immediate = true, service = MDNSClient.class)
 public class MDNSClientImpl implements MDNSClient, NetworkAddressChangeListener {
     private final Logger logger = LoggerFactory.getLogger(MDNSClientImpl.class);
 
@@ -278,9 +278,11 @@ public class MDNSClientImpl implements MDNSClient, NetworkAddressChangeListener 
     @Reference
     protected void setNetworkAddressService(NetworkAddressService networkAddressService) {
         this.networkAddressService = networkAddressService;
+        networkAddressService.addNetworkAddressChangeListener(this);
     }
 
     protected void unsetNetworkAddressService(NetworkAddressService networkAddressService) {
+        networkAddressService.removeNetworkAddressChangeListener(this);
         this.networkAddressService = null;
     }
 }


### PR DESCRIPTION
This is a classic pattern where we run easily into cyclic dependencies: Someone needs a service and wants to be informed about changes from it. If this is done (as at the moment) purely through OSGi services, it immediately results in two services (or rather their implementing classes) depending upon each other.

This PR resolves this by treating the listener interface as a callback of the service - i.e. it is NOT used for registering a service itself, but it is added (by an `addListener` call) to a service that gets injected.

I decided against supporting both ways as I think this can quickly result in confusion on how to correctly use the listener interface. As a result, this PR is API breaking as existing listener implementations have to be adapted in a way that they are not registered as an OSGi service anymore, but rather have to depend on `NetworkAddressService` and register on it by themselves (as it has been done for the `UpnpDiscoveryService` in this PR).

This PR also fixed some nullable warnings on the way.

Solves https://github.com/eclipse/smarthome/issues/6073

Signed-off-by: Kai Kreuzer <kai@openhab.org>