### PR TITLE
Remove Groovy migration leftovers

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/.groovy/suggestions.xdsl
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/.groovy/suggestions.xdsl
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<projectSuggestions/>

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
@@ -8,11 +8,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Import-Package: 
  com.google.common.collect,
- groovy.lang,
- org.codehaus.groovy.reflection,
- org.codehaus.groovy.runtime,
- org.codehaus.groovy.runtime.callsite,
- org.codehaus.groovy.runtime.typehandling,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.events,

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/build.properties
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/build.properties
@@ -1,4 +1,4 @@
-source.. = src/test/groovy/,\
+source.. = src/test/java/,\
            src/test/resources/
 output.. = target/test-classes/
 bin.includes = META-INF/,\

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.core.binding.xml
 Import-Package: 
- groovy.lang,
  org.apache.commons.io,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.binding,

--- a/bundles/model/org.eclipse.smarthome.model.core.test/.project
+++ b/bundles/model/org.eclipse.smarthome.model.core.test/.project
@@ -22,7 +22,6 @@
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.jdt.groovy.core.groovyNature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/bundles/ui/org.eclipse.smarthome.ui.icon.test/.settings/org.eclipse.jdt.groovy.core.prefs
+++ b/bundles/ui/org.eclipse.smarthome.ui.icon.test/.settings/org.eclipse.jdt.groovy.core.prefs
@@ -1,2 +1,0 @@
-eclipse.preferences.version=1
-groovy.compiler.level=-1


### PR DESCRIPTION
Cleans up the Groovy leftovers from projects that had their tests migrated to Java.