### PR TITLE
Remove legacy code for disabling RuleEngineImpl

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
@@ -99,11 +99,6 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
         injector = RulesStandaloneSetup.getInjector();
         triggerManager = new RuleTriggerManager(injector);
 
-        if (!isEnabled()) {
-            logger.info("Rule engine is disabled.");
-            return;
-        }
-
         logger.debug("Started rule engine");
 
         // read all rule files
@@ -268,7 +263,7 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
     @Override
     public void modelChanged(String modelName, org.eclipse.smarthome.model.core.EventType type) {
         if (triggerManager != null) {
-            if (isEnabled() && modelName.endsWith("rules")) {
+            if (modelName.endsWith("rules")) {
                 RuleModel model = (RuleModel) modelRepository.getModel(modelName);
 
                 // remove the rules from the trigger sets
@@ -401,16 +396,6 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
             context.newValue(QualifiedName.create(RulesJvmModelInferrer.VAR_PREVIOUS_STATE), oldThingStatus.toString());
             executeRule(rule, context);
         }
-    }
-
-    /**
-     * we need to be able to deactivate the rule execution, otherwise the Eclipse SmartHome designer would also execute
-     * the rules.
-     *
-     * @return true, if rules should be executed, false otherwise
-     */
-    private boolean isEnabled() {
-        return !"true".equalsIgnoreCase(System.getProperty("noRules"));
     }
 
     @Override


### PR DESCRIPTION
This was used in the Designer (R.I.P) to disable execution of the modified rules.

Signed-off-by: Henning Treu <henning.treu@telekom.de>