### PR TITLE
[core] Added implementation of a ChannelGroupUID

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/ChannelGroupUIDTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/ChannelGroupUIDTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for class {@link ChannelGroupUID}.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+public class ChannelGroupUIDTest {
+
+    private static final String BINDING_ID = "binding";
+    private static final String THING_TYPE_ID = "thing-type";
+    private static final String THING_ID = "thing";
+    private static final String GROUP_ID = "group";
+
+    private static final ThingUID THING_UID = new ThingUID(BINDING_ID, THING_TYPE_ID, THING_ID);
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCharacters() {
+        new ChannelGroupUID(THING_UID, "id_with_invalidchar%");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNotEnoughNumberOfSegments() {
+        new ChannelUID("binding:thing-type:group#");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMissingChannelGroupSeparator() {
+        new ChannelGroupUID("binding:thing-type:thing:group");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipleChannelGroupSeparators() {
+        new ChannelGroupUID("binding:thing-type:thing:group#id#what_ever");
+    }
+
+    @Test
+    public void testChannelGroupUID() {
+        ChannelGroupUID channelGroupUID = new ChannelGroupUID(THING_UID, GROUP_ID);
+        assertEquals("binding:thing-type:thing:group#", channelGroupUID.toString());
+        assertEquals(GROUP_ID, channelGroupUID.getId());
+        assertEquals(THING_UID, channelGroupUID.getThingUID());
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelGroupUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelGroupUID.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * {@link ChannelGroupUID} represents a unique identifier for channel groups.
+ *
+ * @author Christoph Weitkamp - Initial contribution
+ */
+@NonNullByDefault
+public class ChannelGroupUID extends UID {
+
+    private static final String CHANNEL_GROUP_SEGMENT_PATTERN = "[\\w-]*#";
+    private static final String CHANNEL_GROUP_SEPERATOR = "#";
+
+    /**
+     * Default constructor in package scope only. Will allow to instantiate this
+     * class by reflection. Not intended to be used for normal instantiation.
+     */
+    ChannelGroupUID() {
+        super();
+    }
+
+    public ChannelGroupUID(String channelGroupUid) {
+        super(channelGroupUid);
+    }
+
+    /**
+     * @param thingUID the unique identifier of the thing the channel belongs to
+     * @param id the channel group's id
+     */
+    public ChannelGroupUID(ThingUID thingUID, String id) {
+        super(toSegments(thingUID, id));
+    }
+
+    private static List<String> toSegments(ThingUID thingUID, String id) {
+        List<String> ret = new ArrayList<>(thingUID.getAllSegments());
+        ret.add(id + CHANNEL_GROUP_SEPERATOR);
+        return ret;
+    }
+
+    /**
+     * Returns the id.
+     *
+     * @return id
+     */
+    public String getId() {
+        List<String> segments = getAllSegments();
+        return segments.get(segments.size() - 1).replaceAll(CHANNEL_GROUP_SEPERATOR, "");
+    }
+
+    @Override
+    protected int getMinimalNumberOfSegments() {
+        return 4;
+    }
+
+    @Override
+    protected void validateSegment(String segment, int index, int length) {
+        if (index < length - 1) {
+            super.validateSegment(segment, index, length);
+        } else {
+            if (!segment.matches(CHANNEL_GROUP_SEGMENT_PATTERN)) {
+                throw new IllegalArgumentException(String.format(
+                        "UID segment '%s' contains invalid characters. The last segment of the channel UID must match the pattern '%s'.",
+                        segment, CHANNEL_GROUP_SEGMENT_PATTERN));
+            }
+        }
+    }
+
+    /**
+     * Returns the thing UID
+     *
+     * @return the thing UID
+     */
+    public ThingUID getThingUID() {
+        List<String> allSegments = getAllSegments();
+        return new ThingUID(allSegments.subList(0, allSegments.size() - 1).toArray(new String[allSegments.size() - 1]));
+    }
+}

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
@@ -58,6 +58,14 @@ public class ChannelUID extends UID {
     }
 
     /**
+     * @param channelGroupUID the unique identifier of the channel group the channel belongs to
+     * @param id the channel's id
+     */
+    public ChannelUID(ChannelGroupUID channelGroupUID, String id) {
+        super(toSegments(channelGroupUID.getThingUID(), channelGroupUID.getId(), id));
+    }
+
+    /**
      * @param thingUID the unique identifier of the thing the channel belongs to
      * @param groupId the channel's group id
      * @param id the channel's id


### PR DESCRIPTION
Initial idea and for discussion.

As preparation for a `ChannelGroupBuilder` which is accessible from the `ThingHandlerCallback` similar to the `createChannelBuilder()` or `editChannel()` methods I would like to introduce a `ChannelGroupUID` to identify the channel group to be created / edited.

- Added implementation and test of a `ChannelGroupUID`

Signed-off-by:Christoph Weitkamp <github@christophweitkamp.de>