### PR TITLE
Configuration: Support enum fields

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.core.test/src/test/java/org/eclipse/smarthome/config/core/ConfigurationTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.core.test/src/test/java/org/eclipse/smarthome/config/core/ConfigurationTest.java
@@ -32,11 +32,18 @@ import org.junit.Test;
  */
 public class ConfigurationTest {
 
-    @SuppressWarnings("unused")
     public final static class ConfigClass {
-        private int intField;
-        private boolean booleanField;
-        private String stringField;
+        public enum MyEnum {
+            ON,
+            OFF,
+            UNKNOWN
+        };
+
+        public MyEnum enumField = MyEnum.UNKNOWN;
+        public int intField;
+        public boolean booleanField;
+        public String stringField = "somedefault";
+        @SuppressWarnings("unused")
         private static final String CONSTANT = "SOME_CONSTANT";
     }
 
@@ -46,6 +53,7 @@ public class ConfigurationTest {
         configuration.put("intField", 1);
         configuration.put("booleanField", false);
         configuration.put("stringField", "test");
+        configuration.put("enumField", "ON");
         configuration.put("notExisitingProperty", true);
 
         ConfigClass configClass = configuration.as(ConfigClass.class);
@@ -53,6 +61,17 @@ public class ConfigurationTest {
         assertThat(configClass.intField, is(equalTo(1)));
         assertThat(configClass.booleanField, is(false));
         assertThat(configClass.stringField, is("test"));
+        assertThat(configClass.enumField, is(ConfigClass.MyEnum.ON));
+    }
+
+    @Test
+    public void assertGetConfigAsEnumWrongValue() {
+        Configuration configuration = new Configuration();
+        configuration.put("enumField", "TEST");
+
+        ConfigClass configClass = configuration.as(ConfigClass.class);
+
+        assertThat(configClass.enumField, is(ConfigClass.MyEnum.UNKNOWN));
     }
 
     @Test

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/ConfigMapper.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/ConfigMapper.java
@@ -159,6 +159,12 @@ public class ConfigMapper {
                 result = Integer.valueOf(bdValue);
             } else if (type.equals(Boolean.class) || typeName.equals("boolean")) {
                 result = Boolean.valueOf(bdValue);
+            } else if (type.isEnum()) {
+                @SuppressWarnings({ "rawtypes", "unchecked" })
+                final Class<? extends Enum> enumType = (Class<? extends Enum>) type;
+                @SuppressWarnings({ "unchecked" })
+                final Enum<?> enumvalue = Enum.valueOf(enumType, value.toString());
+                result = enumvalue;
             }
         }
         return result;


### PR DESCRIPTION
Support enum fields for configuration holder objects. Example:

Use: `new Configuration(properties).as(PropertyAttributes.class)`
with: `properties` containing "state=ON".

PropertyAttributes.class:
```
public class PropertyAttributes
   public enum StateEnum {
        ON,
        OFF,
        UNKNOWN
   }
   StateEnum state = StateEnum.UNKNOWN;
}
```

Signed-off-by: David Graeff <david.graeff@web.de>