### PR TITLE
update jetty plugin

### DIFF
--- a/third-party/pom.xml
+++ b/third-party/pom.xml
@@ -187,8 +187,9 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>9.3.8.v20160314</version>
+        <version>9.4.12.v20180830</version>
         <configuration>
+          <supportedPackagings>pom</supportedPackagings>
           <scanIntervalSeconds>10</scanIntervalSeconds>
           <webAppSourceDirectory>${project.build.directory}/repository/</webAppSourceDirectory>
           <webApp>


### PR DESCRIPTION
The old one seems not to work anymore (perhaps the Jetty bundles are not
compatible with a more recent JVM).

The plugin is used if you want to host the p2 site easily on your
localhost.

You could use e.g.:

    mvn jetty:run
