### PR TITLE
Fix mqtt thing-types 'broker' thing

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/ESH-INF/thing/thing-types.xml
@@ -27,12 +27,13 @@
 				<label>Secure connection</label>
 				<description>Uses TLS/SSL to establish a secure connection to the
 					broker. Can be "OFF","ON","AUTO". The AUTO setting prefers a secure
-					connection but will fall-back to an insecure one. Default is ON.</description>
+					connection but will fall-back to an insecure one.</description>
 				<options>
 					<option value="ON">Enabled</option>
 					<option value="OFF">Disabled</option>
 					<option value="AUTO">Automatic</option>
 				</options>
+				<default>AUTO</default>
 			</parameter>
 
 			<parameter name="qos" type="integer">


### PR DESCRIPTION
Required secure parameter didn't have a default set.

Signed-off-by: David Gräff <david.graeff@web.de>