### PR TITLE
Fixed OSGiTest method waitForAssert

### DIFF
--- a/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/groovy/org/eclipse/smarthome/test/OSGiTest.java
@@ -57,7 +57,7 @@ public abstract class OSGiTest {
     private final Map<String, List<ServiceRegistration<?>>> registeredServices = new HashMap<>();
     protected BundleContext bundleContext;
 
-    protected static final int TIMEOUT = 1000;
+    protected static final int TIMEOUT = 10000;
     protected static final int SLEEPTIME = 50;
 
     @Before
@@ -397,6 +397,7 @@ public abstract class OSGiTest {
         if (beforeLastCall != null) {
             beforeLastCall.call();
         }
+        assertion.call();
     }
 
     protected void waitForAssert(Closure<?> assertion, Closure<?> beforeLastCall) throws Exception {


### PR DESCRIPTION
@htreu I added the removed assertion() and increased the timeout as it was.