### PR TITLE
prevent NPE if xy field is null

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/LightStateConverter.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/LightStateConverter.java
@@ -217,8 +217,9 @@ public class LightStateConverter {
      * @return HSB type representing the color
      */
     public static HSBType toHSBType(State lightState) {
-        return ColorMode.XY.equals(lightState.getColorMode()) ? fromXYtoHSBType(lightState)
-                : fromHSBtoHSBType(lightState);
+        // even if color mode is reported to be XY, xy field of lightState might be null, while hsb is available
+        boolean isInXYMode = ColorMode.XY.equals(lightState.getColorMode()) && lightState.getXY() != null;
+        return isInXYMode ? fromXYtoHSBType(lightState) : fromHSBtoHSBType(lightState);
     }
 
     private static HSBType fromHSBtoHSBType(State lightState) {


### PR DESCRIPTION
Fixes https://github.com/eclipse/smarthome/issues/6559

Signed-off-by: Kai Kreuzer <kai@openhab.org>