### PR TITLE
Made fields in AbstractRegistry private and added extra methods

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/template/RuleTemplateRegistry.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/template/RuleTemplateRegistry.java
@@ -18,6 +18,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.eclipse.smarthome.automation.template.RuleTemplate;
@@ -57,16 +58,14 @@ public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String,
 
     @Override
     public RuleTemplate get(String templateUID, Locale locale) {
-        for (Provider<RuleTemplate> provider : elementMap.keySet()) {
-            for (RuleTemplate resultTemplate : elementMap.get(provider)) {
-                if (resultTemplate.getUID().equals(templateUID)) {
-                    RuleTemplate t = locale == null ? resultTemplate
-                            : ((RuleTemplateProvider) provider).getTemplate(templateUID, locale);
-                    return createCopy(t);
-                }
-            }
+        Entry<Provider<RuleTemplate>, RuleTemplate> prt = getBoth(templateUID);
+        if (prt == null) {
+            return null;
+        } else {
+            RuleTemplate t = locale == null ? prt.getValue()
+                    : ((RuleTemplateProvider) prt.getKey()).getTemplate(templateUID, locale);
+            return createCopy(t);
         }
-        return null;
     }
 
     private RuleTemplate createCopy(RuleTemplate template) {
@@ -85,16 +84,14 @@ public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String,
     @Override
     public Collection<RuleTemplate> getByTag(String tag, Locale locale) {
         Collection<RuleTemplate> result = new ArrayList<>();
-        for (Provider<RuleTemplate> provider : elementMap.keySet()) {
-            for (RuleTemplate resultTemplate : elementMap.get(provider)) {
-                Collection<String> tags = resultTemplate.getTags();
-                RuleTemplate t = locale == null ? resultTemplate
-                        : ((RuleTemplateProvider) provider).getTemplate(resultTemplate.getUID(), locale);
-                if (tag == null || tags.contains(tag)) {
-                    result.add(t);
-                }
+        forEach((provider, resultTemplate) -> {
+            Collection<String> tags = resultTemplate.getTags();
+            RuleTemplate t = locale == null ? resultTemplate
+                    : ((RuleTemplateProvider) provider).getTemplate(resultTemplate.getUID(), locale);
+            if (tag == null || tags.contains(tag)) {
+                result.add(t);
             }
-        }
+        });
         return result;
     }
 
@@ -107,16 +104,14 @@ public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String,
     public Collection<RuleTemplate> getByTags(Locale locale, String... tags) {
         Set<String> tagSet = tags != null ? new HashSet<>(Arrays.asList(tags)) : null;
         Collection<RuleTemplate> result = new ArrayList<>();
-        for (Provider<RuleTemplate> provider : elementMap.keySet()) {
-            for (RuleTemplate resultTemplate : elementMap.get(provider)) {
-                Collection<String> tTags = resultTemplate.getTags();
-                RuleTemplate t = locale == null ? resultTemplate
-                        : ((RuleTemplateProvider) provider).getTemplate(resultTemplate.getUID(), locale);
-                if (tTags.containsAll(tagSet)) {
-                    result.add(t);
-                }
+        forEach((provider, resultTemplate) -> {
+            Collection<String> tTags = resultTemplate.getTags();
+            RuleTemplate t = locale == null ? resultTemplate
+                    : ((RuleTemplateProvider) provider).getTemplate(resultTemplate.getUID(), locale);
+            if (tTags.containsAll(tagSet)) {
+                result.add(t);
             }
-        }
+        });
         return result;
     }
 

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/template/RuleTemplateRegistry.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/template/RuleTemplateRegistry.java
@@ -58,7 +58,7 @@ public class RuleTemplateRegistry extends AbstractRegistry<RuleTemplate, String,
 
     @Override
     public RuleTemplate get(String templateUID, Locale locale) {
-        Entry<Provider<RuleTemplate>, RuleTemplate> prt = getBoth(templateUID);
+        Entry<Provider<RuleTemplate>, RuleTemplate> prt = getValueAndProvider(templateUID);
         if (prt == null) {
             return null;
         } else {

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/type/ModuleTypeRegistryImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/type/ModuleTypeRegistryImpl.java
@@ -62,7 +62,7 @@ public class ModuleTypeRegistryImpl extends AbstractRegistry<ModuleType, String,
     @Override
     @SuppressWarnings("unchecked")
     public <T extends ModuleType> T get(String moduleTypeUID, Locale locale) {
-        Entry<Provider<ModuleType>, ModuleType> mType = getBoth(moduleTypeUID);
+        Entry<Provider<ModuleType>, ModuleType> mType = getValueAndProvider(moduleTypeUID);
         if (mType == null) {
             return null;
         } else {

--- a/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/type/ModuleTypeRegistryImpl.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.core/src/main/java/org/eclipse/smarthome/automation/core/internal/type/ModuleTypeRegistryImpl.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.eclipse.smarthome.automation.type.ActionType;
@@ -61,16 +62,14 @@ public class ModuleTypeRegistryImpl extends AbstractRegistry<ModuleType, String,
     @Override
     @SuppressWarnings("unchecked")
     public <T extends ModuleType> T get(String moduleTypeUID, Locale locale) {
-        for (Provider<ModuleType> provider : elementMap.keySet()) {
-            for (ModuleType mType : elementMap.get(provider)) {
-                if (mType.getUID().equals(moduleTypeUID)) {
-                    ModuleType mt = locale == null ? mType
-                            : ((ModuleTypeProvider) provider).getModuleType(mType.getUID(), locale);
-                    return (T) createCopy(mt);
-                }
-            }
+        Entry<Provider<ModuleType>, ModuleType> mType = getBoth(moduleTypeUID);
+        if (mType == null) {
+            return null;
+        } else {
+            ModuleType mt = locale == null ? mType.getValue()
+                    : ((ModuleTypeProvider) mType.getKey()).getModuleType(mType.getValue().getUID(), locale);
+            return (T) createCopy(mt);
         }
-        return null;
     }
 
     @Override
@@ -82,18 +81,16 @@ public class ModuleTypeRegistryImpl extends AbstractRegistry<ModuleType, String,
     @SuppressWarnings("unchecked")
     public <T extends ModuleType> Collection<T> getByTag(String moduleTypeTag, Locale locale) {
         Collection<T> result = new ArrayList<T>(20);
-        for (Provider<ModuleType> provider : elementMap.keySet()) {
-            for (ModuleType mType : elementMap.get(provider)) {
-                ModuleType mt = locale == null ? mType
-                        : ((ModuleTypeProvider) provider).getModuleType(mType.getUID(), locale);
-                Collection<String> tags = mt.getTags();
-                if (moduleTypeTag == null) {
-                    result.add((T) createCopy(mt));
-                } else if (tags.contains(moduleTypeTag)) {
-                    result.add((T) createCopy(mt));
-                }
+        forEach((provider, mType) -> {
+            ModuleType mt = locale == null ? mType
+                    : ((ModuleTypeProvider) provider).getModuleType(mType.getUID(), locale);
+            Collection<String> tags = mt.getTags();
+            if (moduleTypeTag == null) {
+                result.add((T) createCopy(mt));
+            } else if (tags.contains(moduleTypeTag)) {
+                result.add((T) createCopy(mt));
             }
-        }
+        });
         return result;
     }
 
@@ -107,17 +104,15 @@ public class ModuleTypeRegistryImpl extends AbstractRegistry<ModuleType, String,
     public <T extends ModuleType> Collection<T> getByTags(Locale locale, String... tags) {
         Set<String> tagSet = tags != null ? new HashSet<String>(Arrays.asList(tags)) : null;
         Collection<T> result = new ArrayList<T>(20);
-        for (Provider<ModuleType> provider : elementMap.keySet()) {
-            for (ModuleType mType : elementMap.get(provider)) {
-                ModuleType mt = locale == null ? mType
-                        : ((ModuleTypeProvider) provider).getModuleType(mType.getUID(), locale);
-                if (tagSet == null) {
-                    result.add((T) createCopy(mt));
-                } else if (mt.getTags().containsAll(tagSet)) {
-                    result.add((T) createCopy(mt));
-                }
+        forEach((provider, mType) -> {
+            ModuleType mt = locale == null ? mType
+                    : ((ModuleTypeProvider) provider).getModuleType(mType.getUID(), locale);
+            if (tagSet == null) {
+                result.add((T) createCopy(mt));
+            } else if (mt.getTags().containsAll(tagSet)) {
+                result.add((T) createCopy(mt));
             }
-        }
+        });
         return result;
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -282,7 +282,7 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
     }
 
     protected void unsetManagedProvider(ManagedThingProvider managedProvider) {
-        super.removeManagedProvider(managedProvider);
+        super.unsetManagedProvider(managedProvider);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/ItemChannelLinkRegistry.java
@@ -105,7 +105,7 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
     }
 
     protected void unsetManagedProvider(final ManagedItemChannelLinkProvider provider) {
-        super.removeManagedProvider(provider);
+        super.unsetManagedProvider(provider);
     }
 
     @Override
@@ -120,11 +120,9 @@ public class ItemChannelLinkRegistry extends AbstractLinkRegistry<ItemChannelLin
     }
 
     public void removeLinksForThing(final ThingUID thingUID) {
-        if (this.managedProvider != null) {
-            ((ManagedItemChannelLinkProvider) this.managedProvider).removeLinksForThing(thingUID);
-        } else {
-            throw new IllegalStateException("ManagedProvider is not available");
-        }
+        ((ManagedItemChannelLinkProvider) getManagedProvider()
+                .orElseThrow(() -> new IllegalStateException("ManagedProvider is not available")))
+                        .removeLinksForThing(thingUID);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
@@ -231,7 +231,13 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
         return null;
     }
 
-    public Entry<Provider<E>, E> getBoth(K key) {
+    /**
+     * This method retrieves an Entry with the provider and the element for the key from the registry.
+     *
+     * @param key key of the element
+     * @return provider and element entry or null if no element was found
+     */
+    public Entry<Provider<E>, E> getValueAndProvider(K key) {
         for (final Map.Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
             for (final E element : entry.getValue()) {
                 if (key.equals(element.getUID())) {
@@ -314,10 +320,22 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
         }
     }
 
+    /**
+     * This method retrieves the provider of an element from the registry.
+     *
+     * @param key key of the element
+     * @return provider or null if no provider was found
+     */
     public Provider<E> getProvider(K key) {
         return getProvider(get(key));
     }
 
+    /**
+     * This method retrieves the provider of an element from the registry.
+     *
+     * @param element the element
+     * @return provider or null if no provider was found
+     */
     public Provider<E> getProvider(E element) {
         for (Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
             if (entry.getValue().contains(element)) {
@@ -327,16 +345,33 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
         return null;
     }
 
+    /**
+     * This method traverses over all elements of a provider in the registry and calls the consumer with each element.
+     *
+     * @param provider provider to traverse elements of
+     * @param consumer function to call with element
+     */
     public void forEach(Provider<E> provider, Consumer<E> consumer) {
         elementMap.get(provider).forEach(consumer);
     }
 
+    /**
+     * This method traverses over all elements in the registry and calls the consumer with each element.
+     *
+     * @param consumer function to call with element
+     */
     public void forEach(Consumer<E> consumer) {
         for (Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
             entry.getValue().forEach(consumer);
         }
     }
 
+    /**
+     * This method traverses over all elements in the registry and calls the consumer with the provider of the
+     * element as the first parameter and the element as the second argument.
+     *
+     * @param consumer function to call with the provider and element
+     */
     public void forEach(BiConsumer<Provider<E>, E> consumer) {
         for (Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
             entry.getValue().forEach(e -> consumer.accept(entry.getKey(), e));

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
@@ -237,7 +237,7 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
      * @param key key of the element
      * @return provider and element entry or null if no element was found
      */
-    public Entry<Provider<E>, E> getValueAndProvider(K key) {
+    protected Entry<Provider<E>, E> getValueAndProvider(K key) {
         for (final Map.Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
             for (final E element : entry.getValue()) {
                 if (key.equals(element.getUID())) {
@@ -246,7 +246,6 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
             }
         }
         return null;
-
     }
 
     @Override
@@ -326,7 +325,7 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
      * @param key key of the element
      * @return provider or null if no provider was found
      */
-    public Provider<E> getProvider(K key) {
+    protected Provider<E> getProvider(K key) {
         return getProvider(get(key));
     }
 
@@ -351,7 +350,7 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
      * @param provider provider to traverse elements of
      * @param consumer function to call with element
      */
-    public void forEach(Provider<E> provider, Consumer<E> consumer) {
+    protected void forEach(Provider<E> provider, Consumer<E> consumer) {
         elementMap.get(provider).forEach(consumer);
     }
 
@@ -360,7 +359,7 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
      *
      * @param consumer function to call with element
      */
-    public void forEach(Consumer<E> consumer) {
+    protected void forEach(Consumer<E> consumer) {
         for (Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
             entry.getValue().forEach(consumer);
         }
@@ -372,7 +371,7 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
      *
      * @param consumer function to call with the provider and element
      */
-    public void forEach(BiConsumer<Provider<E>, E> consumer) {
+    protected void forEach(BiConsumer<Provider<E>, E> consumer) {
         for (Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
             entry.getValue().forEach(e -> consumer.accept(entry.getKey(), e));
         }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/common/registry/AbstractRegistry.java
@@ -12,11 +12,15 @@
  */
 package org.eclipse.smarthome.core.common.registry;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,6 +41,7 @@ import org.slf4j.LoggerFactory;
  * @author Stefan Bußweiler - Migration to new event mechanism
  * @author Victor Toni - provide elements as {@link Stream}
  * @author Kai Kreuzer - switched to parameterized logging
+ * @author Hilbrand Bouwkamp - Made protected fields private and added new methods to give access.
  *
  * @param <E>
  *            type of the element
@@ -55,13 +60,12 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
     private final Class<P> providerClazz;
     private ServiceTracker<P, P> providerTracker;
 
-    protected Map<Provider<E>, Collection<E>> elementMap = new ConcurrentHashMap<Provider<E>, Collection<E>>();
+    private final Map<Provider<E>, Collection<E>> elementMap = new ConcurrentHashMap<Provider<E>, Collection<E>>();
+    private final Collection<RegistryChangeListener<E>> listeners = new CopyOnWriteArraySet<RegistryChangeListener<E>>();
 
-    protected Collection<RegistryChangeListener<E>> listeners = new CopyOnWriteArraySet<RegistryChangeListener<E>>();
+    private Optional<ManagedProvider<E, K>> managedProvider = Optional.empty();
 
-    protected ManagedProvider<E, K> managedProvider;
-
-    protected EventPublisher eventPublisher;
+    private EventPublisher eventPublisher;
 
     /**
      * Constructor.
@@ -227,32 +231,34 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
         return null;
     }
 
+    public Entry<Provider<E>, E> getBoth(K key) {
+        for (final Map.Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
+            for (final E element : entry.getValue()) {
+                if (key.equals(element.getUID())) {
+                    return new SimpleEntry<Provider<E>, E>(entry.getKey(), element);
+                }
+            }
+        }
+        return null;
+
+    }
+
     @Override
     public E add(E element) {
-        if (this.managedProvider != null) {
-            this.managedProvider.add(element);
-            return element;
-        } else {
-            throw new IllegalStateException("ManagedProvider is not available");
-        }
+        managedProvider.orElseThrow(() -> new IllegalStateException("ManagedProvider is not available")).add(element);
+        return element;
     }
 
     @Override
     public E update(E element) {
-        if (this.managedProvider != null) {
-            return this.managedProvider.update(element);
-        } else {
-            throw new IllegalStateException("ManagedProvider is not available");
-        }
+        return managedProvider.orElseThrow(() -> new IllegalStateException("ManagedProvider is not available"))
+                .update(element);
     }
 
     @Override
     public E remove(K key) {
-        if (this.managedProvider != null) {
-            return this.managedProvider.remove(key);
-        } else {
-            throw new IllegalStateException("ManagedProvider is not available");
-        }
+        return managedProvider.orElseThrow(() -> new IllegalStateException("ManagedProvider is not available"))
+                .remove(key);
     }
 
     protected void notifyListeners(E oldElement, E element, EventType eventType) {
@@ -308,6 +314,10 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
         }
     }
 
+    public Provider<E> getProvider(K key) {
+        return getProvider(get(key));
+    }
+
     public Provider<E> getProvider(E element) {
         for (Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
             if (entry.getValue().contains(element)) {
@@ -317,12 +327,32 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
         return null;
     }
 
+    public void forEach(Provider<E> provider, Consumer<E> consumer) {
+        elementMap.get(provider).forEach(consumer);
+    }
+
+    public void forEach(Consumer<E> consumer) {
+        for (Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
+            entry.getValue().forEach(consumer);
+        }
+    }
+
+    public void forEach(BiConsumer<Provider<E>, E> consumer) {
+        for (Entry<Provider<E>, Collection<E>> entry : elementMap.entrySet()) {
+            entry.getValue().forEach(e -> consumer.accept(entry.getKey(), e));
+        }
+    }
+
+    protected Optional<ManagedProvider<E, K>> getManagedProvider() {
+        return managedProvider;
+    }
+
     protected void setManagedProvider(ManagedProvider<E, K> provider) {
-        managedProvider = provider;
+        managedProvider = Optional.ofNullable(provider);
     }
 
     protected void unsetManagedProvider(ManagedProvider<E, K> provider) {
-        managedProvider = null;
+        managedProvider = Optional.empty();
     }
 
     /**
@@ -405,8 +435,8 @@ public abstract class AbstractRegistry<E extends Identifiable<K>, K, P extends P
         }
     }
 
-    protected void removeManagedProvider(ManagedProvider<E, K> managedProvider) {
-        this.managedProvider = null;
+    protected EventPublisher getEventPublisher() {
+        return this.eventPublisher;
     }
 
     protected void setEventPublisher(EventPublisher eventPublisher) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -195,7 +195,7 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     private void injectServices(Item item) {
         if (item instanceof GenericItem) {
             GenericItem genericItem = (GenericItem) item;
-            genericItem.setEventPublisher(eventPublisher);
+            genericItem.setEventPublisher(getEventPublisher());
             genericItem.setStateDescriptionService(stateDescriptionService);
             genericItem.setUnitProvider(unitProvider);
             genericItem.setItemStateConverter(itemStateConverter);
@@ -355,11 +355,9 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     @Override
     public Item remove(String itemName, boolean recursive) {
-        if (this.managedProvider != null) {
-            return ((ManagedItemProvider) this.managedProvider).remove(itemName, recursive);
-        } else {
-            throw new IllegalStateException("ManagedProvider is not available");
-        }
+        return ((ManagedItemProvider) getManagedProvider()
+                .orElseThrow(() -> new IllegalStateException("ManagedProvider is not available"))).remove(itemName,
+                        recursive);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/MetadataRegistryImpl.java
@@ -76,15 +76,14 @@ public class MetadataRegistryImpl extends AbstractRegistry<Metadata, MetadataKey
     }
 
     protected void unsetManagedProvider(ManagedMetadataProvider managedProvider) {
-        super.removeManagedProvider(managedProvider);
+        super.unsetManagedProvider(managedProvider);
     }
 
     @Override
     public void removeItemMetadata(String itemName) {
-        if (managedProvider != null) {
-            // remove our metadata for that item
-            ((ManagedMetadataProvider) managedProvider).removeItemMetadata(itemName);
-        }
+        // remove our metadata for that item
+        getManagedProvider()
+                .ifPresent(managedProvider -> ((ManagedMetadataProvider) managedProvider).removeItemMetadata(itemName));
     }
 
 }


### PR DESCRIPTION
To get things going I've put this part of the improvements in this pr. This is related to improvements mentioned in #6427. The idea is with this change the next step can be done to improve performance of the AbstractRegistry class and next improve inefficient usages of getAll() and stream(). I've made some changes with the best intentions, but it may be in the context of the architecture it should to be implemented differently.

Changes:
- Fields are made private to protect from implementation detail dependencies.
- Added extra methods to iterate instead of getting fields directly.
- The iteration methods hide implementation and thus can later be implemented effectively when the internal data structure would change.
- The idea is also to get ride of the inefficient getAll(), and the forEach methods can help with that.
- Removed removeManagedProvider it's a duplicate of unsetManagedProvider.
