### PR TITLE
[homematic] Support sending datapoints via different rx modes

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClientTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClientTest.java
@@ -1,14 +1,20 @@
 package org.eclipse.smarthome.binding.homematic.internal.communicator.client;
 
+import static org.eclipse.smarthome.binding.homematic.HomematicBindingConstants.RX_BURST_MODE;
+import static org.eclipse.smarthome.binding.homematic.HomematicBindingConstants.RX_WAKEUP_MODE;
 import static org.eclipse.smarthome.binding.homematic.test.util.DimmerHelper.createDimmerDummyChannel;
 import static org.eclipse.smarthome.binding.homematic.test.util.DimmerHelper.createDimmerHmChannel;
 import static org.eclipse.smarthome.binding.homematic.test.util.RpcClientMockImpl.GET_PARAMSET_DESCRIPTION_NAME;
 import static org.eclipse.smarthome.binding.homematic.test.util.RpcClientMockImpl.GET_PARAMSET_NAME;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 
+import org.eclipse.smarthome.binding.homematic.internal.communicator.message.RpcRequest;
+import org.eclipse.smarthome.binding.homematic.internal.communicator.message.XmlRpcRequest;
 import org.eclipse.smarthome.binding.homematic.internal.model.HmChannel;
 import org.eclipse.smarthome.binding.homematic.internal.model.HmParamsetType;
 import org.eclipse.smarthome.binding.homematic.test.util.RpcClientMockImpl;
@@ -79,4 +85,39 @@ public class RpcClientTest extends JavaTest {
         assertThat(rpcClient.numberOfCalls.get(GET_PARAMSET_NAME), is(0));
     }
 
+    @Test
+    public void burstRxModeIsConfiguredAsParameterOnRequest() throws IOException {
+        RpcRequest<String> request = new XmlRpcRequest("setValue");
+
+        rpcClient.configureRxMode(request, RX_BURST_MODE);
+
+        assertThat(request.createMessage(), containsString(String.format("<value>%s</value>", RX_BURST_MODE)));
+    }
+
+    @Test
+    public void wakeupRxModeIsConfiguredAsParameterOnRequest() throws IOException {
+        RpcRequest<String> request = new XmlRpcRequest("setValue");
+
+        rpcClient.configureRxMode(request, RX_WAKEUP_MODE);
+
+        assertThat(request.createMessage(), containsString(String.format("<value>%s</value>", RX_WAKEUP_MODE)));
+    }
+
+    @Test
+    public void rxModeIsNotConfiguredAsParameterOnRequestForNull() throws IOException {
+        RpcRequest<String> request = new XmlRpcRequest("setValue");
+
+        rpcClient.configureRxMode(request, null);
+
+        assertThat(request.createMessage(), not(containsString("<value>")));
+    }
+
+    @Test
+    public void rxModeIsNotConfiguredAsParameterOnRequestForInvalidString() throws IOException {
+        RpcRequest<String> request = new XmlRpcRequest("setValue");
+
+        rpcClient.configureRxMode(request, "SUPER_RX_MODE");
+
+        assertThat(request.createMessage(), not(containsString("<value>")));
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/HomematicBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/HomematicBindingConstants.java
@@ -68,4 +68,7 @@ public class HomematicBindingConstants {
     public static final int INSTALL_MODE_NORMAL = 1;
 
     public static final int CONFIGURATION_CHANNEL_NUMBER = -1;
+
+    public static final String RX_BURST_MODE = "BURST";
+    public static final String RX_WAKEUP_MODE = "WAKEUP";
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/handler/HomematicThingHandler.java
@@ -303,17 +303,22 @@ public class HomematicThingHandler extends BaseThingHandler {
 
     private void sendDatapoint(HmDatapoint dp, HmDatapointConfig config, Object newValue)
             throws IOException, HomematicClientException, GatewayNotAvailableException {
-        getHomematicGateway().sendDatapoint(dp, config, newValue, getRxMode());
+        String rxMode = getRxModeForDatapointTransmission(dp.getName(), dp.getValue(), newValue);
+        getHomematicGateway().sendDatapoint(dp, config, newValue, rxMode);
     }
 
     /**
-     * Returns the rxMode used for transmitting values to the device. Can be overridden by sub-classes to customize the
-     * rxMode for a ThingType.
+     * Returns the rx mode that shall be used for transmitting a new value of a datapoint to the device. The
+     * HomematicThingHandler always uses the default rx mode; custom thing handlers can override this method to
+     * adjust the rx mode.
      * 
+     * @param datapointName The datapoint that will be updated on the device
+     * @param currentValue The current value of the datapoint
+     * @param newValue The value that will be sent to the device
      * @return The rxMode ({@link HomematicBindingConstants#RX_BURST_MODE "BURST"} for burst mode,
      *         {@link HomematicBindingConstants#RX_WAKEUP_MODE "WAKEUP"} for wakeup mode, or null for the default mode)
      */
-    protected String getRxMode() {
+    protected String getRxModeForDatapointTransmission(String datapointName, Object currentValue, Object newValue) {
         return null;
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/AbstractHomematicGateway.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/AbstractHomematicGateway.java
@@ -631,13 +631,13 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
     @Override
     public void sendDatapointIgnoreVirtual(HmDatapoint dp, HmDatapointConfig dpConfig, Object newValue)
             throws IOException, HomematicClientException {
-        sendDatapoint(dp, dpConfig, newValue, true);
+        sendDatapoint(dp, dpConfig, newValue, null, true);
     }
 
     @Override
-    public void sendDatapoint(HmDatapoint dp, HmDatapointConfig dpConfig, Object newValue)
+    public void sendDatapoint(HmDatapoint dp, HmDatapointConfig dpConfig, Object newValue, String rxMode)
             throws IOException, HomematicClientException {
-        sendDatapoint(dp, dpConfig, newValue, false);
+        sendDatapoint(dp, dpConfig, newValue, rxMode, false);
     }
 
     /**
@@ -645,7 +645,7 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
      * executions and auto disabling.
      */
     private void sendDatapoint(final HmDatapoint dp, final HmDatapointConfig dpConfig, final Object newValue,
-            final boolean ignoreVirtualDatapoints) throws IOException, HomematicClientException {
+            final String rxMode, final boolean ignoreVirtualDatapoints) throws IOException, HomematicClientException {
         final HmDatapointInfo dpInfo = new HmDatapointInfo(dp);
         if (dp.isPressDatapoint() || (config.getGatewayInfo().isHomegear() && dp.isVariable())) {
             echoEvents.add(dpInfo);
@@ -677,9 +677,10 @@ public abstract class AbstractHomematicGateway implements RpcEventListener, Home
                                 newValue, id);
                         setVariable(dp, newValue);
                     } else {
-                        logger.debug("Sending datapoint '{}' with value '{}' to gateway with id '{}'", dpInfo, newValue,
-                                id);
-                        getRpcClient(dp.getChannel().getDevice().getHmInterface()).setDatapointValue(dp, newValue);
+                        logger.debug("Sending datapoint '{}' with value '{}' to gateway with id '{}' using rxMode '{}'",
+                                dpInfo, newValue, id, rxMode == null ? "DEFAULT" : rxMode);
+                        getRpcClient(dp.getChannel().getDevice().getHmInterface()).setDatapointValue(dp, newValue,
+                                rxMode);
                     }
                     dp.setValue(newValue);
 

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/HomematicGateway.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/HomematicGateway.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.binding.homematic.internal.communicator;
 
 import java.io.IOException;
 
+import org.eclipse.smarthome.binding.homematic.HomematicBindingConstants;
 import org.eclipse.smarthome.binding.homematic.internal.misc.HomematicClientException;
 import org.eclipse.smarthome.binding.homematic.internal.model.HmChannel;
 import org.eclipse.smarthome.binding.homematic.internal.model.HmDatapoint;
@@ -82,8 +83,16 @@ public interface HomematicGateway {
 
     /**
      * Sends the datapoint to the Homematic gateway or executes virtual datapoints.
+     * 
+     * @param dp The datapoint to send/execute
+     * @param dpConfig The configuration of the datapoint
+     * @param newValue The new value for the datapoint
+     * @param rxMode The rxMode with which the value should be sent to the device
+     *            ({@link HomematicBindingConstants#RX_BURST_MODE "BURST"} for burst mode,
+     *            {@link HomematicBindingConstants#RX_WAKEUP_MODE "WAKEUP"} for wakeup mode, or null for the default
+     *            mode)
      */
-    public void sendDatapoint(HmDatapoint dp, HmDatapointConfig dpConfig, Object newValue)
+    public void sendDatapoint(HmDatapoint dp, HmDatapointConfig dpConfig, Object newValue, String rxMode)
             throws IOException, HomematicClientException;
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/virtual/DisplayOptionsVirtualDatapointHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/virtual/DisplayOptionsVirtualDatapointHandler.java
@@ -80,6 +80,6 @@ public class DisplayOptionsVirtualDatapointHandler extends AbstractVirtualDatapo
             throws IOException, HomematicClientException {
         HmDatapointInfo dpInfo = HmDatapointInfo.createValuesInfo(channel, dpName);
         HmDatapoint dp = gateway.getDatapoint(dpInfo);
-        gateway.sendDatapoint(dp, new HmDatapointConfig(), newValue);
+        gateway.sendDatapoint(dp, new HmDatapointConfig(), newValue, null);
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/virtual/DisplayTextVirtualDatapoint.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/virtual/DisplayTextVirtualDatapoint.java
@@ -374,7 +374,7 @@ public class DisplayTextVirtualDatapoint extends AbstractVirtualDatapointHandler
             message.add(STOP);
 
             gateway.sendDatapoint(channel.getDatapoint(HmParamsetType.VALUES, DATAPOINT_NAME_SUBMIT),
-                    new HmDatapointConfig(), StringUtils.join(message, ","));
+                    new HmDatapointConfig(), StringUtils.join(message, ","), null);
         }
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/virtual/OnTimeAutomaticVirtualDatapointHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/virtual/OnTimeAutomaticVirtualDatapointHandler.java
@@ -78,7 +78,7 @@ public class OnTimeAutomaticVirtualDatapointHandler extends AbstractVirtualDatap
             HmDatapoint dpOnTime = channel
                     .getDatapoint(HmDatapointInfo.createValuesInfo(channel, DATAPOINT_NAME_ON_TIME));
             if (dpOnTime != null) {
-                gateway.sendDatapoint(dpOnTime, new HmDatapointConfig(), getVirtualDatapointValue(channel));
+                gateway.sendDatapoint(dpOnTime, new HmDatapointConfig(), getVirtualDatapointValue(channel), null);
             } else {
                 logger.warn(
                         "Can't find ON_TIME datapoint in channel '{}' in device '{}', ignoring virtual datapoint '{}'",


### PR DESCRIPTION
Provides an endpoint in the HomematicThingHandler for specifying the rx mode when sending datapoints to the homematic gateway. This allows custom ThingHandlers in ESH-based solutions to change the used rxMode from the default one.

Th rx mode can be configured as "BURST" or "WAKEUP". In BURST mode, the datapoint is transmitted to the device immediately by waking it up through burst messages. This, however, requires more duty cycle than a normal message. In WAKEUP mode, the message is only sent once the device wakes up by itself and contacts the homematic gateway.

Signed-off-by: Florian Stolte <fstolte@itemis.de>