### PR TITLE
Rename rule engine thread pool to ruleEngine

### DIFF
--- a/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
+++ b/bundles/model/org.eclipse.smarthome.model.rule.runtime/src/org/eclipse/smarthome/model/rule/runtime/internal/engine/RuleEngineImpl.java
@@ -76,8 +76,9 @@ public class RuleEngineImpl implements ItemRegistryChangeListener, StateChangeLi
 
     private final Logger logger = LoggerFactory.getLogger(RuleEngineImpl.class);
 
-    protected final ScheduledExecutorService scheduler = ThreadPoolManager
-            .getScheduledPool(RuleEngine.class.getSimpleName());
+    private static final String THREAD_POOL_NAME = "ruleEngine";
+
+    protected final ScheduledExecutorService scheduler = ThreadPoolManager.getScheduledPool(THREAD_POOL_NAME);
 
     private ItemRegistry itemRegistry;
     private ModelRepository modelRepository;


### PR DESCRIPTION
To conform to all other thread pool names change the rule engine thread pool name from `RuleEngine` to `ruleEngine`.

Relates to #6289.

Signed-off-by: Henning Treu <henning.treu@telekom.de>