### PR TITLE
[core] ChannelGroupUID without '#'

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/ChannelGroupUIDTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/ChannelGroupUIDTest.java
@@ -37,23 +37,13 @@ public class ChannelGroupUIDTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNotEnoughNumberOfSegments() {
-        new ChannelUID("binding:thing-type:group#");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testMissingChannelGroupSeparator() {
-        new ChannelGroupUID("binding:thing-type:thing:group");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testMultipleChannelGroupSeparators() {
-        new ChannelGroupUID("binding:thing-type:thing:group#id#what_ever");
+        new ChannelUID("binding:thing-type:group");
     }
 
     @Test
     public void testChannelGroupUID() {
         ChannelGroupUID channelGroupUID = new ChannelGroupUID(THING_UID, GROUP_ID);
-        assertEquals("binding:thing-type:thing:group#", channelGroupUID.toString());
+        assertEquals("binding:thing-type:thing:group", channelGroupUID.toString());
         assertEquals(GROUP_ID, channelGroupUID.getId());
         assertEquals(THING_UID, channelGroupUID.getThingUID());
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelGroupUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelGroupUID.java
@@ -25,9 +25,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class ChannelGroupUID extends UID {
 
-    private static final String CHANNEL_GROUP_SEGMENT_PATTERN = "[\\w-]*#";
-    private static final String CHANNEL_GROUP_SEPERATOR = "#";
-
     /**
      * Default constructor in package scope only. Will allow to instantiate this
      * class by reflection. Not intended to be used for normal instantiation.
@@ -50,7 +47,7 @@ public class ChannelGroupUID extends UID {
 
     private static List<String> toSegments(ThingUID thingUID, String id) {
         List<String> ret = new ArrayList<>(thingUID.getAllSegments());
-        ret.add(id + CHANNEL_GROUP_SEPERATOR);
+        ret.add(id);
         return ret;
     }
 
@@ -61,25 +58,12 @@ public class ChannelGroupUID extends UID {
      */
     public String getId() {
         List<String> segments = getAllSegments();
-        return segments.get(segments.size() - 1).replaceAll(CHANNEL_GROUP_SEPERATOR, "");
+        return segments.get(segments.size() - 1);
     }
 
     @Override
     protected int getMinimalNumberOfSegments() {
         return 4;
-    }
-
-    @Override
-    protected void validateSegment(String segment, int index, int length) {
-        if (index < length - 1) {
-            super.validateSegment(segment, index, length);
-        } else {
-            if (!segment.matches(CHANNEL_GROUP_SEGMENT_PATTERN)) {
-                throw new IllegalArgumentException(String.format(
-                        "UID segment '%s' contains invalid characters. The last segment of the channel UID must match the pattern '%s'.",
-                        segment, CHANNEL_GROUP_SEGMENT_PATTERN));
-            }
-        }
     }
 
     /**

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ChannelUID.java
@@ -31,7 +31,7 @@ import org.eclipse.jdt.annotation.Nullable;
 public class ChannelUID extends UID {
 
     private static final String CHANNEL_SEGMENT_PATTERN = "[\\w-]*|[\\w-]*#[\\w-]*";
-    private static final String CHANNEL_GROUP_SEPERATOR = "#";
+    private static final String CHANNEL_GROUP_SEPARATOR = "#";
 
     /**
      * Default constructor in package scope only. Will allow to instantiate this
@@ -120,7 +120,7 @@ public class ChannelUID extends UID {
     }
 
     private static String getChannelId(@Nullable String groupId, String id) {
-        return groupId != null ? groupId + CHANNEL_GROUP_SEPERATOR + id : id;
+        return groupId != null ? groupId + CHANNEL_GROUP_SEPARATOR + id : id;
     }
 
     /**
@@ -142,12 +142,12 @@ public class ChannelUID extends UID {
         if (!isInGroup()) {
             return getId();
         } else {
-            return getId().split(CHANNEL_GROUP_SEPERATOR)[1];
+            return getId().split(CHANNEL_GROUP_SEPARATOR)[1];
         }
     }
 
     public boolean isInGroup() {
-        return getId().contains(CHANNEL_GROUP_SEPERATOR);
+        return getId().contains(CHANNEL_GROUP_SEPARATOR);
     }
 
     /**
@@ -156,7 +156,7 @@ public class ChannelUID extends UID {
      * @return group id or null if channel is not in a group
      */
     public @Nullable String getGroupId() {
-        return isInGroup() ? getId().split(CHANNEL_GROUP_SEPERATOR)[0] : null;
+        return isInGroup() ? getId().split(CHANNEL_GROUP_SEPARATOR)[0] : null;
     }
 
     @Override


### PR DESCRIPTION
- Removed `#` in `ChannelGroupUID` (as String)
- Changed spelling of `SEPARATOR`

see https://github.com/eclipse/smarthome/pull/6103#pullrequestreview-152356557

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>