### PR TITLE
Fix NPE in ScriptRuleTest

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/src/test/java/org/eclipse/smarthome/automation/module/script/ScriptRuleTest.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/src/test/java/org/eclipse/smarthome/automation/module/script/ScriptRuleTest.java
@@ -119,6 +119,7 @@ public class ScriptRuleTest extends JavaOSGiTest {
             Rule rule2 = ruleRegistry.get("javascript.rule1");
             assertThat(rule2, is(notNullValue()));
             RuleStatusInfo ruleStatus2 = ruleEngine.getStatusInfo(rule2.getUID());
+            assertThat(ruleStatus2, is(notNullValue()));
             assertThat(ruleStatus2.getStatus(), is(RuleStatus.IDLE));
         }, 10000, 200);
         Rule rule = ruleRegistry.get("javascript.rule1");

--- a/bundles/test/org.eclipse.smarthome.test/src/test/java/org/eclipse/smarthome/test/java/JavaTestTest.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/test/java/org/eclipse/smarthome/test/java/JavaTestTest.java
@@ -36,7 +36,7 @@ public class JavaTestTest {
     @Test
     public void waitForAssertShouldRunAfterLastCall_whenAssertionSucceeds() {
         Runnable afterLastCall = mock(Runnable.class);
-        javaTest.waitForAssert(() -> assertTrue(true), null, afterLastCall, 1000, 50);
+        javaTest.waitForAssert(() -> assertTrue(true), null, afterLastCall, 100, 50);
         verify(afterLastCall, times(1)).run();
     }
 
@@ -44,10 +44,21 @@ public class JavaTestTest {
     public void waitForAssertShouldRunAfterLastCall_whenAssertionFails() {
         Runnable afterLastCall = mock(Runnable.class);
         try {
-            javaTest.waitForAssert(() -> assertTrue(false), null, afterLastCall, 1000, 50);
+            javaTest.waitForAssert(() -> assertTrue(false), null, afterLastCall, 100, 50);
         } catch (final AssertionError ex) {
         }
         verify(afterLastCall, times(1)).run();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void waitForAssertShouldNotCatchNPE() {
+        javaTest.waitForAssert(() -> {
+            getObject().getClass();
+        });
+    }
+
+    private Object getObject() {
+        return null;
     }
 
 }


### PR DESCRIPTION
Also: test waitForAssert is translucent for NPEs, speed up JavaTestTest.

Signed-off-by: Henning Treu <henning.treu@telekom.de>