### PR TITLE
Support for DS1923 and DS1420 sensors + bug fixes.

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/common.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/common.xml
@@ -17,12 +17,13 @@
 			<parameter name="resolution" type="text">
 				<label>Sensor resolution</label>
 				<options>
+					<option value="">default</option>
 					<option value="9">9 bit</option>
 					<option value="10">10 bit</option>
 					<option value="11">11 bit</option>
 					<option value="12">12 bit</option>
 				</options>
-				<default>10</default>
+				<default></default>
 				<limitToOptions>true</limitToOptions>
 				<required>false</required>
 			</parameter>

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/generic.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/generic.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="onewire" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+	<thing-type id="th">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="owserver" />
+		</supported-bridge-type-refs>
+		<label>TH</label>
+		<description>A 1-wire generic multisensor</description>
+		<channels>
+			<channel id="temperature" typeId="temperature" />
+			<channel id="humidity" typeId="humidity" />
+            <channel id="absolutehumidity" typeId="absolutehumidity" />
+            <channel id="dewpoint" typeId="dewpoint" />
+		</channels>
+		<properties>
+			<property name="sensorCount">1</property>
+		</properties>
+		<config-description>
+			<parameter name="id" type="text">
+				<label>Sensor ID</label>
+				<description>Sensor ID in format: xx.xxxxxxxxxxxx)</description>
+				<required>true</required>
+			</parameter>
+			<parameter name="refresh" type="integer" min="1">
+				<label>Refresh Time</label>
+				<description>Time in seconds after which the thing is refreshed</description>
+				<default>300</default>
+				<unitLabel>s</unitLabel>
+				<required>false</required>
+			</parameter>
+		</config-description>
+	</thing-type>
+</thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
@@ -52,9 +52,16 @@ It has two parameters: sensor id `id` and refresh time `refresh`.
 
 ### iButton (`ibutton`)
 
-The iButton thing supports only the DS2401 chips.
+The iButton thing supports only the DS2401 and DS1420 chips.
 It is used for presence detection and therefore only supports the `present` channel.
 It's value is `ON` if the device is detected on the bus and `OFF` otherwise.
+
+It has two parameters: sensor id `id` and refresh time `refresh`.
+
+### Sensor with Humidity (`th`)
+
+The generic sensor with humidity and temperature using DS1923 chipset. 
+It provides a `temperature` and `humidity` channels.
 
 It has two parameters: sensor id `id` and refresh time `refresh`.
 
@@ -109,16 +116,16 @@ The correct formula for the ambient light is automatically determined from the s
 
 ## Channels
 
-| Type-ID         | Thing                       | Item    | readonly   | Description                                        |
-|-----------------|-----------------------------|---------|------------|----------------------------------------------------|
-| current         | multisensors                | Number  | yes        | current (if light option not installed)            |
-| digital         | digitalX, AMS               | Switch  | no         | digital, can be configured as input or output      |
-| humidity        | multisensors (except ms-tv) | Number  | yes        | relative humidity                                  |
-| light           | ams, bms                    | Number  | yes        | lightness (if installed)                           |
-| present         | all                         | Switch  | yes        | sensor found on bus                                |
-| supplyvoltage   | multisensors                | Number  | yes        | sensor supplyvoltage                               |
-| temperature     | not digitalX, ibutton       | Number  | yes        | environmental temperature                          |
-| voltage         | ms-tv, ams                  | Number  | yes        | voltage input                                      |
+| Type-ID         | Thing                           | Item    | readonly   | Description                                        |
+|-----------------|---------------------------------|---------|------------|----------------------------------------------------|
+| current         | multisensors                    | Number  | yes        | current (if light option not installed)            |
+| digital         | digitalX, AMS                   | Switch  | no         | digital, can be configured as input or output      |
+| humidity        | multisensors (except ms-tv), th | Number  | yes        | relative humidity                                  |
+| light           | ams, bms                        | Number  | yes        | lightness (if installed)                           |
+| present         | all                             | Switch  | yes        | sensor found on bus                                |
+| supplyvoltage   | multisensors                    | Number  | yes        | sensor supplyvoltage                               |
+| temperature     | not digitalX, ibutton           | Number  | yes        | environmental temperature                          |
+| voltage         | ms-tv, ams                      | Number  | yes        | voltage input                                      |
 
 ### Digital I/O (`digitalX`)
 
@@ -134,7 +141,7 @@ In `inverted` mode `ON` is logic low and `OFF` is logic high.
 
 Depending on the sensor, the `humidity` channel may have the `humiditytype` parameter.
 This is only needed for the `ms-th` sensors.
-`ams` and `bms` sensors select the correct sensor type automatically.
+`th`, `ams` and `bms` sensors select the correct sensor type automatically.
 
 Possible options are `/humidity` for HIH-3610 sensors, `/HIH4000/humidity` for HIH-4000 sensors, `/HTM1735/humidity` for HTM-1735 sensors and `/DATANAB/humidity` for sensors from Datanab.
 
@@ -142,7 +149,8 @@ Possible options are `/humidity` for HIH-3610 sensors, `/HIH4000/humidity` for H
 
 The `temperature` channel has one parameter: `resolution`.
 
-OneWire temperature sensors are capable of different resolutions: `9`, `10`, `11` and `12` bits.
+OneWire temperature sensors are capable of different resolutions: `9`, `10`, `11` and `12` bits. 
+Parameter `resolution` can be used for `DS18B20`, but not `DS18S20` or other temperature sensors.   
 This corresponds to 0.5 °C, 0.25 °C, 0.125 °C, 0.0625 °C respectively.
 The conversion time is inverse to that and ranges from 95 ms to 750 ms.
 For best performance it is recommended to set the resolution only as high as needed. 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/OwBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/OwBindingConstants.java
@@ -48,11 +48,12 @@ public class OwBindingConstants {
     public static final ThingTypeUID THING_TYPE_MS_TV = new ThingTypeUID(BINDING_ID, "ms-tv");
     public static final ThingTypeUID THING_TYPE_BMS = new ThingTypeUID(BINDING_ID, "bms");
     public static final ThingTypeUID THING_TYPE_AMS = new ThingTypeUID(BINDING_ID, "ams");
+    public static final ThingTypeUID THING_TYPE_TH = new ThingTypeUID(BINDING_ID, "th");
 
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
             Arrays.asList(THING_TYPE_OWSERVER, THING_TYPE_TEMPERATURE, THING_TYPE_IBUTTON, THING_TYPE_DIGITALIO,
                     THING_TYPE_DIGITALIO2, THING_TYPE_DIGITALIO8, THING_TYPE_AMS, THING_TYPE_BMS, THING_TYPE_MS_TH,
-                    THING_TYPE_MS_THS, THING_TYPE_MS_TV));
+                    THING_TYPE_MS_THS, THING_TYPE_MS_TV, THING_TYPE_TH));
 
     // List of all config options
     public static final String CONFIG_ADDRESS = "network-address";
@@ -98,6 +99,7 @@ public class OwBindingConstants {
         initThingTypeMap.put(OwSensorType.DS1420, THING_TYPE_IBUTTON);
         initThingTypeMap.put(OwSensorType.DS18B20, THING_TYPE_TEMPERATURE);
         initThingTypeMap.put(OwSensorType.DS18S20, THING_TYPE_TEMPERATURE);
+        initThingTypeMap.put(OwSensorType.DS1923, THING_TYPE_TH);
         initThingTypeMap.put(OwSensorType.DS2401, THING_TYPE_IBUTTON);
         initThingTypeMap.put(OwSensorType.DS2405, THING_TYPE_DIGITALIO);
         initThingTypeMap.put(OwSensorType.DS2406, THING_TYPE_DIGITALIO2);
@@ -123,6 +125,7 @@ public class OwBindingConstants {
         initThingLabelMap.put(THING_TYPE_MS_TV, "Multisensor");
         initThingLabelMap.put(THING_TYPE_BMS, "Elaborated Networks BMS");
         initThingLabelMap.put(THING_TYPE_AMS, "Elaborated Networks AMS");
+        initThingLabelMap.put(THING_TYPE_TH, "Temperature and humidity sensor");
         THING_LABEL_MAP = Collections.unmodifiableMap(initThingLabelMap);
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/device/OwSensorType.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/device/OwSensorType.java
@@ -22,6 +22,7 @@ public enum OwSensorType {
     DS1420,
     DS18S20,
     DS18B20,
+    DS1923,
     DS2401,
     DS2405,
     DS2406,

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/MultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/MultisensorThingHandler.java
@@ -50,8 +50,8 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class MultisensorThingHandler extends OwBaseThingHandler {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_MS_TH, THING_TYPE_MS_THS, THING_TYPE_MS_TV, THING_TYPE_AMS, THING_TYPE_BMS));
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(Arrays.asList(THING_TYPE_MS_TH,
+            THING_TYPE_MS_THS, THING_TYPE_MS_TV, THING_TYPE_AMS, THING_TYPE_BMS, THING_TYPE_TH));
 
     private final Logger logger = LoggerFactory.getLogger(MultisensorThingHandler.class);
 
@@ -177,7 +177,8 @@ public class MultisensorThingHandler extends OwBaseThingHandler {
         if (THING_TYPE_MS_TV.equals(thingType)) {
             sensors.get(0).enableChannel(CHANNEL_VOLTAGE);
         } else if (THING_TYPE_AMS.equals(thingType) || THING_TYPE_BMS.equals(thingType)
-                || THING_TYPE_MS_TH.equals(thingType) || THING_TYPE_MS_THS.equals(thingType)) {
+                || THING_TYPE_TH.equals(thingType) || THING_TYPE_MS_TH.equals(thingType)
+                || THING_TYPE_MS_THS.equals(thingType)) {
             sensors.get(0).enableChannel(CHANNEL_HUMIDITY);
             if (thing.getChannel(CHANNEL_ABSOLUTE_HUMIDITY) != null) {
                 sensors.get(0).enableChannel(CHANNEL_ABSOLUTE_HUMIDITY);


### PR DESCRIPTION
* Added support for DS1923 temperature and humidity sensor.
* Added support for DS1420 id.
* Fixed problem with wrong refresh time (10 seconds instead of 300 seconds).
* Fixed problem with `/vis` (current) channel added for non AMS/BSM sensors.
* Fixed problem with enforced resolution to 10 bits for temperature sensors, even for sensors which do not support it - like DS18B20 does, but DS18S20 doesn't.
