### PR TITLE
[core] Added method to provide a list of preconfigured ChannelBuilders of a channel group type

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandlerCallback.java
@@ -12,16 +12,19 @@
  */
 package org.eclipse.smarthome.core.thing.binding;
 
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.config.core.validation.ConfigValidationException;
+import org.eclipse.smarthome.core.thing.ChannelGroupUID;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
@@ -34,6 +37,7 @@ import org.eclipse.smarthome.core.types.State;
  * @author Dennis Nobel - Initial contribution
  * @author Stefan Bußweiler - Added new thing status info, added new configuration update info
  * @author Christoph Weitkamp - Moved OSGI ServiceTracker from BaseThingHandler to ThingHandlerCallback
+ * @author Christoph Weitkamp - Added preconfigured ChannelGroupBuilder
  */
 @NonNullByDefault
 public interface ThingHandlerCallback {
@@ -126,6 +130,17 @@ public interface ThingHandlerCallback {
      * @throw {@link IllegalArgumentException} if no channel with the given UID exists for the given thing
      */
     ChannelBuilder editChannel(Thing thing, ChannelUID channelUID);
+
+    /**
+     * Creates a list of {@link ChannelBuilder}s which are preconfigured with values from the given channel group type.
+     *
+     * @param channelGroupUID the UID of the channel group to be created
+     * @param channelGroupTypeUID the channel group type UID for which the channel should be created
+     * @return a list of preconfigured ChannelBuilders
+     * @throw {@link IllegalArgumentException} if the referenced channel group type is not known
+     */
+    List<ChannelBuilder> createChannelGroupBuilder(ChannelGroupUID channelGroupUID,
+            ChannelGroupTypeUID channelGroupTypeUID);
 
     /**
      * Returns whether at least one item is linked for the given UID of the channel.

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManager.java
@@ -50,6 +50,7 @@ import org.eclipse.smarthome.core.service.ReadyMarkerFilter;
 import org.eclipse.smarthome.core.service.ReadyService;
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelGroupUID;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingRegistry;
@@ -69,6 +70,10 @@ import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.eclipse.smarthome.core.thing.events.ThingEventFactory;
 import org.eclipse.smarthome.core.thing.i18n.ThingStatusInfoI18nLocalizationService;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeRegistry;
+import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
@@ -111,6 +116,7 @@ import com.google.common.collect.SetMultimap;
  * @author Thomas Höfer - Added localization of thing status info
  * @author Christoph Weitkamp - Moved OSGI ServiceTracker from BaseThingHandler to ThingHandlerCallback
  * @author Henning Sudbrock - Consider thing type properties when migrating to new thing type
+ * @author Christoph Weitkamp - Added preconfigured ChannelGroupBuilder
  */
 @Component(immediate = true, service = { ThingTypeMigrationService.class })
 public class ThingManager implements ThingTracker, ThingTypeMigrationService, ReadyService.ReadyTracker {
@@ -139,6 +145,7 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
 
     private ThingTypeRegistry thingTypeRegistry;
     private ChannelTypeRegistry channelTypeRegistry;
+    private ChannelGroupTypeRegistry channelGroupTypeRegistry;
     private ItemChannelLinkRegistry itemChannelLinkRegistry;
 
     private ThingStatusInfoI18nLocalizationService thingStatusInfoI18nLocalizationService;
@@ -280,7 +287,7 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
         public ChannelBuilder createChannelBuilder(ChannelUID channelUID, ChannelTypeUID channelTypeUID) {
             ChannelType channelType = channelTypeRegistry.getChannelType(channelTypeUID);
             if (channelType == null) {
-                throw new IllegalArgumentException("Channel type " + channelTypeUID + " is not known");
+                throw new IllegalArgumentException(String.format("Channel type '%s' is not known", channelTypeUID));
             }
             return ThingFactoryHelper.createChannelBuilder(channelUID, channelType, configDescriptionRegistry);
         };
@@ -290,9 +297,29 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
             Channel channel = thing.getChannel(channelUID.getId());
             if (channel == null) {
                 throw new IllegalArgumentException(
-                        "Channel " + channelUID + "does not exist for thing " + thing.getUID());
+                        String.format("Channel '%s' does not exist for thing '%s'", channelUID, thing.getUID()));
             }
             return ChannelBuilder.create(channel);
+        }
+
+        @Override
+        public List<ChannelBuilder> createChannelGroupBuilder(ChannelGroupUID channelGroupUID,
+                ChannelGroupTypeUID channelGroupTypeUID) {
+            ChannelGroupType channelGroupType = channelGroupTypeRegistry.getChannelGroupType(channelGroupTypeUID);
+            if (channelGroupType == null) {
+                throw new IllegalArgumentException(
+                        String.format("Channel group type '%s' is not known", channelGroupTypeUID));
+            }
+            List<ChannelBuilder> channelBuilders = new ArrayList<>();
+            for (ChannelDefinition channelDefinition : channelGroupType.getChannelDefinitions()) {
+                ChannelType channelType = channelTypeRegistry.getChannelType(channelDefinition.getChannelTypeUID());
+                if (channelType != null) {
+                    ChannelUID channelUID = new ChannelUID(channelGroupUID, channelDefinition.getId());
+                    channelBuilders.add(ThingFactoryHelper.createChannelBuilder(channelUID, channelType,
+                            configDescriptionRegistry));
+                }
+            }
+            return channelBuilders;
         }
 
         @Override
@@ -1161,6 +1188,15 @@ public class ThingManager implements ThingTracker, ThingTypeMigrationService, Re
 
     protected void unsetChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
         this.channelTypeRegistry = null;
+    }
+
+    @Reference
+    protected void setChannelGroupTypeRegistry(ChannelGroupTypeRegistry channelGroupTypeRegistry) {
+        this.channelGroupTypeRegistry = channelGroupTypeRegistry;
+    }
+
+    protected void unsetChannelGroupTypeRegistry(ChannelGroupTypeRegistry channelGroupTypeRegistry) {
+        this.channelGroupTypeRegistry = null;
     }
 
     @Reference


### PR DESCRIPTION
- Added method to provide a list of preconfigured `ChannelBuilders` of a channel group type

Idea behind this (see https://github.com/eclipse/smarthome/pull/6103#issuecomment-418277247).

Example how to create all channels of a channel group type (assumption `channelGroupUID` and `channelGroupTypeUID` are given):
```java
    List<Channel> channels = new ArrayList<>();
    ThingHandlerCallback callback = getCallback();
    if (callback != null) {
        for (ChannelBuilder channelBuilder : callback.createChannelGroupBuilder(channelGroupUID, channelGroupTypeUID)) {
            channels.add(channelBuilder.build());
        }
    }
    updateThing(editThing().withChannels(channels).build());
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>