### PR TITLE
make the explicit disable thing more readable

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1257,7 +1257,7 @@ public class ThingManagerImpl
     }
 
     private boolean isDisabledByStorage(ThingUID thingUID) {
-        return storage == null || Boolean.FALSE.equals(storage.get(thingUID.getAsString()));
+        return storage != null && Boolean.FALSE.equals(storage.get(thingUID.getAsString()));
     }
 
     @Reference

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -632,10 +632,8 @@ public class ThingManagerImpl
     }
 
     private void initializeHandler(Thing thing) {
-        if (storage != null && storage.containsKey(thing.getUID().getAsString())
-                && !storage.get(thing.getUID().getAsString())) {
+        if (isDisabledByStorage(thing.getUID())) {
             logger.debug("Thing '{}' will not be initialized. It is marked as disabled.", thing.getUID());
-
             return;
         }
         if (!isHandlerRegistered(thing)) {
@@ -813,11 +811,7 @@ public class ThingManagerImpl
             }
             thing.setHandler(null);
 
-            boolean enabled = true;
-            if (storage != null && storage.containsKey(thing.getUID().getAsString())
-                    && !storage.get(thing.getUID().getAsString())) {
-                enabled = false;
-            }
+            boolean enabled = !isDisabledByStorage(thing.getUID());
 
             ThingStatusDetail detail = enabled ? ThingStatusDetail.HANDLER_MISSING_ERROR : ThingStatusDetail.DISABLED;
 
@@ -1260,6 +1254,10 @@ public class ThingManagerImpl
     public Boolean isEnabled(ThingUID thingUID) {
         Thing thing = getThing(thingUID);
         return thing.isEnabled();
+    }
+
+    private boolean isDisabledByStorage(ThingUID thingUID) {
+        return storage == null || Boolean.FALSE.equals(storage.get(thingUID.getAsString()));
     }
 
     @Reference


### PR DESCRIPTION
I used "isDisabledByStorage" instead of "isEnabledByStorage" because the current logic only states it is disabled if the storage is present.
So, if the storage is not present it is not disabled (not explicit enabled).

@htreu Can you check the logic itself?