### PR TITLE
add channel definition builder

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/binding/ChangeThingTypeOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/binding/ChangeThingTypeOSGiTest.java
@@ -46,6 +46,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ManagedItemChannelLinkProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
@@ -432,7 +433,7 @@ public class ChangeThingTypeOSGiTest extends JavaOSGiTest {
 
         channelTypes.put(channelTypeUID, channelType);
 
-        ChannelDefinition cd = new ChannelDefinition("channel" + thingTypeUID.getId(), channelTypeUID);
+        ChannelDefinition cd = new ChannelDefinitionBuilder("channel" + thingTypeUID.getId(), channelTypeUID).build();
         channelDefinitions.add(cd);
         return channelDefinitions;
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/binding/ThingFactoryTest.java
@@ -41,6 +41,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.type.BridgeType;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
@@ -115,8 +116,8 @@ public class ThingFactoryTest extends JavaOSGiTest {
 
         registerChannelTypes(Stream.of(channelType1, channelType2).collect(toSet()), emptyList());
 
-        ChannelDefinition cd1 = new ChannelDefinition("channel1", channelType1.getUID());
-        ChannelDefinition cd2 = new ChannelDefinition("channel2", channelType2.getUID());
+        ChannelDefinition cd1 = new ChannelDefinitionBuilder("channel1", channelType1.getUID()).build();
+        ChannelDefinition cd2 = new ChannelDefinitionBuilder("channel2", channelType2.getUID()).build();
 
         return Stream.of(cd1, cd2).collect(toList());
     }
@@ -216,8 +217,8 @@ public class ThingFactoryTest extends JavaOSGiTest {
 
         registerChannelTypes(Stream.of(channelType1, channelType2).collect(toSet()), emptyList());
 
-        ChannelDefinition channelDef1 = new ChannelDefinition("ch1", channelType1.getUID());
-        ChannelDefinition channelDef2 = new ChannelDefinition("ch2", channelType2.getUID());
+        ChannelDefinition channelDef1 = new ChannelDefinitionBuilder("ch1", channelType1.getUID()).build();
+        ChannelDefinition channelDef2 = new ChannelDefinitionBuilder("ch2", channelType2.getUID()).build();
 
         ThingType thingType = ThingTypeBuilder.instance(new ThingTypeUID("bindingId:thingType"), "label")
                 .withSupportedBridgeTypeUIDs(emptyList())
@@ -247,8 +248,8 @@ public class ThingFactoryTest extends JavaOSGiTest {
                 .state(new ChannelTypeUID("bindingId:channelTypeId2"), "channelLabel2", "Dimmer").withTag("tag3")
                 .build();
 
-        ChannelDefinition channelDef1 = new ChannelDefinition("ch1", channelType1.getUID());
-        ChannelDefinition channelDef2 = new ChannelDefinition("ch2", channelType2.getUID());
+        ChannelDefinition channelDef1 = new ChannelDefinitionBuilder("ch1", channelType1.getUID()).build();
+        ChannelDefinition channelDef2 = new ChannelDefinitionBuilder("ch2", channelType2.getUID()).build();
 
         ChannelGroupType channelGroupType1 = ChannelGroupTypeBuilder
                 .instance(new ChannelGroupTypeUID("bindingid:groupTypeId1"), "label").isAdvanced(false)

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ChannelStateDescriptionProviderOSGiTest.java
@@ -51,6 +51,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
@@ -168,14 +169,14 @@ public class ChannelStateDescriptionProviderOSGiTest extends JavaOSGiTest {
         });
 
         List<ChannelDefinition> channelDefinitions = new ArrayList<>();
-        channelDefinitions.add(new ChannelDefinition("1", channelType.getUID()));
-        channelDefinitions.add(new ChannelDefinition("2", channelType2.getUID()));
-        channelDefinitions.add(new ChannelDefinition("3", channelType3.getUID()));
-        channelDefinitions.add(new ChannelDefinition("4", channelType4.getUID()));
-        channelDefinitions.add(new ChannelDefinition("5", channelType5.getUID()));
-        channelDefinitions.add(new ChannelDefinition("6", channelType6.getUID()));
-        channelDefinitions.add(new ChannelDefinition("7_1", channelType7.getUID()));
-        channelDefinitions.add(new ChannelDefinition("7_2", channelType7.getUID()));
+        channelDefinitions.add(new ChannelDefinitionBuilder("1", channelType.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("2", channelType2.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("3", channelType3.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("4", channelType4.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("5", channelType5.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("6", channelType6.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("7_1", channelType7.getUID()).build());
+        channelDefinitions.add(new ChannelDefinitionBuilder("7_2", channelType7.getUID()).build());
 
         registerService(new SimpleThingTypeProvider(Collections.singleton(ThingTypeBuilder
                 .instance(new ThingTypeUID("hue:lamp"), "label").withChannelDefinitions(channelDefinitions).build())));

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManagerOSGiTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingLinkManagerOSGiTest.java
@@ -43,7 +43,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.link.ThingLinkManager;
-import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeProvider;
@@ -79,7 +79,7 @@ public class ThingLinkManagerOSGiTest extends JavaOSGiTest {
     private ItemRegistry itemRegistry;
     private ItemChannelLinkRegistry itemChannelLinkRegistry;
 
-    private Map<String, Object> context = new ConcurrentHashMap<>();
+    private final Map<String, Object> context = new ConcurrentHashMap<>();
 
     @Before
     public void setup() {
@@ -122,7 +122,8 @@ public class ThingLinkManagerOSGiTest extends JavaOSGiTest {
         registerService(channelTypeProvider);
 
         ThingType thingType = ThingTypeBuilder.instance(new ThingTypeUID("hue:lamp"), "label")
-                .withChannelDefinitions(singletonList(new ChannelDefinition("1", channelType.getUID()))).build();
+                .withChannelDefinitions(singletonList(new ChannelDefinitionBuilder("1", channelType.getUID()).build()))
+                .build();
         SimpleThingTypeProvider thingTypeProvider = new SimpleThingTypeProvider(singletonList(thingType));
         registerService(thingTypeProvider);
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -70,7 +70,7 @@ import org.eclipse.smarthome.core.thing.binding.builder.ThingStatusInfoBuilder;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLinkRegistry;
 import org.eclipse.smarthome.core.thing.link.ManagedItemChannelLinkProvider;
-import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeProvider;
@@ -124,7 +124,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     private static final ThingUID BRIDGE_UID = new ThingUID(BRIDGE_TYPE_UID, "bridge");
 
     private static final ChannelUID CHANNEL_UID = new ChannelUID(THING_UID, CHANNEL_ID);
-    
+
     private static final ChannelGroupUID CHANNEL_GROUP_UID = new ChannelGroupUID(THING_UID, CHANNEL_GROUP_ID);
 
     private Thing THING;
@@ -622,7 +622,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         ThingStatusInfo thingStatusInfo = ThingStatusInfoBuilder
                 .create(ThingStatus.UNINITIALIZED, ThingStatusDetail.NONE).build();
         THING.setStatusInfo(thingStatusInfo);
-        
+
         new Thread((Runnable) () -> managedThingProvider.add(THING)).start();
 
         waitForAssert(() -> {
@@ -645,7 +645,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
 
         // Reset the flag
         disposeInvoked.set(false);
-        
+
         // Enable the thing
         thingManager.setEnabled(THING_UID, true);
         waitForAssert(() -> {
@@ -929,7 +929,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
             }).when(mockHandler).setCallback(ArgumentMatchers.isA(ThingHandlerCallback.class));
 
             doAnswer(a -> {
-                
+
                 initializeInvoked.set(true);
 
                 // call thingUpdated() from within initialize()
@@ -1019,7 +1019,8 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     private void registerThingTypeProvider() throws Exception {
         ThingType thingType = ThingTypeBuilder.instance(THING_TYPE_UID, "label")
                 .withConfigDescriptionURI(CONFIG_DESCRIPTION_THING)
-                .withChannelDefinitions(Collections.singletonList(new ChannelDefinition(CHANNEL_ID, CHANNEL_TYPE_UID)))
+                .withChannelDefinitions(
+                        Collections.singletonList(new ChannelDefinitionBuilder(CHANNEL_ID, CHANNEL_TYPE_UID).build()))
                 .build();
 
         ThingTypeProvider mockThingTypeProvider = mock(ThingTypeProvider.class);
@@ -1040,7 +1041,8 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     private void registerChannelGroupTypeProvider() throws Exception {
         ChannelGroupType channelGroupType = ChannelGroupTypeBuilder.instance(CHANNEL_GROUP_TYPE_UID, "Test Group Label")
                 .withDescription("Test Group Description").withCategory("Test Group Category")
-                .withChannelDefinitions(Collections.singletonList(new ChannelDefinition(CHANNEL_ID, CHANNEL_TYPE_UID)))
+                .withChannelDefinitions(
+                        Collections.singletonList(new ChannelDefinitionBuilder(CHANNEL_ID, CHANNEL_TYPE_UID).build()))
                 .build();
 
         ChannelGroupTypeProvider mockChannelGroupTypeProvider = mock(ChannelGroupTypeProvider.class);

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelXmlResult.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml/src/main/java/org/eclipse/smarthome/core/thing/xml/internal/ChannelXmlResult.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.eclipse.smarthome.config.xml.util.NodeValue;
 import org.eclipse.smarthome.core.thing.type.AutoUpdatePolicy;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 
 import com.thoughtworks.xstream.converters.ConversionException;
@@ -131,10 +132,9 @@ public class ChannelXmlResult {
             propertiesMap.put(property.getAttributes().get("name"), (String) property.getValue());
         }
 
-        ChannelDefinition channelDefinition = new ChannelDefinition(id, new ChannelTypeUID(typeUID), propertiesMap,
-                getLabel(), getDescription(), getAutoUpdatePolicy());
-
-        return channelDefinition;
+        return new ChannelDefinitionBuilder(id, new ChannelTypeUID(typeUID)).withProperties(propertiesMap)
+                .withLabel(getLabel()).withDescription(getDescription()).withAutoUpdatePolicy(getAutoUpdatePolicy())
+                .build();
     }
 
     private String getTypeUID(String bindingId, String typeId) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelI18nUtil.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/i18n/ChannelI18nUtil.java
@@ -23,6 +23,7 @@ import org.eclipse.smarthome.core.thing.i18n.ChannelGroupTypeI18nLocalizationSer
 import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
 import org.eclipse.smarthome.core.thing.i18n.ThingTypeI18nLocalizationService;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelType;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeRegistry;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
@@ -65,6 +66,7 @@ public class ChannelI18nUtil {
             final @Nullable Locale locale) {
         List<ChannelDefinition> localizedChannelDefinitions = new ArrayList<>(channelDefinitions.size());
         for (final ChannelDefinition channelDefinition : channelDefinitions) {
+            final ChannelDefinitionBuilder builder = new ChannelDefinitionBuilder(channelDefinition);
             String channelLabel = channelLabelResolver.apply(channelDefinition);
             String channelDescription = channelDescriptionResolver.apply(channelDefinition);
             if (channelLabel == null || channelDescription == null) {
@@ -81,9 +83,9 @@ public class ChannelI18nUtil {
                     }
                 }
             }
-            localizedChannelDefinitions.add(new ChannelDefinition(channelDefinition.getId(),
-                    channelDefinition.getChannelTypeUID(), channelDefinition.getProperties(), channelLabel,
-                    channelDescription, channelDefinition.getAutoUpdatePolicy()));
+            builder.withLabel(channelLabel);
+            builder.withDescription(channelDescription);
+            localizedChannelDefinitions.add(builder.build());
         }
         return localizedChannelDefinitions;
     }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelDefinition.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelDefinition.java
@@ -47,9 +47,11 @@ public class ChannelDefinition {
      * @param id the identifier of the channel (must neither be null nor empty)
      * @param channelTypeUID the type UID of the channel (must not be null)
      * @throws IllegalArgumentException if the ID is null or empty, or the type is null
+     * @deprecated use the builder
      */
+    @Deprecated
     public ChannelDefinition(String id, ChannelTypeUID channelTypeUID) throws IllegalArgumentException {
-        this(id, channelTypeUID, null, null, null, null);
+        this(id, channelTypeUID, (String) null, (String) null, null, null);
     }
 
     /**
@@ -61,10 +63,12 @@ public class ChannelDefinition {
      * @param label the label for the channel to override channelType (could be null)
      * @param description the description for the channel to override channelType (could be null)
      * @throws IllegalArgumentException if the ID is null or empty, or the type is null
+     * @deprecated use the builder
      */
+    @Deprecated
     public ChannelDefinition(String id, ChannelTypeUID channelTypeUID, @Nullable Map<String, String> properties,
             @Nullable String label, @Nullable String description) throws IllegalArgumentException {
-        this(id, channelTypeUID, properties, label, description, null);
+        this(id, channelTypeUID, label, description, properties, null);
     }
 
     /**
@@ -77,9 +81,17 @@ public class ChannelDefinition {
      * @param description the description for the channel to override channelType (could be null)
      * @param autoUpdatePolicy the auto update policy for the channel to override from the thing type (could be null)
      * @throws IllegalArgumentException if the ID is null or empty, or the type is null
+     * @deprecated use the builder
      */
+    @Deprecated
     public ChannelDefinition(String id, ChannelTypeUID channelTypeUID, @Nullable Map<String, String> properties,
             @Nullable String label, @Nullable String description, @Nullable AutoUpdatePolicy autoUpdatePolicy)
+            throws IllegalArgumentException {
+        this(id, channelTypeUID, label, description, properties, autoUpdatePolicy);
+    }
+
+    ChannelDefinition(String id, ChannelTypeUID channelTypeUID, @Nullable String label, @Nullable String description,
+            @Nullable Map<String, String> properties, @Nullable AutoUpdatePolicy autoUpdatePolicy)
             throws IllegalArgumentException {
         if ((id == null) || (id.isEmpty())) {
             throw new IllegalArgumentException("The ID must neither be null nor empty!");

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelDefinitionBuilder.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/type/ChannelDefinitionBuilder.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.thing.type;
+
+import java.util.Map;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Builder for a channel definition.
+ *
+ * @author Markus Rathgeb - Initial Contribution
+ */
+@NonNullByDefault
+public class ChannelDefinitionBuilder {
+
+    private final String id;
+    private final ChannelTypeUID channelTypeUID;
+    private @Nullable Map<String, String> properties;
+    private @Nullable String label;
+    private @Nullable String description;
+    private @Nullable AutoUpdatePolicy autoUpdatePolicy;
+
+    /**
+     * Creates a new channel definition builder.
+     *
+     * @param channelDefinition the channel definition the builder should be initialized by
+     */
+    public ChannelDefinitionBuilder(final ChannelDefinition channelDefinition) {
+        this(channelDefinition.getId(), channelDefinition.getChannelTypeUID());
+        this.properties = channelDefinition.getProperties();
+        this.label = channelDefinition.getLabel();
+        this.description = channelDefinition.getDescription();
+        this.autoUpdatePolicy = channelDefinition.getAutoUpdatePolicy();
+    }
+
+    /**
+     * Creates a new channel definition builder.
+     *
+     * @param id the identifier of the channel (must neither be null nor empty)
+     * @param channelTypeUID the type UID of the channel (must not be null)
+     */
+    public ChannelDefinitionBuilder(final String id, final ChannelTypeUID channelTypeUID) {
+        this.id = id;
+        this.channelTypeUID = channelTypeUID;
+    }
+
+    /**
+     * Sets the properties.
+     *
+     * @param properties the properties
+     * @return the builder
+     */
+    public ChannelDefinitionBuilder withProperties(final @Nullable Map<String, String> properties) {
+        this.properties = properties;
+        return this;
+    }
+
+    /**
+     * Sets the label.
+     *
+     * @param label the label
+     * @return the builder
+     */
+    public ChannelDefinitionBuilder withLabel(final @Nullable String label) {
+        this.label = label;
+        return this;
+    }
+
+    /**
+     * Sets the description.
+     *
+     * @param description the description
+     * @return the builder
+     */
+    public ChannelDefinitionBuilder withDescription(final @Nullable String description) {
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Sets the auto update policy.
+     *
+     * @param autoUpdatePolicy the auto update policy
+     * @return the builder
+     */
+    public ChannelDefinitionBuilder withAutoUpdatePolicy(final @Nullable AutoUpdatePolicy autoUpdatePolicy) {
+        this.autoUpdatePolicy = autoUpdatePolicy;
+        return this;
+    }
+
+    /**
+     * Build a channel definition.
+     *
+     * @return channel definition
+     */
+    public ChannelDefinition build() {
+        return new ChannelDefinition(id, channelTypeUID, label, description, properties, autoUpdatePolicy);
+    }
+
+}

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/DumbThingTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/DumbThingTypeProvider.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder;
@@ -42,8 +43,8 @@ public class DumbThingTypeProvider implements ThingTypeProvider {
     public DumbThingTypeProvider() {
         logger.debug("DumbThingTypeProvider created");
         try {
-            ChannelDefinition channel1 = new ChannelDefinition("channel1",
-                    new ChannelTypeUID(DumbThingHandlerFactory.BINDING_ID, "channel1"));
+            ChannelDefinition channel1 = new ChannelDefinitionBuilder("channel1",
+                    new ChannelTypeUID(DumbThingHandlerFactory.BINDING_ID, "channel1")).build();
             List<ChannelDefinition> channelDefinitions = Collections.singletonList(channel1);
 
             thingTypes.put(DumbThingHandlerFactory.THING_TYPE_TEST,

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/TestHueChannelTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/TestHueChannelTypeProvider.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
-import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeProvider;
@@ -65,8 +65,10 @@ public class TestHueChannelTypeProvider implements ChannelTypeProvider, ChannelG
             ChannelGroupType groupX = ChannelGroupTypeBuilder.instance(GROUP_CHANNEL_GROUP_TYPE_UID, "Channel Group")
                     .withDescription("Channel Group")
                     .withChannelDefinitions(Arrays.asList(
-                            new ChannelDefinition("foo", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID),
-                            new ChannelDefinition("bar", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID)))
+                            new ChannelDefinitionBuilder("foo", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID)
+                                    .build(),
+                            new ChannelDefinitionBuilder("bar", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID)
+                                    .build()))
                     .build();
             channelGroupTypes = Arrays.asList(groupX);
 

--- a/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/TestHueThingTypeProvider.java
+++ b/bundles/model/org.eclipse.smarthome.model.thing.tests/src/test/java/org/eclipse/smarthome/model/thing/test/hue/TestHueThingTypeProvider.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder;
@@ -51,10 +52,11 @@ public class TestHueThingTypeProvider implements ThingTypeProvider {
                     ThingTypeBuilder.instance(TestHueThingHandlerFactory.THING_TYPE_BRIDGE, "HueBridge")
                             .withDescription("HueBridge").isListed(false).buildBridge());
 
-            ChannelDefinition color = new ChannelDefinition("color", TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID);
+            ChannelDefinition color = new ChannelDefinitionBuilder("color",
+                    TestHueChannelTypeProvider.COLOR_CHANNEL_TYPE_UID).build();
 
-            ChannelDefinition colorTemp = new ChannelDefinition("color_temperature",
-                    TestHueChannelTypeProvider.COLOR_TEMP_CHANNEL_TYPE_UID);
+            ChannelDefinition colorTemp = new ChannelDefinitionBuilder("color_temperature",
+                    TestHueChannelTypeProvider.COLOR_TEMP_CHANNEL_TYPE_UID).build();
             thingTypes.put(TestHueThingHandlerFactory.THING_TYPE_LCT001, ThingTypeBuilder
                     .instance(TestHueThingHandlerFactory.THING_TYPE_LCT001, "LCT001")
                     .withSupportedBridgeTypeUIDs(Arrays.asList(TestHueThingHandlerFactory.THING_TYPE_BRIDGE.toString()))
@@ -65,11 +67,11 @@ public class TestHueThingTypeProvider implements ThingTypeProvider {
                     ThingTypeBuilder.instance(TestHueThingHandlerFactoryX.THING_TYPE_BRIDGE, "HueBridge")
                             .withDescription("HueBridge").isListed(false).buildBridge());
 
-            ChannelDefinition colorX = new ChannelDefinition("Xcolor",
-                    TestHueChannelTypeProvider.COLORX_CHANNEL_TYPE_UID);
+            ChannelDefinition colorX = new ChannelDefinitionBuilder("Xcolor",
+                    TestHueChannelTypeProvider.COLORX_CHANNEL_TYPE_UID).build();
 
-            ChannelDefinition colorTempX = new ChannelDefinition("Xcolor_temperature",
-                    TestHueChannelTypeProvider.COLORX_TEMP_CHANNEL_TYPE_UID);
+            ChannelDefinition colorTempX = new ChannelDefinitionBuilder("Xcolor_temperature",
+                    TestHueChannelTypeProvider.COLORX_TEMP_CHANNEL_TYPE_UID).build();
             thingTypes.put(TestHueThingHandlerFactoryX.THING_TYPE_LCT001,
                     ThingTypeBuilder.instance(TestHueThingHandlerFactoryX.THING_TYPE_LCT001, "XLCT001")
                             .withSupportedBridgeTypeUIDs(

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/providers/DsDeviceThingTypeProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/src/main/java/org/eclipse/smarthome/binding/digitalstrom/internal/providers/DsDeviceThingTypeProvider.java
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.core.i18n.TranslationProvider;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.ThingTypeProvider;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
 import org.eclipse.smarthome.core.thing.type.ThingType;
 import org.eclipse.smarthome.core.thing.type.ThingTypeBuilder;
@@ -150,16 +151,18 @@ public class DsDeviceThingTypeProvider extends BaseDsI18n implements ThingTypePr
                 logger.debug("An URISyntaxException occurred: ", e);
             }
             if (SupportedThingTypes.GR.equals(supportedThingType)) {
-                thingTypeBuilder.withChannelDefinitions(Arrays.asList(new ChannelDefinition(DsChannelTypeProvider.SHADE,
-                        new ChannelTypeUID(DigitalSTROMBindingConstants.BINDING_ID, DsChannelTypeProvider.SHADE))));
+                thingTypeBuilder.withChannelDefinitions(Arrays.asList(new ChannelDefinitionBuilder(
+                        DsChannelTypeProvider.SHADE,
+                        new ChannelTypeUID(DigitalSTROMBindingConstants.BINDING_ID, DsChannelTypeProvider.SHADE))
+                                .build()));
             }
             if (SupportedThingTypes.circuit.equals(supportedThingType)) {
                 List<ChannelDefinition> channelDefinitions = new ArrayList<ChannelDefinition>(3);
                 for (MeteringTypeEnum meteringType : MeteringTypeEnum.values()) {
-                    channelDefinitions.add(new ChannelDefinition(
+                    channelDefinitions.add(new ChannelDefinitionBuilder(
                             DsChannelTypeProvider.getMeteringChannelID(meteringType, MeteringUnitsEnum.WH, false),
                             new ChannelTypeUID(DigitalSTROMBindingConstants.BINDING_ID, DsChannelTypeProvider
-                                    .getMeteringChannelID(meteringType, MeteringUnitsEnum.WH, false))));
+                                    .getMeteringChannelID(meteringType, MeteringUnitsEnum.WH, false))).build());
                 }
                 thingTypeBuilder.withChannelDefinitions(channelDefinitions);
             }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/HomematicTypeGeneratorImpl.java
@@ -42,6 +42,7 @@ import org.eclipse.smarthome.core.thing.DefaultSystemChannelTypeProvider;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelDefinition;
+import org.eclipse.smarthome.core.thing.type.ChannelDefinitionBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupDefinition;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupType;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
@@ -160,8 +161,8 @@ public class HomematicTypeGeneratorImpl implements HomematicTypeGenerator {
                                     channelTypeProvider.addChannelType(channelType);
                                 }
 
-                                ChannelDefinition channelDef = new ChannelDefinition(dp.getName(),
-                                        channelType.getUID());
+                                ChannelDefinition channelDef = new ChannelDefinitionBuilder(dp.getName(),
+                                        channelType.getUID()).build();
                                 channelDefinitions.add(channelDef);
                             }
                         }


### PR DESCRIPTION
The current change only adds a channel definition builder.

We could think about marking all constructor except the one that takes all arguments of the channel definition deprecated.

The one that takes all arguments could be changed some time to package private.

WDYT?

With respect to the introduction of all the other builders we would like that the builder instead of the direct constructors are used.