### PR TITLE
MQTT brokers: Rename channel types, use lowercase names. Fix heartbeat test

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/HomieThingHandlerTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/HomieThingHandlerTests.java
@@ -371,6 +371,8 @@ public class HomieThingHandlerTests {
         // Inject spy'ed subscriber object
         doAnswer(this::createSubscriberAnswer).when(thingHandler.device.stats).createSubscriber(any(), any(), any(),
                 anyBoolean());
+        doAnswer(this::createSubscriberAnswer).when(thingHandler.device.attributes).createSubscriber(any(), any(),
+                any(), anyBoolean());
 
         thingHandler.device.attributes.state = ReadyState.ready;
         thingHandler.device.attributes.name = "device";

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/ThingChannelConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/ThingChannelConstants.java
@@ -20,8 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.eclipse.smarthome.binding.mqtt.generic.internal.MqttBindingConstants;
 import org.eclipse.smarthome.config.core.Configuration;
-import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.ThingUID;
@@ -39,11 +39,12 @@ public class ThingChannelConstants {
     final public static ThingUID testHomieThing = new ThingUID(HOMIE300_MQTT_THING, "device123");
     final public static ThingUID testHomeAssistantThing = new ThingUID(HOMEASSISTANT_MQTT_THING, "device234");
 
-    final public static ChannelTypeUID textChannel = new ChannelTypeUID(BINDING_ID, CoreItemFactory.STRING);
-    final public static ChannelTypeUID textWithJsonChannel = new ChannelTypeUID(BINDING_ID, CoreItemFactory.STRING);
-    final public static ChannelTypeUID onoffChannel = new ChannelTypeUID(BINDING_ID, CoreItemFactory.SWITCH);
-    final public static ChannelTypeUID numberChannel = new ChannelTypeUID(BINDING_ID, CoreItemFactory.NUMBER);
-    final public static ChannelTypeUID percentageChannel = new ChannelTypeUID(BINDING_ID, CoreItemFactory.DIMMER);
+    final public static ChannelTypeUID textChannel = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.STRING);
+    final public static ChannelTypeUID textWithJsonChannel = new ChannelTypeUID(BINDING_ID,
+            MqttBindingConstants.STRING);
+    final public static ChannelTypeUID onoffChannel = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.SWITCH);
+    final public static ChannelTypeUID numberChannel = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.NUMBER);
+    final public static ChannelTypeUID percentageChannel = new ChannelTypeUID(BINDING_ID, MqttBindingConstants.DIMMER);
     final public static ChannelTypeUID unknownChannel = new ChannelTypeUID(BINDING_ID, "unknown");
 
     final public static ChannelUID textChannelUID = new ChannelUID(testGenericThing, "mytext");

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/channels.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<channel-type id="String">
+	<channel-type id="string">
 		<item-type>String</item-type>
 		<label>Text value</label>
 		<config-description>
@@ -42,13 +42,13 @@
 		</config-description>
 	</channel-type>
 
-	<channel-type id="Number">
+	<channel-type id="number">
 		<item-type>Number</item-type>
 		<label>Number value</label>
 		<config-description-ref uri="mqtt:number_channel"></config-description-ref>
 	</channel-type>
 
-	<channel-type id="Dimmer">
+	<channel-type id="dimmer">
 		<item-type>Dimmer</item-type>
 		<label>Percentage value</label>
 		<config-description>
@@ -103,7 +103,7 @@
 		</config-description>
 	</channel-type>
 
-	<channel-type id="Switch">
+	<channel-type id="switch">
 		<item-type>Switch</item-type>
 		<label>On/Off switch</label>
 		<config-description>
@@ -148,7 +148,7 @@
 		</config-description>
 	</channel-type>
 
-	<channel-type id="Contact">
+	<channel-type id="contact">
 		<item-type>Contact</item-type>
 		<label>Open/Close contact</label>
 		<config-description>
@@ -189,7 +189,7 @@
 		</config-description>
 	</channel-type>
 
-	<channel-type id="ColorRGB">
+	<channel-type id="colorRGB">
 		<item-type>Color</item-type>
 		<label>Color value (Red,Green,Blue)</label>
 		<description></description>
@@ -235,7 +235,7 @@
 		</config-description>
 	</channel-type>
 
-	<channel-type id="ColorHSB">
+	<channel-type id="colorHSB">
 		<item-type>Color</item-type>
 		<label>Color value (Hue,Saturation,Brightness)</label>
 		<description></description>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/generic-thing.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/generic-thing.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="topic" extensible="String,Number,Dimmer,Switch,Contact,ColorRGB,ColorHSB">
+	<thing-type id="topic" extensible="string,number,dimmer,switch,contact,colorRGB,colorHSB">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker" />
 			<bridge-type-ref id="systemBroker" />

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
@@ -37,13 +37,13 @@ You can manually add the following channels:
 
 ## Supported Channels
 
-* **String**: This channel can show the received text on the given topic and can send text to a given topic.
-* **Number**: This channel can show the received number on the given topic and can send a number to a given topic. It can have a min, max and step values.
-* **Dimmer**: This channel handles numeric values as percentages. It can have min, max and step values.
-* **Contact**: This channel represents a open/close (on/off) state of a given topic.
-* **Switch**: This channel represents a on/off state of a given topic and can send an on/off value to a given topic.
-* **ColorRGB**: This channel handles color values in RGB format.
-* **ColorHSB**: This channel handles color values in HSB format.
+* **string**: This channel can show the received text on the given topic and can send text to a given topic.
+* **number**: This channel can show the received number on the given topic and can send a number to a given topic. It can have a min, max and step values.
+* **dimmer**: This channel handles numeric values as percentages. It can have min, max and step values.
+* **contact**: This channel represents a open/close (on/off) state of a given topic.
+* **switch**: This channel represents a on/off state of a given topic and can send an on/off value to a given topic.
+* **colorRGB**: This channel handles color values in RGB format.
+* **colorHSB**: This channel handles color values in HSB format.
 
 ## Thing and Channel configuration
 
@@ -56,13 +56,13 @@ All things require a configured broker.
 * __commandTopic__: The MQTT topic that commands are send to. This can be empty, the thing channel will be read-only then. Transformations are not applied for sending data.
 * __formatBeforePublish__: Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".
 
-### Channel Type "String"
+### Channel Type "string"
 
 * __allowedStates__: An optional comma separated list of allowed states. Example: "ONE,TWO,THREE"
 
 You can connect this channel to a String item.
 
-### Channel Type "Number"
+### Channel Type "number"
  
 * __min__: An optional minimum value
 * __max__: An optional maximum value
@@ -73,7 +73,7 @@ If any of the parameters is a float/double (has a decimal point value), then a f
 
 You can connect this channel to a Number item.
 
-### Channel Type "Dimmer"
+### Channel Type "dimmer"
  
 * __min__: A required minimum value.
 * __max__: A required maximum value.
@@ -83,17 +83,16 @@ The value is internally stored as a percentage for a value between **min** and *
 
 You can connect this channel to a Rollershutter or Dimmer item.
 
-### Channel Type "Contact", "Switch"
+### Channel Type "contact", "switch"
 
 * __on__: A number (like 1, 10) or a string (like "ON"/"Open") that is recognised as on state.
 * __off__: A number (like 0, -10) or a string (like "OFF"/"Close") that is recognised as off state.
-* __inverse__: Inverse the meaning. A received "ON"/"Open" will switch the thing channel off/closed and vice versa.
 
 The thing by default always recognises `"ON"`,`"1"`, `1` as on state and `"OFF"`, `"0"`, `0` as off state and if **on** and **off** are not configured it sends the integer values `1` for on and `0` for off.
 
 You can connect this channel to a Contact or Switch item.
 
-### Channel Type "ColorRGB", "ColorHSB"
+### Channel Type "colorRGB", "colorHSB"
 
 You can connect this channel to a Color item.
 
@@ -149,11 +148,11 @@ demo.Things:
 ```xtend
 Thing mqtt:mybroker:topic:mything {
 Channels:
-    Type Switch : lamp "Kitchen Lamp" [ mqttstate="lamp/enabled", mqttcommand="lamp/enabled/set" ]
-    Type Switch : fancylamp "Fancy Lamp" [ mqttstate="fancy/lamp/state", mqttcommand="fancy/lamp/command", on="i-am-on", off="i-am-off" ]
-    Type EnumSwitch : alarmpanel "Alarm system" [ mqttstate="alarm/panel/state", mqttcommand="alarm/panel/set", allowedStates="ARMED_HOME,ARMED_AWAY,UNARMED" ]
-    Type Color : lampcolor "Kitchen Lamp color" [ mqttstate="lamp/color", mqttcommand="lamp/color/set", rgb=true ]
-    Type Dimmer : blind "Blind" [ mqttstate="blind/state", mqttcommand="blind/set", min=0, max=5, step=1 ]
+    Type switch : lamp "Kitchen Lamp" [ mqttstate="lamp/enabled", mqttcommand="lamp/enabled/set" ]
+    Type switch : fancylamp "Fancy Lamp" [ mqttstate="fancy/lamp/state", mqttcommand="fancy/lamp/command", on="i-am-on", off="i-am-off" ]
+    Type string : alarmpanel "Alarm system" [ mqttstate="alarm/panel/state", mqttcommand="alarm/panel/set", allowedStates="ARMED_HOME,ARMED_AWAY,UNARMED" ]
+    Type color : lampcolor "Kitchen Lamp color" [ mqttstate="lamp/color", mqttcommand="lamp/color/set", rgb=true ]
+    Type dimmer : blind "Blind" [ mqttstate="blind/state", mqttcommand="blind/set", min=0, max=5, step=1 ]
 }
 ```
 

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/MqttBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/MqttBindingConstants.java
@@ -32,14 +32,14 @@ public class MqttBindingConstants {
     public static final ThingTypeUID HOMEASSISTANT_MQTT_THING = new ThingTypeUID(BINDING_ID, "homeassistant");
 
     // Generic thing channel types
-    public static final String COLOR_RGB = "ColorRGB";
-    public static final String COLOR_HSB = "ColorHSB";
-    public static final String CONTACT = "Contact";
-    public static final String DATETIME = "DateTime";
-    public static final String DIMMER = "Dimmer";
-    public static final String NUMBER = "Number";
-    public static final String STRING = "String";
-    public static final String SWITCH = "Switch";
+    public static final String COLOR_RGB = "colorRGB";
+    public static final String COLOR_HSB = "colorHSB";
+    public static final String CONTACT = "contact";
+    public static final String DATETIME = "dateTime";
+    public static final String DIMMER = "dimmer";
+    public static final String NUMBER = "number";
+    public static final String STRING = "string";
+    public static final String SWITCH = "switch";
 
     public static final String CONFIG_HA_CHANNEL = "mqtt:ha_channel";
     public static final String CONFIG_HOMIE_CHANNEL = "mqtt:homie_channel";


### PR DESCRIPTION
Fixes #6462
Signed-off-by: David Graeff <david.graeff@web.de>