### PR TITLE
onewire binding: drop usage of javax.xml.bind.DatatypeConverter

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/META-INF/MANIFEST.MF
@@ -19,6 +19,7 @@ Import-Package: javax.measure.quantity,
  org.eclipse.smarthome.core.thing.binding.builder,
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.types,
+ org.eclipse.smarthome.core.util,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/OwPageBuffer.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/OwPageBuffer.java
@@ -14,9 +14,8 @@ package org.eclipse.smarthome.binding.onewire.internal;
 
 import java.nio.ByteBuffer;
 
-import javax.xml.bind.DatatypeConverter;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.util.HexUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,7 +94,7 @@ public class OwPageBuffer {
      * @return string representation of the page's data
      */
     public String getPageString(int pageNum) {
-        return DatatypeConverter.printHexBinary(getPage(pageNum)).toUpperCase();
+        return HexUtils.bytesToHex(getPage(pageNum));
     }
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/6206
