### PR TITLE
[core] Added NPE safe-guard in AbstractRegistry

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
@@ -170,9 +170,11 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
                 // the given "element" might not be the live instance but
                 // loaded from storage. operate on the real element:
                 E existingElement = get(element.getUID());
-                onRemoveElement(existingElement);
-                elements.remove(existingElement);
-                notifyListenersAboutRemovedElement(existingElement);
+                if (existingElement != null) {
+                    onRemoveElement(existingElement);
+                    elements.remove(existingElement);
+                    notifyListenersAboutRemovedElement(existingElement);
+                }
             } catch (Exception ex) {
                 logger.warn("Could not remove element: {}", ex.getMessage(), ex);
             }
@@ -192,9 +194,13 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
                 // the given "oldElement" might not be the live instance but
                 // loaded from storage. operate on the real element:
                 E existingElement = get(oldElement.getUID());
-                beforeUpdateElement(existingElement);
+                if (existingElement != null) {
+                    beforeUpdateElement(existingElement);
+                }
                 onUpdateElement(oldElement, element);
-                elements.remove(existingElement);
+                if (existingElement != null) {
+                    elements.remove(existingElement);
+                }
                 elements.add(element);
                 notifyListenersAboutUpdatedElement(oldElement, element);
             } catch (Exception ex) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
@@ -174,6 +174,9 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
                     onRemoveElement(existingElement);
                     elements.remove(existingElement);
                     notifyListenersAboutRemovedElement(existingElement);
+                } else {
+                    logger.debug("{} with key '{}' could not be removed from provider {} because it does not exist!",
+                            element.getClass().getSimpleName(), element.getUID(), provider.getClass().getSimpleName());
                 }
             } catch (Exception ex) {
                 logger.warn("Could not remove element: {}", ex.getMessage(), ex);
@@ -196,6 +199,9 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
                 E existingElement = get(oldElement.getUID());
                 if (existingElement != null) {
                     beforeUpdateElement(existingElement);
+                } else {
+                    logger.debug("{} with key '{}' could not be updated for provider {} because it does not exist!",
+                            element.getClass().getSimpleName(), element.getUID(), provider.getClass().getSimpleName());
                 }
                 onUpdateElement(oldElement, element);
                 if (existingElement != null) {


### PR DESCRIPTION
- Added NPE safe-guard in AbstractRegistry

Addresses https://github.com/eclipse/smarthome/issues/6412#issuecomment-433371559

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>