### PR TITLE
Added Microwatt per Square Centimetre unit

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.test/src/test/java/org/eclipse/smarthome/core/types/SmartHomeUnitsTest.java
@@ -28,6 +28,7 @@ import javax.measure.quantity.Temperature;
 
 import org.eclipse.smarthome.core.library.dimension.ArealDensity;
 import org.eclipse.smarthome.core.library.dimension.Density;
+import org.eclipse.smarthome.core.library.dimension.Intensity;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
 import org.eclipse.smarthome.core.library.unit.MetricPrefix;
@@ -274,6 +275,18 @@ public class SmartHomeUnitsTest {
     @Test
     public void testMicrogramPerCubicMeterUnitSymbol() {
         assertThat(SmartHomeUnits.MICROGRAM_PER_CUBICMETRE.toString(), is("μg/m³"));
+    }
+
+    @Test
+    public void testMicrowattPerSquareCentimetre2KilogramPerSquareCentiMetre() {
+        Quantity<Intensity> one_mw_cm2 = Quantities.getQuantity(BigDecimal.ONE, SmartHomeUnits.IRRADIANCE);
+        Quantity<Intensity> converted = one_mw_cm2.to(SmartHomeUnits.MICROWATT_PER_SQUARE_CENTIMETRE);
+        assertThat(converted.getValue().doubleValue(), is(closeTo(0.01, DEFAULT_ERROR)));
+    }
+
+    @Test
+    public void testMicrowattPerSquareCentimetreUnitSymbol() {
+        assertThat(SmartHomeUnits.MICROWATT_PER_SQUARE_CENTIMETRE.toString(), is("μW/cm²"));
     }
 
 }

--- a/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
+++ b/bundles/core/org.eclipse.smarthome.core/src/main/java/org/eclipse/smarthome/core/library/unit/SmartHomeUnits.java
@@ -92,6 +92,8 @@ public class SmartHomeUnits extends AbstractSystemOfUnits {
      */
     public static final Unit<Intensity> IRRADIANCE = addUnit(
             new AlternateUnit<Intensity>(Units.WATT.divide(Units.SQUARE_METRE), "W/m2"));
+    public static final Unit<Intensity> MICROWATT_PER_SQUARE_CENTIMETRE = addUnit(
+            new TransformedUnit<>(IRRADIANCE, new RationalConverter(BigInteger.valueOf(100), BigInteger.valueOf(1))));
 
     public static final Unit<Dimensionless> ONE = addUnit(AbstractUnit.ONE);
 
@@ -157,6 +159,7 @@ public class SmartHomeUnits extends AbstractSystemOfUnits {
         SimpleUnitFormat.getInstance().label(PARTS_PER_MILLION, "ppm");
         SimpleUnitFormat.getInstance().label(DECIBEL, "dB");
         SimpleUnitFormat.getInstance().label(IRRADIANCE, "W/m²");
+        SimpleUnitFormat.getInstance().label(MICROWATT_PER_SQUARE_CENTIMETRE, "μW/cm²");
         SimpleUnitFormat.getInstance().label(DEGREE_ANGLE, "°");
         SimpleUnitFormat.getInstance().label(MICROGRAM_PER_CUBICMETRE, "μg/m³");
         SimpleUnitFormat.getInstance().label(WATT_SECOND, "Ws");


### PR DESCRIPTION
This additional unit is necessary to nicely support UoM in the sensebox binding.
The data source usually provides data in μW/cm²

Signed-off-by: Hakan Tandogan <hakan@tandogan.com>