### PR TITLE
[homematic] Fix issue #6053: HomematicIP-Devices offline with 2.4.0 Snapshot 1330

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClientTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClientTest.java
@@ -1,0 +1,82 @@
+package org.eclipse.smarthome.binding.homematic.internal.communicator.client;
+
+import static org.eclipse.smarthome.binding.homematic.test.util.DimmerHelper.createDimmerDummyChannel;
+import static org.eclipse.smarthome.binding.homematic.test.util.DimmerHelper.createDimmerHmChannel;
+import static org.eclipse.smarthome.binding.homematic.test.util.RpcClientMockImpl.GET_PARAMSET_DESCRIPTION_NAME;
+import static org.eclipse.smarthome.binding.homematic.test.util.RpcClientMockImpl.GET_PARAMSET_NAME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+
+import org.eclipse.smarthome.binding.homematic.internal.model.HmChannel;
+import org.eclipse.smarthome.binding.homematic.internal.model.HmParamsetType;
+import org.eclipse.smarthome.binding.homematic.test.util.RpcClientMockImpl;
+import org.eclipse.smarthome.test.java.JavaTest;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RpcClientTest extends JavaTest {
+
+    private RpcClientMockImpl rpcClient;
+
+    @Before
+    public void setup() throws IOException {
+        this.rpcClient = new RpcClientMockImpl();
+    }
+
+    @Test
+    public void valuesParamsetDescriptionIsLoadedForChannel() throws IOException {
+        HmChannel channel = createDimmerHmChannel();
+
+        rpcClient.addChannelDatapoints(channel, HmParamsetType.VALUES);
+
+        assertThat(rpcClient.numberOfCalls.get(GET_PARAMSET_DESCRIPTION_NAME), is(1));
+    }
+
+    @Test
+    public void masterParamsetDescriptionIsLoadedForDummyChannel() throws IOException {
+        HmChannel channel = createDimmerDummyChannel();
+
+        rpcClient.addChannelDatapoints(channel, HmParamsetType.MASTER);
+
+        assertThat(rpcClient.numberOfCalls.get(GET_PARAMSET_DESCRIPTION_NAME), is(1));
+    }
+
+    @Test
+    public void valuesParamsetDescriptionIsNotLoadedForDummyChannel() throws IOException {
+        HmChannel channel = createDimmerDummyChannel();
+
+        rpcClient.addChannelDatapoints(channel, HmParamsetType.VALUES);
+
+        assertThat(rpcClient.numberOfCalls.get(GET_PARAMSET_DESCRIPTION_NAME), is(0));
+    }
+
+    @Test
+    public void valuesParamsetIsLoadedForChannel() throws IOException {
+        HmChannel channel = createDimmerHmChannel();
+
+        rpcClient.setChannelDatapointValues(channel, HmParamsetType.VALUES);
+
+        assertThat(rpcClient.numberOfCalls.get(GET_PARAMSET_NAME), is(1));
+    }
+
+    @Test
+    public void masterParamsetIsLoadedForDummyChannel() throws IOException {
+        HmChannel channel = createDimmerDummyChannel();
+
+        rpcClient.setChannelDatapointValues(channel, HmParamsetType.MASTER);
+
+        assertThat(rpcClient.numberOfCalls.get(GET_PARAMSET_NAME), is(1));
+    }
+
+    @Test
+    public void valuesParamsetIsNotLoadedForDummyChannel() throws IOException {
+        HmChannel channel = createDimmerDummyChannel();
+
+        rpcClient.setChannelDatapointValues(channel, HmParamsetType.VALUES);
+
+        assertThat(rpcClient.numberOfCalls.get(GET_PARAMSET_NAME), is(0));
+    }
+
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/test/util/DimmerHelper.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/test/util/DimmerHelper.java
@@ -47,6 +47,13 @@ public class DimmerHelper {
         return hmChannel;
     }
 
+    public static HmChannel createDimmerDummyChannel() {
+        HmChannel hmChannel = new HmChannel("HM-LC-Dim1-Pl3", -1);
+        hmChannel.setDevice(createDimmerHmDevice());
+
+        return hmChannel;
+    }
+
     public static HmDatapoint createDimmerHmDatapoint() {
         HmDatapoint hmDatapoint = new HmDatapoint();
         hmDatapoint.setName("DIMMER");

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/test/util/RpcClientMockImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/test/util/RpcClientMockImpl.java
@@ -1,0 +1,82 @@
+package org.eclipse.smarthome.binding.homematic.test.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.smarthome.binding.homematic.internal.common.HomematicConfig;
+import org.eclipse.smarthome.binding.homematic.internal.communicator.client.RpcClient;
+import org.eclipse.smarthome.binding.homematic.internal.communicator.message.RpcRequest;
+
+public class RpcClientMockImpl extends RpcClient<String> {
+
+    public static final String GET_PARAMSET_DESCRIPTION_NAME = "getParamsetDescription";
+    public static final String GET_PARAMSET_NAME = "getParamset";
+
+    public Map<String, Integer> numberOfCalls = new HashMap<String, Integer>();
+
+    public RpcClientMockImpl() throws IOException {
+        this(new HomematicConfig());
+    }
+
+    public RpcClientMockImpl(HomematicConfig config) throws IOException {
+        super(config);
+
+        Arrays.asList(GET_PARAMSET_DESCRIPTION_NAME, GET_PARAMSET_NAME).forEach(method -> numberOfCalls.put(method, 0));
+    }
+
+    @Override
+    protected Object[] sendMessage(int port, RpcRequest<String> request) throws IOException {
+        String methodName = request.getMethodName();
+
+        increaseNumberOfCalls(methodName);
+
+        return mockResponse();
+    }
+
+    private void increaseNumberOfCalls(String methodName) {
+        Integer currentNumber = numberOfCalls.get(methodName);
+        if (currentNumber == null) {
+            numberOfCalls.put(methodName, 1);
+        } else {
+            numberOfCalls.put(methodName, currentNumber + 1);
+        }
+    }
+
+    private Object[] mockResponse() {
+        Object[] response = new Object[1];
+        response[0] = new HashMap<String, Object>();
+        return response;
+    }
+
+    @Override
+    protected RpcRequest<String> createRpcRequest(String methodName) {
+        return new RpcRequest<String>() {
+
+            @Override
+            public void addArg(Object arg) {
+            }
+
+            @Override
+            public String createMessage() {
+                return null;
+            }
+
+            @Override
+            public String getMethodName() {
+                return methodName;
+            }
+
+        };
+    }
+
+    @Override
+    public void dispose() {
+    }
+
+    @Override
+    protected String getRpcCallbackUrl() {
+        return null;
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/HomematicBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/HomematicBindingConstants.java
@@ -66,4 +66,6 @@ public class HomematicBindingConstants {
     public static final String PROPERTY_DYNAMIC_FUNCTION_FORMAT = "dynamicFunction-%d";
     
     public static final int INSTALL_MODE_NORMAL = 1;
+
+    public static final int CONFIGURATION_CHANNEL_NUMBER = -1;
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClient.java
@@ -171,6 +171,11 @@ public abstract class RpcClient<T> {
      * Loads all datapoint metadata into the given channel.
      */
     public void addChannelDatapoints(HmChannel channel, HmParamsetType paramsetType) throws IOException {
+        if (isDummyChannel(channel) && paramsetType != HmParamsetType.MASTER) {
+            // The dummy channel only has a MASTER Paramset, so there is nothing to load
+            return;
+        }
+
         RpcRequest<T> request = createRpcRequest("getParamsetDescription");
         request.addArg(getRpcAddress(channel.getDevice().getAddress()) + getChannelSuffix(channel));
         request.addArg(paramsetType.toString());
@@ -181,6 +186,11 @@ public abstract class RpcClient<T> {
      * Sets all datapoint values for the given channel.
      */
     public void setChannelDatapointValues(HmChannel channel, HmParamsetType paramsetType) throws IOException {
+        if (isDummyChannel(channel) && paramsetType != HmParamsetType.MASTER) {
+            // The dummy channel only has a MASTER Paramset, so there is nothing to load
+            return;
+        }
+
         RpcRequest<T> request = createRpcRequest("getParamset");
         request.addArg(getRpcAddress(channel.getDevice().getAddress()) + getChannelSuffix(channel));
         request.addArg(paramsetType.toString());
@@ -391,11 +401,18 @@ public abstract class RpcClient<T> {
 
     /**
      * Returns the address suffix that specifies the channel for a given HmChannel. This is either a colon ":" followed
-     * by the channel number, or the empty string. The empty string is returned for the channel -1, since this channel
-     * encapsulates the ParamSets of a device that do not belong to one of its channels.
+     * by the channel number, or the empty string for a dummy channel.
      */
     private String getChannelSuffix(HmChannel channel) {
-        return channel.getNumber() != -1 ? ":" + channel.getNumber() : "";
+        return isDummyChannel(channel) ? "" : ":" + channel.getNumber();
+    }
+
+    /**
+     * Checks whether a channel is a dummy channel. The dummy channel of a device encapsulates the MASTER Paramset that
+     * does not belong to one of its channels.
+     */
+    private boolean isDummyChannel(HmChannel channel) {
+        return channel.getNumber() == -1;
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClient.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.homematic.internal.communicator.client;
 
 import static org.eclipse.smarthome.binding.homematic.HomematicBindingConstants.INSTALL_MODE_NORMAL;
+import static org.eclipse.smarthome.binding.homematic.HomematicBindingConstants.CONFIGURATION_CHANNEL_NUMBER;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -171,8 +172,8 @@ public abstract class RpcClient<T> {
      * Loads all datapoint metadata into the given channel.
      */
     public void addChannelDatapoints(HmChannel channel, HmParamsetType paramsetType) throws IOException {
-        if (isDummyChannel(channel) && paramsetType != HmParamsetType.MASTER) {
-            // The dummy channel only has a MASTER Paramset, so there is nothing to load
+        if (isConfigurationChannel(channel) && paramsetType != HmParamsetType.MASTER) {
+            // The configuration channel only has a MASTER Paramset, so there is nothing to load
             return;
         }
 
@@ -186,8 +187,8 @@ public abstract class RpcClient<T> {
      * Sets all datapoint values for the given channel.
      */
     public void setChannelDatapointValues(HmChannel channel, HmParamsetType paramsetType) throws IOException {
-        if (isDummyChannel(channel) && paramsetType != HmParamsetType.MASTER) {
-            // The dummy channel only has a MASTER Paramset, so there is nothing to load
+        if (isConfigurationChannel(channel) && paramsetType != HmParamsetType.MASTER) {
+            // The configuration channel only has a MASTER Paramset, so there is nothing to load
             return;
         }
 
@@ -401,18 +402,18 @@ public abstract class RpcClient<T> {
 
     /**
      * Returns the address suffix that specifies the channel for a given HmChannel. This is either a colon ":" followed
-     * by the channel number, or the empty string for a dummy channel.
+     * by the channel number, or the empty string for a configuration channel.
      */
     private String getChannelSuffix(HmChannel channel) {
-        return isDummyChannel(channel) ? "" : ":" + channel.getNumber();
+        return isConfigurationChannel(channel) ? "" : ":" + channel.getNumber();
     }
 
     /**
-     * Checks whether a channel is a dummy channel. The dummy channel of a device encapsulates the MASTER Paramset that
-     * does not belong to one of its channels.
+     * Checks whether a channel is a configuration channel. The configuration channel of a device encapsulates the
+     * MASTER Paramset that does not belong to one of its actual channels.
      */
-    private boolean isDummyChannel(HmChannel channel) {
-        return channel.getNumber() == -1;
+    private boolean isConfigurationChannel(HmChannel channel) {
+        return channel.getNumber() == CONFIGURATION_CHANNEL_NUMBER;
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/parser/ListDevicesParser.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/parser/ListDevicesParser.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.smarthome.binding.homematic.internal.communicator.parser;
 
+import static org.eclipse.smarthome.binding.homematic.HomematicBindingConstants.CONFIGURATION_CHANNEL_NUMBER;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -56,7 +58,7 @@ public class ListDevicesParser extends CommonRpcParser<Object[], Collection<HmDe
 
                 HmDevice device = new HmDevice(address, hmInterface, type, config.getGatewayInfo().getId(), id,
                         firmware);
-                device.addChannel(new HmChannel(type, -1));
+                device.addChannel(new HmChannel(type, CONFIGURATION_CHANNEL_NUMBER));
                 devices.put(address, device);
             } else {
                 // channel


### PR DESCRIPTION
With this fix, the RpcClient does not try to retrieve information about the VALUES Paramset of a logical device anymore, if that logical device does not correspond to a channel.

This is necessary since there is one non-channel logical device for each physical device, and this non-channel device only has a MASTER Paramset.

When the RpcClient tried to retrieve the VALUES Paramset for a non-channel logical device, it received an Error in case of HmIP, which results in the device not being successfully discovered by the binding.

This should fix the problems reported in #6053, but since I do not have any HmIP devices available, I could not confirm this myself.

Signed-off-by: Florian Stolte <fstolte@itemis.de>