### PR TITLE
Add new status ONLINE/DEACTIVATED

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusDetail.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingStatusDetail.java
@@ -36,7 +36,17 @@ public enum ThingStatusDetail {
      * the thing handler should be removed.
      */
     GONE,
-    DISABLED;
+    DISABLED,
+
+    /**
+     * A device which can be reached by the handler and is ONLINE while it can not receive or respond to command sent to
+     * it. A vendor application might set/unset this status.
+     * E.g. a speaker which is paired as a slave in a stereo pair and will not react to commands. But it will send
+     * updates about its pairing status or even updates on channel states. Only the vendor application can unpair the
+     * speaker to make it ONLINE/NONE again.
+     *
+     */
+    DEACTIVATED;
 
     public static final UninitializedStatus UNINITIALIZED = new UninitializedStatus();
     public static final NoneOnlyStatus INITIALIZING = new NoneOnlyStatus();
@@ -71,6 +81,7 @@ public enum ThingStatusDetail {
 
         public ThingStatusDetail NONE = ThingStatusDetail.NONE;
         public ThingStatusDetail CONFIGURATION_PENDING = ThingStatusDetail.CONFIGURATION_PENDING;
+        public ThingStatusDetail DEACTIVATED = ThingStatusDetail.DEACTIVATED;
     };
 
     public static final class OfflineStatus {


### PR DESCRIPTION
I propose a new status detail `ONLINE/DEACTIVATED` for reachable, online things which will not respond to commands but which will report status updates (like becoming ONLINE/NONE again) or channel state updates.
A vendor application might set the device in such a state and also is the only way to bring it back ONLINE/NONE again.
An example (and the reason behind this PR): A speaker is paired as a slave in a stereo pair. As a slave it can not react on commands sent to it, so a UI should hide linked items or display them as deactivated. The handler will continue to hold contact to the device and should be able to determine if the status is ONLINE/DEACTIVATED or changes.

Paper UI is still to be adopted, I want to see comments on this proposal first.

Signed-off-by: Henning Treu <henning.treu@telekom.de>