### PR TITLE
Added null check to avoid possible NPE when createThing return null

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -248,8 +248,14 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
         for (ThingHandlerFactory thingHandlerFactory : thingHandlerFactories) {
             if (thingHandlerFactory.supportsThingType(thingTypeUID)) {
                 Thing thing = thingHandlerFactory.createThing(thingTypeUID, configuration, thingUID, bridgeUID);
-                thing.setLabel(label);
-                return thing;
+                if (thing == null) {
+                    logger.warn(
+                            "Cannot create thing of type '{}'. Binding '{}' says it supports it, but it could not be created.",
+                            thingTypeUID, thingHandlerFactory.getClass().getName());
+                } else {
+                    thing.setLabel(label);
+                    return thing;
+                }
             }
         }
         logger.warn("Cannot create thing. No binding found that supports creating a thing of type '{}'.", thingTypeUID);


### PR DESCRIPTION
createThing can return null so if that happens it would result in a NPE.
I think when it would happen that might be a bug in a binding and if I understand it correctly can happen if the binding would report it supports the found thing, but then when it's created it doesn't know how create it and returns null.

Moved this change to separate pr following comment in #6429

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>