### PR TITLE
[core] Changed pattern for validating the last segment of a ChannelUID

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/ChannelUIDTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/ChannelUIDTest.java
@@ -16,15 +16,56 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+/**
+ * Tests for class {@link ChannelUID}.
+ *
+ * @author Simon Kaufmann - Initial contribution
+ * @author Christoph Weitkamp - Changed pattern for validating last segment to contain either a single `#` or none
+ */
 public class ChannelUIDTest {
+
+    private static final String BINDING_ID = "binding";
+    private static final String THING_TYPE_ID = "thing-type";
+    private static final String THING_ID = "thing";
+    private static final String GROUP_ID = "group";
+    private static final String CHANNEL_ID = "id";
+    private static final ThingUID THING_UID = new ThingUID(BINDING_ID, THING_TYPE_ID, THING_ID);
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCharacters() {
+        new ChannelUID(THING_UID, "id_with_invalidchar%");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNotEnoughNumberOfSegments() {
+        new ChannelUID("binding:thing-type:group#id");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipleChannelGroupSeparators() {
+        new ChannelUID("binding:thing-type:thing:group#id#what_ever");
+    }
 
     @Test
     public void testChannelUID() {
-        ChannelUID channelUID = new ChannelUID("binding", "thing-type", "thing", "group", "id");
+        ChannelUID channelUID = new ChannelUID(THING_UID, CHANNEL_ID);
+        assertEquals("binding:thing-type:thing:id", channelUID.toString());
+        assertFalse(channelUID.isInGroup());
+        assertEquals(CHANNEL_ID, channelUID.getId());
+        assertEquals(CHANNEL_ID, channelUID.getIdWithoutGroup());
+        assertNull(channelUID.getGroupId());
+        assertEquals(THING_UID, channelUID.getThingUID());
+    }
+
+    @Test
+    public void testChannelUIDWithGroup() {
+        ChannelUID channelUID = new ChannelUID(THING_UID, GROUP_ID, CHANNEL_ID);
         assertEquals("binding:thing-type:thing:group#id", channelUID.toString());
         assertTrue(channelUID.isInGroup());
         assertEquals("group#id", channelUID.getId());
-        assertEquals("id", channelUID.getIdWithoutGroup());
+        assertEquals(CHANNEL_ID, channelUID.getIdWithoutGroup());
+        assertEquals(GROUP_ID, channelUID.getGroupId());
+        assertEquals(THING_UID, channelUID.getThingUID());
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
@@ -15,21 +15,22 @@ package org.eclipse.smarthome.core.thing;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * {@link ChannelUID} represents a unique identifier for channels.
  *
- * @author Oliver Libutzki - Initital contribution
+ * @author Oliver Libutzki - Initial contribution
  * @author Jochen Hiller - Bugfix 455434: added default constructor
  * @author Dennis Nobel - Added channel group id
  * @author Kai Kreuzer - Changed creation of channels to not require a thing type
+ * @author Christoph Weitkamp - Changed pattern for validating last segment to contain either a single `#` or none
  */
 @NonNullByDefault
 public class ChannelUID extends UID {
 
+    private static final String CHANNEL_SEGMENT_PATTERN = "[\\w-]*|[\\w-]*#[\\w-]*";
     private static final String CHANNEL_GROUP_SEPERATOR = "#";
 
     /**
@@ -160,9 +161,10 @@ public class ChannelUID extends UID {
         if (index < length - 1) {
             super.validateSegment(segment, index, length);
         } else {
-            if (!segment.matches("[A-Za-z0-9_#-]*")) {
-                throw new IllegalArgumentException("UID segment '" + segment
-                        + "' contains invalid characters. The last segment of the channel UID must match the pattern [A-Za-z0-9_-#]*.");
+            if (!segment.matches(CHANNEL_SEGMENT_PATTERN)) {
+                throw new IllegalArgumentException(String.format(
+                        "UID segment '%s' contains invalid characters. The last segment of the channel UID must match the pattern '%s'.",
+                        segment, CHANNEL_SEGMENT_PATTERN));
             }
         }
     }
@@ -173,7 +175,7 @@ public class ChannelUID extends UID {
      * @return the thing UID
      */
     public ThingUID getThingUID() {
-        List<@NonNull String> allSegments = getAllSegments();
+        List<String> allSegments = getAllSegments();
         return new ThingUID(allSegments.subList(0, allSegments.size() - 1).toArray(new String[allSegments.size() - 1]));
     }
 


### PR DESCRIPTION
- Changed pattern for validating the last segment of a ChannelUID to contain either a single '#' or none

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>