### PR TITLE
[LIFX] Fix IAE whenever light returns color temperature outside valid range

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/util/LifxMessageUtil.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/util/LifxMessageUtil.java
@@ -95,8 +95,11 @@ public final class LifxMessageUtil {
         if (temperatureRange.getRange() == 0) {
             return PercentType.HUNDRED;
         }
-        return new PercentType(
-                BigDecimal.valueOf((kelvin - temperatureRange.getMaximum()) / (temperatureRange.getRange() / -100)));
+        BigDecimal value = BigDecimal
+                .valueOf((kelvin - temperatureRange.getMaximum()) / (temperatureRange.getRange() / -100));
+        value = value.min(HUNDRED);
+        value = value.max(ZERO);
+        return new PercentType(value);
     }
 
     public static int percentTypeToKelvin(PercentType temperature, TemperatureRange temperatureRange) {


### PR DESCRIPTION
Color temperature values outside the valid range may have been set previously.
So whenever the light returns such values the binding should be able to handle them by using 0/100 as min/max.

Fixes:

```
java.lang.IllegalArgumentException: Value must be between 0 and 100
	at org.eclipse.smarthome.core.library.types.PercentType.validateValue(PercentType.java:58) ~[?:?]
	at org.eclipse.smarthome.core.library.types.PercentType.<init>(PercentType.java:53) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.internal.util.LifxMessageUtil.kelvinToPercentType(LifxMessageUtil.java:98) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler$CurrentLightState.updateColorChannels(LifxLightHandler.java:173) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.handler.LifxLightHandler$CurrentLightState.setColors(LifxLightHandler.java:146) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.internal.LifxLightState.setColor(LifxLightState.java:119) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.internal.LifxLightCurrentStateUpdater.handleLightStatus(LifxLightCurrentStateUpdater.java:176) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.internal.LifxLightCurrentStateUpdater.handleResponsePacket(LifxLightCurrentStateUpdater.java:150) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.internal.LifxLightCommunicationHandler.lambda$3(LifxLightCommunicationHandler.java:243) ~[?:?]
	at java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:891) ~[?:?]
	at org.eclipse.smarthome.binding.lifx.internal.LifxLightCommunicationHandler.lambda$2(LifxLightCommunicationHandler.java:243) ~[?:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180) ~[?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
	at java.lang.Thread.run(Thread.java:748) [?:?]
```

See also this [openHAB community thread](https://community.openhab.org/t/oh-2-4-0-m6-testing-results/57321/48?u=wborn).