### PR TITLE
[BoseSoundTouch] Make presets a State Options to allow simple selection

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/BoseSoundTouchHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/BoseSoundTouchHandlerFactory.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.Reference;
 public class BoseSoundTouchHandlerFactory extends BaseThingHandlerFactory {
 
     private StorageService storageService;
+    private BoseStateDescriptionOptionProvider stateOptionProvider;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -45,7 +46,8 @@ public class BoseSoundTouchHandlerFactory extends BaseThingHandlerFactory {
     protected ThingHandler createHandler(Thing thing) {
         Storage<ContentItem> storage = storageService.getStorage(thing.getUID().toString(),
                 ContentItem.class.getClassLoader());
-        BoseSoundTouchHandler handler = new BoseSoundTouchHandler(thing, new PresetContainer(storage));
+        BoseSoundTouchHandler handler = new BoseSoundTouchHandler(thing, new PresetContainer(storage),
+                stateOptionProvider);
         return handler;
     }
 
@@ -58,4 +60,12 @@ public class BoseSoundTouchHandlerFactory extends BaseThingHandlerFactory {
         this.storageService = null;
     }
 
+    @Reference
+    protected void setPresetChannelTypeProvider(BoseStateDescriptionOptionProvider stateOptionProvider) {
+        this.stateOptionProvider = stateOptionProvider;
+    }
+
+    protected void unsetPresetChannelTypeProvider(BoseStateDescriptionOptionProvider stateOptionProvider) {
+        this.stateOptionProvider = null;
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/BoseStateDescriptionOptionProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/BoseStateDescriptionOptionProvider.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.binding.bosesoundtouch.internal;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.thing.Channel;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
+import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.StateOption;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * Dynamic provider of state options while leaving other state description fields as original.
+ *
+ * @author Ivaylo Ivanov - Initial contribution
+ */
+@Component(service = { DynamicStateDescriptionProvider.class, BoseStateDescriptionOptionProvider.class })
+@NonNullByDefault
+public class BoseStateDescriptionOptionProvider implements DynamicStateDescriptionProvider {
+    private final Map<ChannelUID, @Nullable List<StateOption>> channelOptionsMap = new ConcurrentHashMap<>();
+
+    public void setStateOptions(ChannelUID channelUID, List<StateOption> options) {
+        channelOptionsMap.put(channelUID, options);
+    }
+
+    @Override
+    public @Nullable StateDescription getStateDescription(Channel channel, @Nullable StateDescription original,
+            @Nullable Locale locale) {
+        List<StateOption> options = channelOptionsMap.get(channel.getUID());
+        if (options == null) {
+            return original;
+        }
+
+        if (original != null) {
+            return new StateDescription(original.getMinimum(), original.getMaximum(), original.getStep(),
+                    original.getPattern(), original.isReadOnly(), options);
+        }
+
+        return new StateDescription(null, null, null, null, false, options);
+    }
+
+    @Deactivate
+    public void deactivate() {
+        channelOptionsMap.clear();
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
@@ -57,6 +57,28 @@ public class CommandExecutor implements AvailableSources {
         this.handler = handler;
         init();
     }
+    
+    /**
+     * Synchronizes the underlying storage container with the current value for the presets stored on the player
+     * by updating the available ones and deleting the cleared ones
+     * 
+     * @param playerPresets a Map<Integer, ContentItems> containing the items currently stored on the player
+     */
+    public void updatePresetContainerFromPlayer(Map<Integer, ContentItem> playerPresets) {
+        playerPresets.forEach((k,v) -> {
+            try {
+                if (v != null) {
+                    handler.getPresetContainer().put(k, v);                    
+                } else {
+                    handler.getPresetContainer().remove(k);
+                }
+            } catch (ContentItemNotPresetableException e) {
+                logger.debug("{}: ContentItem is not presetable", handler.getDeviceName());
+            }
+        });
+        
+        handler.refreshPresetChannel();
+    }
 
     /**
      * Adds a ContentItem to the PresetContainer
@@ -72,6 +94,7 @@ public class CommandExecutor implements AvailableSources {
         } catch (ContentItemNotPresetableException e) {
             logger.debug("{}: ContentItem is not presetable", handler.getDeviceName());
         }
+        handler.refreshPresetChannel();
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/PresetContainer.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/PresetContainer.java
@@ -77,6 +77,15 @@ public class PresetContainer {
             throw new ContentItemNotPresetableException();
         }
     }
+    
+    /**
+     * Remove the Preset stored under the specified Id
+     * @param presetID
+     */
+    public void remove(int presetID) {
+        mapOfPresets.remove(presetID);
+        writeToStorage();
+    }
 
     /**
      * Returns the Preset with presetID

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/XMLResponseHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/XMLResponseHandler.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.binding.bosesoundtouch.internal;
 
 import static org.eclipse.smarthome.binding.bosesoundtouch.BoseSoundTouchBindingConstants.*;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 
@@ -60,6 +61,8 @@ public class XMLResponseHandler extends DefaultHandler {
     private OnOffType skipPreviousEnabled;
 
     private State nowPlayingSource;
+    
+    private Map<Integer, ContentItem> playerPresets;
 
     /**
      * Creates a new instance of this class
@@ -173,6 +176,13 @@ public class XMLResponseHandler extends DefaultHandler {
                     }
                 } else if ("zone".equals(localName)) {
                     state = XMLHandlerState.Zone;
+                } else if ("presets".equals(localName)) {
+                    // reset the current playerPrests
+                    playerPresets = new HashMap<>();
+                    for (int i=1; i<=6; i++) {
+                        playerPresets.put(i, null);
+                    }
+                    state = XMLHandlerState.Presets;
                 } else {
                     state = stateMap.get(localName);
                     if (state == null) {
@@ -369,7 +379,7 @@ public class XMLResponseHandler extends DefaultHandler {
                 break;
             case Preset:
                 if (state == XMLHandlerState.Presets) {
-                    commandExecutor.addContentItemToPresetContainer(contentItem.getPresetID(), contentItem);
+                    playerPresets.put(contentItem.getPresetID(), contentItem);
                     contentItem = null;
                 }
                 break;
@@ -404,6 +414,10 @@ public class XMLResponseHandler extends DefaultHandler {
                 break;
             case ZoneUpdated:
                 commandExecutor.getInformations(APIRequest.GET_ZONE);
+                break;
+            case Presets:
+                commandExecutor.updatePresetContainerFromPlayer(playerPresets);
+                playerPresets = null;
                 break;
             default:
                 // no actions...

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/XMLResponseProcessor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/XMLResponseProcessor.java
@@ -94,6 +94,7 @@ public class XMLResponseProcessor {
         updatesMap.put("volumeUpdated", XMLHandlerState.MsgBody);
         updatesMap.put("zoneUpdated", XMLHandlerState.ZoneUpdated); // just notifies but dosn't provide details
         updatesMap.put("bassUpdated", XMLHandlerState.BassUpdated);
+        updatesMap.put("presetsUpdated", XMLHandlerState.MsgBody);
 
         Map<String, XMLHandlerState> volume = new HashMap<>();
         stateSwitchingMap.put(XMLHandlerState.Volume, volume);


### PR DESCRIPTION
1. Make stored presets a Channel State Options
2. Allow deletion of presets from the internal storage
3. Reduce the websocket client stop timeout to 1 seconds (it's 30 seconds by default)

Signed-off-by: Ivaylo Ivanov <ivivanov.bg@gmail.com>