### PR TITLE
fix thing handler's "set callback" documentation

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/binding/ThingHandler.java
@@ -80,7 +80,7 @@ public interface ThingHandler {
      * <p>
      * The callback is added after the handler instance has been tracked by the framework and before
      * {@link #initialize()} is called. The callback is removed (set to null) after the handler
-     * instance is no longer tracked and before {@link #dispose()} is called.
+     * instance is no longer tracked and after {@link #dispose()} is called.
      * <p>
      *
      * @param thingHandlerCallback the callback (can be null)


### PR DESCRIPTION
The callback is removed after the thing handler has been disposed.

The calling order of initialize, set callback and dispose of the thing handler implementation is:

    registerAndInitializeHandler
      registerHandler
        doRegisterHandler
          set callback to non-null
      inizializeHandler
        doInitializeHandler
          calls inizialize using the safe caller

    unregisterAndDisposeHandler
      disposeHandler
        doDisposeHandler
          calls dispose using the safe caller
      unregisterHandler
        doUnregisterHandler
          set callback to null
