### PR TITLE
Extract ItemBuilderFactory from ItemRegistry

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemBuilderTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/internal/items/ItemBuilderTest.java
@@ -36,7 +36,7 @@ import org.mockito.Mock;
  */
 public class ItemBuilderTest {
 
-    private ItemRegistryImpl itemRegistry;
+    private ItemBuilderFactoryImpl itemBuilderFactory;
     private @Mock ItemFactory mockFactory;
     private @Mock ActiveItem mockItem;
     private @Mock Item originalItem;
@@ -44,15 +44,15 @@ public class ItemBuilderTest {
     @Before
     public void setup() {
         initMocks(this);
-        itemRegistry = new ItemRegistryImpl();
-        itemRegistry.addItemFactory(mockFactory);
+        itemBuilderFactory = new ItemBuilderFactoryImpl();
+        itemBuilderFactory.addItemFactory(mockFactory);
     }
 
     @Test
     public void testMinimal() {
         when(mockFactory.createItem(anyString(), anyString())).thenReturn(mockItem);
 
-        Item res = itemRegistry.newItemBuilder("String", "test").build();
+        Item res = itemBuilderFactory.newItemBuilder("String", "test").build();
 
         assertSame(mockItem, res);
         verify(mockFactory).createItem(eq("String"), eq("test"));
@@ -63,7 +63,7 @@ public class ItemBuilderTest {
 
     @Test
     public void testMinimalGroupItem() {
-        Item resItem = itemRegistry.newItemBuilder("Group", "test").build();
+        Item resItem = itemBuilderFactory.newItemBuilder("Group", "test").build();
 
         assertEquals(GroupItem.class, resItem.getClass());
         GroupItem res = (GroupItem) resItem;
@@ -79,7 +79,7 @@ public class ItemBuilderTest {
     public void testFull() {
         when(mockFactory.createItem(anyString(), anyString())).thenReturn(mockItem);
 
-        Item res = itemRegistry.newItemBuilder("String", "test") //
+        Item res = itemBuilderFactory.newItemBuilder("String", "test") //
                 .withCategory("category") //
                 .withGroups(Arrays.asList("a", "b")) //
                 .withLabel("label") //
@@ -97,7 +97,7 @@ public class ItemBuilderTest {
         Item baseItem = mock(Item.class);
         GroupFunction mockFunction = mock(GroupFunction.class);
 
-        Item resItem = itemRegistry.newItemBuilder("Group", "test") //
+        Item resItem = itemBuilderFactory.newItemBuilder("Group", "test") //
                 .withCategory("category") //
                 .withGroups(Arrays.asList("a", "b")) //
                 .withLabel("label") //
@@ -125,7 +125,7 @@ public class ItemBuilderTest {
 
         when(mockFactory.createItem(anyString(), anyString())).thenReturn(mockItem);
 
-        Item res = itemRegistry.newItemBuilder(originalItem).build();
+        Item res = itemBuilderFactory.newItemBuilder(originalItem).build();
 
         assertSame(mockItem, res);
         verify(mockFactory).createItem(eq("type"), eq("name"));
@@ -143,7 +143,7 @@ public class ItemBuilderTest {
         originalItem.setLabel("label");
         originalItem.addGroupNames("a", "b");
 
-        Item resItem = itemRegistry.newItemBuilder(originalItem).build();
+        Item resItem = itemBuilderFactory.newItemBuilder(originalItem).build();
 
         assertEquals(GroupItem.class, resItem.getClass());
         GroupItem res = (GroupItem) resItem;
@@ -158,19 +158,19 @@ public class ItemBuilderTest {
     @Test(expected = IllegalStateException.class)
     public void testNoFactory() {
         when(mockFactory.createItem(anyString(), anyString())).thenReturn(null);
-        itemRegistry.newItemBuilder("String", "test").build();
+        itemBuilderFactory.newItemBuilder("String", "test").build();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testFunctionOnNonGroupItem() {
         GroupFunction mockFunction = mock(GroupFunction.class);
-        itemRegistry.newItemBuilder("String", "test").withGroupFunction(mockFunction);
+        itemBuilderFactory.newItemBuilder("String", "test").withGroupFunction(mockFunction);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testBaseItemOnNonGroupItem() {
         Item mockItem = mock(Item.class);
-        itemRegistry.newItemBuilder("String", "test").withBaseItem(mockItem);
+        itemBuilderFactory.newItemBuilder("String", "test").withBaseItem(mockItem);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ItemRegistryImplTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/items/ItemRegistryImplTest.java
@@ -109,7 +109,6 @@ public class ItemRegistryImplTest extends JavaTest {
 
                 setManagedProvider(itemProvider);
                 setEventPublisher(ItemRegistryImplTest.this.eventPublisher);
-                setCoreItemFactory(coreItemFactory);
                 setStateDescriptionService(mock(StateDescriptionService.class));
                 setUnitProvider(mock(UnitProvider.class));
                 setItemStateConverter(mock(ItemStateConverter.class));

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemBuilderFactoryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemBuilderFactoryImpl.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.internal.items;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.items.Item;
+import org.eclipse.smarthome.core.items.ItemBuilder;
+import org.eclipse.smarthome.core.items.ItemBuilderFactory;
+import org.eclipse.smarthome.core.items.ItemFactory;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+/**
+ * Provides an {@link ItemBuilder} with all available {@link ItemFactory}s set. The {@link CoreItemFactory} will always
+ * be present.
+ *
+ * @author Henning Treu - initial contribution and API
+ *
+ */
+@NonNullByDefault
+@Component
+public class ItemBuilderFactoryImpl implements ItemBuilderFactory {
+
+    private final @NonNullByDefault({}) Set<ItemFactory> itemFactories = new CopyOnWriteArraySet<>();
+
+    @Override
+    public ItemBuilder newItemBuilder(Item item) {
+        return new ItemBuilderImpl(itemFactories, item);
+    }
+
+    @Override
+    public ItemBuilder newItemBuilder(String itemType, String itemName) {
+        return new ItemBuilderImpl(itemFactories, itemType, itemName);
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    protected void addItemFactory(ItemFactory itemFactory) {
+        itemFactories.add(itemFactory);
+    }
+
+    protected void removeItemFactory(ItemFactory itemFactory) {
+        itemFactories.remove(itemFactory);
+    }
+
+    @Reference(target = "(component.name=org.eclipse.smarthome.core.library.CoreItemFactory)")
+    protected void setCoreItemFactory(ItemFactory coreItemFactory) {
+        itemFactories.add(coreItemFactory);
+    }
+
+    protected void unsetCoreItemFactory(ItemFactory coreItemFactory) {
+        itemFactories.remove(coreItemFactory);
+    }
+
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/internal/items/ItemRegistryImpl.java
@@ -17,9 +17,7 @@ import static java.util.stream.Collectors.toList;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.eclipse.smarthome.core.common.registry.AbstractRegistry;
 import org.eclipse.smarthome.core.common.registry.Provider;
@@ -28,8 +26,6 @@ import org.eclipse.smarthome.core.i18n.UnitProvider;
 import org.eclipse.smarthome.core.items.GenericItem;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
-import org.eclipse.smarthome.core.items.ItemBuilder;
-import org.eclipse.smarthome.core.items.ItemFactory;
 import org.eclipse.smarthome.core.items.ItemNotFoundException;
 import org.eclipse.smarthome.core.items.ItemNotUniqueException;
 import org.eclipse.smarthome.core.items.ItemProvider;
@@ -68,7 +64,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
     private final List<RegistryHook<Item>> registryHooks = new CopyOnWriteArrayList<>();
     private StateDescriptionService stateDescriptionService;
     private MetadataRegistry metadataRegistry;
-    private final Set<ItemFactory> itemFactories = new CopyOnWriteArraySet<>();
 
     private UnitProvider unitProvider;
     private ItemStateConverter itemStateConverter;
@@ -429,16 +424,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
         registryHooks.remove(hook);
     }
 
-    @Override
-    public ItemBuilder newItemBuilder(Item item) {
-        return new ItemBuilderImpl(itemFactories, item);
-    }
-
-    @Override
-    public ItemBuilder newItemBuilder(String itemType, String itemName) {
-        return new ItemBuilderImpl(itemFactories, itemType, itemName);
-    }
-
     @Activate
     protected void activate(final ComponentContext componentContext) {
         super.activate(componentContext.getBundleContext());
@@ -482,24 +467,6 @@ public class ItemRegistryImpl extends AbstractRegistry<Item, String, ItemProvide
 
     protected void unsetMetadataRegistry(MetadataRegistry metadataRegistry) {
         this.metadataRegistry = null;
-    }
-
-    @Reference(cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC)
-    protected void addItemFactory(ItemFactory itemFactory) {
-        itemFactories.add(itemFactory);
-    }
-
-    protected void removeItemFactory(ItemFactory itemFactory) {
-        itemFactories.remove(itemFactory);
-    }
-
-    @Reference(target = "(component.name=org.eclipse.smarthome.core.library.CoreItemFactory)")
-    protected void setCoreItemFactory(ItemFactory coreItemFactory) {
-        itemFactories.add(coreItemFactory);
-    }
-
-    protected void unsetCoreItemFactory(ItemFactory coreItemFactory) {
-        itemFactories.remove(coreItemFactory);
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemBuilderFactory.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemBuilderFactory.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.core.items;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+/**
+ * Creates a new {@link ItemBuilder} which is based on all available {@link ItemFactory}s.
+ *
+ * @author Henning Treu - initial contribution and API
+ *
+ */
+@NonNullByDefault
+public interface ItemBuilderFactory {
+
+    /**
+     * Create a new {@link ItemBuilder}, which is initialized by the given item.
+     *
+     * @param item the template to initialize the builder with
+     *
+     * @return an ItemBuilder instance
+     */
+    ItemBuilder newItemBuilder(Item item);
+
+    /**
+     * Create a new {@link ItemBuilder}, which is initialized by the given item.
+     *
+     * @param itemType the item type to create
+     * @param itemName the name of the item to create
+     *
+     * @return an ItemBuilder instance
+     */
+    ItemBuilder newItemBuilder(String itemType, String itemName);
+}

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/ItemRegistry.java
@@ -13,10 +13,14 @@
 package org.eclipse.smarthome.core.items;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.common.registry.Registry;
+import org.eclipse.smarthome.core.internal.items.ItemBuilderImpl;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.slf4j.LoggerFactory;
 
 /**
  * The ItemRegistry is the central place, where items are kept in memory and their state
@@ -131,8 +135,15 @@ public interface ItemRegistry extends Registry<Item, String> {
      *
      * @param item the template to initialize the builder with
      * @return an ItemBuilder instance
+     *
+     * @deprecated Use the {@link ItemBuilderFactory} service instead.
      */
-    ItemBuilder newItemBuilder(Item item);
+    @Deprecated
+    default ItemBuilder newItemBuilder(Item item) {
+        LoggerFactory.getLogger(getClass())
+                .warn("Deprecation: You are using a deprecated API. Please use the ItemBuilder OSGi service instead.");
+        return new ItemBuilderImpl(Collections.singleton(new CoreItemFactory()), item);
+    }
 
     /**
      * Create a new {@link ItemBuilder}, which is initialized by the given item.
@@ -140,7 +151,14 @@ public interface ItemRegistry extends Registry<Item, String> {
      * @param itemType the item type to create
      * @param itemName the name of the item to create
      * @return an ItemBuilder instance
+     *
+     * @deprecated Use the {@link ItemBuilderFactory} service instead.
      */
-    ItemBuilder newItemBuilder(String itemType, String itemName);
+    @Deprecated
+    default ItemBuilder newItemBuilder(String itemType, String itemName) {
+        LoggerFactory.getLogger(getClass())
+                .warn("Deprecation: You are using a deprecated API. Please use the ItemBuilder OSGi service instead.");
+        return new ItemBuilderImpl(Collections.singleton(new CoreItemFactory()), itemType, itemName);
+    }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/items/dto/ItemDTOMapper.java
@@ -25,7 +25,7 @@ import org.eclipse.smarthome.core.items.GroupFunction;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemBuilder;
-import org.eclipse.smarthome.core.items.ItemRegistry;
+import org.eclipse.smarthome.core.items.ItemBuilderFactory;
 import org.eclipse.smarthome.core.library.items.NumberItem;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.TypeParser;
@@ -47,25 +47,25 @@ public class ItemDTOMapper {
      * Maps item DTO into item object.
      *
      * @param itemDTO the DTO
-     * @param itemRegistry the item registry
+     * @param itemBuilderFactory the item registry
      * @return the item object
      */
-    public static @Nullable Item map(ItemDTO itemDTO, ItemRegistry itemRegistry) {
+    public static @Nullable Item map(ItemDTO itemDTO, ItemBuilderFactory itemBuilderFactory) {
         if (itemDTO == null) {
             throw new IllegalArgumentException("The argument 'itemDTO' must no be null.");
         }
-        if (itemRegistry == null) {
-            throw new IllegalArgumentException("The argument 'itemRegistry' must no be null.");
+        if (itemBuilderFactory == null) {
+            throw new IllegalArgumentException("The argument 'itemBuilderFactory' must no be null.");
         }
 
         if (itemDTO.type != null) {
-            ItemBuilder builder = itemRegistry.newItemBuilder(itemDTO.type, itemDTO.name);
+            ItemBuilder builder = itemBuilderFactory.newItemBuilder(itemDTO.type, itemDTO.name);
 
             if (itemDTO instanceof GroupItemDTO && GroupItem.TYPE.equals(itemDTO.type)) {
                 GroupItemDTO groupItemDTO = (GroupItemDTO) itemDTO;
                 Item baseItem = null;
                 if (!StringUtils.isEmpty(groupItemDTO.groupType)) {
-                    baseItem = itemRegistry.newItemBuilder(groupItemDTO.groupType, itemDTO.name).build();
+                    baseItem = itemBuilderFactory.newItemBuilder(groupItemDTO.groupType, itemDTO.name).build();
                     builder.withBaseItem(baseItem);
                 }
                 GroupFunction function = new GroupFunction.Equality();

--- a/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
+++ b/bundles/ui/org.eclipse.smarthome.ui/src/main/java/org/eclipse/smarthome/ui/internal/items/ItemUIRegistryImpl.java
@@ -38,6 +38,7 @@ import org.eclipse.smarthome.core.common.registry.RegistryChangeListener;
 import org.eclipse.smarthome.core.items.GroupItem;
 import org.eclipse.smarthome.core.items.Item;
 import org.eclipse.smarthome.core.items.ItemBuilder;
+import org.eclipse.smarthome.core.items.ItemBuilderFactory;
 import org.eclipse.smarthome.core.items.ItemNotFoundException;
 import org.eclipse.smarthome.core.items.ItemNotUniqueException;
 import org.eclipse.smarthome.core.items.ItemRegistry;
@@ -125,6 +126,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     protected ItemRegistry itemRegistry;
 
+    private ItemBuilderFactory itemBuilderFactory;
+
     private final Map<Widget, Widget> defaultWidgets = Collections.synchronizedMap(new WeakHashMap<Widget, Widget>());
 
     public ItemUIRegistryImpl() {
@@ -146,6 +149,15 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     public void removeItemUIProvider(ItemUIProvider itemUIProvider) {
         itemUIProviders.remove(itemUIProvider);
+    }
+
+    @Reference(policy = ReferencePolicy.DYNAMIC)
+    protected void setItemBuilderFactory(ItemBuilderFactory itemBuilderFactory) {
+        this.itemBuilderFactory = itemBuilderFactory;
+    }
+
+    protected void unsetItemBuilderFactory(ItemBuilderFactory itemBuilderFactory) {
+        this.itemBuilderFactory = null;
     }
 
     @Override
@@ -1338,8 +1350,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     @Override
     public ItemBuilder newItemBuilder(Item item) {
-        if (itemRegistry != null) {
-            return itemRegistry.newItemBuilder(item);
+        if (itemBuilderFactory != null) {
+            return itemBuilderFactory.newItemBuilder(item);
         } else {
             throw new IllegalStateException("Cannot create an item builder without the item registry");
         }
@@ -1347,8 +1359,8 @@ public class ItemUIRegistryImpl implements ItemUIRegistry {
 
     @Override
     public ItemBuilder newItemBuilder(String itemType, String itemName) {
-        if (itemRegistry != null) {
-            return itemRegistry.newItemBuilder(itemType, itemName);
+        if (itemBuilderFactory != null) {
+            return itemBuilderFactory.newItemBuilder(itemType, itemName);
         } else {
             throw new IllegalStateException("Cannot create an item builder without the item registry");
         }


### PR DESCRIPTION
The ItemRegistry did offer `newItemBuilder` methods which depended on a list of ItemFactories. In the ItemRegistryImpl nothing else did depend on the ItemFactories.
With ESH in the Felix OSGi runtime there are circumstances where a circular dependency is detected for an ItemProvider implementation which depends on the ItemRegistry for ItemBuilder access.
This extracts the new `ItemBuilderFactory` service from the ItemRegistry and provides the same API. The now deprecated API from ItemRegistry provides a fallback implementation based on a single instance of CoreItemFactory.

This is API breaking.

Signed-off-by: Henning Treu <henning.treu@googlemail.com>