### PR TITLE
[homematic] Provide more functionality in the bridge handler

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicBridgeHandler.java
@@ -73,6 +73,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
 
     private final String ipv4Address;
     private boolean isInDutyCycle = false;
+    private int dutyCycleRatio = 0;
 
     public HomematicBridgeHandler(@NonNull Bridge bridge, HomematicTypeGenerator typeGenerator, String ipv4Address,
             HttpClient httpClient) {
@@ -341,6 +342,7 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
     @Override
     public void onDutyCycleRatioUpdate(int dutyCycleRatio) {
         synchronized (dutyCycleRatioUpdateLock) {
+            this.dutyCycleRatio = dutyCycleRatio;
             Channel dutyCycleRatioChannel = thing.getChannel(CHANNEL_TYPE_DUTY_CYCLE_RATIO);
             if (dutyCycleRatioChannel != null) {
                 this.updateState(dutyCycleRatioChannel.getUID(), new DecimalType(dutyCycleRatio));
@@ -358,6 +360,15 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
                 this.updateStatus(ThingStatus.ONLINE);
             }
         }
+    }
+
+    /**
+     * Returns the last value for the duty cycle ratio that was retrieved from the homematic gateway.
+     * 
+     * @return The duty cycle ratio of the gateway
+     */
+    public int getDutyCycleRatio() {
+        return dutyCycleRatio;
     }
 
     @Override
@@ -385,6 +396,16 @@ public class HomematicBridgeHandler extends BaseBridgeHandler implements Homemat
         if (((HomematicThingHandler) childHandler).isDeletionPending()) {
             deleteFromGateway(UidUtils.getHomematicAddress(childThing), false, true, false);
         }
+    }
+
+    /**
+     * Updates the {@link HmDatapoint} by reloading the value from the homematic gateway.
+     * 
+     * @param dp The HmDatapoint that shall be updated
+     * @throws IOException If there is a problem while communicating to the gateway
+     */
+    public void updateDatapoint(HmDatapoint dp) throws IOException {
+        getGateway().loadDatapointValue(dp);
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -519,6 +519,11 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
     }
 
     @Override
+    public void loadDatapointValue(HmDatapoint dp) throws IOException {
+        getRpcClient(dp.getChannel().getDevice().getHmInterface()).getDatapointValue(dp);
+    }
+
+    @Override
     public void loadRssiValues() throws IOException {
         for (HmInterface hmInterface : availableInterfaces.keySet()) {
             if (hmInterface == HmInterface.RF || hmInterface == HmInterface.CUXD) {

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/HomematicGateway.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/HomematicGateway.java
@@ -64,6 +64,13 @@ public interface HomematicGateway {
     public void loadChannelValues(HmChannel channel) throws IOException;
 
     /**
+     * Loads the value of the given {@link HmDatapoint} from the device.
+     * 
+     * @param dp The HmDatapoint that shall be loaded
+     */
+    public void loadDatapointValue(HmDatapoint dp) throws IOException;
+
+    /**
      * Reenumerates the set of VALUES datapoints for the given channel.
      */
     public void updateChannelValueDatapoints(HmChannel channel) throws IOException;

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClient.java
@@ -219,12 +219,7 @@ public abstract class RpcClient<T> {
      */
     private void setChannelDatapointValues(HmChannel channel) throws IOException {
         for (HmDatapoint dp : channel.getDatapoints()) {
-            if (dp.isReadable() && !dp.isVirtual() && dp.getParamsetType() == HmParamsetType.VALUES) {
-                RpcRequest<T> request = createRpcRequest("getValue");
-                request.addArg(getRpcAddress(channel.getDevice().getAddress()) + getChannelSuffix(channel));
-                request.addArg(dp.getName());
-                new GetValueParser(dp).parse(sendMessage(config.getRpcPort(channel), request));
-            }
+            getDatapointValue(dp);
         }
     }
 
@@ -311,6 +306,21 @@ public abstract class RpcClient<T> {
             request.addArg(paramSet);
         }
         sendMessage(config.getRpcPort(dp.getChannel()), request);
+    }
+
+    /**
+     * Retrieves the value of a single {@link HmDatapoint} from the device. Can only be used for the paramset "VALUES".
+     * 
+     * @param dp The HmDatapoint that shall be loaded
+     * @throws IOException If there is a problem while communicating to the gateway
+     */
+    public void getDatapointValue(HmDatapoint dp) throws IOException {
+        if (dp.isReadable() && !dp.isVirtual() && dp.getParamsetType() == HmParamsetType.VALUES) {
+            RpcRequest<T> request = createRpcRequest("getValue");
+            request.addArg(getRpcAddress(dp.getChannel().getDevice().getAddress()) + getChannelSuffix(dp.getChannel()));
+            request.addArg(dp.getName());
+            new GetValueParser(dp).parse(sendMessage(config.getRpcPort(dp.getChannel()), request));
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds two functionalities to the HomematicBridgeHandler:
- A getter for the current duty cycle of the bridge
- A method to update a single HmDatapoint by reloading it from the device

### Motivation
The homematic binding allows to exclude certain thing-types from the dynamic generation, so that an ESH solution can provide custom static thing-types instead. This also allows to customize thing handlers for these thing types. The newly added functionality can be used by custom thing handlers.

For example, the temperature of a temperature sensor could be updated more frequently by polling the temperature datapoint. This behavior could then be limited to times where the duty cycle is low (to avoid running out of duty cycle).

Signed-off-by: Florian Stolte <fstolte@itemis.de>