### PR TITLE
Mqtt fixes

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/channels.xml
@@ -33,6 +33,12 @@
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="postCommand" type="boolean">
+				<label>Is command</label>
+				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
 
 			<parameter name="allowedStates" type="text">
 				<label>Allowed states</label>
@@ -74,6 +80,12 @@
 			<parameter name="retained" type="boolean">
 				<label>Retained</label>
 				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="postCommand" type="boolean">
+				<label>Is command</label>
+				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -132,6 +144,12 @@
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="postCommand" type="boolean">
+				<label>Is command</label>
+				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
 
 			<parameter name="on" type="text">
 				<label>ON value</label>
@@ -170,6 +188,12 @@
 			<parameter name="retained" type="boolean">
 				<label>Retained</label>
 				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="postCommand" type="boolean">
+				<label>Is command</label>
+				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
@@ -219,6 +243,12 @@
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>
+			<parameter name="postCommand" type="boolean">
+				<label>Is command</label>
+				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
 
 			<parameter name="on" type="text">
 				<label>ON value</label>
@@ -262,6 +292,12 @@
 			<parameter name="retained" type="boolean">
 				<label>Retained</label>
 				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+				<default>false</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="postCommand" type="boolean">
+				<label>Is command</label>
+				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
 				<default>false</default>
 				<advanced>true</advanced>
 			</parameter>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homie300/Property.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homie300/Property.java
@@ -163,8 +163,12 @@ public class Property implements AttributeChanged {
                 break;
         }
 
-        ChannelConfigBuilder b = ChannelConfigBuilder.create().withStateTopic(stateTopic)
-                .withRetain(attributes.retained);
+        ChannelConfigBuilder b = ChannelConfigBuilder.create().withRetain(attributes.retained);
+
+        if (attributes.retained) {
+            b = b.withStateTopic(stateTopic);
+        }
+
         if (attributes.settable) {
             b = b.withCommandTopic(commandTopic);
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/discovery/HomeAssistantDiscovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/discovery/HomeAssistantDiscovery.java
@@ -70,11 +70,11 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         String name = "";
     }
 
-    final static String baseTopic = "homeassistant";
+    static final String BASE_TOPIC = "homeassistant";
 
     public HomeAssistantDiscovery() {
         super(Stream.of(MqttBindingConstants.HOMEASSISTANT_MQTT_THING).collect(Collectors.toSet()), 3, true,
-                baseTopic + "/#");
+                BASE_TOPIC + "/#");
     }
 
     @NonNullByDefault({})
@@ -159,7 +159,7 @@ public class HomeAssistantDiscovery extends AbstractMQTTDiscovery {
         Map<String, Object> properties = new HashMap<>();
         properties.put("objectid", topicParts.objectID);
         properties.put("nodeid", topicParts.nodeID);
-        properties.put("basetopic", baseTopic);
+        properties.put("basetopic", BASE_TOPIC);
         // First remove an already discovered thing with the same ID
         thingRemoved(thingUID);
         // Because we need the new properties map with the updated "components" list

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/discovery/Homie300Discovery.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/discovery/Homie300Discovery.java
@@ -44,11 +44,11 @@ import org.slf4j.LoggerFactory;
 public class Homie300Discovery extends AbstractMQTTDiscovery {
     private final Logger logger = LoggerFactory.getLogger(Homie300Discovery.class);
 
-    final static String baseTopic = "homie";
+    static final String BASE_TOPIC = "homie";
 
     public Homie300Discovery() {
         super(Stream.of(MqttBindingConstants.HOMIE300_MQTT_THING).collect(Collectors.toSet()), 3, true,
-                baseTopic + "/+/$homie");
+                BASE_TOPIC + "/+/$homie");
     }
 
     @NonNullByDefault({})
@@ -119,7 +119,7 @@ public class Homie300Discovery extends AbstractMQTTDiscovery {
     void publishDevice(ThingUID connectionBridge, MqttBrokerConnection connection, String deviceID, String name) {
         Map<String, Object> properties = new HashMap<>();
         properties.put("deviceid", deviceID);
-        properties.put("basetopic", baseTopic);
+        properties.put("basetopic", BASE_TOPIC);
 
         thingDiscovered(DiscoveryResultBuilder
                 .create(new ThingUID(MqttBindingConstants.HOMIE300_MQTT_THING, connectionBridge, deviceID))

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelConfig.java
@@ -28,6 +28,12 @@ public class ChannelConfig {
     public String stateTopic = "";
     public String commandTopic = "";
 
+    /**
+     * If true, the channel state is not updated on a new message.
+     * Instead a postCommand() call is performed.
+     */
+    public boolean postCommand = false;
+    /** If true publishes messages as retained messages */
     public boolean retained = false;
     public String unit = "";
 

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelState.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelState.java
@@ -44,26 +44,31 @@ import org.slf4j.LoggerFactory;
 public class ChannelState implements MqttMessageSubscriber {
     private final Logger logger = LoggerFactory.getLogger(ChannelState.class);
 
-    protected @Nullable MqttBrokerConnection connection;
-    private final boolean readOnly;
+    // Immutable channel configuration
+    protected final boolean readOnly;
     protected final ChannelUID channelUID;
+    protected final boolean trigger;
+    protected final ChannelConfig config;
+
+    /** Channel value **/
     protected final Value value;
 
+    // Runtime variables
+
+    protected @Nullable MqttBrokerConnection connection;
     protected final List<ChannelStateTransformation> transformations = new ArrayList<>();
     private @Nullable ChannelStateUpdateListener channelStateUpdateListener;
     protected boolean hasSubscribed = false;
     private @Nullable ScheduledFuture<?> scheduledFuture;
     private CompletableFuture<@Nullable Void> future = new CompletableFuture<>();
 
-    final ChannelConfig config;
-
     /**
      * Creates a new channel state.
      *
-     * @param stateTopic The state topic. Might be null for a no-state channel
-     * @param commandTopic The command topic, Might be null for a read-only channel
+     * @param config The channel configuration
      * @param channelUID The channelUID is used for the {@link ChannelStateUpdateListener} to notify about value changes
      * @param value The channel state value.
+     * @param channelStateUpdateListener A channel state update listener
      */
     public ChannelState(ChannelConfig config, ChannelUID channelUID, Value value,
             @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
@@ -72,6 +77,7 @@ public class ChannelState implements MqttMessageSubscriber {
         this.channelUID = channelUID;
         this.value = value;
         this.readOnly = StringUtils.isBlank(config.commandTopic);
+        this.trigger = StringUtils.isBlank(config.stateTopic);
     }
 
     public boolean isReadOnly() {
@@ -131,12 +137,20 @@ public class ChannelState implements MqttMessageSubscriber {
             strvalue = t.processValue(strvalue);
         }
 
-        try {
-            final State updatedState = value.update(strvalue);
-            channelStateUpdateListener.updateChannelState(channelUID, updatedState);
-        } catch (IllegalArgumentException e) {
-            logger.warn("Incoming payload '{}' not supported by type '{}'", strvalue, value.getClass().getSimpleName(),
-                    e);
+        if (trigger) {
+            channelStateUpdateListener.triggerChannel(channelUID, strvalue);
+        } else {
+            try {
+                final State updatedState = value.update(strvalue);
+                if (config.postCommand) {
+                    channelStateUpdateListener.postChannelState(channelUID, (Command) updatedState);
+                } else {
+                    channelStateUpdateListener.updateChannelState(channelUID, updatedState);
+                }
+            } catch (IllegalArgumentException e) {
+                logger.warn("Incoming payload '{}' not supported by type '{}'", strvalue,
+                        value.getClass().getSimpleName(), e);
+            }
         }
 
         receivedOrTimeout();

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateUpdateListener.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateUpdateListener.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.binding.mqtt.generic.internal.generic;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 
 /**
@@ -21,5 +22,29 @@ import org.eclipse.smarthome.core.types.State;
  */
 @NonNullByDefault
 public interface ChannelStateUpdateListener {
+    /**
+     * A new value got published on a configured MQTT topic associated with the given channel uid.
+     *
+     * @param channelUID The channel uid
+     * @param value The new value. Doesn't necessarily need to be different than the value before.
+     */
     void updateChannelState(ChannelUID channelUID, State value);
+
+    /**
+     * A new value got published on a configured MQTT topic associated with the given channel uid.
+     * The channel is configured to post the new state as command.
+     *
+     * @param channelUID The channel uid
+     * @param value The new value. Doesn't necessarily need to be different than the value before.
+     */
+    void postChannelState(ChannelUID channelUID, Command value);
+
+    /**
+     * A new value got published on a configured MQTT topic associated with the given channel uid.
+     * The channel is of kind Trigger.
+     *
+     * @param channelUID The channel uid
+     * @param value The new value. Doesn't necessarily need to be different than the value before.
+     */
+    void triggerChannel(ChannelUID channelUID, String eventPayload);
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/AbstractMQTTThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/AbstractMQTTThingHandler.java
@@ -19,8 +19,8 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelState;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.MqttChannelTypeProvider;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.TransformationServiceProvider;
 import org.eclipse.smarthome.binding.mqtt.handler.AbstractBrokerHandler;
@@ -222,4 +222,13 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
         super.updateState(channelUID, value);
     }
 
+    @Override
+    public void triggerChannel(ChannelUID channelUID, String event) {
+        super.triggerChannel(channelUID, event);
+    }
+
+    @Override
+    public void postChannelState(ChannelUID channelUID, Command command) {
+        postCommand(channelUID, command);
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ColorValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ColorValue.java
@@ -114,7 +114,11 @@ public class ColorValue implements Value {
             throw new IllegalArgumentException("Didn't recognise the color value " + command.toString());
         }
         state = colorValue;
-        return colorValue.toString();
+        if (isRGB) {
+            return colorValue.getRed() + "," + colorValue.getGreen() + "," + colorValue.getBlue();
+        } else {
+            return colorValue.toString();
+        }
     }
 
     /**
@@ -152,7 +156,8 @@ public class ColorValue implements Value {
 
     @Override
     public StateDescription createStateDescription(String unit, boolean readOnly) {
-        return new StateDescription(null, null, null, "%s " + unit, readOnly, Collections.emptyList());
+        return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), readOnly,
+                Collections.emptyList());
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/NumberValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/NumberValue.java
@@ -155,8 +155,8 @@ public class NumberValue implements Value {
 
     @Override
     public StateDescription createStateDescription(String unit, boolean readOnly) {
-        return new StateDescription(new BigDecimal(min), new BigDecimal(max), new BigDecimal(step), "%s " + unit,
-                readOnly, Collections.emptyList());
+        return new StateDescription(new BigDecimal(min), new BigDecimal(max), new BigDecimal(step),
+                "%s " + unit.replace("%", "%%"), readOnly, Collections.emptyList());
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/OnOffValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/OnOffValue.java
@@ -126,12 +126,13 @@ public class OnOffValue implements Value {
 
     @Override
     public String channelTypeID() {
-        return receivesOnly ? CoreItemFactory.CONTACT : CoreItemFactory.SWITCH;
+        return CoreItemFactory.SWITCH;
     }
 
     @Override
     public StateDescription createStateDescription(String unit, boolean readOnly) {
-        return new StateDescription(null, null, null, "%s " + unit, receivesOnly || readOnly, Collections.emptyList());
+        return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), receivesOnly || readOnly,
+                Collections.emptyList());
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/TextValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/TextValue.java
@@ -110,7 +110,7 @@ public class TextValue implements Value {
                 stateOptions.add(new StateOption(state, state));
             }
         }
-        return new StateDescription(null, null, null, "%s " + unit, readOnly, stateOptions);
+        return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), readOnly, stateOptions);
     }
 
     @Override


### PR DESCRIPTION
* Return RGB value for an RGB channel.
* Use triggerChannel instead of updateChannel for a trigger channel
* Allow the user to choose between updateChannel and postCommand
  for generic channels.
* Escape "%" character for a channel value unit type

Fixes #6515
Fixes #6522 
Fixes #6496

Signed-off-by: David Graeff <david.graeff@web.de>