### PR TITLE
Update README.md

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lirc/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.lirc/README.md
@@ -40,7 +40,7 @@ a bridge is configured.
 ### Things
 
 ```xtend
-Bridge lirc:bridge:local [ host="192.168.1.120", port="9001" ] {
+Bridge lirc:bridge:local [ host="192.168.1.120", portNumber="9001" ] {
     Thing remote Onkyo_RC_799M [ remote="Onkyo_RC-799M" ]
     Thing remote Samsung [ remote="Samsung" ]
 }


### PR DESCRIPTION
Fixed wrong parameter name for port in things configuration. See https://community.openhab.org/t/setup-lirc-bridge/47321/9