### PR TITLE
[hotfix] [io.net.test] Small cleanup and unbrick build

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.net.test/src/test/java/org/eclipse/smarthome/io/net/http/internal/ExtensibleTrustManagerTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/src/test/java/org/eclipse/smarthome/io/net/http/internal/ExtensibleTrustManagerTest.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.smarthome.io.net.http.internal;
 
 import static org.mockito.Mockito.*;
@@ -20,6 +32,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+/**
+ * Tests which validate the behaviour of the ExtensibleTrustManager
+ *
+ * @author Martin van Wingerden - Initial contribution
+ */
 public class ExtensibleTrustManagerTest {
     private ExtensibleTrustManager subject;
 

--- a/bundles/io/org.eclipse.smarthome.io.net.test/src/test/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryTest.java
+++ b/bundles/io/org.eclipse.smarthome.io.net.test/src/test/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryTest.java
@@ -65,7 +65,7 @@ public class WebClientFactoryTest {
         webClientFactory.setTrustmanagerProvider(trustmanagerProvider);
         webClientFactory.setExtensibleTrustManager(extensibleTrustManager);
 
-        webClientFactory.activate(createConfigMap(10, 200, 60, 5, 10, 60));
+        webClientFactory.activate(createConfigMap(4, 200, 60, 2, 10, 60));
     }
 
     @After
@@ -83,6 +83,7 @@ public class WebClientFactoryTest {
     }
 
     @Test
+    @Ignore("connecting to the outside world makes this test flaky")
     public void testCommonClientUsesExtensibleTrustManager() throws Exception {
         ArgumentCaptor<X509Certificate[]> certificateChainCaptor = ArgumentCaptor.forClass(X509Certificate[].class);
         ArgumentCaptor<SSLEngine> sslEngineCaptor = ArgumentCaptor.forClass(SSLEngine.class);
@@ -100,8 +101,6 @@ public class WebClientFactoryTest {
         assertThat(sslEngineCaptor.getValue().getPeerPort(), is(443));
         assertThat(certificateChainCaptor.getValue()[0].getSubjectX500Principal().getName(),
                 containsString("eclipse.org"));
-
-        httpClient.stop();
     }
 
     @Test
@@ -137,8 +136,6 @@ public class WebClientFactoryTest {
             httpClient.GET(TEST_URL);
         } catch (ExecutionException e) {
             throw e.getCause();
-        } finally {
-            httpClient.stop();
         }
     }
 

--- a/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryImpl.java
+++ b/bundles/io/org.eclipse.smarthome.io.net/src/main/java/org/eclipse/smarthome/io/net/http/internal/WebClientFactoryImpl.java
@@ -391,12 +391,10 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
     }
 
     @Reference
-    @Deprecated
     protected void setExtensibleTrustManager(ExtensibleTrustManager extensibleTrustManager) {
         this.extensibleTrustManager = extensibleTrustManager;
     }
 
-    @Deprecated
     protected void unsetExtensibleTrustManager(ExtensibleTrustManager extensibleTrustManager) {
         if (this.extensibleTrustManager == extensibleTrustManager) {
             this.extensibleTrustManager = null;
@@ -404,10 +402,12 @@ public class WebClientFactoryImpl implements HttpClientFactory, WebSocketFactory
     }
 
     @Reference(service = TrustManagerProvider.class, cardinality = ReferenceCardinality.OPTIONAL, policy = ReferencePolicy.DYNAMIC)
+    @Deprecated
     protected void setTrustmanagerProvider(TrustManagerProvider trustmanagerProvider) {
         this.trustmanagerProvider = trustmanagerProvider;
     }
 
+    @Deprecated
     protected void unsetTrustmanagerProvider(TrustManagerProvider trustmanagerProvider) {
         if (this.trustmanagerProvider == trustmanagerProvider) {
             this.trustmanagerProvider = null;


### PR DESCRIPTION
- Added missing file-level copyright
- Moved the @Deprecated to the correct place
- Ignore test using the external world

See https://github.com/eclipse/smarthome/pull/6281#issuecomment-438792684

> @martinvw Something does not seem to be right about the `WebClientFactoryTest`- looking at https://ci.eclipse.org/smarthome/job/SmartHomeDistribution-Nightly/, all builds are hanging since this has merged and the test never seems to complete, so Jenkins aborts the job.

CC: @kaikreuzer 