### PR TITLE
[core] Extended ThingBuilder by 'withoutChannels' methods

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ThingBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/builder/ThingBuilder.java
@@ -92,7 +92,19 @@ public class ThingBuilder {
         while (iterator.hasNext()) {
             if (iterator.next().getUID().equals(channelUID)) {
                 iterator.remove();
+                break;
             }
+        }
+        return this;
+    }
+
+    public ThingBuilder withoutChannels(Channel... channels) {
+        return withoutChannels(Arrays.asList(channels));
+    }
+
+    public ThingBuilder withoutChannels(List<Channel> channels) {
+        for (Channel channel : channels) {
+            withoutChannel(channel.getUID());
         }
         return this;
     }


### PR DESCRIPTION
- Extended `ThingBuilder` by `withoutChannels` methods

In order to make the most out of #6151 I added those methods to shorten the code needed to remove existing channels ("channel groups").

Before:
```
    List<Channel> channels = new ArrayList<>();
    ...
    ThingBuilder thingBuilder = editThing();
    for (Channel channel : getThing().getChannels()) {
        thingBuilder.withoutChannel(channel.getUID());
    }
    updateThing(thingBuilder.withChannels(channels).build());
```

After:
```
    List<Channel> channels = new ArrayList<>();
    ...
    updateThing(editThing().withoutChannels(getThing().getChannels()).withChannels(channels).build());
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>