### PR TITLE
Allow metric prefixes on unit ONE

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
@@ -43,6 +43,7 @@ import tec.uom.se.unit.Units;
  * @author Henning Treu - initial contribution and API
  *
  */
+@SuppressWarnings("null")
 public class SmartHomeUnitsTest {
 
     private static final double DEFAULT_ERROR = 0.0000000000000001d;
@@ -261,6 +262,16 @@ public class SmartHomeUnitsTest {
     public void testBar2Pascal() {
         Quantity<Pressure> bar = Quantities.getQuantity(BigDecimal.valueOf(1), SmartHomeUnits.BAR);
         assertThat(bar.to(SIUnits.PASCAL), is(Quantities.getQuantity(100000, SIUnits.PASCAL)));
+    }
+
+    @Test
+    public void testOne() {
+        QuantityType<Dimensionless> one = new QuantityType<>("100");
+
+        assertThat(new QuantityType<>("1000").toFullString(),
+                is(one.toUnit(MetricPrefix.DECI(SmartHomeUnits.ONE)).toFullString()));
+        assertThat(new QuantityType<>("10").toFullString(),
+                is(one.toUnit(MetricPrefix.DEKA(SmartHomeUnits.ONE)).toFullString()));
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/types/QuantityType.java
@@ -270,7 +270,7 @@ public class QuantityType<T extends Quantity<T>> extends Number
 
     @Override
     public String toFullString() {
-        if (quantity.getUnit() == AbstractUnit.ONE) {
+        if (quantity.getUnit().toString().endsWith("one")) {
             return quantity.getValue().toString();
         } else {
             return quantity.toString();


### PR DESCRIPTION
Do not print unit like `done` or `kone` when using metric prefixes with the abstract unit ONE. This may be used to scale scalar values, see #5930.

Fixes #5930.

Signed-off-by: Henning Treu <henning.treu@telekom.de>