### PR TITLE
Remove automation.thingsupport dependency from magic bundle

### DIFF
--- a/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
+++ b/bundles/test/org.eclipse.smarthome.magic/META-INF/MANIFEST.MF
@@ -17,7 +17,6 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.automation,
  org.eclipse.smarthome.automation.annotation;resolution:=optional,
- org.eclipse.smarthome.automation.thingsupport,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.config.core.metadata,
  org.eclipse.smarthome.config.discovery,


### PR DESCRIPTION
See https://github.com/eclipse/smarthome/pull/6398#issuecomment-440643599

Signed-off-by: Stefan Triller <stefan.triller@telekom.de>