### PR TITLE
[Bose SoundTouch] Fix DynamicStateDescriptionProvider

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/BoseStateDescriptionOptionProvider.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/BoseStateDescriptionOptionProvider.java
@@ -46,7 +46,7 @@ public class BoseStateDescriptionOptionProvider implements DynamicStateDescripti
             @Nullable Locale locale) {
         List<StateOption> options = channelOptionsMap.get(channel.getUID());
         if (options == null) {
-            return original;
+            return null;
         }
 
         if (original != null) {


### PR DESCRIPTION
In case the channel is not know we should return NULL for dynamic state description instead the original

Signed-off-by: Ivaylo Ivanov <ivivanov.bg@gmail.com>