### PR TITLE
rfc2217: set connect (not default) timeout

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx.rfc2217/src/main/java/org/eclipse/smarthome/io/transport/serial/rxtx/rfc2217/internal/SerialPortIdentifierImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial.rxtx.rfc2217/src/main/java/org/eclipse/smarthome/io/transport/serial/rxtx/rfc2217/internal/SerialPortIdentifierImpl.java
@@ -32,7 +32,7 @@ import gnu.io.rfc2217.TelnetSerialPort;
 public class SerialPortIdentifierImpl implements SerialPortIdentifier {
 
     final TelnetSerialPort id;
-    private URI uri;
+    private final URI uri;
 
     /**
      * Constructor.
@@ -53,7 +53,7 @@ public class SerialPortIdentifierImpl implements SerialPortIdentifier {
     @Override
     public SerialPort open(String owner, int timeout) throws PortInUseException {
         try {
-            id.getTelnetClient().setDefaultTimeout(timeout);
+            id.getTelnetClient().setConnectTimeout(timeout);
             id.getTelnetClient().connect(uri.getHost(), uri.getPort());
             return new RxTxSerialPort(id);
         } catch (Exception e) {


### PR DESCRIPTION
The "timeout" parameter of the our "open" method has uses a timeout parameter.
That parameter defined the timeout we may block until the port is opened.

The RFC2217 implementation sets the timeout parameter for the underlying telnet client using that method "setDefaultTimeout".

Reading the code of the telnet client it seems the JavaDoc for that method is misleading.

The default timeout is not used on opening the port but the connect timeout is.

The default timeout will influence the reading.
If you try to read from the (virtual) serial port and there is no input data for a period of "default timeout", an exception is thrown.

But that is not the "timeout" parameter on our open is used for.