### PR TITLE
added debug log information for unknown devices

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.tradfri/src/main/java/org/eclipse/smarthome/binding/tradfri/internal/discovery/TradfriDiscoveryService.java
@@ -136,6 +136,8 @@ public class TradfriDiscoveryService extends AbstractDiscoveryService implements
 
                 if (thingId == null) {
                     // we didn't identify any device, so let's quit
+                    logger.debug("Ignoring unknown device on TRADFRI gateway:\n\ttype : {}\n\tmodel: {}\n\tinfo : {}",
+                            type, model, deviceInfo.getAsString());
                     return;
                 }
 


### PR DESCRIPTION
This should be helpful for reports like https://github.com/eclipse/smarthome/issues/6269

Signed-off-by: Kai Kreuzer <kai@openhab.org>