### PR TITLE
drop tycho compiler warning about missing project specific JDT settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
           <artifactId>tycho-compiler-plugin</artifactId>
           <version>${tycho-version}</version>
           <configuration>
+            <useProjectSettings>false</useProjectSettings>
             <extraClasspathElements>
               <extraClasspathElement>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
The Maven build currently shows a warning for every project that looks like:

    [WARNING] Parameter 'useProjectSettings' is set to true, but preferences file '...' could not be found!

This is caused by the tycho-compiler-plugin's setting "useProjectSettings" that defaults to "true".

The documentation of the plugin states:

If set to true, the settings file ${project.basedir}/.settings/org.eclipse.jdt.core.prefs will be passed to the compiler. If the file is not present, the build will not fail.

We do not use project specific JDT settings at all, so we can set the option to false globally and get rid of that warning.
