### PR TITLE
Improved error reporting in inbox approve REST resource

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/discovery/InboxResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/discovery/InboxResource.java
@@ -104,8 +104,7 @@ public class InboxResource implements RESTResource {
             thing = inbox.approve(thingUIDObject, notEmptyLabel);
         } catch (IllegalArgumentException e) {
             logger.error("Thing {} unable to be approved: {}", thingUID, e.getLocalizedMessage());
-            return JSONResponse.createErrorResponse(Status.NOT_FOUND,
-                    "Thing unable to be approved: " + e.getLocalizedMessage());
+            return JSONResponse.createErrorResponse(Status.NOT_FOUND, "Thing unable to be approved.");
         }
 
         // inbox.approve returns null if no handler is found that supports this thing


### PR DESCRIPTION
As per #6129 it's currently not possible to work out why an inbox entry failed to be approved - the current reason is "Inbox entry not found" and this is not the only reason. This PR returns the reason for failing to approve an inbox entry to the UI, and also logs the error in the logfile.

Partially fixes #6129 (PaperUI probably should be updated to report the error as 404 is insufficient to allow a user to know what happened).

Log entry will now look like this -:
```
Thing zwave:device:15f24d360d4:node18 unable to be approved: Duplicate channels zwave:device:15f24d360d4:node18:alarm_heat
```

Signed-off-by: Chris Jackson <chris@cd-jackson.com>