### PR TITLE
MQTT broker fixes

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.test/src/test/java/org/eclipse/smarthome/binding/mqtt/handler/BrokerHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.test/src/test/java/org/eclipse/smarthome/binding/mqtt/handler/BrokerHandlerTest.java
@@ -107,7 +107,7 @@ public class BrokerHandlerTest {
         assertThat(initializeHandlerWaitForTimeout(), is(true));
 
         ArgumentCaptor<ThingStatusInfo> statusInfoCaptor = ArgumentCaptor.forClass(ThingStatusInfo.class);
-        verify(callback, times(3)).statusUpdated(eq(thing), statusInfoCaptor.capture());
+        verify(callback, atLeast(3)).statusUpdated(eq(thing), statusInfoCaptor.capture());
         Assert.assertThat(statusInfoCaptor.getValue().getStatus(), is(ThingStatus.ONLINE));
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/ESH-INF/thing/thing-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/ESH-INF/thing/thing-types.xml
@@ -23,17 +23,10 @@
 				<advanced>true</advanced>
 			</parameter>
 
-			<parameter name="secure" type="text" required="true">
+			<parameter name="secure" type="boolean" required="true">
 				<label>Secure connection</label>
-				<description>Uses TLS/SSL to establish a secure connection to the
-					broker. Can be "OFF","ON","AUTO". The AUTO setting prefers a secure
-					connection but will fall-back to an insecure one.</description>
-				<options>
-					<option value="ON">Enabled</option>
-					<option value="OFF">Disabled</option>
-					<option value="AUTO">Automatic</option>
-				</options>
-				<default>AUTO</default>
+				<description>Uses TLS/SSL to establish a secure connection to the broker.</description>
+				<default>false</default>
 			</parameter>
 
 			<parameter name="qos" type="integer">
@@ -187,6 +180,10 @@
             <parameter name="payload" type="text" required="false">
                 <label>Payload condition</label>
                 <description>An optional condition on the value of the MQTT topic that must match before this channel is triggered.</description>
+            </parameter>
+            <parameter name="separator" type="text" required="false">
+                <label>Separator character</label>
+                <description>The trigger channel payload usually only contains the received MQTT topic value. If you define a separator character, for example '#', the topic and received value will be in the trigger channel payload. For example: my_topic#my_received_value.</description>
             </parameter>
         </config-description>
     </channel-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/BrokerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/BrokerHandler.java
@@ -182,7 +182,9 @@ public class BrokerHandler extends AbstractBrokerHandler implements PinnedCallba
         if (StringUtils.isBlank(host) || host == null) {
             throw new IllegalArgumentException("Host is empty!");
         }
-        final MqttBrokerConnection connection = new MqttBrokerConnection(host, config.port, false, config.clientID);
+
+        final MqttBrokerConnection connection = new MqttBrokerConnection(host, config.port, config.secure,
+                config.clientID);
 
         final String username = config.username;
         final String password = config.password;

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/PublishTriggerChannel.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/PublishTriggerChannel.java
@@ -52,7 +52,11 @@ public class PublishTriggerChannel implements MqttMessageSubscriber {
         if (expectedPayload != null && !value.equals(expectedPayload)) {
             return;
         }
-        handler.triggerChannel(uid, value);
+        if (config.separator.isEmpty()) {
+            handler.triggerChannel(uid, value);
+        } else {
+            handler.triggerChannel(uid, topic + config.separator + value);
+        }
     }
 
     public CompletableFuture<Boolean> stop() {

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/PublishTriggerChannelConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/PublishTriggerChannelConfig.java
@@ -23,5 +23,6 @@ import org.eclipse.jdt.annotation.Nullable;
 @NonNullByDefault
 public class PublishTriggerChannelConfig {
     public String stateTopic = "";
+    public String separator = "";
     public @Nullable String payload;
 }


### PR DESCRIPTION
* Don't ignore secure setting for an mqtt broker
* Use the topic name and topic value for the trigger channel payload, if a separator is defined.

Fixes #5896