### PR TITLE
#6577 Fix NPE in ThingManager.setEnabled()

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerTest.java
@@ -76,4 +76,20 @@ public class ThingManagerTest {
         verify(mockFactory2, atLeastOnce()).supportsThingType(any());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testCallSetEnabledWithUnknownThingUID() throws Exception {
+        ThingUID unknownUID = new ThingUID("someBundle", "someType", "someID");
+        ThingManagerImpl thingManager = new ThingManagerImpl();
+
+        thingManager.setEnabled(unknownUID, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCallIsEnabledWithUnknownThingUID() throws Exception {
+        ThingUID unknownUID = new ThingUID("someBundle", "someType", "someID");
+        ThingManagerImpl thingManager = new ThingManagerImpl();
+
+        thingManager.isEnabled(unknownUID);
+    }
+
 }

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingManager.java
@@ -27,6 +27,7 @@ public interface ThingManager {
      * @param thingUID UID of the {@link Thing}.
      * @return {@code false} when the {@link Thing} has {@link ThingStatus} with {@link ThingStatusDetail#DISABLED}.
      *         Returns {@code true} in all other cases.
+     * @throws IllegalArgumentException if there is no Thing with thingUID as its UID.
      */
     public boolean isEnabled(ThingUID thingUID);
 
@@ -37,6 +38,7 @@ public interface ThingManager {
      *
      * @param thingUID UID of the {@link Thing}.
      * @param isEnabled a new <b>enabled / disabled</b> state of the {@link Thing}.
+     * @throws IllegalArgumentException if there is no Thing with thingUID as its UID.
      */
     public void setEnabled(ThingUID thingUID, boolean isEnabled);
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1208,6 +1208,11 @@ public class ThingManagerImpl
     @Override
     public void setEnabled(ThingUID thingUID, boolean enabled) {
         Thing thing = getThing(thingUID);
+        
+        if (thing == null) {
+            throw new IllegalArgumentException(String.format("Thing with the UID '%s' is unknown, cannot set its enabled status.", thingUID));
+        }
+        
         if (enabled) {
             // Enable a thing
             // Clear the disabled thing storage. Otherwise the handler will NOT be initialized later.
@@ -1256,6 +1261,11 @@ public class ThingManagerImpl
     @Override
     public boolean isEnabled(ThingUID thingUID) {
         Thing thing = getThing(thingUID);
+
+        if (thing == null) {
+            throw new IllegalArgumentException(String.format("Thing with the UID '%s' is unknown, cannot get its enabled status.", thingUID));
+        }
+        
         return thing.isEnabled();
     }
 


### PR DESCRIPTION
The methods `setEnabled()` and `isEnabled()` of the ThingManagerImpl now throw an `IllegalArgumentException` with appropriate error message if there is no Thing for the given ThingUID. This is now also documented in the ThingManager Javadoc.

Solves #6577