### PR TITLE
[core] Added 'getChannelsOfGroup' method to Thing

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Thing.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/Thing.java
@@ -78,6 +78,14 @@ public interface Thing extends Identifiable<ThingUID> {
     List<Channel> getChannels();
 
     /**
+     * Gets the channels of the given channel group or an empty list if no channel group with the id exists or the
+     * channel group does not have channels.
+     *
+     * @return the channels of the given channel group
+     */
+    List<Channel> getChannelsOfGroup(String channelGroupId);
+
+    /**
      * Gets the channel for the given id or null if no channel with the id
      * exists.
      *

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingImpl.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
@@ -132,6 +133,18 @@ public class ThingImpl implements Thing {
     @Override
     public List<Channel> getChannels() {
         return Collections.unmodifiableList(new ArrayList<>(this.channels));
+    }
+
+    @Override
+    public List<Channel> getChannelsOfGroup(String channelGroupId) {
+        List<Channel> channels = new ArrayList<>();
+        for (Channel channel : this.channels) {
+            ChannelUID channelUID = channel.getUID();
+            if (channelUID.isInGroup() && channelUID.getGroupId().equals(channelGroupId)) {
+                channels.add(channel);
+            }
+        }
+        return Collections.unmodifiableList(channels);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingImpl.java
@@ -139,8 +139,7 @@ public class ThingImpl implements Thing {
     public List<Channel> getChannelsOfGroup(String channelGroupId) {
         List<Channel> channels = new ArrayList<>();
         for (Channel channel : this.channels) {
-            ChannelUID channelUID = channel.getUID();
-            if (channelUID.isInGroup() && channelUID.getGroupId().equals(channelGroupId)) {
+            if (channelGroupId.equals(channel.getUID().getGroupId())) {
                 channels.add(channel);
             }
         }


### PR DESCRIPTION
- Added `getChannelsOfGroup` method to `Thing`

... which makes it easier to retrieve all channels of a certain channel group.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>