### PR TITLE
Added new device type ID in check

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/discovery/eq3udp/Eq3UdpResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/discovery/eq3udp/Eq3UdpResponse.java
@@ -59,7 +59,8 @@ public class Eq3UdpResponse {
      * Returns true, if this response is from a Homematic CCU gateway.
      */
     public boolean isValid() {
-        return this.senderId == Eq3UdpRequest.getSenderId() && deviceTypeId.startsWith("eQ3-HM-CCU")
+        return this.senderId == Eq3UdpRequest.getSenderId()
+                && (deviceTypeId.startsWith("eQ3-HM-CCU") || deviceTypeId.startsWith("eQ3-HmIP-CCU3"))
                 && !serialNumber.contains(Eq3UdpRequest.getEq3SerialNumber());
     }
 


### PR DESCRIPTION
RaspberryMatic 3.7 with RPI-RF-MOD uses a different device typ ID than
the CCU2. Probably a CCU3 will use the same ID.

Fixes #6314

Signed-off-by: Martin Herbst <develop@mherbst.de>