### PR TITLE
[homematic] bugfix in QuantityType

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/converter/type/QuantityTypeConverter.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/converter/type/QuantityTypeConverter.java
@@ -61,6 +61,11 @@ public class QuantityTypeConverter extends AbstractTypeConverter<QuantityType<? 
 
     private QuantityType<? extends Quantity<?>> toUnitFromDatapoint(QuantityType<? extends Quantity<?>> type,
             HmDatapoint dp) {
+        if (dp == null || dp.getUnit().isEmpty()) {
+            // datapoint is dimensionless, nothing to convert
+            return type;
+        }
+
         // convert the given QuantityType to a QuantityType with the unit of the target datapoint
         switch (dp.getUnit()) {
             case "minutes":
@@ -96,7 +101,8 @@ public class QuantityTypeConverter extends AbstractTypeConverter<QuantityType<? 
         }
 
         // create a QuantityType from the datapoint's value based on the datapoint's unit
-        switch (dp.getUnit()) {
+        String unit = dp.getUnit() != null ? dp.getUnit() : "";
+        switch (unit) {
             case "°C":
                 return new QuantityType<Temperature>(number, SIUnits.CELSIUS);
             case "V":

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/MetadataUtils.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/MetadataUtils.java
@@ -167,7 +167,7 @@ public class MetadataUtils {
      */
     public static String getStatePattern(HmDatapoint dp) {
         String unit = getUnit(dp);
-        if (unit != null) {
+        if (unit != null && unit != "") {
             String pattern = getPattern(dp);
             if (pattern != null) {
                 return String.format("%s %s", pattern, "%unit%");


### PR DESCRIPTION
Turned out that #6512 introduced tree potential errors:
* dp.getUnit() may return null which is not handled
* dp.getUnit() may return an empty string which should not put %unit% in the pattern

Signed-off-by: Michael Reitler <michael.reitler@telekom.de>