### PR TITLE
defined version for maven-deploy-plugin and moved maven-install-plugin to pluginManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,14 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <plugin>
           <groupId>${tycho-groupid}</groupId>
           <artifactId>target-platform-configuration</artifactId>
           <version>${tycho-version}</version>
@@ -399,10 +407,6 @@
             </fileset>
           </filesets>
         </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
I believe that https://github.com/eclipse/smarthome/pull/6294 mistakenly added the maven-install-plugin to the build plugins section instead of the pluginManagement section - this PR moves it to the correct place.

Furthermore, our stable build does not work anymore, see https://ci.eclipse.org/smarthome/job/SmartHomeDistribution-Stable/298/console.
It seems that the maven-deploy-plugin has exactly the same issue, so I fixed it to 2.8.2 as well.
Note that this issue didn't turn up in the openHAB build (and thus was not addressed by https://github.com/openhab/openhab-core/pull/408) as openHAB already uses [the 2.8.2 version explicitly](https://github.com/openhab/openhab-core/pull/408/files#diff-e33318487d2ecef1337c03ddf9e29768L171).

Signed-off-by: Kai Kreuzer <kai@openhab.org>