### PR TITLE
correctly register the implementation as a WebSocketFactory

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryImpl.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  * @author Michael Bock - Initial contribution
  * @author Kai Kreuzer - added web socket support
  */
-@Component(service = HttpClientFactory.class, immediate = true, configurationPid = "org.eclipse.smarthome.webclient")
+@Component(immediate = true, configurationPid = "org.eclipse.smarthome.webclient")
 @NonNullByDefault
 public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory {
 


### PR DESCRIPTION
... and not just as a an HttpClientFactory.

Signed-off-by: Kai Kreuzer <kai@openhab.org>