### PR TITLE
add missing license header to homematic test files

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClientTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/RpcClientTest.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.smarthome.binding.homematic.internal.communicator.client;
 
 import static org.eclipse.smarthome.binding.homematic.HomematicBindingConstants.RX_BURST_MODE;

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/test/util/RpcClientMockImpl.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/test/util/RpcClientMockImpl.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.eclipse.smarthome.binding.homematic.test.util;
 
 import java.io.IOException;


### PR DESCRIPTION
@FStolte If new files are added you need to ensure that the license header is present.
I  forget it myself from time to time, too. :wink: 