### PR TITLE
Fix OneWire bridge handler test

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/OwserverBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/OwserverBridgeHandler.java
@@ -77,11 +77,13 @@ public class OwserverBridgeHandler extends OwBaseBridgeHandler {
             owserverConnection.setPort(((BigDecimal) configuration.get(CONFIG_PORT)).intValue());
         }
 
+        // makes it possible for unit tests to differentiate direct update and
+        // postponed update through the owserverConnection:
+        updateStatus(ThingStatus.UNKNOWN);
+
         scheduler.execute(() -> {
             owserverConnection.start();
         });
-
-        updateStatus(ThingStatus.UNKNOWN);
     }
 
     @Override

--- a/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__HandlerTest.java
+++ b/tools/archetype/binding.test/src/main/resources/archetype-resources/src/test/java/__bindingIdCamelCase__HandlerTest.java
@@ -19,8 +19,8 @@
  */
 package ${package};
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -32,6 +32,7 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerCallback;
+import org.eclipse.smarthome.test.java.JavaTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -42,7 +43,7 @@ import org.mockito.Mock;
  *
  * @author ${author} - Initial contribution
  */
-public class ${bindingIdCamelCase}HandlerTest {
+public class ${bindingIdCamelCase}HandlerTest extends JavaTest {
 
     private ThingHandler handler;
 
@@ -73,11 +74,17 @@ public class ${bindingIdCamelCase}HandlerTest {
         ArgumentCaptor<ThingStatusInfo> statusInfoCaptor = ArgumentCaptor.forClass(ThingStatusInfo.class);
 
         // verify the interaction with the callback and capture the ThingStatusInfo argument:
-        verify(callback).statusUpdated(eq(thing), statusInfoCaptor.capture());
+        waitForAssert(() -> {
+            verify(callback, times(2)).statusUpdated(eq(thing), statusInfoCaptor.capture());
+        });
         
-        // assert that the ThingStatusInfo given to the callback was build with the (temporary) UNKNOWN status:
-        ThingStatusInfo thingStatusInfo = statusInfoCaptor.getValue();
-        assertThat(thingStatusInfo.getStatus(), is(equalTo(ThingStatus.UNKNOWN)));
+        // assert that the (temporary) UNKNOWN status was given first:
+        assertThat(statusInfoCaptor.getAllValues().get(0).getStatus(), is(ThingStatus.UNKNOWN));
+        
+        
+        // assert that ONLINE status was given later:
+        assertThat(statusInfoCaptor.getAllValues().get(1).getStatus(), is(ThingStatus.ONLINE));
+
         
         // See the documentation at 
         // https://www.eclipse.org/smarthome/documentation/development/testing.html#assertions 

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
@@ -82,7 +82,7 @@ public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
 
         // set the thing status to UNKNOWN temporarily and let the background task decide for the real status.
         // the framework is then able to reuse the resources from the thing handler initialization.
-        // we set this upfront to reliably check status updste sin unit tests.
+        // we set this upfront to reliably check status updates in unit tests.
         updateStatus(ThingStatus.UNKNOWN);
         
         // Example for background initialization:

--- a/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
+++ b/tools/archetype/binding/src/main/resources/archetype-resources/src/main/java/internal/__bindingIdCamelCase__Handler.java
@@ -80,20 +80,22 @@ public class ${bindingIdCamelCase}Handler extends BaseThingHandler {
         // access or similar) you should set status UNKNOWN here and then decide the real status asynchronously in the
         // background.
 
+        // set the thing status to UNKNOWN temporarily and let the background task decide for the real status.
+        // the framework is then able to reuse the resources from the thing handler initialization.
+        // we set this upfront to reliably check status updste sin unit tests.
+        updateStatus(ThingStatus.UNKNOWN);
+        
         // Example for background initialization:
         scheduler.execute(() -> {
             boolean thingReachable = true; // <background task with long running initialization here>
             // when done do:
             if (thingReachable) {
-                // updateStatus(ThingStatus.ONLINE); // commented for stable test execution
+                updateStatus(ThingStatus.ONLINE);
             } else {
-                // updateStatus(ThingStatus.OFFLINE);
+                updateStatus(ThingStatus.OFFLINE);
             }
         });
 
-        // set the thing status to UNKNOWN temporarily and let the background task decide for the real status.
-        // the framework is then able to reuse the resources from the thing handler initialization.
-        updateStatus(ThingStatus.UNKNOWN);
         // logger.debug("Finished initializing!");
 
         // Note: When initialization can NOT be done set the status with more details for further


### PR DESCRIPTION
Addresses occasionally failing tests, see https://github.com/eclipse/smarthome/pull/6153#issuecomment-419007236

Signed-off-by: Henning Treu <henning.treu@telekom.de>