### PR TITLE
[uom] Add Miligram per Cubic Metre unit

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
@@ -27,6 +27,7 @@ import javax.measure.quantity.Speed;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.smarthome.core.library.dimension.ArealDensity;
+import org.eclipse.smarthome.core.library.dimension.Density;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.MetricPrefix;
@@ -261,6 +262,18 @@ public class SmartHomeUnitsTest {
     public void testBar2Pascal() {
         Quantity<Pressure> bar = Quantities.getQuantity(BigDecimal.valueOf(1), SmartHomeUnits.BAR);
         assertThat(bar.to(SIUnits.PASCAL), is(Quantities.getQuantity(100000, SIUnits.PASCAL)));
+    }
+
+    @Test
+    public void testMicrogramPerCubicMeter2KilogramPerCubicMeter() {
+        Quantity<Density> one_kg_m3 = Quantities.getQuantity(BigDecimal.ONE, SmartHomeUnits.KILOGRAM_PER_CUBICMETRE);
+        Quantity<Density> converted = one_kg_m3.to(SmartHomeUnits.MICROGRAM_PER_CUBICMETRE);
+        assertThat(converted.getValue().doubleValue(), is(closeTo(1000000000, DEFAULT_ERROR)));
+    }
+
+    @Test
+    public void testMicrogramPerCubicMeterUnitSymbol() {
+        assertThat(SmartHomeUnits.MICROGRAM_PER_CUBICMETRE.toString(), is("μg/m³"));
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
@@ -137,6 +137,8 @@ public class SmartHomeUnits extends AbstractSystemOfUnits {
     public static final Unit<Volume> LITRE = addUnit(Units.LITRE);
     public static final Unit<Density> KILOGRAM_PER_CUBICMETRE = addUnit(
             new ProductUnit<Density>(Units.KILOGRAM.divide(Units.METRE.pow(3))));
+    public static final Unit<Density> MICROGRAM_PER_CUBICMETRE = addUnit(
+            new TransformedUnit<>(KILOGRAM_PER_CUBICMETRE, new RationalConverter(BigInteger.valueOf(1), BigInteger.valueOf(1000000000))));
     public static final Unit<Energy> WATT_SECOND = addUnit(new ProductUnit<Energy>(Units.WATT.multiply(Units.SECOND)));
     public static final Unit<Energy> WATT_HOUR = addUnit(new ProductUnit<Energy>(Units.WATT.multiply(Units.HOUR)));
     public static final Unit<Energy> KILOWATT_HOUR = addUnit(MetricPrefix.KILO(WATT_HOUR));
@@ -156,6 +158,7 @@ public class SmartHomeUnits extends AbstractSystemOfUnits {
         SimpleUnitFormat.getInstance().label(DECIBEL, "dB");
         SimpleUnitFormat.getInstance().label(IRRADIANCE, "W/m²");
         SimpleUnitFormat.getInstance().label(DEGREE_ANGLE, "°");
+        SimpleUnitFormat.getInstance().label(MICROGRAM_PER_CUBICMETRE, "μg/m³");
         SimpleUnitFormat.getInstance().label(WATT_SECOND, "Ws");
         SimpleUnitFormat.getInstance().label(WATT_HOUR, "Wh");
         SimpleUnitFormat.getInstance().label(KILOWATT_HOUR, "kWh");


### PR DESCRIPTION
This additional unit is necessary to nicely support UoM in the sensebox binding.
The data source usually provides data in μg/m³

Signed-off-by: Hakan Tandogan <hakan@tandogan.com>