### PR TITLE
Fix state update handling in transformation profiles

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.exec/src/main/java/org/eclipse/smarthome/transform/exec/internal/profiles/ExecTransformationProfile.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.exec/src/main/java/org/eclipse/smarthome/transform/exec/internal/profiles/ExecTransformationProfile.java
@@ -83,7 +83,7 @@ public class ExecTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleCommand((Command) state);
+        callback.handleUpdate(state);
     }
 
     @Override

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/profiles/JavascriptTransformationProfile.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/profiles/JavascriptTransformationProfile.java
@@ -84,7 +84,7 @@ public class JavascriptTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleCommand((Command) state);
+        callback.handleUpdate(state);
     }
 
     @Override

--- a/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/profiles/JSonPathTransformationProfile.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.jsonpath/src/main/java/org/eclipse/smarthome/transform/jsonpath/internal/profiles/JSonPathTransformationProfile.java
@@ -84,7 +84,7 @@ public class JSonPathTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleCommand((Command) state);
+        callback.handleUpdate(state);
     }
 
     @Override

--- a/extensions/transform/org.eclipse.smarthome.transform.map/src/main/java/org/eclipse/smarthome/transform/map/internal/profiles/MapTransformationProfile.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.map/src/main/java/org/eclipse/smarthome/transform/map/internal/profiles/MapTransformationProfile.java
@@ -83,7 +83,7 @@ public class MapTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleCommand((Command) state);
+        callback.handleUpdate(state);
     }
 
     @Override

--- a/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/profiles/RegexTransformationProfile.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.regex/src/main/java/org/eclipse/smarthome/transform/regex/internal/profiles/RegexTransformationProfile.java
@@ -83,7 +83,7 @@ public class RegexTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleCommand((Command) state);
+        callback.handleUpdate(state);
     }
 
     @Override

--- a/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/profiles/ScaleTransformationProfile.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.scale/src/main/java/org/eclipse/smarthome/transform/scale/internal/profiles/ScaleTransformationProfile.java
@@ -83,7 +83,7 @@ public class ScaleTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleCommand((Command) state);
+        callback.handleUpdate(state);
     }
 
     @Override

--- a/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/profiles/XPathTransformationProfile.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xpath/src/main/java/org/eclipse/smarthome/transform/xpath/internal/profiles/XPathTransformationProfile.java
@@ -83,7 +83,7 @@ public class XPathTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleCommand((Command) state);
+        callback.handleUpdate(state);
     }
 
     @Override

--- a/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/profiles/XSLTTransformationProfile.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.xslt/src/main/java/org/eclipse/smarthome/transform/xslt/internal/profiles/XSLTTransformationProfile.java
@@ -83,7 +83,7 @@ public class XSLTTransformationProfile implements StateProfile {
 
     @Override
     public void onStateUpdateFromItem(State state) {
-        callback.handleCommand((Command) state);
+        callback.handleUpdate(state);
     }
 
     @Override


### PR DESCRIPTION
I see no reason why the transformation profiles should treat state updates by the item differently than the default profile, so I guess this is just a mistake / bug which I intend to fix with this PR.

Signed-off-by: Patrick Fink <mail@pfink.de>