### PR TITLE
MQTT embedded broker: fix missing import

### DIFF
--- a/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker/META-INF/MANIFEST.MF
+++ b/extensions/io/org.eclipse.smarthome.io.mqttembeddedbroker/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: ., lib/moquette-broker-0.11.jar, lib/netty-all-4.1.19.Final.jar
 Import-Package: 
+ javax.security.cert,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.apache.commons.net.util,


### PR DESCRIPTION
Fixes: https://github.com/eclipse/smarthome/issues/6246

The error has been caused by a missing Import-Package for a javax.security
related one (see diff) that is used by Netty internally.

I tracked it down the road:

* io.netty.channel.ChannelException: Unable to create Channel from class class io.netty.channel.socket.nio.NioServerSocketChannel
* Caused by: java.lang.NoClassDefFoundError: Could not initialize class io.netty.channel.DefaultChannelId
* java.lang.NoClassDefFoundError: Could not initialize class io.netty.util.internal.EmptyArrays
* java.lang.NoClassDefFoundError: javax/security/cert/X509Certificate