### PR TITLE
Remove old MDNS discovery results

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.mdns/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.mdns/src/main/java/org/eclipse/smarthome/config/discovery/mdns/internal/MDNSDiscoveryService.java
@@ -120,6 +120,12 @@ public class MDNSDiscoveryService extends AbstractDiscoveryService implements Se
         startScan(false);
     }
 
+    @Override
+    protected synchronized void stopScan() {
+        removeOlderResults(getTimestampOfLastScan());
+        super.stopScan();
+    }
+
     private void startScan(boolean isBackground) {
         scheduler.schedule(new Runnable() {
             @Override


### PR DESCRIPTION
...after completion of a scan, so that it becomes symmetric to
what the UPnP discovery service does (and no stale results keep
hanging around).

Signed-off-by: Simon Kaufmann <simon.kfm@googlemail.com>