### PR TITLE
[WIP] Fix thing creation with updated XML

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ManagedThingProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ManagedThingProvider.java
@@ -12,10 +12,23 @@
  */
 package org.eclipse.smarthome.core.thing;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+
 import org.eclipse.smarthome.core.common.registry.DefaultAbstractManagedProvider;
+import org.eclipse.smarthome.core.service.ReadyMarker;
+import org.eclipse.smarthome.core.service.ReadyMarkerFilter;
+import org.eclipse.smarthome.core.service.ReadyService;
 import org.eclipse.smarthome.core.storage.StorageService;
+import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
+import org.eclipse.smarthome.core.util.BundleResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 
 /**
@@ -29,7 +42,16 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * @author Michael Grammling - Added dynamic configuration update
  */
 @Component(immediate = true, service = { ThingProvider.class, ManagedThingProvider.class })
-public class ManagedThingProvider extends DefaultAbstractManagedProvider<Thing, ThingUID> implements ThingProvider {
+public class ManagedThingProvider extends DefaultAbstractManagedProvider<Thing, ThingUID>
+        implements ThingProvider, ReadyService.ReadyTracker {
+    private static final String XML_THING_TYPE = "esh.xmlThingTypes";
+
+    private Set<String> loadedXmlThingTypes = new CopyOnWriteArraySet<>();
+    private List<ThingHandlerFactory> thingHandlerFactories = new CopyOnWriteArrayList<ThingHandlerFactory>();
+
+    private BundleResolver bundleResolver;
+
+    private Collection<Thing> thingsList = new ArrayList<>();
 
     @Override
     protected String getStorageName() {
@@ -50,6 +72,93 @@ public class ManagedThingProvider extends DefaultAbstractManagedProvider<Thing, 
     @Override
     protected void unsetStorageService(StorageService storageService) {
         super.unsetStorageService(storageService);
+    }
+
+    @Reference
+    protected void setBundleResolver(BundleResolver bundleResolver) {
+        this.bundleResolver = bundleResolver;
+    }
+
+    protected void unsetBundleResolver(BundleResolver bundleResolver) {
+        this.bundleResolver = null;
+    }
+
+    @Reference
+    protected void setReadyService(ReadyService readyService) {
+        readyService.registerTracker(this, new ReadyMarkerFilter().withType(XML_THING_TYPE));
+        logger.info("set {}", readyService);
+    }
+
+    protected void unsetReadyService(ReadyService readyService) {
+        readyService.unregisterTracker(this);
+        logger.info("unset {}", readyService);
+    }
+
+    @Override
+    public void onReadyMarkerAdded(ReadyMarker readyMarker) {
+        String bsn = readyMarker.getIdentifier();
+        loadedXmlThingTypes.add(bsn);
+        handleXmlThingTypesLoaded(bsn);
+        logger.info("marker added {}", readyMarker);
+    }
+
+    private void handleXmlThingTypesLoaded(String bsn) {
+        thingHandlerFactories.stream().filter(thingHandlerFactory -> getBundleName(thingHandlerFactory).equals(bsn))
+                .forEach(thingHandlerFactory -> thingHandlerFactoryAdded(thingHandlerFactory));
+    }
+
+    @Override
+    public void onReadyMarkerRemoved(ReadyMarker readyMarker) {
+        String bsn = readyMarker.getIdentifier();
+        loadedXmlThingTypes.remove(bsn);
+        logger.info("marker removed {}", readyMarker);
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    protected void addThingHandlerFactory(ThingHandlerFactory thingHandlerFactory) {
+        logger.debug("ThingHandlerFactory added {}", thingHandlerFactory);
+        thingHandlerFactories.add(thingHandlerFactory);
+        thingHandlerFactoryAdded(thingHandlerFactory);
+    }
+
+    protected void removeThingHandlerFactory(ThingHandlerFactory thingHandlerFactory) {
+        thingHandlerFactories.remove(thingHandlerFactory);
+        thingHandlerFactoryRemoved();
+    }
+
+    private void thingHandlerFactoryRemoved() {
+        // Don't do anything, Things should not be deleted
+    }
+
+    private void thingHandlerFactoryAdded(ThingHandlerFactory thingHandlerFactory) {
+        Collection<Thing> storageList = super.getAll();
+        storageList.stream().forEach(thing -> createThingFromStorageForThingHandlerFactory(thing, thingHandlerFactory));
+    }
+
+    @Override
+    public Collection<Thing> getAll() {
+        return thingsList;
+    }
+
+    private void createThingFromStorageForThingHandlerFactory(Thing thing, ThingHandlerFactory factory) {
+        if (!loadedXmlThingTypes.contains(getBundleName(factory))) {
+            return;
+        }
+
+        if (factory.supportsThingType(thing.getThingTypeUID())) {
+            if (thingsList.contains(thing)) {
+                notifyListenersAboutUpdatedElement(thing, thing);
+                logger.info("updated {} from {}", thing, factory);
+            } else {
+                thingsList.add(thing);
+                notifyListenersAboutAddedElement(thing);
+                logger.info("added {} from {}", thing, factory);
+            }
+        }
+    }
+
+    private String getBundleName(ThingHandlerFactory thingHandlerFactory) {
+        return bundleResolver.resolveBundle(thingHandlerFactory.getClass()).getSymbolicName();
     }
 
 }


### PR DESCRIPTION
Fixes #2555

This is intended as a design-idea. I would appreciate some comments. 

Basically this lets the thing creation wait for the handler factory to be available and then checks if the stored managed thing has all channels a newly created thing of the same type would have. 

Missing channels are added, channels with changed `ChannelTypeUID` or accepted item-types are updated to the new version.

Removed channels are not removed, which is a little bit unsatisfying and still different from the textual configuration. I'll have to check if it is possible to find out which channels (especially in extensible things) are user-added and should be preserved.