### PR TITLE
MQTT Brokers: Add trigger channel

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/ESH-INF/thing/thing-types.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<bridge-type id="broker">
+	<bridge-type id="broker" extensible="publishTrigger">
 		<label>MQTT Broker</label>
 		<description>A connection to a MQTT broker</description>
 
@@ -156,7 +156,7 @@
 		</config-description>
 	</bridge-type>
 
-	<bridge-type id="systemBroker">
+	<bridge-type id="systemBroker" extensible="publishTrigger">
 		<label>System MQTT Broker</label>
 		<description>A system configured and therefore read-only broker
 			connection. Properties are reflecting the configuration and internal
@@ -173,4 +173,21 @@
 			<property name="keep_alive_time_ms" />
 		</properties>
 	</bridge-type>
+	
+    <channel-type id="publishTrigger">
+        <kind>trigger</kind>
+        <label>Publish trigger</label>
+        <description>This channel is triggered when a value is published to the configured MQTT topic on this broker connection. The event payload will be the received MQTT topic value.</description>
+        <event></event>
+        <config-description>
+            <parameter name="stateTopic" type="text" required="true">
+                <label>MQTT Topic</label>
+                <description>This channel will trigger on this MQTT topic. This topic can contain wildcards like + and # for example "all/in/#" or "sensors/+/config".</description>
+            </parameter>
+            <parameter name="payload" type="text" required="false">
+                <label>Payload condition</label>
+                <description>An optional condition on the value of the MQTT topic that must match before this channel is triggered</description>
+            </parameter>
+        </config-description>
+    </channel-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/MqttBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/MqttBindingConstants.java
@@ -26,4 +26,6 @@ public class MqttBindingConstants {
     // List of all Thing Type UIDs
     public static final ThingTypeUID BRIDGE_TYPE_SYSTEMBROKER = new ThingTypeUID(BINDING_ID, "systemBroker");
     public static final ThingTypeUID BRIDGE_TYPE_BROKER = new ThingTypeUID(BINDING_ID, "broker");
+
+    public static final String PUBLISH_TRIGGER_CHANNEL = "publishTrigger";
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/AbstractBrokerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/AbstractBrokerHandler.java
@@ -12,12 +12,15 @@
  */
 package org.eclipse.smarthome.binding.mqtt.handler;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.thing.Bridge;
+import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
@@ -27,6 +30,8 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionObserver;
 import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionState;
 import org.eclipse.smarthome.io.transport.mqtt.MqttService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This base implementation handles connection changes of the {@link MqttBrokerConnection}
@@ -37,8 +42,10 @@ import org.eclipse.smarthome.io.transport.mqtt.MqttService;
  */
 @NonNullByDefault
 public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements MqttConnectionObserver {
+    private final Logger logger = LoggerFactory.getLogger(AbstractBrokerHandler.class);
     public static int TIMEOUT_DEFAULT = 1200; /* timeout in milliseconds */
     protected final String brokerID;
+    final Map<ChannelUID, PublishTriggerChannel> channelStateByChannelUID = new HashMap<>();
 
     @NonNullByDefault({})
     protected MqttBrokerConnection connection;
@@ -77,6 +84,13 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
      */
     @Override
     public void initialize() {
+        for (Channel channel : thing.getChannels()) {
+            final PublishTriggerChannelConfig channelConfig = channel.getConfiguration()
+                    .as(PublishTriggerChannelConfig.class);
+            PublishTriggerChannel c = new PublishTriggerChannel(channelConfig, channel.getUID(), connection, this);
+            channelStateByChannelUID.put(channel.getUID(), c);
+        }
+
         connection.addConnectionObserver(this);
 
         connection.start().exceptionally(e -> {
@@ -96,7 +110,9 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
     public void connectionStateChanged(MqttConnectionState state, @Nullable Throwable error) {
         if (state == MqttConnectionState.CONNECTED) {
             updateStatus(ThingStatus.ONLINE);
+            channelStateByChannelUID.values().forEach(c -> c.start());
         } else {
+            channelStateByChannelUID.values().forEach(c -> c.stop());
             if (error == null) {
                 updateStatus(ThingStatus.OFFLINE);
             } else {
@@ -105,11 +121,18 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
         }
     }
 
+    @Override
+    protected void triggerChannel(ChannelUID channelUID, String event) {
+        super.triggerChannel(channelUID, event);
+    }
+
     /**
      * Removes listeners to the {@link MqttBrokerConnection}.
      */
     @Override
     public void dispose() {
+        channelStateByChannelUID.values().forEach(c -> c.stop());
+        channelStateByChannelUID.clear();
         connection.removeConnectionObserver(this);
         this.connection = null;
         super.dispose();

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/PublishTriggerChannel.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/PublishTriggerChannel.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.binding.mqtt.handler;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
+import org.eclipse.smarthome.io.transport.mqtt.MqttMessageSubscriber;
+
+/**
+ * Subscribes to a state topic and calls {@link AbstractBrokerHandler#triggerChannel(ChannelUID, String)} if a value got
+ * received.
+ *
+ * @author David Graeff - Initial contribution
+ */
+@NonNullByDefault
+public class PublishTriggerChannel implements MqttMessageSubscriber {
+    private final MqttBrokerConnection connection;
+    private final PublishTriggerChannelConfig config;
+    private final ChannelUID uid;
+    private final AbstractBrokerHandler handler;
+
+    PublishTriggerChannel(PublishTriggerChannelConfig config, ChannelUID uid, MqttBrokerConnection connection,
+            AbstractBrokerHandler handler) {
+        this.config = config;
+        this.uid = uid;
+        this.connection = connection;
+        this.handler = handler;
+    }
+
+    CompletableFuture<Boolean> start() {
+        return stop().thenCompose(b -> connection.subscribe(config.stateTopic, this));
+    }
+
+    @Override
+    public void processMessage(String topic, byte[] payload) {
+        String value = new String(payload);
+        // Check condition
+        String expectedPayload = config.payload;
+        if (expectedPayload != null && !value.equals(expectedPayload)) {
+            return;
+        }
+        handler.triggerChannel(uid, value);
+    }
+
+    public CompletableFuture<Boolean> stop() {
+        return connection.unsubscribe(config.stateTopic, this);
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/PublishTriggerChannelConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/PublishTriggerChannelConfig.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.binding.mqtt.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+
+/**
+ * Holds the configuration of a {@link PublishTriggerChannel}.
+ *
+ * @author David Graeff - Initial contribution
+ */
+@NonNullByDefault
+public class PublishTriggerChannelConfig {
+    public String stateTopic = "";
+    public @Nullable String payload;
+}


### PR DESCRIPTION
Configured brokers are now extensible.
A trigger channel can be added that triggers if a specific value or
any value got received on a configured MQTT topic.

Signed-off-by: David Graeff <david.graeff@web.de>