### PR TITLE
drop most usage of Guava's com.google.common package

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.event.test/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-SymbolicName: org.eclipse.smarthome.automation.event.test;singlet
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.events,

--- a/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.integration.test/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-SymbolicName: org.eclipse.smarthome.automation.integration.test;s
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.events,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.media/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.media/META-INF/MANIFEST.MF
@@ -10,7 +10,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.automation.module.media.handler
 Import-Package: 
- com.google.common.collect,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.test/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Fragment-Host: org.eclipse.smarthome.automation.module.script
 Import-Package: 
- com.google.common.collect,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer.test/META-INF/MANIFEST.MF
@@ -7,7 +7,6 @@ Bundle-SymbolicName: org.eclipse.smarthome.automation.module.timer.test;
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.events,

--- a/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.timer/META-INF/MANIFEST.MF
@@ -13,7 +13,6 @@ Export-Package:
  org.eclipse.smarthome.automation.module.timer.factory,
  org.eclipse.smarthome.automation.module.timer.handler
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.handler,

--- a/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.core/META-INF/MANIFEST.MF
@@ -14,7 +14,6 @@ Export-Package:
  org.eclipse.smarthome.config.core.status.events,
  org.eclipse.smarthome.config.core.validation
 Import-Package: 
- com.google.common.collect,
  com.google.gson,
  com.google.gson.annotations,
  org.apache.commons.lang.reflect,

--- a/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/validation/TypeIntrospections.java
+++ b/bundles/config/org.eclipse.smarthome.config.core/src/main/java/org/eclipse/smarthome/config/core/internal/validation/TypeIntrospections.java
@@ -13,11 +13,14 @@
 package org.eclipse.smarthome.config.core.internal.validation;
 
 import java.math.BigDecimal;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.config.core.ConfigDescriptionParameter.Type;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * The {@link TypeIntrospections} provides a corresponding {@link TypeIntrospection} for each config description
@@ -27,9 +30,12 @@ import com.google.common.collect.ImmutableMap;
  */
 final class TypeIntrospections {
 
-    private static final Map<Type, TypeIntrospection> INTROSPECTIONS = new ImmutableMap.Builder<Type, TypeIntrospection>()
-            .put(Type.BOOLEAN, new BooleanIntrospection()).put(Type.TEXT, new StringIntrospection())
-            .put(Type.INTEGER, new IntegerIntrospection()).put(Type.DECIMAL, new FloatIntrospection()).build();
+    private static final Map<Type, TypeIntrospection> INTROSPECTIONS = Collections.unmodifiableMap(Stream
+            .of(new SimpleEntry<>(Type.BOOLEAN, new BooleanIntrospection()),
+                    new SimpleEntry<>(Type.TEXT, new StringIntrospection()),
+                    new SimpleEntry<>(Type.INTEGER, new IntegerIntrospection()),
+                    new SimpleEntry<>(Type.DECIMAL, new FloatIntrospection()))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
 
     private TypeIntrospections() {
         super();

--- a/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/java/org/eclipse/smarthome/config/discovery/inbox/InboxPredicatesTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.test/src/test/java/org/eclipse/smarthome/config/discovery/inbox/InboxPredicatesTest.java
@@ -16,10 +16,14 @@ import static org.eclipse.smarthome.config.discovery.inbox.InboxPredicates.*;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 
+import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultFlag;
@@ -28,8 +32,6 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * Tests for {@link InboxPredicates}.
@@ -58,10 +60,10 @@ public class InboxPredicatesTest {
     private final static ThingTypeUID THING_TYPE_UID12 = new ThingTypeUID(BINDING_ID1, THING_TYPE_ID2);
     private final static ThingTypeUID THING_TYPE_UID21 = new ThingTypeUID(BINDING_ID2, THING_TYPE_ID1);
 
-    private final static Map<String, Object> PROPS1 = new ImmutableMap.Builder<String, Object>().put(PROP1, PROP_VAL1)
-            .put(PROP2, PROP_VAL2).build();
-    private final static Map<String, Object> PROPS2 = new ImmutableMap.Builder<String, Object>().put(PROP2, PROP_VAL2)
-            .build();
+    private final static Map<String, Object> PROPS1 = Collections
+            .unmodifiableMap(Stream.of(new SimpleEntry<>(PROP1, PROP_VAL1), new SimpleEntry<>(PROP2, PROP_VAL2))
+                    .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
+    private final static Map<String, Object> PROPS2 = Collections.singletonMap(PROP2, PROP_VAL2);
 
     private final static List<DiscoveryResultImpl> results = Arrays.asList(
             new DiscoveryResultImpl(THING_TYPE_UID11, THING_UID11, null, PROPS1, PROP1, "label",

--- a/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Export-Package:
  org.eclipse.smarthome.config.discovery.inbox,
  org.eclipse.smarthome.config.discovery.inbox.events
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.discovery,

--- a/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Export-Package:
  org.eclipse.smarthome.config.discovery.inbox,
  org.eclipse.smarthome.config.discovery.inbox.events
 Import-Package: 
- com.google.common.base,
  com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/AbstractDiscoveryService.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
@@ -93,7 +94,7 @@ public abstract class AbstractDiscoveryService implements DiscoveryService {
         if (supportedThingTypes == null) {
             this.supportedThingTypes = Collections.emptySet();
         } else {
-            this.supportedThingTypes = supportedThingTypes;
+            this.supportedThingTypes = Collections.unmodifiableSet(new HashSet<>(supportedThingTypes));
         }
 
         if (timeout < 0) {

--- a/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/events/InboxEventFactory.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery/src/main/java/org/eclipse/smarthome/config/discovery/inbox/events/InboxEventFactory.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.smarthome.config.discovery.inbox.events;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.dto.DiscoveryResultDTO;
 import org.eclipse.smarthome.config.discovery.dto.DiscoveryResultDTOMapper;
@@ -19,8 +22,6 @@ import org.eclipse.smarthome.core.events.AbstractEventFactory;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFactory;
 import org.osgi.service.component.annotations.Component;
-
-import com.google.common.collect.Sets;
 
 /**
  * An {@link InboxEventFactory} is responsible for creating inbox event instances.
@@ -40,7 +41,8 @@ public class InboxEventFactory extends AbstractEventFactory {
      * Constructs a new InboxEventFactory.
      */
     public InboxEventFactory() {
-        super(Sets.newHashSet(InboxAddedEvent.TYPE, InboxUpdatedEvent.TYPE, InboxRemovedEvent.TYPE));
+        super(Stream.of(InboxAddedEvent.TYPE, InboxUpdatedEvent.TYPE, InboxRemovedEvent.TYPE)
+                .collect(Collectors.toSet()));
     }
 
     @Override

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.fragment/META-INF/MANIFEST.MF
@@ -8,6 +8,5 @@ Bundle-SymbolicName: ConfigDescriptionsFragmentTest.fragment;singleton:=
 Bundle-Version: 0.0.1.qualifier
 Fragment-Host: ConfigDescriptionsFragmentTest.host
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsFragmentTest.host/META-INF/MANIFEST.MF
@@ -6,6 +6,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ConfigDescriptionsFragmentTest.host;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
@@ -7,6 +7,5 @@ Bundle-SymbolicName: LoadingConfigDescriptionsTest.bundle;singleton:=tru
  e
 Bundle-Version: 0.0.1.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/config/org.eclipse.smarthome.config.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -7,6 +7,5 @@ Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.7.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTest.bundle/META-INF/MANIFEST.MF
@@ -6,6 +6,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: BundleInfoTest.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTestNoAuthor.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/BundleInfoTestNoAuthor.bundle/META-INF/MANIFEST.MF
@@ -6,6 +6,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: BundleInfoTestNoAuthor.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.binding.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -7,6 +7,5 @@ Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.7.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactoryTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactoryTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import org.eclipse.smarthome.core.events.Event;
@@ -25,8 +26,6 @@ import org.eclipse.smarthome.core.thing.binding.firmware.ProgressStep;
 import org.eclipse.smarthome.test.java.JavaTest;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.google.common.collect.Lists;
 
 /**
  *
@@ -97,7 +96,7 @@ public class FirmwareEventFactoryTest extends JavaTest {
     public void testSerializationAndDeserializationFirmwareUpdateProgressInfo() throws Exception {
         FirmwareUpdateProgressInfo firmwareUpdateProgressInfo = FirmwareUpdateProgressInfo
                 .createFirmwareUpdateProgressInfo(thingUID, "1.2.3", ProgressStep.UPDATING,
-                        Lists.newArrayList(ProgressStep.WAITING, ProgressStep.UPDATING), false, 10);
+                        Arrays.asList(ProgressStep.WAITING, ProgressStep.UPDATING), false, 10);
         FirmwareUpdateProgressInfoEvent progressInfoEvent = FirmwareEventFactory
                 .createFirmwareUpdateProgressInfoEvent(firmwareUpdateProgressInfo);
 

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesI18nTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesI18nTest.bundle/META-INF/MANIFEST.MF
@@ -6,6 +6,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ChannelTypesI18nTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ChannelTypesTest.bundle/META-INF/MANIFEST.MF
@@ -6,6 +6,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ChannelTypesTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ConfigDescriptionsTest.bundle/META-INF/MANIFEST.MF
@@ -6,6 +6,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ConfigDescriptionsTest.bundle;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannels.bundle/META-INF/MANIFEST.MF
@@ -7,6 +7,5 @@ Bundle-SymbolicName: SystemChannels.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsInChannelGroups.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsInChannelGroups.bundle/META-INF/MANIFEST.MF
@@ -8,6 +8,5 @@ Bundle-SymbolicName: SystemChannelsInChannelGroups.bundle;singleton:=tru
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsNoThingTypes.bundle/META-INF/MANIFEST.MF
@@ -7,6 +7,5 @@ Bundle-SymbolicName: SystemChannelsNoThingTypes.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/SystemChannelsUser.bundle/META-INF/MANIFEST.MF
@@ -7,6 +7,5 @@ Bundle-SymbolicName: SystemChannelsUser.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ThingTypesTest.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/ThingTypesTest.bundle/META-INF/MANIFEST.MF
@@ -6,6 +6,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-SymbolicName: ThingTypesTest.bundle;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing.xml.test/src/test/resources/test-bundle-pool/yahooweather.bundle/META-INF/MANIFEST.MF
@@ -7,6 +7,5 @@ Bundle-SymbolicName: yahooweather.bundle;singleton:=true
 Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 1.0.0.qualifier
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.osgi.framework

--- a/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core.thing/META-INF/MANIFEST.MF
@@ -24,7 +24,6 @@ Export-Package:
  org.eclipse.smarthome.core.thing.type,
  org.eclipse.smarthome.core.thing.util
 Import-Package: 
- com.google.common.collect,
  javax.measure,
  javax.measure.quantity,
  org.apache.commons.collections.iterators,

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/events/ThingEventFactory.java
@@ -14,6 +14,8 @@ package org.eclipse.smarthome.core.thing.events;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.events.AbstractEventFactory;
 import org.eclipse.smarthome.core.events.Event;
@@ -26,8 +28,6 @@ import org.eclipse.smarthome.core.thing.dto.ThingDTO;
 import org.eclipse.smarthome.core.thing.dto.ThingDTOMapper;
 import org.eclipse.smarthome.core.types.Type;
 import org.osgi.service.component.annotations.Component;
-
-import com.google.common.collect.Sets;
 
 /**
  * A {@link ThingEventFactory} is responsible for creating thing event instances, e.g. {@link ThingStatusInfoEvent}s.
@@ -53,8 +53,10 @@ public class ThingEventFactory extends AbstractEventFactory {
      * Constructs a new ThingEventFactory.
      */
     public ThingEventFactory() {
-        super(Sets.newHashSet(ThingStatusInfoEvent.TYPE, ThingStatusInfoChangedEvent.TYPE, ThingAddedEvent.TYPE,
-                ThingRemovedEvent.TYPE, ThingUpdatedEvent.TYPE, ChannelTriggeredEvent.TYPE));
+        super(Stream
+                .of(ThingStatusInfoEvent.TYPE, ThingStatusInfoChangedEvent.TYPE, ThingAddedEvent.TYPE,
+                        ThingRemovedEvent.TYPE, ThingUpdatedEvent.TYPE, ChannelTriggeredEvent.TYPE)
+                .collect(Collectors.toSet()));
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/firmware/FirmwareEventFactory.java
@@ -12,12 +12,13 @@
  */
 package org.eclipse.smarthome.core.thing.firmware;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.eclipse.smarthome.core.events.AbstractEventFactory;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFactory;
 import org.osgi.service.component.annotations.Component;
-
-import com.google.common.collect.ImmutableSet;
 
 /**
  * The {@link FirmwareEventFactory} is registered as an OSGi service and is responsible to create firmware events. It
@@ -44,8 +45,8 @@ public final class FirmwareEventFactory extends AbstractEventFactory {
      * Creates a new firmware event factory.
      */
     public FirmwareEventFactory() {
-        super(ImmutableSet.of(FirmwareStatusInfoEvent.TYPE, FirmwareUpdateProgressInfoEvent.TYPE,
-                FirmwareUpdateResultInfoEvent.TYPE));
+        super(Stream.of(FirmwareStatusInfoEvent.TYPE, FirmwareUpdateProgressInfoEvent.TYPE,
+                FirmwareUpdateResultInfoEvent.TYPE).collect(Collectors.toSet()));
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/events/LinkEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/link/events/LinkEventFactory.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.smarthome.core.thing.link.events;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.eclipse.smarthome.core.events.AbstractEventFactory;
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFactory;
@@ -19,8 +22,6 @@ import org.eclipse.smarthome.core.thing.link.AbstractLink;
 import org.eclipse.smarthome.core.thing.link.ItemChannelLink;
 import org.eclipse.smarthome.core.thing.link.dto.ItemChannelLinkDTO;
 import org.osgi.service.component.annotations.Component;
-
-import com.google.common.collect.Sets;
 
 /**
  * This is an {@link EventFactory} for creating link events. The following event types are supported by this
@@ -42,7 +43,7 @@ public class LinkEventFactory extends AbstractEventFactory {
      * Constructs a new LinkEventFactory.
      */
     public LinkEventFactory() {
-        super(Sets.newHashSet(ItemChannelLinkAddedEvent.TYPE, ItemChannelLinkRemovedEvent.TYPE));
+        super(Stream.of(ItemChannelLinkAddedEvent.TYPE, ItemChannelLinkRemovedEvent.TYPE).collect(Collectors.toSet()));
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
+++ b/bundles/core/org.eclipse.smarthome.core/META-INF/MANIFEST.MF
@@ -37,7 +37,6 @@ Ignore-Package: org.eclipse.smarthome.core.internal.items,org.eclipse.sm
  arthome.core.internal,org.eclipse.smarthome.core.internal.events,org.ec
  lipse.smarthome.core.internal.logging
 Import-Package: 
- com.google.common.collect,
  com.google.gson,
  javax.measure,
  javax.measure.quantity,

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/events/AbstractEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/events/AbstractEventFactory.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.core.events;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import com.google.gson.Gson;
@@ -37,7 +38,7 @@ public abstract class AbstractEventFactory implements EventFactory {
      * @param supportedEventTypes the supported event types
      */
     public AbstractEventFactory(Set<String> supportedEventTypes) {
-        this.supportedEventTypes = Collections.unmodifiableSet(supportedEventTypes);
+        this.supportedEventTypes = Collections.unmodifiableSet(new HashSet<>(supportedEventTypes));
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/AbstractItemEventSubscriber.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/AbstractItemEventSubscriber.java
@@ -12,28 +12,30 @@
  */
 package org.eclipse.smarthome.core.items.events;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.events.Event;
 import org.eclipse.smarthome.core.events.EventFilter;
 import org.eclipse.smarthome.core.events.EventSubscriber;
 
-import com.google.common.collect.ImmutableSet;
-
 /**
  * <p>
  * The {@link AbstractItemEventSubscriber} defines an abstract implementation of the {@link EventSubscriber} interface
  * for receiving {@link ItemStateEvent}s and {@link ItemCommandEvent}s from the Eclipse SmartHome event bus.
- * 
+ *
  * A subclass can implement the methods {@link #receiveUpdate(ItemStateEvent)} and
  * {@link #receiveCommand(ItemCommandEvent)} in order to receive and handle such events.
- * 
+ *
  * @author Stefan Bußweiler - Initial contribution
  */
 public abstract class AbstractItemEventSubscriber implements EventSubscriber {
 
-    private final Set<String> subscribedEventTypes = ImmutableSet.of(ItemStateEvent.TYPE, ItemCommandEvent.TYPE);
-    
+    private final Set<String> subscribedEventTypes = Collections
+            .unmodifiableSet(Stream.of(ItemStateEvent.TYPE, ItemCommandEvent.TYPE).collect(Collectors.toSet()));
+
     @Override
     public Set<String> getSubscribedEventTypes() {
         return subscribedEventTypes;
@@ -55,7 +57,7 @@ public abstract class AbstractItemEventSubscriber implements EventSubscriber {
 
     /**
      * Callback method for receiving item command events from the Eclipse SmartHome event bus.
-     * 
+     *
      * @param commandEvent the item command event
      */
     protected void receiveCommand(ItemCommandEvent commandEvent) {
@@ -65,7 +67,7 @@ public abstract class AbstractItemEventSubscriber implements EventSubscriber {
 
     /**
      * Callback method for receiving item update events from the Eclipse SmartHome event bus.
-     * 
+     *
      * @param updateEvent the item update event
      */
     protected void receiveUpdate(ItemStateEvent updateEvent) {

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/events/ItemEventFactory.java
@@ -16,6 +16,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
 import org.eclipse.smarthome.core.events.AbstractEventFactory;
@@ -30,8 +32,6 @@ import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.Type;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.osgi.service.component.annotations.Component;
-
-import com.google.common.collect.Sets;
 
 /**
  * An {@link ItemEventFactory} is responsible for creating item event instances, e.g. {@link ItemCommandEvent}s and
@@ -66,9 +66,9 @@ public class ItemEventFactory extends AbstractEventFactory {
      * Constructs a new ItemEventFactory.
      */
     public ItemEventFactory() {
-        super(Sets.newHashSet(ItemCommandEvent.TYPE, ItemStateEvent.TYPE, ItemStatePredictedEvent.TYPE,
+        super(Stream.of(ItemCommandEvent.TYPE, ItemStateEvent.TYPE, ItemStatePredictedEvent.TYPE,
                 ItemStateChangedEvent.TYPE, ItemAddedEvent.TYPE, ItemUpdatedEvent.TYPE, ItemRemovedEvent.TYPE,
-                GroupItemStateChangedEvent.TYPE));
+                GroupItemStateChangedEvent.TYPE).collect(Collectors.toSet()));
     }
 
     @Override

--- a/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.monitor/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Ignore-Package: org.eclipse.smarthome.core.monitor.internal
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.core.events,
  org.eclipse.smarthome.core.items,

--- a/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/META-INF/MANIFEST.MF
@@ -14,7 +14,6 @@ Export-Package:
  org.eclipse.smarthome.io.rest.core.service,
  org.eclipse.smarthome.io.rest.core.thing
 Import-Package: 
- com.google.common.collect,
  com.google.gson,
  io.swagger.annotations;resolution:=optional,
  javax.annotation.security;resolution:=optional,

--- a/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sse/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Export-Package:
  org.eclipse.smarthome.io.rest.sse,
  org.eclipse.smarthome.io.rest.sse.beans
 Import-Package: 
- com.google.common.collect,
  io.swagger.annotations;resolution:=optional,
  javax.annotation.security;resolution:=optional,
  javax.inject,

--- a/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.rest/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Export-Package: org.eclipse.smarthome.io.rest
 Import-Package: 
- com.google.common.collect,
  com.google.gson,
  com.google.gson.stream,
  io.swagger.annotations;resolution:=optional,

--- a/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
@@ -12,7 +12,6 @@ Export-Package:
  org.eclipse.smarthome.magic.binding.handler,
  org.eclipse.smarthome.magic.service
 Import-Package: 
- com.google.common.collect,
  javax.measure.quantity,
  javax.servlet.http,
  org.eclipse.jdt.annotation;resolution:=optional,

--- a/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
+++ b/bundles/test/org.eclipse.smarthome.magic/src/main/java/org/eclipse/smarthome/magic/binding/internal/MagicHandlerFactory.java
@@ -14,7 +14,10 @@ package org.eclipse.smarthome.magic.binding.internal;
 
 import static org.eclipse.smarthome.magic.binding.MagicBindingConstants.*;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
@@ -41,8 +44,6 @@ import org.eclipse.smarthome.magic.binding.handler.MagicRolllershutterHandler;
 import org.eclipse.smarthome.magic.binding.handler.MagicThermostatThingHandler;
 import org.osgi.service.component.annotations.Component;
 
-import com.google.common.collect.Sets;
-
 /**
  * The {@link MagicHandlerFactory} is responsible for creating things and thing
  * handlers.
@@ -52,12 +53,13 @@ import com.google.common.collect.Sets;
 @Component(service = ThingHandlerFactory.class, configurationPid = "binding.magic")
 public class MagicHandlerFactory extends BaseThingHandlerFactory {
 
-    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Sets.newHashSet(THING_TYPE_EXTENSIBLE_THING,
-            THING_TYPE_ON_OFF_LIGHT, THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_COLOR_LIGHT, THING_TYPE_CONTACT_SENSOR,
-            THING_TYPE_CONFIG_THING, THING_TYPE_DELAYED_THING, THING_TYPE_LOCATION, THING_TYPE_THERMOSTAT,
-            THING_TYPE_FIRMWARE_UPDATE, THING_TYPE_BRIDGE_1, THING_TYPE_BRIDGE_2, THING_TYPE_BRIDGED_THING,
-            THING_TYPE_CHATTY_THING, THING_TYPE_ROLLERSHUTTER, THING_TYPE_PLAYER, THING_TYPE_IMAGE,
-            THING_TYPE_ONLINE_OFFLINE);
+    private static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream
+            .of(THING_TYPE_EXTENSIBLE_THING, THING_TYPE_ON_OFF_LIGHT, THING_TYPE_DIMMABLE_LIGHT, THING_TYPE_COLOR_LIGHT,
+                    THING_TYPE_CONTACT_SENSOR, THING_TYPE_CONFIG_THING, THING_TYPE_DELAYED_THING, THING_TYPE_LOCATION,
+                    THING_TYPE_THERMOSTAT, THING_TYPE_FIRMWARE_UPDATE, THING_TYPE_BRIDGE_1, THING_TYPE_BRIDGE_2,
+                    THING_TYPE_BRIDGED_THING, THING_TYPE_CHATTY_THING, THING_TYPE_ROLLERSHUTTER, THING_TYPE_PLAYER,
+                    THING_TYPE_IMAGE, THING_TYPE_ONLINE_OFFLINE)
+            .collect(Collectors.toSet()));
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {

--- a/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.test/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Export-Package:
  org.eclipse.smarthome.test.java,
  org.eclipse.smarthome.test.storage,
  org.eclipse.smarthome.test;uses:="org.osgi.framework"
-Import-Package: com.google.common.collect,
+Import-Package: 
  groovy.lang,
  javax.servlet,
  javax.servlet.http,

--- a/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/SyntheticBundleInstaller.java
+++ b/bundles/test/org.eclipse.smarthome.test/src/main/java/org/eclipse/smarthome/test/SyntheticBundleInstaller.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.io.IOUtils;
@@ -41,8 +43,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
-
-import com.google.common.collect.ImmutableSet;
 
 /**
  * Utility class for creation, installation, update and uninstallation of
@@ -73,7 +73,8 @@ public class SyntheticBundleInstaller {
     /**
      * A list of default extensions to be included in the synthetic bundle.
      */
-    private static Set<String> DEFAULT_EXTENSIONS = ImmutableSet.of("*.xml", "*.properties", "*.json", ".keep");
+    private static Set<String> DEFAULT_EXTENSIONS = Collections
+            .unmodifiableSet(Stream.of("*.xml", "*.properties", "*.json", ".keep").collect(Collectors.toSet()));
 
     /**
      * Install synthetic bundle, denoted by its name, into the test runtime (by using the given bundle context). Only

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Import-Package: 
- com.google.common.collect,
  com.google.gson,
  com.google.gson.annotations,
  com.google.gson.reflect,

--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/BoseSoundTouchBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/BoseSoundTouchBindingConstants.java
@@ -12,12 +12,13 @@
  */
 package org.eclipse.smarthome.binding.bosesoundtouch;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
-
-import com.google.common.collect.Sets;
 
 /**
  * The {@link BoseSoundTouchBindinConstantsg} class defines common constants, which are
@@ -42,12 +43,12 @@ public class BoseSoundTouchBindingConstants {
             "waveSoundTouchMusicSystemIV");
     public final static ThingTypeUID BST_SA5A_THING_TYPE_UID = new ThingTypeUID(BINDING_ID, "sa5Amplifier");
 
-    public static final Set<ThingTypeUID> SUPPORTED_KNOWN_THING_TYPES_UIDS = Sets.newHashSet(BST_UNKNOWN_THING_TYPE_UID,
-            BST_10_THING_TYPE_UID, BST_20_THING_TYPE_UID, BST_30_THING_TYPE_UID, BST_300_THING_TYPE_UID,
-            BST_WLA_THING_TYPE_UID, BST_WSMS_THING_TYPE_UID, BST_SA5A_THING_TYPE_UID);
+    public static final Set<ThingTypeUID> SUPPORTED_KNOWN_THING_TYPES_UIDS = Collections.unmodifiableSet(Stream
+            .of(BST_UNKNOWN_THING_TYPE_UID, BST_10_THING_TYPE_UID, BST_20_THING_TYPE_UID, BST_30_THING_TYPE_UID,
+                    BST_300_THING_TYPE_UID, BST_WLA_THING_TYPE_UID, BST_WSMS_THING_TYPE_UID, BST_SA5A_THING_TYPE_UID)
+            .collect(Collectors.toSet()));
 
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>(
-            SUPPORTED_KNOWN_THING_TYPES_UIDS);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = new HashSet<>(SUPPORTED_KNOWN_THING_TYPES_UIDS);
 
     // List of all Channel IDs
     public static final String CHANNEL_POWER = "power";

--- a/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.digitalstrom/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Export-Package:
  org.eclipse.smarthome.binding.digitalstrom,
  org.eclipse.smarthome.binding.digitalstrom.handler
 Import-Package: 
- com.google.common.collect,
  com.google.gson,
  javax.jmdns,
  javax.net.ssl,

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/META-INF/MANIFEST.MF
@@ -11,7 +11,6 @@ Export-Package:
  org.eclipse.smarthome.binding.dmx,
  org.eclipse.smarthome.binding.dmx.handler
 Import-Package: 
- com.google.common.collect,
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.binding.dmx,
  org.eclipse.smarthome.binding.dmx.handler,

--- a/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/DmxBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.dmx/src/main/java/org/eclipse/smarthome/binding/dmx/DmxBindingConstants.java
@@ -12,12 +12,13 @@
  */
 package org.eclipse.smarthome.binding.dmx;
 
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
-
-import com.google.common.collect.ImmutableSet;
 
 /**
  * The {@link DmxBindingConstants} class defines common constants, which are
@@ -38,9 +39,9 @@ public class DmxBindingConstants {
     public static final ThingTypeUID THING_TYPE_LIB485_BRIDGE = new ThingTypeUID(BINDING_ID, "lib485-bridge");
     public static final ThingTypeUID THING_TYPE_SACN_BRIDGE = new ThingTypeUID(BINDING_ID, "sacn-bridge");
 
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = ImmutableSet.of(THING_TYPE_ARTNET_BRIDGE,
-            THING_TYPE_LIB485_BRIDGE, THING_TYPE_SACN_BRIDGE, THING_TYPE_CHASER, THING_TYPE_COLOR, THING_TYPE_DIMMER,
-            THING_TYPE_TUNABLEWHITE);
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(
+            Stream.of(THING_TYPE_ARTNET_BRIDGE, THING_TYPE_LIB485_BRIDGE, THING_TYPE_SACN_BRIDGE, THING_TYPE_CHASER,
+                    THING_TYPE_COLOR, THING_TYPE_DIMMER, THING_TYPE_TUNABLEWHITE).collect(Collectors.toSet()));
 
     // List of all config options
     public static final String CONFIG_UNIVERSE = "universe";

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/META-INF/MANIFEST.MF
@@ -13,7 +13,6 @@ Export-Package:
  org.eclipse.smarthome.binding.homematic.handler,
  org.eclipse.smarthome.binding.homematic.type
 Import-Package: 
- com.google.common.collect,
  com.thoughtworks.xstream,
  com.thoughtworks.xstream.annotations,
  com.thoughtworks.xstream.io,

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/discovery/HomematicDeviceDiscoveryService.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.binding.homematic.internal.discovery;
 
 import static org.eclipse.smarthome.binding.homematic.HomematicBindingConstants.BINDING_ID;
 
+import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -32,8 +33,6 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableSet;
-
 /**
  * The {@link HomematicDeviceDiscoveryService} is used to discover devices that are connected to a Homematic gateway.
  *
@@ -50,7 +49,7 @@ public class HomematicDeviceDiscoveryService extends AbstractDiscoveryService {
     private volatile int installModeDuration = HomematicConfig.DEFAULT_INSTALL_MODE_DURATION;
 
     public HomematicDeviceDiscoveryService(HomematicBridgeHandler bridgeHandler) {
-        super(ImmutableSet.of(new ThingTypeUID(BINDING_ID, "-")), DISCOVER_TIMEOUT_SECONDS, false);
+        super(Collections.singleton(new ThingTypeUID(BINDING_ID, "-")), DISCOVER_TIMEOUT_SECONDS, false);
         this.bridgeHandler = bridgeHandler;
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-Version: 0.10.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .
 Import-Package: 
- com.google.common.collect,
  org.apache.commons.io,
  org.apache.commons.lang,
  org.apache.commons.net.util,

--- a/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.weatherunderground/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Bundle-Version: 0.10.0.qualifier
 Export-Package: 
  org.eclipse.smarthome.binding.weatherunderground,
  org.eclipse.smarthome.binding.weatherunderground.handler
-Import-Package: com.google.common.collect,
+Import-Package: 
  com.google.gson,
  javax.measure,
  javax.measure.quantity,


### PR DESCRIPTION
This drops the most usage of `com.google.common`.

The model bundle has been kept untouched as Xtext itself needs Guava and generates code that uses it.

The other remaining usages (all can be done in another PR and should not block this cleanup):

| bundle (esh) | class | Guava (collect) | note |
| --- | --- | --- | --- |
| `io.rest.sitemap` | `SitemapResource.java` | `MapMaker` | It uses some weak reference related stuff. @kaikreuzer AFAIK this has been introduced by you. Correct? Can you come up with some other suggestion? |
|  ~`config.discovery`~ | ~`DiscoveryServiceRegistryImpl`~ | ~`HashMultimap`~ | |
| ~`core.thing`~ | ~`ThingManagerImpl`~ | ~`HashMultimap`~ | |
| ~`core.thing`~ | ~`ThingManagerImpl`~ | ~`Multimaps`~ | |
| ~`core.thing`~ | ~`ThingManagerImpl`~ | ~`SetMultimap`~ | |
