### PR TITLE
[LIFX] Use light specific TemperatureRange with temperature channel calculations

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/LifxBindingConstants.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.binding.lifx;
 
-import static org.eclipse.smarthome.binding.lifx.internal.util.LifxMessageUtil.kelvinToPercentType;
-
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -49,7 +47,7 @@ public class LifxBindingConstants {
     public static final int MAX_ZONE_INDEX = 255;
 
     // Fallback light state defaults
-    public static final HSBK DEFAULT_COLOR = new HSBK(HSBType.WHITE, kelvinToPercentType(3000));
+    public static final HSBK DEFAULT_COLOR = new HSBK(HSBType.WHITE, 3000);
     public static final PercentType DEFAULT_BRIGHTNESS = PercentType.HUNDRED;
 
     // List of all Channel IDs

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/LifxLightState.java
@@ -137,17 +137,17 @@ public class LifxLightState {
         listeners.forEach(listener -> listener.handlePowerStateChange(oldPowerState, newPowerState));
     }
 
-    public void setTemperature(PercentType temperature) {
+    public void setTemperature(int kelvin) {
         HSBK[] newColors = getColors();
         for (HSBK newColor : newColors) {
-            newColor.setTemperature(temperature);
+            newColor.setKelvin(kelvin);
         }
         setColors(newColors);
     }
 
-    public void setTemperature(PercentType temperature, int zoneIndex) {
+    public void setTemperature(int kelvin, int zoneIndex) {
         HSBK newColor = getColor(zoneIndex);
-        newColor.setTemperature(temperature);
+        newColor.setKelvin(kelvin);
         setColor(newColor, zoneIndex);
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/fields/HSBK.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/fields/HSBK.java
@@ -44,9 +44,9 @@ public class HSBK {
         this(other.hue, other.saturation, other.brightness, other.kelvin);
     }
 
-    public HSBK(HSBType hsb, PercentType temperature) {
+    public HSBK(HSBType hsb, int kelvin) {
         setHSB(hsb);
-        setTemperature(temperature);
+        this.kelvin = kelvin;
     }
 
     public int getHue() {
@@ -72,10 +72,6 @@ public class HSBK {
         return new HSBType(hue, saturation, brightness);
     }
 
-    public PercentType getTemperature() {
-        return kelvinToPercentType(kelvin);
-    }
-
     public void setHSB(HSBType hsb) {
         setHue(hsb.getHue());
         setSaturation(hsb.getSaturation());
@@ -94,8 +90,8 @@ public class HSBK {
         this.brightness = percentTypeToBrightness(brightness);
     }
 
-    public void setTemperature(PercentType temperature) {
-        kelvin = percentTypeToKelvin(temperature);
+    public void setKelvin(int kelvin) {
+        this.kelvin = kelvin;
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Product.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Product.java
@@ -146,6 +146,15 @@ public enum Product {
         public int getMaximum() {
             return maximum;
         }
+
+        /**
+         * The color temperature range in degrees Kelvin.
+         *
+         * @return difference between maximum and minimum color temperature values
+         */
+        public int getRange() {
+            return maximum - minimum;
+        }
     }
 
     private final Vendor vendor;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/util/LifxMessageUtil.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/util/LifxMessageUtil.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.lifx.internal.fields.HSBK;
+import org.eclipse.smarthome.binding.lifx.internal.protocol.Product.TemperatureRange;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
 import org.eclipse.smarthome.core.library.types.PercentType;
@@ -90,14 +91,17 @@ public final class LifxMessageUtil {
         return percentTypeToInt(brightness);
     }
 
-    public static PercentType kelvinToPercentType(int kelvin) {
-        // range is from 2500-9000K
-        return new PercentType((kelvin - 9000) / (-65));
+    public static PercentType kelvinToPercentType(int kelvin, TemperatureRange temperatureRange) {
+        if (temperatureRange.getRange() == 0) {
+            return PercentType.HUNDRED;
+        }
+        return new PercentType(
+                BigDecimal.valueOf((kelvin - temperatureRange.getMaximum()) / (temperatureRange.getRange() / -100)));
     }
 
-    public static int percentTypeToKelvin(PercentType temperature) {
-        // range is from 2500-9000K
-        return 9000 - (temperature.intValue() * 65);
+    public static int percentTypeToKelvin(PercentType temperature, TemperatureRange temperatureRange) {
+        return Math.round(
+                temperatureRange.getMaximum() - (temperature.floatValue() * (temperatureRange.getRange() / 100)));
     }
 
     public static PercentType infraredToPercentType(int infrared) {


### PR DESCRIPTION
This PR uses the `TemperatureRange` (added in #6476) for state calculations on the color `temperature` channel. E.g. for the "LIFX Mini Day and Dusk" now a 1500-4000K range will be used instead of a 2500-9000K temperature range.