### PR TITLE
Added methods to smarthome serial interface.

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortEventImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortEventImpl.java
@@ -39,4 +39,9 @@ public class SerialPortEventImpl implements SerialPortEvent {
         return event.getEventType();
     }
 
+    @Override
+    public boolean getNewValue() {
+        return event.getNewValue();
+    }
+
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortIdentifierImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortIdentifierImpl.java
@@ -16,6 +16,7 @@ import javax.comm.CommPort;
 import javax.comm.CommPortIdentifier;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.transport.serial.PortInUseException;
 import org.eclipse.smarthome.io.transport.serial.SerialPort;
 import org.eclipse.smarthome.io.transport.serial.SerialPortIdentifier;
@@ -66,7 +67,7 @@ public class SerialPortIdentifierImpl implements SerialPortIdentifier {
     }
 
     @Override
-    public String getCurrentOwner() {
+    public @Nullable String getCurrentOwner() {
         return id.getCurrentOwner();
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortIdentifierImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortIdentifierImpl.java
@@ -60,4 +60,13 @@ public class SerialPortIdentifierImpl implements SerialPortIdentifier {
         }
     }
 
+    @Override
+    public boolean isCurrentlyOwned() {
+        return id.isCurrentlyOwned();
+    }
+
+    @Override
+    public String getCurrentOwner() {
+        return id.getCurrentOwner();
+    }
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.javacomm/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortImpl.java
@@ -94,6 +94,31 @@ public class SerialPortImpl implements SerialPort {
     }
 
     @Override
+    public void notifyOnBreakInterrupt(boolean enable) {
+        sp.notifyOnBreakInterrupt(enable);
+    }
+
+    @Override
+    public void notifyOnFramingError(boolean enable) {
+        sp.notifyOnFramingError(enable);
+    }
+
+    @Override
+    public void notifyOnOverrunError(boolean enable) {
+        sp.notifyOnOverrunError(enable);
+    }
+
+    @Override
+    public void notifyOnParityError(boolean enable) {
+        sp.notifyOnParityError(enable);
+    }
+
+    @Override
+    public void setRTS(boolean enable) {
+        sp.setRTS(enable);
+    }
+
+    @Override
     public void enableReceiveTimeout(int timeout) throws UnsupportedCommOperationException {
         if (timeout < 0) {
             throw new IllegalArgumentException(String.format("timeout must be non negative (is: %d)", timeout));

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx.rfc2217/src/main/java/org/eclipse/smarthome/io/transport/serial/rxtx/rfc2217/internal/SerialPortIdentifierImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx.rfc2217/src/main/java/org/eclipse/smarthome/io/transport/serial/rxtx/rfc2217/internal/SerialPortIdentifierImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.smarthome.io.transport.serial.rxtx.rfc2217.internal;
 import java.net.URI;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.transport.serial.PortInUseException;
 import org.eclipse.smarthome.io.transport.serial.SerialPort;
 import org.eclipse.smarthome.io.transport.serial.SerialPortIdentifier;
@@ -61,4 +62,15 @@ public class SerialPortIdentifierImpl implements SerialPortIdentifier {
         }
     }
 
+    @Override
+    public boolean isCurrentlyOwned() {
+        // Check if the socket is not available for use, if true interpret as being owned.
+        return !id.getTelnetClient().isAvailable();
+    }
+
+    @Override
+    public @Nullable String getCurrentOwner() {
+        // Unknown who owns a socket connection. Therefore return null.
+        return null;
+    }
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortEventImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortEventImpl.java
@@ -39,4 +39,9 @@ public class SerialPortEventImpl implements SerialPortEvent {
         return event.getEventType();
     }
 
+    @Override
+    public boolean getNewValue() {
+        return event.getNewValue();
+    }
+
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortIdentifierImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortIdentifierImpl.java
@@ -61,4 +61,13 @@ public class SerialPortIdentifierImpl implements SerialPortIdentifier {
         }
     }
 
+    @Override
+    public boolean isCurrentlyOwned() {
+        return id.isCurrentlyOwned();
+    }
+
+    @Override
+    public String getCurrentOwner() {
+        return id.getCurrentOwner();
+    }
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortIdentifierImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/internal/SerialPortIdentifierImpl.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.io.transport.serial.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.io.transport.serial.PortInUseException;
 import org.eclipse.smarthome.io.transport.serial.SerialPort;
 import org.eclipse.smarthome.io.transport.serial.SerialPortIdentifier;
@@ -67,7 +68,7 @@ public class SerialPortIdentifierImpl implements SerialPortIdentifier {
     }
 
     @Override
-    public String getCurrentOwner() {
+    public @Nullable String getCurrentOwner() {
         return id.getCurrentOwner();
     }
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/rxtx/RxTxSerialPort.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx/src/main/java/org/eclipse/smarthome/io/transport/serial/rxtx/RxTxSerialPort.java
@@ -94,6 +94,31 @@ public class RxTxSerialPort implements SerialPort {
     }
 
     @Override
+    public void notifyOnBreakInterrupt(boolean enable) {
+        sp.notifyOnBreakInterrupt(enable);
+    }
+
+    @Override
+    public void notifyOnFramingError(boolean enable) {
+        sp.notifyOnFramingError(enable);
+    }
+
+    @Override
+    public void notifyOnOverrunError(boolean enable) {
+        sp.notifyOnOverrunError(enable);
+    }
+
+    @Override
+    public void notifyOnParityError(boolean enable) {
+        sp.notifyOnParityError(enable);
+    }
+
+    @Override
+    public void setRTS(boolean enable) {
+        sp.setRTS(enable);
+    }
+
+    @Override
     public void enableReceiveTimeout(int timeout) throws UnsupportedCommOperationException {
         if (timeout < 0) {
             throw new IllegalArgumentException(String.format("timeout must be non negative (is: %d)", timeout));

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/PortInUseException.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/PortInUseException.java
@@ -22,6 +22,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class PortInUseException extends Exception {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -2709480420743139383L;
 
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPort.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPort.java
@@ -218,7 +218,7 @@ public interface SerialPort extends Closeable {
     /**
      * Sets or clears the RTS (Request To Send) bit in the UART, if supported by the underlying implementation.
      *
-     * @param rts true rts is set, false if rst cleared
+     * @param rts true rts is set, false if rts cleared
      */
     void setRTS(boolean rts);
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPort.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPort.java
@@ -154,6 +154,34 @@ public interface SerialPort extends Closeable {
     void notifyOnDataAvailable(boolean enable);
 
     /**
+     * Enable / disable the notification on break interrupt.
+     *
+     * @param enable true if the notification should be enabled
+     */
+    void notifyOnBreakInterrupt(boolean enable);
+
+    /**
+     * Enable / disable the notification on framing error.
+     *
+     * @param enable true if the notification should be enabled
+     */
+    void notifyOnFramingError(boolean enable);
+
+    /**
+     * Enable / disable the notification on overrun error.
+     *
+     * @param enable true if the notification should be enabled
+     */
+    void notifyOnOverrunError(boolean enable);
+
+    /**
+     * Enable / disable the notification on parity error.
+     *
+     * @param enable true if the notification should be enabled
+     */
+    void notifyOnParityError(boolean enable);
+
+    /**
      * Enables the receive timeout.
      *
      * <p>
@@ -186,4 +214,11 @@ public interface SerialPort extends Closeable {
      * @throws UnsupportedCommOperationException Unsupported Comm Operation Exception.
      */
     void enableReceiveThreshold(int i) throws UnsupportedCommOperationException;
+
+    /**
+     * Sets or clears the RTS (Request To Send) bit in the UART, if supported by the underlying implementation.
+     *
+     * @param rts true rts is set, false if rst cleared
+     */
+    void setRTS(boolean rts);
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPortEvent.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPortEvent.java
@@ -38,4 +38,10 @@ public interface SerialPortEvent {
      * @return the event type
      */
     int getEventType();
+
+    /**
+     * Gets the new value of the state change that caused the SerialPortEvent to be propagated. For example, when the CD
+     * bit changes, newValue reflects the new value of the CD bit.
+     */
+    boolean getNewValue();
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPortIdentifier.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPortIdentifier.java
@@ -34,6 +34,25 @@ public interface SerialPortIdentifier {
      * @param owner name of the owner that port should be assigned to
      * @param timeout time in milliseconds to block waiting for opening the port
      * @return a serial port
+     * @throws PortInUseException thrown when the serial port is already in use
      */
     SerialPort open(String owner, int timeout) throws PortInUseException;
+
+    /**
+     * Determines whether the associated port is in use by an application (including this application).
+     *
+     * @return true if an application is using the port, false if the port is not currently owned.
+     */
+    boolean isCurrentlyOwned();
+
+    /**
+     * Returns a textual representation of the current owner of the port. An owner is an application which is currently
+     * using the port (in the sense that it opened the port and has not closed it yet).
+     *
+     * To check if a port is owned use the <code>isCurrentlyOwned</code> method. Do not rely on this method to return
+     * null. It can't be guaranteed that owned ports have a non null owner.
+     *
+     * @return the port owner or null if the port is not currently owned
+     */
+    String getCurrentOwner();
 }

--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPortIdentifier.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPortIdentifier.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.io.transport.serial;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Interface of a serial port identifier.
@@ -54,5 +55,5 @@ public interface SerialPortIdentifier {
      *
      * @return the port owner or null if the port is not currently owned
      */
-    String getCurrentOwner();
+    @Nullable String getCurrentOwner();
 }


### PR DESCRIPTION
These methods are used by the new openHAB dsmr binding and needed to let that binding use the smarthome serial service.

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>