### PR TITLE
[core / expiring-cache] Add Nullable annotations & add new constructor

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/cache/ExpiringCacheTest.java
@@ -37,11 +37,6 @@ public class ExpiringCacheTest {
         subject = new ExpiringCache<>(CACHE_EXPIRY, CACHE_ACTION);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testIllegalArgumentException1() throws IllegalArgumentException {
-        new ExpiringCache<>(CACHE_EXPIRY, null);
-    }
-
     @Test
     public void testGetValue() {
         // use the same key twice

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCache.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/cache/ExpiringCache.java
@@ -13,9 +13,10 @@
 package org.eclipse.smarthome.core.cache;
 
 import java.lang.ref.SoftReference;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import java.util.function.Supplier;
 
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
@@ -25,14 +26,28 @@ import org.eclipse.jdt.annotation.Nullable;
  * answer from the last calculation is not valid anymore, i.e. if it is expired.
  *
  * @author Christoph Weitkamp - Initial contribution
+ * @author Martin van Wingerden - Add Null annotations and Duration constructor
  *
  * @param <V> the type of the value
  */
+@NonNullByDefault
 public class ExpiringCache<V> {
     private final long expiry;
-    private final Supplier<V> action;
-    private SoftReference<V> value;
+    private final Supplier<@Nullable V> action;
+
+    private SoftReference<@Nullable V> value = new SoftReference<>(null);
     private long expiresAt;
+
+    /**
+     * Create a new instance.
+     *
+     * @param expiry the duration for how long the value stays valid
+     * @param action the action to retrieve/calculate the value
+     */
+    public ExpiringCache(Duration expiry, Supplier<@Nullable V> action) {
+        this.expiry = expiry.toNanos();
+        this.action = action;
+    }
 
     /**
      * Create a new instance.
@@ -40,15 +55,8 @@ public class ExpiringCache<V> {
      * @param expiry the duration in milliseconds for how long the value stays valid
      * @param action the action to retrieve/calculate the value
      */
-    public ExpiringCache(long expiry, Supplier<V> action) {
-        if (action == null) {
-            throw new IllegalArgumentException("ExpiringCacheItem cannot be created as action is null.");
-        }
-
-        this.expiry = TimeUnit.MILLISECONDS.toNanos(expiry);
-        this.action = action;
-
-        invalidateValue();
+    public ExpiringCache(long expiry, Supplier<@Nullable V> action) {
+        this(Duration.ofMillis(expiry), action);
     }
 
     /**


### PR DESCRIPTION
Add Nullable annotations & add new constructor

The current semi annotated implementation gives problems when combining with completely annotated classes, this solves the problem and makes sure work arounds are not needed. 

It seems that it does not break backwards compatibility but please let me know when it does,.

CC: @cweitkamp @maggu2810 @triller-telekom 

See also: 

https://github.com/openhab/openhab2-addons/pull/4182#discussion_r230594545
https://github.com/Hilbrand/openhab2-addons/pull/1