### PR TITLE
changed config params to follow the general ESH config parameter naming scheme

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.http.auth/src/main/java/org/eclipse/smarthome/io/http/auth/internal/AuthenticationHandler.java
+++ b/bundles/io/org.eclipse.smarthome.io.http.auth/src/main/java/org/eclipse/smarthome/io/http/auth/internal/AuthenticationHandler.java
@@ -46,8 +46,8 @@ import org.slf4j.LoggerFactory;
 @Component(configurationPid = "org.eclipse.smarthome.auth")
 public class AuthenticationHandler implements Handler {
 
-    private static final String AUTHENTICATION_ENABLED = "authentication.enabled";
-    private static final String AUTHENTICATION_ENDPOINT = "authentication.loginUri";
+    private static final String AUTHENTICATION_ENABLED = "enabled";
+    private static final String AUTHENTICATION_ENDPOINT = "loginUri";
     private static final String DEFAULT_LOGIN_URI = "/login";
     static final String REDIRECT_PARAM_NAME = "redirect";
 


### PR DESCRIPTION
The prefix is rather odd, not used for other services and anyhow superfluous.

Signed-off-by: Kai Kreuzer <kai@openhab.org>