### PR TITLE
Improvements to the OAuth2 implementation

### DIFF
--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client.test/README.md
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client.test/README.md
@@ -7,38 +7,63 @@ Simply deploy it to the runtime; then smarthome oauth commands will be registere
 # Example 1: (Using authorization code)
 
 ## Try these on the OSGI console:
+
+```
 smarthome oauth Code cleanupEverything
 smarthome oauth Code create
 smarthome oauth Code getClient <fill in handle from create step>
 smarthome oauth Code getAuthorizationUrl
-### now open browser with the URL from above step, authenticate yourself
-### to a real oauth provider
-### if everything works properly, it should redirect you to your redirectURL
-### Read the code http parameter from the redirectURL 
+```
+
+```
+now open browser with the URL from above step, authenticate yourself
+to a real oauth provider
+if everything works properly, it should redirect you to your redirectURL
+Read the code http parameter from the redirectURL
+```
+
+```
 smarthome oauth Code getAccessTokenByCode <code from redirectURL parameter>
 smarthome oauth Code getCachedAccessToken
 smarthome oauth Code refresh
 smarthome oauth Code close
-
+```
 
 # Example 2: (Using ResourceOwner credentials i.e. you have the user's username and password directly)
 
 ## Try these on the OSGI console:
+
+```
 smarthome oauth ResourceOwner create
 smarthome oauth ResourceOwner getClient <fill in handle from create step>
 smarthome oauth ResourceOwner getAccessTokenByResourceOwnerPassword
 smarthome oauth ResourceOwner getCachedAccessToken
 smarthome oauth ResourceOwner refresh
 smarthome oauth ResourceOwner close
+```
+
 ### load again, similar to reboot/restart
+
+```
 smarthome oauth ResourceOwner getClient <fill in handle from create step>
 smarthome oauth ResourceOwner getCachedAccessToken
 smarthome oauth ResourceOwner refresh
+```
+
 ### Done playing, delete this service permanently
+
+```
 smarthome oauth ResourceOwner delete <fill in handle from create step>
+```
 
 ### Verify this is deleted (will throw exception)
-smarthome oauth ResourceOwner getCachedAccessToken 
-### Cannot get the client after delete
-smarthome oauth ResourceOwner getClient <fill in handle from create step>
 
+```
+smarthome oauth ResourceOwner getCachedAccessToken 
+```
+
+### Cannot get the client after delete
+
+```
+smarthome oauth ResourceOwner getClient <fill in handle from create step>
+```

--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client.test/src/main/java/org/eclipse/smarthome/auth/oauth2client/test/internal/TestAgent.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client.test/src/main/java/org/eclipse/smarthome/auth/oauth2client/test/internal/TestAgent.java
@@ -27,7 +27,7 @@ import org.eclipse.smarthome.core.auth.client.oauth2.OAuthResponseException;
  */
 public interface TestAgent {
 
-    String testCreateClient();
+    OAuthClientService testCreateClient();
 
     AccessTokenResponse testGetAccessTokenByResourceOwnerPasswordCredentials()
             throws OAuthException, IOException, OAuthResponseException;

--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client.test/src/main/java/org/eclipse/smarthome/auth/oauth2client/test/internal/console/ConsoleOAuthCommandExtension.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client.test/src/main/java/org/eclipse/smarthome/auth/oauth2client/test/internal/console/ConsoleOAuthCommandExtension.java
@@ -40,7 +40,7 @@ import org.osgi.service.component.annotations.Reference;
 public class ConsoleOAuthCommandExtension extends AbstractConsoleCommandExtension implements ConsoleCommandExtension {
 
     public ConsoleOAuthCommandExtension() {
-        super("oauth", "Test of oauth client with console.  Available test agent: {Code, ResourceOwner}.\n"
+        super("oauth", "Test of oauth client with console. Available test agent: {Code, ResourceOwner}.\n"
                 + "The commands in oauth requires oauth provider data to be inputted in configuration admin.");
     }
 
@@ -67,8 +67,8 @@ public class ConsoleOAuthCommandExtension extends AbstractConsoleCommandExtensio
         try {
             switch (args[1]) {
                 case "create":
-                    String handle = agent.testCreateClient();
-                    console.println("handle: " + handle);
+                    OAuthClientService newService = agent.testCreateClient();
+                    console.println("handle: " + agent.handle + ", service: " + newService);
                     break;
                 case "getAccessTokenByResourceOwnerPassword":
                     response = agent.testGetAccessTokenByResourceOwnerPasswordCredentials();

--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthConnector.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthConnector.java
@@ -84,10 +84,10 @@ public class OAuthConnector {
      * @param scope Optional space separated list of scope (will be URL-encoded)
      *
      * @return A URL based on the authorizationEndpoint, with query parameters added.
-     * @see https://tools.ietf.org/html/rfc6749#section-4.1.1
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.1">rfc6749 section-4.1.1</a>
      */
-    public String getAuthorizationUrl(String authorizationEndpoint, String clientId,
-            @Nullable String redirectURI, @Nullable String state, @Nullable String scope) {
+    public String getAuthorizationUrl(String authorizationEndpoint, String clientId, @Nullable String redirectURI,
+            @Nullable String state, @Nullable String scope) {
         StringBuilder authorizationUrl = new StringBuilder(authorizationEndpoint);
 
         if (authorizationUrl.indexOf("?") == -1) {
@@ -119,7 +119,7 @@ public class OAuthConnector {
     /**
      * Resource Owner Password Credentials Grant
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-4.3
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.3">rfc6749 section-4.3</a>
      *
      * @param tokenUrl URL of the oauth provider that accepts access token requests.
      * @param username The resource owner username.
@@ -155,7 +155,7 @@ public class OAuthConnector {
     /**
      * Refresh Token
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-6
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-6">rfc6749 section-6</a>
      *
      * @param tokenUrl URL of the oauth provider that accepts access token requests.
      * @param refreshToken The refresh token, which can be used to obtain new access tokens using authorization grant
@@ -190,7 +190,7 @@ public class OAuthConnector {
     /**
      * Authorization Code Grant - part (E)
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-4.1.3
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.3">rfc6749 section-4.1.3</a>
      *
      * @param tokenUrl URL of the oauth provider that accepts access token requests.
      * @param authorizationCode to be used to trade with the oauth provider for access token
@@ -226,7 +226,7 @@ public class OAuthConnector {
     /**
      * Client Credentials Grant
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-4.4
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.4">rfc6749 section-4.4</a>
      *
      * @param tokenUrl URL of the oauth provider that accepts access token requests.
      * @param clientId The client identifier issued to the client during the registration process

--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthStoreHandler.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthStoreHandler.java
@@ -16,7 +16,6 @@ import java.security.GeneralSecurityException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.auth.oauth2client.internal.OAuthClientServiceImpl.PersistedParams;
 import org.eclipse.smarthome.core.auth.client.oauth2.AccessTokenResponse;
 
 /**
@@ -35,7 +34,7 @@ public interface OAuthStoreHandler {
      * If the storage is not available, it is still possible to get the AccessTokenResponse from memory cache.
      * However, the last-used statistics will be broken. It is a measured risk to take.
      *
-     * @param handle, the handle given by the call
+     * @param handle the handle given by the call
      *            {@code OAuthFactory#createOAuthClientService(String, String, String, String, String, Boolean)}
      * @return AccessTokenResponse if available, null if not.
      * @throws GeneralSecurityException when the token cannot be decrypted.

--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthStoreHandlerImpl.java
@@ -28,7 +28,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.auth.oauth2client.internal.OAuthClientServiceImpl.PersistedParams;
 import org.eclipse.smarthome.auth.oauth2client.internal.cipher.SymmetricKeyCipher;
 import org.eclipse.smarthome.core.auth.client.oauth2.AccessTokenResponse;
 import org.eclipse.smarthome.core.auth.client.oauth2.StorageCipher;

--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/PersistedParams.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/PersistedParams.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.auth.oauth2client.internal;
+
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Params that need to be persisted.
+ *
+ * @author Michael Bock - Initial contribution
+ * @author Gary Tse - Initial contribution
+ * @author Hilbrand Bouwkamp - Moved class to it's own file and added hashCode and equals methods
+ */
+class PersistedParams {
+    String handle;
+    String tokenUrl;
+    String authorizationUrl;
+    String clientId;
+    String clientSecret;
+    String scope;
+    Boolean supportsBasicAuth;
+    String state;
+    String redirectUri;
+    int tokenExpiresInSeconds = 60;
+
+    /**
+     * Default constructor needed for json serialization.
+     */
+    public PersistedParams() {
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param handle the handle to the oauth service
+     * @param tokenUrl the token url of the oauth provider. This is used for getting access token.
+     * @param authorizationUrl the authorization url of the oauth provider. This is used purely for generating
+     *            authorization code/ url.
+     * @param clientId the client id
+     * @param clientSecret the client secret (optional)
+     * @param scope the desired scope
+     * @param supportsBasicAuth whether the OAuth provider supports basic authorization or the client id and client
+     *            secret should be passed as form params. true - use http basic authentication, false - do not use http
+     *            basic authentication, null - unknown (default to do not use)
+     * @param tokenExpiresInSeconds Positive integer; a small time buffer in seconds. It is used to calculate the expiry
+     *            of the access tokens. This allows the access token to expire earlier than the
+     *            official stated expiry time; thus prevents the caller obtaining a valid token at the time of invoke,
+     *            only to find the token immediately expired.
+     */
+    public PersistedParams(String handle, String tokenUrl, String authorizationUrl, String clientId,
+            String clientSecret, String scope, Boolean supportsBasicAuth, int tokenExpiresInSeconds) {
+        this.handle = handle;
+        this.tokenUrl = tokenUrl;
+        this.authorizationUrl = authorizationUrl;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.scope = scope;
+        this.supportsBasicAuth = supportsBasicAuth;
+        this.tokenExpiresInSeconds = tokenExpiresInSeconds;
+
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((authorizationUrl == null) ? 0 : authorizationUrl.hashCode());
+        result = prime * result + ((clientId == null) ? 0 : clientId.hashCode());
+        result = prime * result + ((clientSecret == null) ? 0 : clientSecret.hashCode());
+        result = prime * result + ((handle == null) ? 0 : handle.hashCode());
+        result = prime * result + ((redirectUri == null) ? 0 : redirectUri.hashCode());
+        result = prime * result + ((scope == null) ? 0 : scope.hashCode());
+        result = prime * result + ((state == null) ? 0 : state.hashCode());
+        result = prime * result + ((supportsBasicAuth == null) ? 0 : supportsBasicAuth.hashCode());
+        result = prime * result + tokenExpiresInSeconds;
+        result = prime * result + ((tokenUrl == null) ? 0 : tokenUrl.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        PersistedParams other = (PersistedParams) obj;
+        if (authorizationUrl == null) {
+            if (other.authorizationUrl != null) {
+                return false;
+            }
+        } else if (!authorizationUrl.equals(other.authorizationUrl)) {
+            return false;
+        }
+        if (clientId == null) {
+            if (other.clientId != null) {
+                return false;
+            }
+        } else if (!clientId.equals(other.clientId)) {
+            return false;
+        }
+        if (clientSecret == null) {
+            if (other.clientSecret != null) {
+                return false;
+            }
+        } else if (!clientSecret.equals(other.clientSecret)) {
+            return false;
+        }
+        if (handle == null) {
+            if (other.handle != null) {
+                return false;
+            }
+        } else if (!handle.equals(other.handle)) {
+            return false;
+        }
+        if (redirectUri == null) {
+            if (other.redirectUri != null) {
+                return false;
+            }
+        } else if (!redirectUri.equals(other.redirectUri)) {
+            return false;
+        }
+        if (scope == null) {
+            if (other.scope != null) {
+                return false;
+            }
+        } else if (!scope.equals(other.scope)) {
+            return false;
+        }
+        if (state == null) {
+            if (other.state != null) {
+                return false;
+            }
+        } else if (!state.equals(other.state)) {
+            return false;
+        }
+        if (supportsBasicAuth == null) {
+            if (other.supportsBasicAuth != null) {
+                return false;
+            }
+        } else if (!supportsBasicAuth.equals(other.supportsBasicAuth)) {
+            return false;
+        }
+        if (tokenExpiresInSeconds != other.tokenExpiresInSeconds) {
+            return false;
+        }
+        if (tokenUrl == null) {
+            if (other.tokenUrl != null) {
+                return false;
+            }
+        } else if (!tokenUrl.equals(other.tokenUrl)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/AccessTokenRefreshListener.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/AccessTokenRefreshListener.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.auth.client.oauth2;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Handler to act up on changes of the access token.
+ *
+ * @author Hilbrand Bouwkamp - Initial contribution
+ */
+@NonNullByDefault
+public interface AccessTokenRefreshListener {
+
+    /**
+     * Notifies of a successful token response from {@link OAuthClientService#refreshToken()}.
+     *
+     * @param tokenResponse token response
+     */
+    void onAccessTokenResponse(AccessTokenResponse tokenResponse);
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/AccessTokenResponse.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/AccessTokenResponse.java
@@ -40,24 +40,25 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * The access token issued by the authorization server. It is used
      * by the client to gain access to a resource.
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-1.4
+     * <p>
+     * This token must be confidential in transit and storage.
      *
-     *      This token must be confidential in transit and storage.
-     * @see https://tools.ietf.org/html/rfc6749#section-10.3
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-1.4">rfc6749 section-1.4</a>
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-10.3">rfc6749 section-10.3</a>
      */
     private String accessToken;
 
     /**
      * Token type. e.g. Bearer, MAC
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-7.1
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-7.1">rfc6749 section-7.1</a>
      */
     private String tokenType;
 
     /**
      * Number of seconds that this OAuthToken is valid for since the time it was created.
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-4.2.2
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.2.2">rfc6749 section-4.2.2</a>
      */
     private long expiresIn;
 
@@ -67,10 +68,11 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * intended for use only with authorization servers and are never sent
      * to resource servers.
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-1.5
+     * <p>
+     * This token must be confidential in transit and storage.
      *
-     *      This token must be confidential in transit and storage.
-     * @see https://tools.ietf.org/html/rfc6749#section-10.4
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-1.5">rfc6749 section-1.5</a>
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-10.4">rfc6749 section-10.4</a>
      */
     private String refreshToken;
 
@@ -79,7 +81,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * by the authorization server to inform the client of the scope of the access token
      * issued.
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-3.3
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.3">rfc6749 section-3.3</a>
      */
     private String scope;
 
@@ -87,7 +89,7 @@ public final class AccessTokenResponse implements Serializable, Cloneable {
      * If the {@code state} parameter was present in the access token request.
      * The exact value should be returned as-is from the authorization provider.
      *
-     * https://tools.ietf.org/html/rfc6749#section-4.2.2
+     * <a href="https://tools.ietf.org/html/rfc6749#section-4.2.2">rfc6749 section-4.2.2</a>
      */
     private String state;
 

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/OAuthClientService.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/OAuthClientService.java
@@ -21,46 +21,62 @@ import org.eclipse.jdt.annotation.Nullable;
  * This is the service factory to produce a OAuth2 service client that authenticates using OAUTH2.
  * This is a service factory pattern; the OAuthe2 service client is not shared between bundles.
  *
+ * <p>
  * The basic uses of this OAuthClient are as follows:
  *
+ * <p>
  * Use case 1 - For the full authorization code grant flow, as described in RFC 6749 section 4.1
  * https://tools.ietf.org/html/rfc6749#section-4.1
  *
- * 1. Method {@code #getAuthorizationUrl(String, String, String)} to get an authorization code url
- * 2. Redirect the user-agent/ real user (outside scope of this client)
- * 3. Method {@code #extractAuthCodeFromAuthResponse(String)} to verify and extract the authorization
+ * <ul>
+ * <li>Method {@code #getAuthorizationUrl(String, String, String)} to get an authorization code url
+ * <li>Redirect the user-agent/ real user (outside scope of this client)
+ * <li>Method {@code #extractAuthCodeFromAuthResponse(String)} to verify and extract the authorization
  * code from the response
- * 4. Method {@code #getAccessTokenResponseByAuthorizationCode(String, String)} to get an access token (may contain
+ * <li>Method {@code #getAccessTokenResponseByAuthorizationCode(String, String)} to get an access token (may contain
  * optional refresh token) by authorization code extracted in above step.
- * 5. Use the {@code AccessTokenResponse} in code
- * 6. When access token is expired, see Use case 3 - refresh token.
+ * <li>Use the {@code AccessTokenResponse} in code
+ * <li>When access token is expired, see Use case 3 - refresh token.
+ * </ul>
  *
  * Use case 2 - For Resource Owner Password Credentials Grant, as described in RFC 6749 section 4.3
  * https://tools.ietf.org/html/rfc6749#section-4.3
  *
- * 1. Method {@code #getAccessTokenByResourceOwnerPasswordCredentials(String, String, String)} to get
+ * <ul>
+ * <li>Method {@code #getAccessTokenByResourceOwnerPasswordCredentials(String, String, String)} to get
  * {@code AccessTokenResponse} (may contain optional refresh token) by username and password
- * 2. Use the {@code AccessTokenResponse} in code
- * 3. When access token is expired, Use {@code #refreshToken()} to get another access token
+ * <li>Use the {@code AccessTokenResponse} in code
+ * <li>When access token is expired, Use {@code #refreshToken()} to get another access token
+ * </ul>
  *
  * Use case 3 - Refresh token
- * 1. Method {@code #refreshToken}
+ * <ul>
+ * <li>Method {@code #refreshToken}
+ * </ul>
  *
  * Use case 4 - Client Credentials. This is used to get the AccessToken by purely the client credential (ESH).
- * 1. Method {@code #getAccessTokenByClientCredentials(String)}
+ * <ul>
+ * <li>Method {@code #getAccessTokenByClientCredentials(String)}
+ * </ul>
  *
  * Use case 5 - Implicit Grant (RFC 6749 section 4.2). The implicit grant usually involves browser/javascript
  * redirection flows.
- * 1. Method {@code #getAccessTokenByImplicit(String, String, String)}
- *
+ * <ul>
+ * <li>Method {@code #getAccessTokenByImplicit(String, String, String)}
+ * </ul>
  * Use case 6 - Import OAuth access token for data migration. Existing implementations may choose to migrate
  * existing OAuth access tokens to be managed by this client.
- * 1. Method {@code #importAccessTokenResponse(AccessTokenResponse)}
+ * <ul>
+ * <li>Method {@code #importAccessTokenResponse(AccessTokenResponse)}
+ * </ul>
  *
  * Use case 7 - Get tokens - continue from Use case 1/2/4/5.
- * 1. Method {@code #getAccessTokenResponse()}
+ * <ul>
+ * <li>Method {@code #getAccessTokenResponse()}
+ * </ul>
  *
  * @author Gary Tse - Initial contribution
+ * @author Hilbrand Bouwkamp - Added AccessTokenRefreshListener, fixed javadoc warnings
  *
  */
 @NonNullByDefault
@@ -73,13 +89,15 @@ public interface OAuthClientService extends AutoCloseable {
      * The OAuthClientService generate an authorization URL, which contains the HTTP query parameters needed for
      * authorization code grant.
      *
-     * @see https://tools.ietf.org/html/rfc6749#section-4.1 Authorization Code Grant illustration
-     * @see https://tools.ietf.org/html/rfc6749#section-4.1.1 Concerning which parameters must be set and which ones are
-     *      optional.
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1">Authorization Code Grant illustration - rfc6749
+     *      section-4.1</a>
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.1">Concerning which parameters must be set and
+     *      which ones are optional - rfc6749 section-4.1.1</a>
      * @param redirectURI is the http request parameter which tells the oauth provider the URI to redirect the
      *            user-agent. This may/ may not be present as per agreement with the oauth provider.
      *            e.g. after the human user authenticate with the oauth provider by the browser, the oauth provider
      *            will redirect the browser to this redirectURL.
+     * @param scope Specific scopes, if null the service specified scopes will be used
      * @param state If the state is not null, it will be added as the HTTP query parameter state=xxxxxxxx .
      *            If the state is null, a random UUID will be generated and added state=<random UUID>,
      *            the state will be assigned to the requestParams in this case.
@@ -97,7 +115,8 @@ public interface OAuthClientService extends AutoCloseable {
      * Grant, part (C).
      *
      * @param redirectURLwithParams This is the full redirectURI from Part (A),
-     *            {@link #getAuthorizationUrl(String, String)}, but added with authorizationCode and state parameters
+     *            {@link #getAuthorizationUrl(String, String, String)}, but added with authorizationCode and state
+     *            parameters
      *            returned by the oauth provider. It is encoded in application/x-www-form-urlencoded format
      *            as stated in RFC 6749 section 4.1.2.
      *            To quote from the RFC:
@@ -107,7 +126,8 @@ public interface OAuthClientService extends AutoCloseable {
      * @throws OAuthException If the state from redirectURLwithParams does not exactly match the expectedState, or
      *             exceptions arise while parsing redirectURLwithParams.
      * @see #getAuthorizationUrl(String, String, String) for part (A)
-     * @see https://tools.ietf.org/html/rfc6749#section-4.1 Authorization Code Grant illustration
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1">Authorization Code Grant illustration - rfc6749
+     *      section-4.1</a>
      */
     String extractAuthCodeFromAuthResponse(String redirectURLwithParams) throws OAuthException;
 
@@ -119,14 +139,18 @@ public interface OAuthClientService extends AutoCloseable {
      * RFC 4.1.3 Access Token Request
      *
      * @param authorizationCode authorization code given by part (C) of the Authorization Code Grant
-     *            {{@link #extractAuthCodeFromAuthResponse(String, String)}
+     *            {{@link #extractAuthCodeFromAuthResponse(String)}
+     * @param redirectURI is the http request parameter which tells the oauth provider the URI to redirect the
+     *            user-agent. This may/ may not be present as per agreement with the oauth provider.
+     *            e.g. after the human user authenticate with the oauth provider by the browser, the oauth provider
+     *            will redirect the browser to this redirectURL.
      * @return AccessTokenResponse
      * @throws IOException IO/ network exceptions
      * @throws OAuthException Other exceptions
      * @throws OAuthErrorException Error codes given by authorization provider, as in RFC 6749 section 5.2 Error
      *             Response
-     * @see https://tools.ietf.org/html/rfc6749#section-4.1.3 Access Token Request
-     * @see https://tools.ietf.org/html/rfc6749#section-5.2 Error Response
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.3">Access Token Request - rfc6749 section-4.1.3</a>
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-5.2">Error Response - rfc6749 section-5.2</a>
      */
     AccessTokenResponse getAccessTokenResponseByAuthorizationCode(String authorizationCode, String redirectURI)
             throws OAuthException, IOException, OAuthResponseException;
@@ -143,7 +167,7 @@ public interface OAuthClientService extends AutoCloseable {
      * @throws OAuthException Other exceptions
      * @throws OAuthErrorException Error codes given by authorization provider, as in RFC 6749 section 5.2 Error
      *             Response
-     * @see https://tools.ietf.org/html/rfc6749#section-4.3.2
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.3.2">rfc6749 section-4.3.2</>
      */
     AccessTokenResponse getAccessTokenByResourceOwnerPasswordCredentials(String username, String password,
             @Nullable String scope) throws OAuthException, IOException, OAuthResponseException;
@@ -159,7 +183,7 @@ public interface OAuthClientService extends AutoCloseable {
      * @throws IOException Web/ network issues etc.
      * @throws OAuthErrorException For OAUTH error responses.
      * @throws OAuthException For other exceptions.
-     * @see https://tools.ietf.org/html/rfc6749#section-5.2
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-5.2">rfc6749 section-5.2</a>
      */
     AccessTokenResponse refreshToken() throws OAuthException, IOException, OAuthResponseException;
 
@@ -193,7 +217,7 @@ public interface OAuthClientService extends AutoCloseable {
      * @throws IOException Web/ network issues etc.
      * @throws OAuthErrorException For OAUTH error responses.
      * @throws OAuthException For other exceptions.
-     * @see https://tools.ietf.org/html/rfc6749#section-4.2 Implicit Grant
+     * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.2>Implicit Grant - rfc6749 section-4.2</a>
      */
     AccessTokenResponse getAccessTokenByImplicit(@Nullable String redirectURI, @Nullable String scope,
             @Nullable String state) throws OAuthException, IOException, OAuthResponseException;
@@ -202,9 +226,7 @@ public interface OAuthClientService extends AutoCloseable {
      * Use case 6 - Import This method is used for importing/ migrating existing Access Token Response to be stored by
      * this service.
      *
-     * @param oauthProviderParams
-     * @param requestParams Request parameters
-     * @param oAuthToken
+     * @param accessTokenResponse
      * @throws OAuthException if client is closed
      */
     void importAccessTokenResponse(AccessTokenResponse accessTokenResponse) throws OAuthException;
@@ -251,5 +273,19 @@ public interface OAuthClientService extends AutoCloseable {
      * @return true if client is closed. i.e. {@link #close()} has been called.
      */
     boolean isClosed();
+
+    /**
+     * Adds a {@link AccessTokenRefreshListener}.
+     *
+     * @param listener the listener to add
+     */
+    void addAccessTokenRefreshListener(AccessTokenRefreshListener listener);
+
+    /**
+     * Removes the {@link AccessTokenRefreshListener}.
+     *
+     * @param listener the listener to remove
+     */
+    boolean removeAccessTokenRefreshListener(AccessTokenRefreshListener listener);
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/OAuthFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/OAuthFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.Nullable;
  *
  * @author Michael Bock - Initial Contribution
  * @author Gary Tse - ESH Adaptation
+ * @author Hilbrand Bouwkamp - Change create to have a handle as parameter.
  */
 @NonNullByDefault
 public interface OAuthFactory {
@@ -28,6 +29,7 @@ public interface OAuthFactory {
      * Creates a new oauth service. Use this method only once to obtain a handle and store
      * this handle for further in a persistent storage container.
      *
+     * @param handle the handle to the oauth service
      * @param tokenUrl the token url of the oauth provider. This is used for getting access token.
      * @param authorizationUrl the authorization url of the oauth provider. This is used purely for generating
      *            authorization code/ url.
@@ -37,19 +39,20 @@ public interface OAuthFactory {
      * @param supportsBasicAuth whether the OAuth provider supports basic authorization or the client id and client
      *            secret should be passed as form params. true - use http basic authentication, false - do not use http
      *            basic authentication, null - unknown (default to do not use)
-     * @return a handle to the oauth service
+     * @return the oauth service
      */
-    String createOAuthClientService(String tokenUrl, @Nullable String authorizationUrl, String clientId,
-            @Nullable String clientSecret, @Nullable String scope, @Nullable Boolean supportsBasicAuth);
+    OAuthClientService createOAuthClientService(String handle, String tokenUrl, @Nullable String authorizationUrl,
+            String clientId, @Nullable String clientSecret, @Nullable String scope,
+            @Nullable Boolean supportsBasicAuth);
 
     /**
      * Gets the oauth service for a given handle
      *
      * @param handle the handle to the oauth service
-     * @return the oauth service
-     * @throws OAuthException if the handle does not exist
+     * @return the oauth service or null if it doesn't exist
      */
-    OAuthClientService getOAuthClientService(String handle) throws OAuthException;
+    @Nullable
+    OAuthClientService getOAuthClientService(String handle);
 
     /**
      * Unget an oauth service, this unget/unregister the service, and frees the resources.

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/OAuthResponseException.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/auth/client/oauth2/OAuthResponseException.java
@@ -16,16 +16,18 @@ package org.eclipse.smarthome.core.auth.client.oauth2;
  * This is an exception class for OAUTH specific errors. i.e. The error responses described in the
  * RFC6749. Do NOT confuse this with Java errors.
  *
+ * <p>
  * To keep it simple, this exception class serves for both Authorization Request and Authorization Grant
  * error response
  *
+ * <p>
  * The field names are kept exactly the same as the specification.
  * This allows the error responses to be directly deserialized from JSON.
  *
  * @author Gary Tse - initial contribution
  *
- * @see https://tools.ietf.org/html/rfc6749#section-4.1.2.1
- * @see https://tools.ietf.org/html/rfc6749#section-5.2
+ * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.1.2.1">rfc6749 section-4.1.2.1</a>
+ * @see <a href="https://tools.ietf.org/html/rfc6749#section-5.2">rfc6749 section-5.2</a>
  */
 public class OAuthResponseException extends Exception {
 


### PR DESCRIPTION
While working on the Spotify binding (https://github.com/openhab/openhab2-addons/pull/2295) for openHAB it requires OAuth2 authorization. The initial binding has implemented this by itself. @kaikreuzer pointed me to the new OAuth2 implementation in Smart Home. However it needs some changed to be useable in the Spotify binding (or probably in general). With this pull request I've added improvements to the OAuth2 implementation to make it work for the Spotify binding (and probably other bindings as well). 

Feel free to comment/discuss my implementation changes if you think it should be different.

---
Changes to OAuthFactoryImpl#createOAuthClientService:
- Instead of returning a handle the method required a handle (string). This because if a binding wants to use this method it should have a handle that is derived in the binding. If it were a random uuid the binding would need to store this string and that is not convenient. A typical handle could be the thing uid.
- The create checks if there the parameters are already stored and if so it will update the parameters in the storage. This makes it possible to update the parameters for example if the clientId would change this change makes it possible to update those values. With the previous implementation it was never possible to check if things like clientId were changed.
Other changes:
- Added a AccessTokenRefreshListener to let users of the service be able to get notifications of a change of the access token.
- OAuthClientServiceImpl#getAuthorizationUrl does not store scope in the persistedParams params because according to the spec this parameter can be a subset or null of the initial scope with which the service was authorized so it should not override the initial set here.
- Fixed javadoc warnings.