### PR TITLE
Remove unit placeholder for items w/o dimension

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
@@ -94,7 +94,7 @@ public class NumberItem extends GenericItem {
     @Override
     public @Nullable StateDescription getStateDescription(@Nullable Locale locale) {
         StateDescription stateDescription = super.getStateDescription(locale);
-        if (getDimension() == null && stateDescription != null
+        if (getDimension() == null && stateDescription != null && stateDescription.getPattern() != null
                 && stateDescription.getPattern().contains(UnitUtils.UNIT_PLACEHOLDER)) {
             return StateDescriptionFragmentBuilder.create(stateDescription)
                     .withPattern(stateDescription.getPattern().replaceAll(UnitUtils.UNIT_PLACEHOLDER, "").trim())

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/items/NumberItem.java
@@ -15,6 +15,7 @@ package org.eclipse.smarthome.core.library.items;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import javax.measure.Dimension;
 import javax.measure.Quantity;
@@ -31,6 +32,7 @@ import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateDescriptionFragmentBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.core.types.util.UnitUtils;
 
@@ -87,6 +89,19 @@ public class NumberItem extends GenericItem {
 
     public void send(DecimalType command) {
         internalSend(command);
+    }
+
+    @Override
+    public @Nullable StateDescription getStateDescription(@Nullable Locale locale) {
+        StateDescription stateDescription = super.getStateDescription(locale);
+        if (getDimension() == null && stateDescription != null
+                && stateDescription.getPattern().contains(UnitUtils.UNIT_PLACEHOLDER)) {
+            return StateDescriptionFragmentBuilder.create(stateDescription)
+                    .withPattern(stateDescription.getPattern().replaceAll(UnitUtils.UNIT_PLACEHOLDER, "").trim())
+                    .build().toStateDescription();
+        }
+
+        return stateDescription;
     }
 
     /**
@@ -162,7 +177,7 @@ public class NumberItem extends GenericItem {
      * the system default unit of the given dimension.
      *
      * @param originalType the source {@link DecimalType}.
-     * @param dimension    the dimension to which the new {@link QuantityType} should adhere.
+     * @param dimension the dimension to which the new {@link QuantityType} should adhere.
      * @return the new {@link QuantityType} from the given originalType, {@code null} if a unit could not be calculated.
      */
     public @Nullable QuantityType<?> toQuantityType(DecimalType originalType,

--- a/bundles/ui/org.eclipse.smarthome.ui.test/src/test/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
+++ b/bundles/ui/org.eclipse.smarthome.ui.test/src/test/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImplTest.java
@@ -108,7 +108,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithStringValue() throws ItemNotFoundException {
+    public void getLabel_labelWithStringValue() {
         String testLabel = "Label [%s]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -118,7 +118,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithIntegerValue() throws ItemNotFoundException {
+    public void getLabel_labelWithIntegerValue() {
         String testLabel = "Label [%d]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -129,7 +129,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithIntegerValueAndWidth() throws ItemNotFoundException {
+    public void getLabel_labelWithIntegerValueAndWidth() {
         String testLabel = "Label [%3d]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -140,7 +140,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithHexValueAndWidth() throws ItemNotFoundException {
+    public void getLabel_labelWithHexValueAndWidth() {
         String testLabel = "Label [%3x]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -151,7 +151,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithDecimalValue() throws ItemNotFoundException {
+    public void getLabel_labelWithDecimalValue() {
         String testLabel = "Label [%.3f]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -242,7 +242,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithPercent() throws ItemNotFoundException {
+    public void getLabel_labelWithPercent() {
         String testLabel = "Label [%.1f %%]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -253,7 +253,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithPercentType() throws ItemNotFoundException {
+    public void getLabel_labelWithPercentType() {
         String testLabel = "Label [%d %%]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -263,7 +263,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithDate() throws ItemNotFoundException {
+    public void getLabel_labelWithDate() {
         String testLabel = "Label [%1$td.%1$tm.%1$tY]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -286,7 +286,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithTime() throws ItemNotFoundException {
+    public void getLabel_labelWithTime() {
         String testLabel = "Label [%1$tT]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -310,20 +310,20 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_widgetWithoutLabelAndItem() throws ItemNotFoundException {
+    public void getLabel_widgetWithoutLabelAndItem() {
         Widget w = mock(Widget.class);
         String label = uiRegistry.getLabel(w);
         assertEquals("", label);
     }
 
     @Test
-    public void getLabel_widgetWithoutLabel() throws ItemNotFoundException {
+    public void getLabel_widgetWithoutLabel() {
         String label = uiRegistry.getLabel(widget);
         assertEquals("Item", label);
     }
 
     @Test
-    public void getLabel_labelFromUIProvider() throws ItemNotFoundException {
+    public void getLabel_labelFromUIProvider() {
 
         ItemUIProvider provider = mock(ItemUIProvider.class);
         uiRegistry.addItemUIProvider(provider);
@@ -334,7 +334,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelForUndefinedStringItemState() throws ItemNotFoundException {
+    public void getLabel_labelForUndefinedStringItemState() {
         String testLabel = "Label [%s]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -344,7 +344,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelForUndefinedIntegerItemState() throws ItemNotFoundException {
+    public void getLabel_labelForUndefinedIntegerItemState() {
         String testLabel = "Label [%d]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -354,7 +354,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelForUndefinedDecimalItemState() throws ItemNotFoundException {
+    public void getLabel_labelForUndefinedDecimalItemState() {
         String testLabel = "Label [%.2f]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -364,7 +364,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelForUndefinedDateItemState() throws ItemNotFoundException {
+    public void getLabel_labelForUndefinedDateItemState() {
         String testLabel = "Label [%1$td.%1$tm.%1$tY]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -374,7 +374,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelForUndefinedQuantityItemState() throws ItemNotFoundException {
+    public void getLabel_labelForUndefinedQuantityItemState() {
         String testLabel = "Label [%.2f " + UnitUtils.UNIT_PLACEHOLDER + "]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -396,7 +396,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithFunctionValue() throws ItemNotFoundException {
+    public void getLabel_labelWithFunctionValue() {
         String testLabel = "Label [MAP(de.map):%s]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -406,7 +406,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_groupLabelWithValue() throws ItemNotFoundException {
+    public void getLabel_groupLabelWithValue() {
         String testLabel = "Label [%d]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -498,7 +498,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithoutStateDescription() throws ItemNotFoundException {
+    public void getLabel_labelWithoutStateDescription() {
         String testLabel = "Label";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -509,7 +509,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithoutPatternInStateDescription() throws ItemNotFoundException {
+    public void getLabel_labelWithoutPatternInStateDescription() {
         String testLabel = "Label";
 
         StateDescription stateDescription = mock(StateDescription.class);
@@ -522,7 +522,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithPatternInStateDescription() throws ItemNotFoundException {
+    public void getLabel_labelWithPatternInStateDescription() {
         String testLabel = "Label";
 
         StateDescription stateDescription = mock(StateDescription.class);
@@ -535,7 +535,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithEmptyPattern() throws ItemNotFoundException {
+    public void getLabel_labelWithEmptyPattern() {
         String testLabel = "Label []";
 
         StateDescription stateDescription = mock(StateDescription.class);
@@ -548,7 +548,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithMappedOption() throws ItemNotFoundException {
+    public void getLabel_labelWithMappedOption() {
         String testLabel = "Label";
 
         StateDescription stateDescription = mock(StateDescription.class);
@@ -565,7 +565,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabel_labelWithUnmappedOption() throws ItemNotFoundException {
+    public void getLabel_labelWithUnmappedOption() {
         String testLabel = "Label";
 
         StateDescription stateDescription = mock(StateDescription.class);
@@ -596,7 +596,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabelColor_labelWithDecimalValue() throws ItemNotFoundException {
+    public void getLabelColor_labelWithDecimalValue() {
         String testLabel = "Label [%.3f]";
 
         when(widget.getLabel()).thenReturn(testLabel);
@@ -616,7 +616,7 @@ public class ItemUIRegistryImplTest {
     }
 
     @Test
-    public void getLabelColor_labelWithUnitValue() throws ItemNotFoundException {
+    public void getLabelColor_labelWithUnitValue() {
         String testLabel = "Label [%.3f " + UnitUtils.UNIT_PLACEHOLDER + "]";
 
         when(widget.getLabel()).thenReturn(testLabel);


### PR DESCRIPTION
Fixes #6055.

Also: Remove some obsolete `throws` declarations.

Signed-off-by: Henning Treu <henning.treu@telekom.de>