### PR TITLE
Added information to not use spaces in installpath when using windows to IDE Install Documentation

### DIFF
--- a/docs/documentation/development/ide.md
+++ b/docs/documentation/development/ide.md
@@ -28,7 +28,7 @@ Simply follow these steps:
 4. Expand the "SmartHome" entry, double click "Runtime" and select "Next":
 ![Step 2](images/ide2.png)
 
-5. Now provide an installation folder and your Github id (used to push your changesets to) and select "Next":
+5. Now provide an installation folder (don't use spaces in the path on Windows!) and your Github id (used to push your changesets to) and select "Next":
 ![Step 3](images/ide3.png)
 
 6. The installation will now begin when pressing "Finish".


### PR DESCRIPTION
In OpenHab the information to not use space in the installpath for the IDE
when set up is present, yet the information is missing in the Eclipse
Smarthome documentation. This commit fixes that and closes #6514.

Signed-off-by: Dominik Schlierf <dominik.schlierf.esh@web.de>