### PR TITLE
Improvements to handle OAuth2 storage availability

### DIFF
--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthClientServiceImpl.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthClientServiceImpl.java
@@ -61,8 +61,7 @@ public class OAuthClientServiceImpl implements OAuthClientService {
 
     private transient final Logger logger = LoggerFactory.getLogger(OAuthClientServiceImpl.class);
 
-    @NonNullByDefault({})
-    private OAuthStoreHandler storeHandler;
+    private @NonNullByDefault({}) OAuthStoreHandler storeHandler;
 
     // Constructor params - static
     private final String handle;

--- a/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthStoreHandler.java
+++ b/bundles/auth/org.eclipse.smarthome.auth.oauth2client/src/main/java/org/eclipse/smarthome/auth/oauth2client/internal/OAuthStoreHandler.java
@@ -45,7 +45,7 @@ public interface OAuthStoreHandler {
     /**
      * Save the {@code AccessTokenResponse} by the handle
      *
-     * @param handle secure random string used as a handle/ reference to the OAuth client service, and the underlying
+     * @param handle unique string used as a handle/ reference to the OAuth client service, and the underlying
      *            access tokens, configs.
      * @param accessTokenResponse This can be null, which explicitly removes the AccessTokenResponse from store.
      */
@@ -54,7 +54,7 @@ public interface OAuthStoreHandler {
     /**
      * Remove the token for the given handler. No exception is thrown in all cases
      *
-     * @param handle secure random string used as a handle/ reference to the OAuth client service, and the underlying
+     * @param handle unique string used as a handle/ reference to the OAuth client service, and the underlying
      *            access tokens, configs.
      */
     void remove(String handle);
@@ -67,7 +67,7 @@ public interface OAuthStoreHandler {
     /**
      * Save the {@code PersistedParams} into the store
      *
-     * @param handle secure random string used as a handle/ reference to the OAuth client service, and the underlying
+     * @param handle unique string used as a handle/ reference to the OAuth client service, and the underlying
      *            access tokens, configs.
      * @param persistedParams These parameters are static with respect to the oauth provider and thus can be persisted.
      */
@@ -76,11 +76,10 @@ public interface OAuthStoreHandler {
     /**
      * Load the {@code PersistedParams} from the store
      *
-     * @param handle secure random string used as a handle/ reference to the OAuth client service, and the underlying
+     * @param handle unique string used as a handle/ reference to the OAuth client service, and the underlying
      *            access tokens, configs.
      * @return PersistedParams when available, null if not exist
      */
     @Nullable
     PersistedParams loadPersistedParams(String handle);
-
 }


### PR DESCRIPTION
When creating a OAuth2Service it uses a storage service. However this service might not yet be available when the a OAuth2 service is available. This will result in a failure to create the OAuth2 service. This can happen during startup. To handle this case the creating is bound to availability of the storage service. Instead of directly returning the service it will be passed via a Consumer. This is triggered when the storage is set.

I don't know if the suggested changes are the preferred solution. This solution is what I could think of that would be the simplest to use for the user of the oauth2 service without having to build al kind of code to handle availability (and just not to be aware of the fact that the library depends on something that might not be directly available). So please let me know if this change makes sense and if so, if naming make sense. 

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl>