### PR TITLE
Add support for volumetric flow rate units.

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/VolumetricFlowRateTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/VolumetricFlowRateTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.types;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import javax.measure.Unit;
+
+import org.eclipse.smarthome.core.library.dimension.VolumetricFlowRate;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.types.util.UnitUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import tec.uom.se.ComparableQuantity;
+import tec.uom.se.quantity.Quantities;
+
+/**
+ * Test for volumentric flow rate constants defined in {@link SmartHomeUnits}.
+ *
+ * @author Łukasz Dywicki - initial contribution and API
+ */
+@RunWith(Parameterized.class)
+public class VolumetricFlowRateTest {
+
+    /**
+     * While its not SI base unit it produces nice and fairly rounded numbers (si base is m3/s).
+     */
+    private final static Unit<VolumetricFlowRate> BASE_UNIT = SmartHomeUnits.CUBICMETRE_PER_HOUR;
+
+    private final Unit<VolumetricFlowRate> unit;
+    private final String symbol;
+    private final Double value;
+    private final Double valueInBaseUnit;
+
+    public VolumetricFlowRateTest(Unit<VolumetricFlowRate> unit, String symbol, Double value, Double valueInBaseUnit) {
+        this.unit = unit;
+        this.symbol = symbol;
+        this.value = value;
+        this.valueInBaseUnit = valueInBaseUnit;
+    }
+
+    /**
+     * An additional test which converts given test quantity into base unit and then compares it with expected value.
+     *
+     * This basic test confirms that values of different flow rates can be exchanged to given base unit.
+     */
+    @Test
+    public void testValueConversionToM3s() {
+        ComparableQuantity<VolumetricFlowRate> quantity = Quantities.getQuantity(value, unit);
+        ComparableQuantity<VolumetricFlowRate> quantityInBase = Quantities.getQuantity(valueInBaseUnit, BASE_UNIT);
+
+        ComparableQuantity<VolumetricFlowRate> convertedQuantity = quantity.to(BASE_UNIT);
+
+        assertThat(convertedQuantity, is(equalTo(quantityInBase)));
+    }
+
+    /**
+     * Verifies that given symbol is recognized by {@link UnitUtils}.
+     */
+    @Test
+    public void testSymbolLookup() {
+        Unit<?> parsedUnit = UnitUtils.parseUnit(symbol);
+
+        assertThat(parsedUnit, is(notNullValue()));
+        assertThat(parsedUnit, is(equalTo(unit)));
+    }
+
+    @Parameters
+    public static Object[] params() {
+        return new Object[] { new Object[] { SmartHomeUnits.LITRE_PER_MINUTE, "l/min", 100.0, 6.0 },
+                new Object[] { SmartHomeUnits.CUBICMETRE_PER_SECOND, "m³/s", 100.0, 360000.0 },
+                new Object[] { SmartHomeUnits.CUBICMETRE_PER_MINUTE, "m³/min", 100.0, 6000.0 },
+                new Object[] { SmartHomeUnits.CUBICMETRE_PER_HOUR, "m³/h", 100.0, 100.0 },
+                new Object[] { SmartHomeUnits.CUBICMETRE_PER_DAY, "m³/d", 100.0, 4.166666666666667 } };
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/dimension/VolumetricFlowRate.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/dimension/VolumetricFlowRate.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.library.dimension;
+
+import javax.measure.Quantity;
+
+/**
+ * Define Volumetric Flow Rate type (basic unit is m^3/s).
+ *
+ * @author Łukasz Dywicki - initial contribution
+ *
+ */
+public interface VolumetricFlowRate extends Quantity<VolumetricFlowRate> {
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
@@ -50,6 +50,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.core.library.dimension.ArealDensity;
 import org.eclipse.smarthome.core.library.dimension.Density;
 import org.eclipse.smarthome.core.library.dimension.Intensity;
+import org.eclipse.smarthome.core.library.dimension.VolumetricFlowRate;
 
 import tec.uom.se.AbstractSystemOfUnits;
 import tec.uom.se.AbstractUnit;
@@ -139,8 +140,8 @@ public class SmartHomeUnits extends AbstractSystemOfUnits {
     public static final Unit<Volume> LITRE = addUnit(Units.LITRE);
     public static final Unit<Density> KILOGRAM_PER_CUBICMETRE = addUnit(
             new ProductUnit<Density>(Units.KILOGRAM.divide(Units.METRE.pow(3))));
-    public static final Unit<Density> MICROGRAM_PER_CUBICMETRE = addUnit(
-            new TransformedUnit<>(KILOGRAM_PER_CUBICMETRE, new RationalConverter(BigInteger.valueOf(1), BigInteger.valueOf(1000000000))));
+    public static final Unit<Density> MICROGRAM_PER_CUBICMETRE = addUnit(new TransformedUnit<>(KILOGRAM_PER_CUBICMETRE,
+            new RationalConverter(BigInteger.valueOf(1), BigInteger.valueOf(1000000000))));
     public static final Unit<Energy> WATT_SECOND = addUnit(new ProductUnit<Energy>(Units.WATT.multiply(Units.SECOND)));
     public static final Unit<Energy> WATT_HOUR = addUnit(new ProductUnit<Energy>(Units.WATT.multiply(Units.HOUR)));
     public static final Unit<Energy> KILOWATT_HOUR = addUnit(MetricPrefix.KILO(WATT_HOUR));
@@ -151,6 +152,16 @@ public class SmartHomeUnits extends AbstractSystemOfUnits {
     public static final Unit<Pressure> MILLIBAR = addUnit(MetricPrefix.MILLI(BAR));
     public static final Unit<ArealDensity> DOBSON_UNIT = addUnit(
             new ProductUnit<ArealDensity>(MetricPrefix.MILLI(Units.MOLE).multiply(0.4462).divide(Units.METRE.pow(2))));
+    public static final Unit<VolumetricFlowRate> LITRE_PER_MINUTE = addUnit(
+            new ProductUnit<VolumetricFlowRate>(Units.LITRE.divide(Units.MINUTE)));
+    public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_SECOND = addUnit(
+            new ProductUnit<VolumetricFlowRate>(Units.CUBIC_METRE.divide(Units.SECOND)));
+    public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_MINUTE = addUnit(
+            new ProductUnit<VolumetricFlowRate>(Units.CUBIC_METRE.divide(Units.MINUTE)));
+    public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_HOUR = addUnit(
+            new ProductUnit<VolumetricFlowRate>(Units.CUBIC_METRE.divide(Units.HOUR)));
+    public static final Unit<VolumetricFlowRate> CUBICMETRE_PER_DAY = addUnit(
+            new ProductUnit<VolumetricFlowRate>(Units.CUBIC_METRE.divide(Units.DAY)));
 
     /**
      * Add unit symbols for custom ESH units.
@@ -170,6 +181,11 @@ public class SmartHomeUnits extends AbstractSystemOfUnits {
         SimpleUnitFormat.getInstance().label(MILLIBAR, "mbar");
         SimpleUnitFormat.getInstance().label(KNOT, KNOT.getSymbol());
         SimpleUnitFormat.getInstance().label(DOBSON_UNIT, "DU");
+        SimpleUnitFormat.getInstance().label(LITRE_PER_MINUTE, "l/min");
+        SimpleUnitFormat.getInstance().label(CUBICMETRE_PER_SECOND, "m³/s");
+        SimpleUnitFormat.getInstance().label(CUBICMETRE_PER_MINUTE, "m³/min");
+        SimpleUnitFormat.getInstance().label(CUBICMETRE_PER_HOUR, "m³/h");
+        SimpleUnitFormat.getInstance().label(CUBICMETRE_PER_DAY, "m³/d");
     }
 
     /**


### PR DESCRIPTION
First units is SI `m³/s`. Additional unit are `m³/h` and `L/s` for consumer flow meters. Solves #6549.