### PR TITLE
Do not switch the lights on, if the color temperature is changed

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
@@ -216,9 +216,17 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
 
     private void handleException(FullLight light, StateUpdate stateUpdate, Throwable e) {
         if (e instanceof DeviceOffException) {
-            updateLightState(light, LightStateConverter.toOnOffLightState(OnOffType.ON));
-            updateLightState(light, stateUpdate);
-        } else if (e instanceof IOException) {
+            if (stateUpdate.getColorTemperature() != null && stateUpdate.getBrightness() == null) {
+                // If there is only a change of the color temperature, we do not want the light
+                // to be turned on (i.e. change its brightness).
+                return;
+            } else {
+                updateLightState(light, LightStateConverter.toOnOffLightState(OnOffType.ON));
+                updateLightState(light, stateUpdate);
+            }
+        } else if (e instanceof IOException)
+
+        {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof ApiException) {
             // This should not happen - if it does, it is most likely some bug that should be reported.

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueBridgeHandler.java
@@ -224,9 +224,7 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                 updateLightState(light, LightStateConverter.toOnOffLightState(OnOffType.ON));
                 updateLightState(light, stateUpdate);
             }
-        } else if (e instanceof IOException)
-
-        {
+        } else if (e instanceof IOException) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
         } else if (e instanceof ApiException) {
             // This should not happen - if it does, it is most likely some bug that should be reported.

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/handler/HueLightHandler.java
@@ -227,6 +227,11 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
                 } else if (command instanceof IncreaseDecreaseType) {
                     lightState = convertBrightnessChangeToStateUpdate((IncreaseDecreaseType) command, light);
                 }
+                if (lightState != null && lastSentColorTemp != null) {
+                    // make sure that the light also has the latest color temp
+                    // this might not have been yet set in the light, if it was off
+                    lightState.setColorTemperature(lastSentColorTemp);
+                }
                 break;
             case CHANNEL_SWITCH:
                 logger.trace("CHANNEL_SWITCH handling command {}", command);
@@ -235,6 +240,11 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
                     if (isOsramPar16) {
                         lightState = addOsramSpecificCommands(lightState, (OnOffType) command);
                     }
+                }
+                if (lightState != null && lastSentColorTemp != null) {
+                    // make sure that the light also has the latest color temp
+                    // this might not have been yet set in the light, if it was off
+                    lightState.setColorTemperature(lastSentColorTemp);
                 }
                 break;
             case CHANNEL_COLOR:
@@ -293,8 +303,7 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
     /*
      * Applies additional {@link StateUpdate} commands as a workaround for Osram
      * Lightify PAR16 TW firmware bug. Also see
-     * http://www.everyhue.com/vanilla/discussion
-     * /1756/solved-lightify-turning-off
+     * http://www.everyhue.com/vanilla/discussion/1756/solved-lightify-turning-off
      */
     private StateUpdate addOsramSpecificCommands(StateUpdate lightState, OnOffType actionType) {
         if (actionType.equals(OnOffType.ON)) {


### PR DESCRIPTION
Currently, sending a value to the color temperature channel turns the light on, if it was off before.
This is imho not what should be expected - when sending a color temperature, it should not change the current brightness.

This change fixes this behavior - the brightness stays as it is and the color temperature value is set.

This enables a rather nice use case: One can have rules that adapt the color temperature to the time of day, while not having any impact on the on/off state of the light. But if the light is then manually turned on (or by motion detector or some other rule), it will have the correct color temperature.

Signed-off-by: Kai Kreuzer <kai@openhab.org>