### PR TITLE
Send POWER command when the player is in StandBy mode

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
@@ -191,7 +191,7 @@ public class CommandExecutor implements AvailableSources {
     public void postPlayerControl(Command command) {
         if (command.equals(PlayPauseType.PLAY)) {
             if (currentOperationMode == OperationModeType.STANDBY) {
-                postRemoteKey(RemoteKeyType.PLAY_PAUSE);
+                postRemoteKey(RemoteKeyType.POWER);
             } else {
                 postRemoteKey(RemoteKeyType.PLAY);
             }


### PR DESCRIPTION
According to BOSE - Sending the POWER key command will bring the player out of StandBy mode and it will resume the last playback state.
Therefore it makes sense when the player is in StandBy mode to send the power command instead of a PLAY_PAUSE command, as the PLAY_PAUSE command
is NOT supported by all models

Signed-off-by: Ivaylo Ivanov <ivivanov.bg@gmail.com>