### PR TITLE
[DMX] new feature: dynamic turn-on value

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/ArtnetBridgeHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/ArtnetBridgeHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/ChaserThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/ChaserThingHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 import static org.eclipse.smarthome.binding.dmx.test.TestBridgeHandler.THING_TYPE_TEST_BRIDGE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/ColorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/ColorThingHandlerTest.java
@@ -66,6 +66,7 @@ public class ColorThingHandlerTest extends AbstractDmxThingTest {
         thingProperties.put(CONFIG_DMX_ID, TEST_CHANNEL_CONFIG);
         thingProperties.put(CONFIG_DIMMER_FADE_TIME, TEST_FADE_TIME);
         thingProperties.put(CONFIG_DIMMER_TURNONVALUE, "255,128,0");
+        thingProperties.put(CONFIG_DIMMER_DYNAMICTURNONVALUE, true);
         dimmerThing = ThingBuilder.create(THING_TYPE_COLOR, "testdimmer").withLabel("Dimmer Thing")
                 .withBridge(bridge.getUID()).withConfiguration(new Configuration(thingProperties))
                 .withChannel(ChannelBuilder.create(CHANNEL_UID_BRIGHTNESS_R, "Brightness R")
@@ -128,6 +129,46 @@ public class ColorThingHandlerTest extends AbstractDmxThingTest {
             assertChannelStateUpdate(CHANNEL_UID_BRIGHTNESS_R, state -> assertEquals(PercentType.ZERO, state));
             assertChannelStateUpdate(CHANNEL_UID_BRIGHTNESS_G, state -> assertEquals(PercentType.ZERO, state));
             assertChannelStateUpdate(CHANNEL_UID_BRIGHTNESS_B, state -> assertEquals(PercentType.ZERO, state));
+        });
+    }
+
+    @Test
+    public void testDynamicTurnOnValue() {
+        long currentTime = System.currentTimeMillis();
+
+        // turn on with arbitrary value
+        dimmerThingHandler.handleCommand(CHANNEL_UID_COLOR, TEST_COLOR);
+        currentTime = dmxBridgeHandler.calcBuffer(currentTime, TEST_FADE_TIME);
+
+        waitForAssert(() -> {
+            assertChannelStateUpdate(CHANNEL_UID_COLOR,
+                    state -> assertThat(((HSBType) state).getHue().doubleValue(), is(closeTo(280, 2))));
+            assertChannelStateUpdate(CHANNEL_UID_COLOR,
+                    state -> assertThat(((HSBType) state).getSaturation().doubleValue(), is(closeTo(100.0, 1))));
+            assertChannelStateUpdate(CHANNEL_UID_COLOR,
+                    state -> assertThat(((HSBType) state).getBrightness().doubleValue(), is(closeTo(100.0, 1))));
+        });
+
+        // turn off and hopefully store last value
+        dimmerThingHandler.handleCommand(CHANNEL_UID_COLOR, OnOffType.OFF);
+        currentTime = dmxBridgeHandler.calcBuffer(currentTime, TEST_FADE_TIME);
+
+        waitForAssert(() -> {
+            assertChannelStateUpdate(CHANNEL_UID_COLOR,
+                    state -> assertThat(((HSBType) state).getBrightness().doubleValue(), is(closeTo(0.0, 1))));
+        });
+
+        // turn on and restore value
+        dimmerThingHandler.handleCommand(CHANNEL_UID_COLOR, OnOffType.ON);
+        currentTime = dmxBridgeHandler.calcBuffer(currentTime, TEST_FADE_TIME);
+
+        waitForAssert(() -> {
+            assertChannelStateUpdate(CHANNEL_UID_COLOR,
+                    state -> assertThat(((HSBType) state).getHue().doubleValue(), is(closeTo(280, 2))));
+            assertChannelStateUpdate(CHANNEL_UID_COLOR,
+                    state -> assertThat(((HSBType) state).getSaturation().doubleValue(), is(closeTo(100.0, 1))));
+            assertChannelStateUpdate(CHANNEL_UID_COLOR,
+                    state -> assertThat(((HSBType) state).getBrightness().doubleValue(), is(closeTo(100.0, 1))));
         });
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/ColorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/ColorThingHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.Assert.*;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/DmxBridgeHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/DmxBridgeHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/Lib485BridgeHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/Lib485BridgeHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/SacnBridgeHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/SacnBridgeHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/TunableWhiteThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/TunableWhiteThingHandlerTest.java
@@ -63,6 +63,7 @@ public class TunableWhiteThingHandlerTest extends AbstractDmxThingTest {
         thingProperties.put(CONFIG_DMX_ID, TEST_CHANNEL_CONFIG);
         thingProperties.put(CONFIG_DIMMER_FADE_TIME, TEST_FADE_TIME);
         thingProperties.put(CONFIG_DIMMER_TURNONVALUE, "127,127");
+        thingProperties.put(CONFIG_DIMMER_DYNAMICTURNONVALUE, true);
         dimmerThing = ThingBuilder.create(THING_TYPE_TUNABLEWHITE, "testdimmer").withLabel("Dimmer Thing")
                 .withBridge(bridge.getUID()).withConfiguration(new Configuration(thingProperties))
                 .withChannel(ChannelBuilder.create(CHANNEL_UID_BRIGHTNESS, "Brightness")
@@ -126,6 +127,39 @@ public class TunableWhiteThingHandlerTest extends AbstractDmxThingTest {
                     state -> assertEquals(OnOffType.OFF, state.as(OnOffType.class)));
             assertChannelStateUpdate(CHANNEL_UID_BRIGHTNESS_CW, state -> assertEquals(PercentType.ZERO, state));
             assertChannelStateUpdate(CHANNEL_UID_BRIGHTNESS_WW, state -> assertEquals(PercentType.ZERO, state));
+        });
+    }
+
+    @Test
+    public void testDynamicTurnOnValue() {
+        long currentTime = System.currentTimeMillis();
+        int testValue = 75;
+
+        // turn on with arbitrary value
+        dimmerThingHandler.handleCommand(CHANNEL_UID_BRIGHTNESS, new PercentType(testValue));
+        currentTime = dmxBridgeHandler.calcBuffer(currentTime, TEST_FADE_TIME);
+
+        waitForAssert(() -> {
+            assertChannelStateUpdate(CHANNEL_UID_BRIGHTNESS,
+                    state -> assertThat(((PercentType) state).doubleValue(), is(closeTo(testValue, 1.0))));
+        });
+
+        // turn off and hopefully store last value
+        dimmerThingHandler.handleCommand(CHANNEL_UID_BRIGHTNESS, OnOffType.OFF);
+        currentTime = dmxBridgeHandler.calcBuffer(currentTime, TEST_FADE_TIME);
+
+        waitForAssert(() -> {
+            assertChannelStateUpdate(CHANNEL_UID_BRIGHTNESS,
+                    state -> assertEquals(OnOffType.OFF, state.as(OnOffType.class)));
+        });
+
+        // turn on and restore value
+        dimmerThingHandler.handleCommand(CHANNEL_UID_BRIGHTNESS, OnOffType.ON);
+        currentTime = dmxBridgeHandler.calcBuffer(currentTime, TEST_FADE_TIME);
+
+        waitForAssert(() -> {
+            assertChannelStateUpdate(CHANNEL_UID_BRIGHTNESS,
+                    state -> assertThat(((PercentType) state).doubleValue(), is(closeTo(testValue, 1.0))));
         });
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/TunableWhiteThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/TunableWhiteThingHandlerTest.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.Assert.*;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/multiverse/DmxChannelTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/multiverse/DmxChannelTest.java
@@ -15,8 +15,8 @@ package org.eclipse.smarthome.binding.dmx.multiverse;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import org.eclipse.smarthome.binding.dmx.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.handler.DimmerThingHandler;
+import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.action.FadeAction;
 import org.eclipse.smarthome.binding.dmx.internal.action.ResumeAction;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.DmxChannel;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/test/TestBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx.test/src/test/java/org/eclipse/smarthome/binding/dmx/test/TestBridgeHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.test;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.BINDING_ID;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.BINDING_ID;
 
 import java.util.Collections;
 import java.util.Set;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/ESH-INF/thing/color-thing.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/ESH-INF/thing/color-thing.xml
@@ -3,16 +3,16 @@
 	<!-- Dimmer -->
 	<thing-type id="color">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="artnet-bridge"/>
-			<bridge-type-ref id="lib485-bridge"/>
-			<bridge-type-ref id="sacn-bridge"/>
+			<bridge-type-ref id="artnet-bridge" />
+			<bridge-type-ref id="lib485-bridge" />
+			<bridge-type-ref id="sacn-bridge" />
 		</supported-bridge-type-refs>
 		<label>DMX Color (RGB) Dimmer</label>
 		<description>A RGB capable dimmer</description>
 		<channels>
-			<channel id="brightness_r" typeId="brightness"/>
-			<channel id="brightness_g" typeId="brightness"/>
-			<channel id="brightness_b" typeId="brightness"/>
+			<channel id="brightness_r" typeId="brightness" />
+			<channel id="brightness_g" typeId="brightness" />
+			<channel id="brightness_b" typeId="brightness" />
 			<channel id="color" typeId="color" />
 		</channels>
 		<config-description>
@@ -41,6 +41,12 @@
 				<label>Turn-Off value(s)</label>
 				<description>Format is "value[, value, ...]". If less values than channels are defined, they are reused from the beginning. </description>
 				<advanced>true</advanced>
+			</parameter>
+			<parameter name="dynamicturnonvalue" type="boolean">
+				<label>Dynamic Turn-On Value</label>
+				<description>If enabled, values are stored on OFF command and restored on ON command</description>
+				<required>false</required>
+				<default>false</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/ESH-INF/thing/dimmer-thing.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/ESH-INF/thing/dimmer-thing.xml
@@ -1,29 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<thing:thing-descriptions bindingId="dmx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0" xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+<thing:thing-descriptions bindingId="dmx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 	<!-- Dimmer -->
 	<thing-type id="dimmer">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="artnet-bridge"/>
-			<bridge-type-ref id="lib485-bridge"/>
-			<bridge-type-ref id="sacn-bridge"/>
+			<bridge-type-ref id="artnet-bridge" />
+			<bridge-type-ref id="lib485-bridge" />
+			<bridge-type-ref id="sacn-bridge" />
 		</supported-bridge-type-refs>
 		<label>DMX Dimmer</label>
 		<description>A single/multi-channel dimmer</description>
 		<channels>
-			<channel id="brightness" typeId="brightness"/>
+			<channel id="brightness" typeId="brightness" />
 			<channel id="switch" typeId="switch" />
 		</channels>
 		<config-description>
-			<parameter name="dimmertype" type="text">
-				<label>Dimmer Type</label>
-				<description>Type of connected dimmer: normal, three-channel color light (RGB), two-channel tunable white (Tunable white)</description>
-				<options>
-					<option value="normal">Normal</option>
-					<option value="rgb">RGB</option>
-					<option value="tunablewhite">Tunable white</option>
-				</options>
-				<default>normal</default>
-			</parameter>
 			<parameter name="dmxid" type="text">
 				<label>DMX channel configuration</label>
 				<description>Format is channel[,channel, ...] or channel[/width]</description>
@@ -49,6 +41,12 @@
 				<label>Turn-Off value(s)</label>
 				<description>Format is "value[, value, ...]". If less values than channels are defined, they are reused from the beginning. </description>
 				<advanced>true</advanced>
+			</parameter>
+			<parameter name="dynamicturnonvalue" type="boolean">
+				<label>Dynamic Turn-On Value</label>
+				<description>If enabled, values are stored on OFF command and restored on ON command</description>
+				<required>false</required>
+				<default>false</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/ESH-INF/thing/tunablewhite-thing.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/ESH-INF/thing/tunablewhite-thing.xml
@@ -3,16 +3,16 @@
 	<!-- Dimmer -->
 	<thing-type id="tunablewhite">
 		<supported-bridge-type-refs>
-			<bridge-type-ref id="artnet-bridge"/>
-			<bridge-type-ref id="lib485-bridge"/>
-			<bridge-type-ref id="sacn-bridge"/>
+			<bridge-type-ref id="artnet-bridge" />
+			<bridge-type-ref id="lib485-bridge" />
+			<bridge-type-ref id="sacn-bridge" />
 		</supported-bridge-type-refs>
 		<label>DMX Tunable White Dimmer</label>
 		<description>A tunable white capable dimmer</description>
 		<channels>
-			<channel id="brightness" typeId="brightness"/>
-			<channel id="brightness_cw" typeId="brightness"/>
-			<channel id="brightness_ww" typeId="brightness"/>
+			<channel id="brightness" typeId="brightness" />
+			<channel id="brightness_cw" typeId="brightness" />
+			<channel id="brightness_ww" typeId="brightness" />
 			<channel id="color_temperature" typeId="color_temperature" />
 		</channels>
 		<config-description>
@@ -41,6 +41,12 @@
 				<label>Turn-Off value(s)</label>
 				<description>Format is "value[, value, ...]". If less values than channels are defined, they are reused from the beginning. </description>
 				<advanced>true</advanced>
+			</parameter>
+			<parameter name="dynamicturnonvalue" type="boolean">
+				<label>Dynamic Turn-On Value</label>
+				<description>If enabled, values are stored on OFF command and restored on ON command</description>
+				<required>false</required>
+				<default>false</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/README.md
@@ -120,7 +120,7 @@ The `fadetime` option allows a smooth transition from the current to the new val
 The time unit is ms and the interval is for a fade from 0-100%.
 If the current value is 25% and the new value is 75% the time needed for this change is half of `fadetime`.
 `fadetime`is used for absolute values or ON/OFF commands send to the `brightness` channel. 
-Related is the `dimtime` option: it defines the time in ms from 0-100% if incremental dimming (`INCREASE`/`DECREASE`) is used.
+Related is the `dimtime` option: it defines the time in ms from 0-100% if incremental dimming (`INCREASE`/`DECREASE`) is the thingused.
 For convenient use `dimtime` usually is set to a larger value than `fadetime`.
 Typical values are 500-1000 ms for `fadetime` and 2000-5000 ms for `dimtime`. 
 
@@ -129,6 +129,10 @@ They default to 255 (equals 100%) and 0 (equals 0%) respectively.
 This value can be set individually for all DMX channels, the format is `value1,value2, ...` with values from 0 to 255.
 If less values than DMX channels are defined, the values will be re-used from the beginning (i.e. if two values are defined, value1 will be used for channel1, channel3, ... and value2 will be used for channel2, channel4, ...).
 These values will be used if the thing receives an ON or OFF command. 
+
+The `dynamicturnonvalue` can be set to `true` or `false` (default).
+If enabled, thing overwrites the previous turn-on value with the current channel values.
+The next `ON` command uses these values instead of the default (or configuration supplied) values. 
 
 ### Color Thing (`color`)
 
@@ -151,6 +155,10 @@ This value can be set individually for all DMX channels, the format is `value1,v
 If less values than DMX channels are defined, the values will be re-used from the beginning (i.e. if two values are defined, value1 will be used for channel1, channel3, ... and value2 will be used for channel2, channel4, ...).
 These values will be used if the thing receives an ON or OFF command. 
 
+The `dynamicturnonvalue` can be set to `true` or `false` (default).
+If enabled, thing overwrites the previous turn-on value with the current channel values.
+The next `ON` command uses these values instead of the default (or configuration supplied) values. 
+
 ### Tunable White Thing (`tunablewhite`)
 
 There is one mandatory configuration value for a dimmer thing. 
@@ -172,6 +180,11 @@ They default to 255 (equals 100%) and 0 (equals 0%) respectively.
 This value can be set individually for all DMX channels, the format is `value1,value2, ...` with values from 0 to 255.
 If less values than DMX channels are defined, the values will be re-used from the beginning (i.e. if two values are defined, value1 will be used for channel1, channel3, ... and value2 will be used for channel2, channel4, ...). 
 These values will be used if the thing receives an ON or OFF command. 
+ 
+The `dynamicturnonvalue` can be set to `true` or `false` (default).
+If enabled, thing overwrites the previous turn-on value with the current channel values.
+The next `ON` command uses these values instead of the default (or configuration supplied) values. 
+ 
  
 ## Channels
 

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/README.md
@@ -120,7 +120,7 @@ The `fadetime` option allows a smooth transition from the current to the new val
 The time unit is ms and the interval is for a fade from 0-100%.
 If the current value is 25% and the new value is 75% the time needed for this change is half of `fadetime`.
 `fadetime`is used for absolute values or ON/OFF commands send to the `brightness` channel. 
-Related is the `dimtime` option: it defines the time in ms from 0-100% if incremental dimming (`INCREASE`/`DECREASE`) is the thingused.
+Related is the `dimtime` option: it defines the time in ms from 0-100% if incremental dimming (`INCREASE`/`DECREASE`) is used.
 For convenient use `dimtime` usually is set to a larger value than `fadetime`.
 Typical values are 500-1000 ms for `fadetime` and 2000-5000 ms for `dimtime`. 
 

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/ArtnetBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/ArtnetBridgeHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.handler;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.util.Collections;
 import java.util.Set;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/ChaserThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/ChaserThingHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.handler;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,10 +20,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 
-import org.eclipse.smarthome.binding.dmx.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.DmxBridgeHandler;
 import org.eclipse.smarthome.binding.dmx.internal.DmxThingHandler;
 import org.eclipse.smarthome.binding.dmx.internal.ValueSet;
+import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.action.FadeAction;
 import org.eclipse.smarthome.binding.dmx.internal.action.ResumeAction;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.BaseDmxChannel;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/ColorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/ColorThingHandler.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.DmxBridgeHandler;
 import org.eclipse.smarthome.binding.dmx.internal.DmxThingHandler;
 import org.eclipse.smarthome.binding.dmx.internal.Util;
 import org.eclipse.smarthome.binding.dmx.internal.ValueSet;
-import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.action.FadeAction;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.BaseDmxChannel;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.DmxChannel;
@@ -69,6 +69,7 @@ public class ColorThingHandler extends DmxThingHandler {
     private int fadeTime = 0;
     private int dimTime = 0;
 
+    private boolean dynamicTurnOnValue = false;
     private boolean isDimming = false;
 
     public ColorThingHandler(Thing dimmerThing) {
@@ -119,7 +120,18 @@ public class ColorThingHandler extends DmxThingHandler {
             case CHANNEL_COLOR: {
                 if (command instanceof OnOffType) {
                     logger.trace("adding {} fade to channels in thing {}", command, this.thing.getUID());
-                    targetValueSet = ((OnOffType) command).equals(OnOffType.ON) ? turnOnValue : turnOffValue;
+                    if (((OnOffType) command) == OnOffType.ON) {
+                        targetValueSet = turnOnValue;
+                    } else {
+                        if (dynamicTurnOnValue) {
+                            turnOnValue.clear();
+                            for (DmxChannel channel : channels) {
+                                turnOnValue.addValue(channel.getValue());
+                            }
+                            logger.trace("stored channel values fort next turn-on");
+                        }
+                        targetValueSet = turnOffValue;
+                    }
                 } else if (command instanceof HSBType) {
                     logger.trace("adding color fade to channels in thing {}", this.thing.getUID());
                     targetValueSet.addValue(((HSBType) command).getRed());
@@ -199,7 +211,7 @@ public class ColorThingHandler extends DmxThingHandler {
             }
         }
 
-        if (configuration.get(CONFIG_DMX_ID) == null) {
+        if (!configuration.containsKey(CONFIG_DMX_ID)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "DMX channel configuration missing");
             dmxHandlerStatus = ThingStatusDetail.CONFIGURATION_ERROR;
@@ -222,17 +234,17 @@ public class ColorThingHandler extends DmxThingHandler {
         currentValues.add(DmxChannel.MIN_VALUE);
         currentValues.add(DmxChannel.MIN_VALUE);
 
-        if (configuration.get(CONFIG_DIMMER_FADE_TIME) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_FADE_TIME)) {
             fadeTime = ((BigDecimal) configuration.get(CONFIG_DIMMER_FADE_TIME)).intValue();
             logger.debug("setting fadeTime to {} ms in {}", fadeTime, this.thing.getUID());
         }
 
-        if (configuration.get(CONFIG_DIMMER_DIM_TIME) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_DIM_TIME)) {
             dimTime = ((BigDecimal) configuration.get(CONFIG_DIMMER_DIM_TIME)).intValue();
             logger.trace("setting dimTime to {} ms in {}", fadeTime, this.thing.getUID());
         }
 
-        if (configuration.get(CONFIG_DIMMER_TURNONVALUE) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_TURNONVALUE)) {
             String turnOnValueString = String.valueOf(fadeTime) + ":"
                     + ((String) configuration.get(CONFIG_DIMMER_TURNONVALUE)) + ":-1";
             ValueSet turnOnValue = ValueSet.fromString(turnOnValueString);
@@ -247,7 +259,11 @@ public class ColorThingHandler extends DmxThingHandler {
         }
         this.turnOnValue.setFadeTime(fadeTime);
 
-        if (configuration.get(CONFIG_DIMMER_TURNOFFVALUE) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_DYNAMICTURNONVALUE)) {
+            dynamicTurnOnValue = (Boolean) configuration.get(CONFIG_DIMMER_DYNAMICTURNONVALUE);
+        }
+
+        if (configuration.containsKey(CONFIG_DIMMER_TURNOFFVALUE)) {
             String turnOffValueString = String.valueOf(fadeTime) + ":"
                     + ((String) configuration.get(CONFIG_DIMMER_TURNOFFVALUE)) + ":-1";
             ValueSet turnOffValue = ValueSet.fromString(turnOffValueString);

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/ColorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/ColorThingHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.handler;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import org.eclipse.smarthome.binding.dmx.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.DmxBridgeHandler;
 import org.eclipse.smarthome.binding.dmx.internal.DmxThingHandler;
 import org.eclipse.smarthome.binding.dmx.internal.Util;
 import org.eclipse.smarthome.binding.dmx.internal.ValueSet;
+import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.action.FadeAction;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.BaseDmxChannel;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.DmxChannel;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/DimmerThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/DimmerThingHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.handler;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import org.eclipse.smarthome.binding.dmx.DmxBindingConstants.ListenerType;
+import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.DmxBridgeHandler;
 import org.eclipse.smarthome.binding.dmx.internal.DmxThingHandler;
 import org.eclipse.smarthome.binding.dmx.internal.Util;
@@ -66,6 +66,7 @@ public class DimmerThingHandler extends DmxThingHandler {
 
     private int fadeTime = 0, dimTime = 0;
 
+    private boolean dynamicTurnOnValue = false;
     private boolean isDimming = false;
 
     public DimmerThingHandler(Thing dimmerThing) {
@@ -85,7 +86,18 @@ public class DimmerThingHandler extends DmxThingHandler {
                     targetValueSet.addValue(brightness);
                 } else if (command instanceof OnOffType) {
                     logger.trace("adding {} fade to channels in thing {}", command, this.thing.getUID());
-                    targetValueSet = ((OnOffType) command).equals(OnOffType.ON) ? turnOnValue : turnOffValue;
+                    if (((OnOffType) command) == OnOffType.ON) {
+                        targetValueSet = turnOnValue;
+                    } else {
+                        if (dynamicTurnOnValue) {
+                            turnOnValue.clear();
+                            for (DmxChannel channel : channels) {
+                                turnOnValue.addValue(channel.getValue());
+                            }
+                            logger.trace("stored channel values fort next turn-on");
+                        }
+                        targetValueSet = turnOffValue;
+                    }
                 } else if (command instanceof IncreaseDecreaseType) {
                     if (isDimming && ((IncreaseDecreaseType) command).equals(IncreaseDecreaseType.INCREASE)) {
                         logger.trace("stopping fade in thing {}", this.thing.getUID());
@@ -199,6 +211,10 @@ public class DimmerThingHandler extends DmxThingHandler {
             }
         }
         this.turnOffValue.setFadeTime(fadeTime);
+
+        if (configuration.containsKey(CONFIG_DIMMER_DYNAMICTURNONVALUE)) {
+            dynamicTurnOnValue = (Boolean) configuration.get(CONFIG_DIMMER_DYNAMICTURNONVALUE);
+        }
 
         // register feedback listener
         channels.get(0).addListener(new ChannelUID(this.thing.getUID(), CHANNEL_BRIGHTNESS), this, ListenerType.VALUE);

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/DimmerThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/DimmerThingHandler.java
@@ -153,7 +153,7 @@ public class DimmerThingHandler extends DmxThingHandler {
             }
         }
 
-        if (configuration.get(CONFIG_DMX_ID) == null) {
+        if (!configuration.containsKey(CONFIG_DMX_ID)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "DMX channel configuration missing");
             dmxHandlerStatus = ThingStatusDetail.CONFIGURATION_ERROR;
@@ -172,17 +172,17 @@ public class DimmerThingHandler extends DmxThingHandler {
             return;
         }
 
-        if (configuration.get(CONFIG_DIMMER_FADE_TIME) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_FADE_TIME)) {
             fadeTime = ((BigDecimal) configuration.get(CONFIG_DIMMER_FADE_TIME)).intValue();
             logger.debug("setting fadeTime to {} ms in {}", fadeTime, this.thing.getUID());
         }
 
-        if (configuration.get(CONFIG_DIMMER_DIM_TIME) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_DIM_TIME)) {
             dimTime = ((BigDecimal) configuration.get(CONFIG_DIMMER_DIM_TIME)).intValue();
             logger.trace("setting dimTime to {} ms in {}", fadeTime, this.thing.getUID());
         }
 
-        if (configuration.get(CONFIG_DIMMER_TURNONVALUE) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_TURNONVALUE)) {
             String turnOnValueString = String.valueOf(fadeTime) + ":"
                     + ((String) configuration.get(CONFIG_DIMMER_TURNONVALUE)) + ":-1";
             ValueSet turnOnValue = ValueSet.fromString(turnOnValueString);
@@ -197,7 +197,11 @@ public class DimmerThingHandler extends DmxThingHandler {
         }
         this.turnOnValue.setFadeTime(fadeTime);
 
-        if (configuration.get(CONFIG_DIMMER_TURNOFFVALUE) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_DYNAMICTURNONVALUE)) {
+            dynamicTurnOnValue = (Boolean) configuration.get(CONFIG_DIMMER_DYNAMICTURNONVALUE);
+        }
+
+        if (configuration.containsKey(CONFIG_DIMMER_TURNOFFVALUE)) {
             String turnOffValueString = String.valueOf(fadeTime) + ":"
                     + ((String) configuration.get(CONFIG_DIMMER_TURNOFFVALUE)) + ":-1";
             ValueSet turnOffValue = ValueSet.fromString(turnOffValueString);

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/Lib485BridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/Lib485BridgeHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.handler;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.io.IOException;
 import java.net.Socket;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/SacnBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/SacnBridgeHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.handler;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/TunableWhiteThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/TunableWhiteThingHandler.java
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
+import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.DmxBridgeHandler;
 import org.eclipse.smarthome.binding.dmx.internal.DmxThingHandler;
 import org.eclipse.smarthome.binding.dmx.internal.Util;
 import org.eclipse.smarthome.binding.dmx.internal.ValueSet;
-import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.action.FadeAction;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.BaseDmxChannel;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.DmxChannel;
@@ -68,6 +68,7 @@ public class TunableWhiteThingHandler extends DmxThingHandler {
 
     private int fadeTime = 0, dimTime = 0;
 
+    private boolean dynamicTurnOnValue = false;
     private boolean isDimming = false;
 
     public TunableWhiteThingHandler(Thing dimmerThing) {
@@ -90,7 +91,18 @@ public class TunableWhiteThingHandler extends DmxThingHandler {
                             Util.toDmxValue(Util.toDmxValue(brightness) * currentColorTemperature.intValue() / 100));
                 } else if (command instanceof OnOffType) {
                     logger.trace("adding {} fade to channels in thing {}", command, this.thing.getUID());
-                    targetValueSet = ((OnOffType) command).equals(OnOffType.ON) ? turnOnValue : turnOffValue;
+                    if (((OnOffType) command) == OnOffType.ON) {
+                        targetValueSet = turnOnValue;
+                    } else {
+                        if (dynamicTurnOnValue) {
+                            turnOnValue.clear();
+                            for (DmxChannel channel : channels) {
+                                turnOnValue.addValue(channel.getValue());
+                            }
+                            logger.trace("stored channel values fort next turn-on");
+                        }
+                        targetValueSet = turnOffValue;
+                    }
                 } else if (command instanceof IncreaseDecreaseType) {
                     if (isDimming && ((IncreaseDecreaseType) command).equals(IncreaseDecreaseType.INCREASE)) {
                         logger.trace("stopping fade in thing {}", this.thing.getUID());
@@ -191,7 +203,7 @@ public class TunableWhiteThingHandler extends DmxThingHandler {
             }
         }
 
-        if (configuration.get(CONFIG_DMX_ID) == null) {
+        if (!configuration.containsKey(CONFIG_DMX_ID)) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "DMX channel configuration missing");
             dmxHandlerStatus = ThingStatusDetail.CONFIGURATION_ERROR;
@@ -220,17 +232,17 @@ public class TunableWhiteThingHandler extends DmxThingHandler {
         currentValues.add(DmxChannel.MIN_VALUE);
         currentValues.add(DmxChannel.MIN_VALUE);
 
-        if (configuration.get(CONFIG_DIMMER_FADE_TIME) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_FADE_TIME)) {
             fadeTime = ((BigDecimal) configuration.get(CONFIG_DIMMER_FADE_TIME)).intValue();
             logger.debug("setting fadeTime to {} ms in {}", fadeTime, this.thing.getUID());
         }
 
-        if (configuration.get(CONFIG_DIMMER_DIM_TIME) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_DIM_TIME)) {
             dimTime = ((BigDecimal) configuration.get(CONFIG_DIMMER_DIM_TIME)).intValue();
             logger.trace("setting dimTime to {} ms in {}", fadeTime, this.thing.getUID());
         }
 
-        if (configuration.get(CONFIG_DIMMER_TURNONVALUE) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_TURNONVALUE)) {
             String turnOnValueString = String.valueOf(fadeTime) + ":"
                     + ((String) configuration.get(CONFIG_DIMMER_TURNONVALUE)) + ":-1";
             ValueSet turnOnValue = ValueSet.fromString(turnOnValueString);
@@ -245,7 +257,11 @@ public class TunableWhiteThingHandler extends DmxThingHandler {
         }
         this.turnOnValue.setFadeTime(fadeTime);
 
-        if (configuration.get(CONFIG_DIMMER_TURNOFFVALUE) != null) {
+        if (configuration.containsKey(CONFIG_DIMMER_DYNAMICTURNONVALUE)) {
+            dynamicTurnOnValue = (Boolean) configuration.get(CONFIG_DIMMER_DYNAMICTURNONVALUE);
+        }
+
+        if (configuration.containsKey(CONFIG_DIMMER_TURNOFFVALUE)) {
             String turnOffValueString = String.valueOf(fadeTime) + ":"
                     + ((String) configuration.get(CONFIG_DIMMER_TURNOFFVALUE)) + ":-1";
             ValueSet turnOffValue = ValueSet.fromString(turnOffValueString);

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/TunableWhiteThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/handler/TunableWhiteThingHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.handler;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -21,11 +21,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import org.eclipse.smarthome.binding.dmx.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.DmxBridgeHandler;
 import org.eclipse.smarthome.binding.dmx.internal.DmxThingHandler;
 import org.eclipse.smarthome.binding.dmx.internal.Util;
 import org.eclipse.smarthome.binding.dmx.internal.ValueSet;
+import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.action.FadeAction;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.BaseDmxChannel;
 import org.eclipse.smarthome.binding.dmx.internal.multiverse.DmxChannel;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/DmxBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/DmxBindingConstants.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.smarthome.binding.dmx;
+package org.eclipse.smarthome.binding.dmx.internal;
 
 import java.util.Collections;
 import java.util.Set;
@@ -59,6 +59,7 @@ public class DmxBindingConstants {
     public static final String CONFIG_DIMMER_DIM_TIME = "dimtime";
     public static final String CONFIG_DIMMER_TURNONVALUE = "turnonvalue";
     public static final String CONFIG_DIMMER_TURNOFFVALUE = "turnoffvalue";
+    public static final String CONFIG_DIMMER_DYNAMICTURNONVALUE = "dynamicturnonvalue";
     public static final String CONFIG_CHASER_STEPS = "steps";
     public static final String CONFIG_CHASER_RESUME_AFTER = "resumeafter";
 

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/DmxBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/DmxBridgeHandler.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.smarthome.binding.dmx.internal;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
 import java.math.BigDecimal;
 import java.util.concurrent.ScheduledFuture;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/DmxHandlerFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/DmxHandlerFactory.java
@@ -12,9 +12,8 @@
  */
 package org.eclipse.smarthome.binding.dmx.internal;
 
-import static org.eclipse.smarthome.binding.dmx.DmxBindingConstants.*;
+import static org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.*;
 
-import org.eclipse.smarthome.binding.dmx.DmxBindingConstants;
 import org.eclipse.smarthome.binding.dmx.handler.ArtnetBridgeHandler;
 import org.eclipse.smarthome.binding.dmx.handler.ChaserThingHandler;
 import org.eclipse.smarthome.binding.dmx.handler.ColorThingHandler;

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/ValueSet.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/ValueSet.java
@@ -140,6 +140,13 @@ public class ValueSet {
     }
 
     /**
+     * remove all elements from ValueSet
+     */
+    public void clear() {
+        values.clear();
+    }
+
+    /**
      * parse this value set from a string
      *
      * @param valueSetConfig a string holding a complete value set configuration fadeTime:value,value2,...:holdTime

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/ActionState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/ActionState.java
@@ -20,7 +20,7 @@ package org.eclipse.smarthome.binding.dmx.internal.action;
  * completed : action has completed, proceed to next action
  * completedfinal : action has completed, hold here
  *
- * @author Jan N. Klug
+ * @author Jan N. Klug - Initial contribution
  */
 public enum ActionState {
     WAITING,

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/BaseAction.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/BaseAction.java
@@ -17,8 +17,8 @@ import org.eclipse.smarthome.binding.dmx.internal.multiverse.DmxChannel;
 /**
  * The {@link BaseAction} is the base class for Actions like faders, chasers, etc..
  *
- * @author Davy Vanherbergen
- * @author Jan N. Klug
+ * @author Davy Vanherbergen - Initial contribution
+ * @author Jan N. Klug - Refactoring for ESH
  */
 public abstract class BaseAction {
 

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/FadeAction.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/FadeAction.java
@@ -21,8 +21,8 @@ import org.eclipse.smarthome.core.library.types.PercentType;
  * state in the given amount of time. After the fade, the new state is held for
  * a given or indefinite time.
  *
- * @author Davy Vanherbergen
- * @author Jan N. Klug
+ * @author Davy Vanherbergen - Initial contribution
+ * @author Jan N. Klug - Refactoring for ESH
  */
 public class FadeAction extends BaseAction {
     /** Time in ms to hold the target value. -1 is indefinite */

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/FadeDirection.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/FadeDirection.java
@@ -15,7 +15,7 @@ package org.eclipse.smarthome.binding.dmx.internal.action;
 /**
  * The {@link FadeDirection} gives the direction for fading
  *
- * @author Jan N. Klug
+ * @author Jan N. Klug - Initial contribution
  */
 enum FadeDirection {
     UP,

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/ResumeAction.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/action/ResumeAction.java
@@ -17,8 +17,8 @@ import org.eclipse.smarthome.binding.dmx.internal.multiverse.DmxChannel;
 /**
  * Resume action. Restores previously suspended value or actions on an item.
  *
- * @author Davy Vanherbergen
- * @author Jan N. Klug
+ * @author Davy Vanherbergen - Initial contribution
+ * @author Jan N. Klug - Refactoring for ESH
  */
 public class ResumeAction extends BaseAction {
 

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/multiverse/DmxChannel.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/internal/multiverse/DmxChannel.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.eclipse.smarthome.binding.dmx.DmxBindingConstants.ListenerType;
+import org.eclipse.smarthome.binding.dmx.internal.DmxBindingConstants.ListenerType;
 import org.eclipse.smarthome.binding.dmx.internal.DmxThingHandler;
 import org.eclipse.smarthome.binding.dmx.internal.Util;
 import org.eclipse.smarthome.binding.dmx.internal.action.ActionState;
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * handlers.
  *
  * @author Jan N. Klug - Initial contribution
- * @author Davy Vanherbergen
+ * @author Davy Vanherbergen - Initial contribution
  */
 public class DmxChannel extends BaseDmxChannel {
     public static final int MIN_VALUE = 0;


### PR DESCRIPTION
Some updates to the DMX binding.

- [x] move `DmxBindingConstants` to internal
- [x] add a new feature to remember the current value when receiving an OFF command and restore that when the next ON command is processed.
- [x] wait for test reports

