### PR TITLE
Fix: parse auto update policy from thing XML

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/AutoUpdateManagerTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/AutoUpdateManagerTest.java
@@ -43,6 +43,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.AutoUpdatePolicy;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -110,6 +111,7 @@ public class AutoUpdateManagerTest {
         aum.setEventPublisher(mockEventPublisher);
         aum.setThingRegistry(mockThingRegistry);
         aum.setMetadataRegistry(mockMetadataRegistry);
+        aum.setChannelTypeRegistry(mock(ChannelTypeRegistry.class));
     }
 
     private void assertStateEvent(String expectedContent, String extectedSource) {

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesTest.bundle/ESH-INF/thing/thing-types.xml
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesTest.bundle/ESH-INF/thing/thing-types.xml
@@ -7,9 +7,15 @@
 	<thing-type id="something">
 
 		<label>Something</label>
-		
+
 		<channels>
 			<channel id="channel1" typeId="color">
+				<label>Channel without reference</label>
+				<description>Channel Description</description>
+				<properties>
+					<property name="property1">value</property>
+				</properties>
+				<autoUpdatePolicy>recommend</autoUpdatePolicy>
 			</channel>
 		</channels>
 	</thing-type>
@@ -22,8 +28,10 @@
 	<channel-type id="channel-without-reference">
 		<item-type>Number</item-type>
 		<label>Channel without reference</label>
+		<description>Channel Description</description>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
-	
+
 	<channel-group-type id="channelgroup">
 		<label>Channel group</label>
 		<category>Temperature</category>

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelConverter.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelConverter.java
@@ -60,8 +60,8 @@ public class ChannelConverter extends GenericUnmarshaller<ChannelXmlResult> {
         String typeId = attributes.get("typeId");
         String label = (String) nodeIterator.nextValue("label", false);
         String description = (String) nodeIterator.nextValue("description", false);
-        AutoUpdatePolicy autoUpdatePolicy = readAutoUpdatePolicy(nodeIterator);
         List<NodeValue> properties = getProperties(nodeIterator);
+        AutoUpdatePolicy autoUpdatePolicy = readAutoUpdatePolicy(nodeIterator);
 
         ChannelXmlResult channelXmlResult = new ChannelXmlResult(id, typeId, label, description, properties,
                 autoUpdatePolicy);

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelTypeConverter.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelTypeConverter.java
@@ -155,10 +155,11 @@ public class ChannelTypeConverter extends AbstractDescriptionTypeConverter<Chann
         String description = super.readDescription(nodeIterator);
         String category = readCategory(nodeIterator);
         Set<String> tags = readTags(nodeIterator);
-        AutoUpdatePolicy autoUpdatePolicy = readAutoUpdatePolicy(nodeIterator);
 
         StateDescription stateDescription = readStateDescription(nodeIterator);
         EventDescription eventDescription = readEventDescription(nodeIterator);
+
+        AutoUpdatePolicy autoUpdatePolicy = readAutoUpdatePolicy(nodeIterator);
 
         Object[] configDescriptionObjects = super.getConfigDescriptionObjects(nodeIterator);
 

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingDescriptionReader.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ThingDescriptionReader.java
@@ -110,6 +110,7 @@ public class ThingDescriptionReader extends XmlDocumentReader<List<?>> {
         xstream.alias("properties", NodeList.class);
         xstream.alias("property", NodeValue.class);
         xstream.alias("representation-property", NodeValue.class);
+        xstream.alias("autoUpdatePolicy", NodeValue.class);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Channel.java
@@ -62,7 +62,7 @@ public class Channel {
 
     private Set<String> defaultTags = new LinkedHashSet<>();
 
-    private final AutoUpdatePolicy autoUpdatePolicy;
+    private @Nullable AutoUpdatePolicy autoUpdatePolicy;
 
     /**
      * Package protected default constructor to allow reflective instantiation.
@@ -71,7 +71,6 @@ public class Channel {
         this.kind = ChannelKind.STATE;
         this.configuration = new Configuration();
         this.properties = Collections.unmodifiableMap(new HashMap<String, String>(0));
-        this.autoUpdatePolicy = AutoUpdatePolicy.DEFAULT;
     }
 
     /**
@@ -84,7 +83,6 @@ public class Channel {
         this.kind = ChannelKind.STATE;
         this.configuration = new Configuration();
         this.properties = Collections.unmodifiableMap(new HashMap<String, String>(0));
-        this.autoUpdatePolicy = AutoUpdatePolicy.DEFAULT;
     }
 
     /**
@@ -93,7 +91,7 @@ public class Channel {
     @Deprecated
     public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration) {
         this(uid, null, acceptedItemType, ChannelKind.STATE, configuration, new HashSet<String>(0), null, null, null,
-                AutoUpdatePolicy.DEFAULT);
+                null);
     }
 
     /**
@@ -101,8 +99,7 @@ public class Channel {
      */
     @Deprecated
     public Channel(ChannelUID uid, String acceptedItemType, Set<String> defaultTags) {
-        this(uid, null, acceptedItemType, ChannelKind.STATE, null, defaultTags, null, null, null,
-                AutoUpdatePolicy.DEFAULT);
+        this(uid, null, acceptedItemType, ChannelKind.STATE, null, defaultTags, null, null, null, null);
     }
 
     /**
@@ -111,8 +108,7 @@ public class Channel {
     @Deprecated
     public Channel(ChannelUID uid, String acceptedItemType, Configuration configuration, Set<String> defaultTags,
             Map<String, String> properties) {
-        this(uid, null, acceptedItemType, ChannelKind.STATE, null, defaultTags, properties, null, null,
-                AutoUpdatePolicy.DEFAULT);
+        this(uid, null, acceptedItemType, ChannelKind.STATE, null, defaultTags, properties, null, null, null);
     }
 
     /**
@@ -122,7 +118,7 @@ public class Channel {
     public Channel(ChannelUID uid, @Nullable ChannelTypeUID channelTypeUID, @Nullable String acceptedItemType,
             ChannelKind kind, @Nullable Configuration configuration, Set<String> defaultTags,
             @Nullable Map<String, String> properties, @Nullable String label, @Nullable String description,
-            AutoUpdatePolicy autoUpdatePolicy) {
+            @Nullable AutoUpdatePolicy autoUpdatePolicy) {
         this.uid = uid;
         this.channelTypeUID = channelTypeUID;
         this.acceptedItemType = acceptedItemType;
@@ -229,7 +225,7 @@ public class Channel {
         return defaultTags;
     }
 
-    public AutoUpdatePolicy getAutoUpdatePolicy() {
+    public @Nullable AutoUpdatePolicy getAutoUpdatePolicy() {
         return autoUpdatePolicy;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ChannelBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ChannelBuilder.java
@@ -45,7 +45,7 @@ public class ChannelBuilder {
     private @Nullable String label;
     private @Nullable String description;
     private @Nullable ChannelTypeUID channelTypeUID;
-    private AutoUpdatePolicy autoUpdatePolicy = AutoUpdatePolicy.DEFAULT;
+    private @Nullable AutoUpdatePolicy autoUpdatePolicy;
 
     private ChannelBuilder(ChannelUID channelUID, @Nullable String acceptedItemType, Set<String> defaultTags) {
         this.channelUID = channelUID;
@@ -175,11 +175,7 @@ public class ChannelBuilder {
      * @return channel builder
      */
     public ChannelBuilder withAutoUpdatePolicy(@Nullable AutoUpdatePolicy policy) {
-        if (policy != null) {
-            this.autoUpdatePolicy = policy;
-        } else {
-            this.autoUpdatePolicy = AutoUpdatePolicy.DEFAULT;
-        }
+        this.autoUpdatePolicy = policy;
         return this;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/i18n/ChannelTypeI18nLocalizationService.java
@@ -90,7 +90,7 @@ public class ChannelTypeI18nLocalizationService {
                         .state(channelTypeUID, label == null ? defaultLabel : label, channelType.getItemType())
                         .isAdvanced(channelType.isAdvanced()).withCategory(channelType.getCategory())
                         .withConfigDescriptionURI(channelType.getConfigDescriptionURI()).withTags(channelType.getTags())
-                        .withStateDescription(state);
+                        .withStateDescription(state).withAutoUpdatePolicy(channelType.getAutoUpdatePolicy());
                 if (description != null) {
                     stateBuilder.withDescription(description);
                 }
@@ -109,7 +109,8 @@ public class ChannelTypeI18nLocalizationService {
                 return new ChannelType(channelTypeUID, channelType.isAdvanced(), channelType.getItemType(),
                         channelType.getKind(), label == null ? defaultLabel : label, description,
                         channelType.getCategory(), channelType.getTags(), channelType.getState(),
-                        channelType.getEvent(), channelType.getConfigDescriptionURI());
+                        channelType.getEvent(), channelType.getConfigDescriptionURI(),
+                        channelType.getAutoUpdatePolicy());
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/AutoUpdateManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/AutoUpdateManager.java
@@ -33,6 +33,8 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.AutoUpdatePolicy;
+import org.eclipse.smarthome.core.thing.type.ChannelType;
+import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.osgi.service.component.annotations.Activate;
@@ -68,6 +70,7 @@ public class AutoUpdateManager {
     private @NonNullByDefault({}) ThingRegistry thingRegistry;
     private @NonNullByDefault({}) EventPublisher eventPublisher;
     private @NonNullByDefault({}) MetadataRegistry metadataRegistry;
+    private @NonNullByDefault({}) ChannelTypeRegistry channelTypeRegistry;
 
     private boolean enabled = true;
     private boolean sendOptimisticUpdates = false;
@@ -210,7 +213,15 @@ public class AutoUpdateManager {
             AutoUpdatePolicy policy = AutoUpdatePolicy.DEFAULT;
             Channel channel = thing.getChannel(channelUID.getId());
             if (channel != null) {
-                policy = channel.getAutoUpdatePolicy();
+                AutoUpdatePolicy channelpolicy = channel.getAutoUpdatePolicy();
+                if (channelpolicy != null) {
+                    policy = channelpolicy;
+                } else {
+                    ChannelType channelType = channelTypeRegistry.getChannelType(channel.getChannelTypeUID());
+                    if (channelType != null && channelType.getAutoUpdatePolicy() != null) {
+                        policy = channelType.getAutoUpdatePolicy();
+                    }
+                }
             }
 
             switch (policy) {
@@ -310,6 +321,15 @@ public class AutoUpdateManager {
 
     protected void unsetMetadataRegistry(MetadataRegistry metadataRegistry) {
         this.metadataRegistry = null;
+    }
+
+    @Reference
+    protected void setChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
+        this.channelTypeRegistry = channelTypeRegistry;
+    }
+
+    protected void unsetChannelTypeRegistry(ChannelTypeRegistry channelTypeRegistry) {
+        this.channelTypeRegistry = null;
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelI18nUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelI18nUtil.java
@@ -81,9 +81,9 @@ public class ChannelI18nUtil {
                     }
                 }
             }
-            localizedChannelDefinitions
-                    .add(new ChannelDefinition(channelDefinition.getId(), channelDefinition.getChannelTypeUID(),
-                            channelDefinition.getProperties(), channelLabel, channelDescription));
+            localizedChannelDefinitions.add(new ChannelDefinition(channelDefinition.getId(),
+                    channelDefinition.getChannelTypeUID(), channelDefinition.getProperties(), channelLabel,
+                    channelDescription, channelDefinition.getAutoUpdatePolicy()));
         }
         return localizedChannelDefinitions;
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelType.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelType.java
@@ -62,7 +62,7 @@ public class ChannelType extends AbstractDescriptionType {
             String description, String category, Set<String> tags, StateDescription state, EventDescription event,
             URI configDescriptionURI) throws IllegalArgumentException {
         this(uid, advanced, itemType, kind, label, description, category, tags, state, event, configDescriptionURI,
-                AutoUpdatePolicy.DEFAULT);
+                null);
     }
 
     /**

--- a/bundles/test/org.eclipse.smarthome.magic/ESH-INF/thing/channel-types.xml
+++ b/bundles/test/org.eclipse.smarthome.magic/ESH-INF/thing/channel-types.xml
@@ -8,6 +8,7 @@
 		<item-type>Switch</item-type>
 		<label>Switch</label>
 		<description>The on/off channel allows to toggle between on and off.</description>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 		<config-description>
 			<parameter name="invert" type="boolean">
 				<label>Invert operation</label>
@@ -20,6 +21,7 @@
 		<label>Dimmer</label>
 		<description>The dimmer channel allows to control the brightness.</description>
 		<category>DimmableLight</category>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="color">
@@ -32,6 +34,7 @@
 		<tags>
 			<tag>Lighting</tag>
 		</tags>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 		<config-description>
 			<parameter name="boostRed" type="decimal" min="0" max="100">
 				<label>Red boost</label>
@@ -59,27 +62,32 @@
 				<option value="LSELECT">Long Alert</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="contact">
 		<item-type>Contact</item-type>
 		<label>Contact</label>
 		<state readOnly="true"></state>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="location">
 		<item-type>Location</item-type>
 		<label>Location</label>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="number">
 		<item-type>Number</item-type>
 		<label>Thing Online(&gt;0)/Offline(&lt;0) Delay</label>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="text">
 		<item-type>String</item-type>
 		<label>Text channel</label>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="temperature">
@@ -92,6 +100,7 @@
 		<item-type>Number:Temperature</item-type>
 		<label>Set Point</label>
 		<state readOnly="false" pattern="%.1f %unit%" min="12" max="38" step="0.5" />
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="choosy">
@@ -104,16 +113,19 @@
 				<option value="2">Two</option>
 			</options>
 		</state>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="rollershutter">
 		<item-type>Rollershutter</item-type>
 		<label>Rollershutter</label>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="player">
 		<item-type>Player</item-type>
 		<label>Player</label>
+		<autoUpdatePolicy>recommend</autoUpdatePolicy>
 	</channel-type>
 
 	<channel-type id="image">


### PR DESCRIPTION
Fixes parsing channels and channel types from thing type XMLs. Defines autoUpdatePolicy as nullable in Channel and ChannelType, the default value will now be determined in AutoUpdateManager when both channel and channel type do not define a value.

Fixes #6180.

Also: Add autoUpdatePolicy flag to magic bundle channel types.

Signed-off-by: Henning Treu <henning.treu@telekom.de>