### PR TITLE
bump tycho (1.2.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <maven.compiler.source>${esh.java.version}</maven.compiler.source>
     <maven.compiler.target>${esh.java.version}</maven.compiler.target>
     <maven.compiler.compilerVersion>${esh.java.version}</maven.compiler.compilerVersion>
-    <tycho-version>1.1.0</tycho-version>
+    <tycho-version>1.2.0</tycho-version>
     <tycho-groupid>org.eclipse.tycho</tycho-groupid>
     <xtext-version>2.12.0</xtext-version>
     <karaf.version>4.2.0</karaf.version>


### PR DESCRIPTION
There is perhaps currently no real need to bump the Tycho version, but I assume it is okay to use the most recent version of the build toolchain (as long as nothing is broken).

The changes for Tycho 1.2.0 can be found here: https://bugs.eclipse.org/bugs/buglist.cgi?classification=Technology&order=bug_id&product=Tycho&query_format=advanced&target_milestone=1.2.0

IMHO https://bugs.eclipse.org/bugs/show_bug.cgi?id=533873 is nice as it does remove Maven build warnings.
Also the work on Java 10 support can perhaps be of interest some time.