### PR TITLE
Support system trigger channels in Homie (closes #6542)

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
@@ -17,6 +17,11 @@ Your Homie base topic needs to be **homie**. The mapping is structured like this
 | Node     | Channel Group | homie/super-car/engine             |
 | Property | Channel       | homie/super-car/engine/temperature |
 
+System trigger channels are supported using non-retained properties, with enum datatype and with the following formats:
+* Format: "PRESSED,RELEASED" -> system.rawbutton
+* Format: "SHORT\_PRESSED,DOUBLE\_PRESSED,LONG\_PRESSED" -> system.button
+* Format: "DIR1\_PRESSED,DIR1\_RELEASED,DIR2\_PRESSED,DIR2\_RELEASED" -> system.rawrocker
+
 ---
 
 HomeAssistant MQTT Components are recognized as well. The base topic needs to be **homeassistant**. 


### PR DESCRIPTION
This PR adds support for system trigger channels in Homie properties. Allows to model buttons and link them to items very easily with profiles.

Signed-off-by: Aitor Iturrioz <riturrioz@gmail.com>