### PR TITLE
Set RemoveOnCancelPolicy to true for ScheduledExecutors obtained in T…

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/ThreadPoolManager.java
@@ -126,6 +126,7 @@ public class ThreadPoolManager {
                     pool = new WrappedScheduledExecutorService(cfg, new NamedThreadFactory(poolName));
                     ((ThreadPoolExecutor) pool).setKeepAliveTime(THREAD_TIMEOUT, TimeUnit.SECONDS);
                     ((ThreadPoolExecutor) pool).allowCoreThreadTimeOut(true);
+                    ((ScheduledThreadPoolExecutor)pool).setRemoveOnCancelPolicy(true);
                     pools.put(poolName, pool);
                     LOGGER.debug("Created scheduled thread pool '{}' of size {}", new Object[] { poolName, cfg });
                 }


### PR DESCRIPTION
…hreadPoolManager.

This is needed to prevent temporary thread (and in turn resource/memory) leaks when canceling ScheduledFutures with large periodic execution rates (or delays).

Signed-off-by: IVAN GEORGIEV ILIEV <ivan.iliev@musala.com>