### PR TITLE
LSP requires Gson 2.7 that exports internal packages

### DIFF
--- a/features/karaf/esh-tp/src/main/feature/feature.xml
+++ b/features/karaf/esh-tp/src/main/feature/feature.xml
@@ -125,11 +125,11 @@
 
   <feature name="esh.tp-lsp4j" description="Eclipse LSP4J" version="${project.version}">
     <capability>esh.tp;feature=lsp4j;version=0.4.1</capability>
-    <feature dependency="true">esh.tp-xtext</feature>
-    <bundle dependency="true">mvn:com.google.code.gson/gson/2.7</bundle>
+    <bundle>mvn:org.eclipse.lsp4j/org.eclipse.lsp4j/0.4.1</bundle>
+    <bundle>mvn:org.eclipse.lsp4j/org.eclipse.lsp4j.jsonrpc/0.4.1</bundle>
 
-    <bundle dependency="true">mvn:org.eclipse.lsp4j/org.eclipse.lsp4j/0.4.1</bundle>
-    <bundle dependency="true">mvn:org.eclipse.lsp4j/org.eclipse.lsp4j.jsonrpc/0.4.1</bundle>
+    <feature dependency="true">esh.tp-xtext</feature>
+    <bundle dependency="true">mvn:org.eclipse.orbit.bundles/com.google.gson/2.7.0.v20170129-0911</bundle>
   </feature>
 
   <feature name="esh.tp-mapdb" description="MapDB" version="${project.version}">


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/6250
