### PR TITLE
Persist status of unknown things in ThingManager

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerTest.java
@@ -13,11 +13,10 @@
 package org.eclipse.smarthome.core.thing.internal;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,7 +29,6 @@ import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.eclipse.smarthome.core.util.BundleResolver;
-import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -99,26 +97,15 @@ public class ThingManagerTest {
         verify(mockStorage).put(eq(unknownUID.getAsString()), eq(false));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testCallIsEnabledWithUnknownThingUID() throws Exception {
-        ThingUID unknownUID = new ThingUID("someBundle", "someType", "someID");
-        ThingManagerImpl thingManager = new ThingManagerImpl();
-
-        when(mockStorageService.getStorage(eq("thing_status_storage"), any(ClassLoader.class))).thenReturn(mockStorage);
-        verify(mockStorage).remove(eq(unknownUID.getAsString()));
-        thingManager.isEnabled(unknownUID);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testCallIsEnabledWithUnknownThingUIDAndNullStorage() throws Exception {
         ThingUID unknownUID = new ThingUID("someBundle", "someType", "someID");
         ThingManagerImpl thingManager = new ThingManagerImpl();
 
-        when(mockStorage.get(unknownUID.getAsString())).thenReturn(true);
         when(mockStorageService.getStorage(eq("thing_status_storage"), any(ClassLoader.class))).thenReturn(null);
-
         thingManager.setStorageService(mockStorageService);
-        thingManager.isEnabled(unknownUID);
+        assertEquals(thingManager.isEnabled(unknownUID), true);
+
     }
 
     @Test

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerTest.java
@@ -94,7 +94,7 @@ public class ThingManagerTest {
         verify(mockStorage).remove(eq(unknownUID.getAsString()));
 
         thingManager.setEnabled(unknownUID, false);
-        verify(mockStorage).put(eq(unknownUID.getAsString()), eq(false));
+        verify(mockStorage).put(eq(unknownUID.getAsString()), eq(""));
     }
 
     @Test
@@ -113,12 +113,12 @@ public class ThingManagerTest {
         ThingUID unknownUID = new ThingUID("someBundle", "someType", "someID");
         ThingManagerImpl thingManager = new ThingManagerImpl();
 
-        when(mockStorage.get(unknownUID.getAsString())).thenReturn(true);
+        when(mockStorage.containsKey(unknownUID.getAsString())).thenReturn(false);
         when(mockStorageService.getStorage(eq("thing_status_storage"), any(ClassLoader.class))).thenReturn(mockStorage);
         thingManager.setStorageService(mockStorageService);
         assertEquals(thingManager.isEnabled(unknownUID), true);
 
-        when(mockStorage.get(unknownUID.getAsString())).thenReturn(false);
+        when(mockStorage.containsKey(unknownUID.getAsString())).thenReturn(true);
         when(mockStorageService.getStorage(eq("thing_status_storage"), any(ClassLoader.class))).thenReturn(mockStorage);
         thingManager.setStorageService(mockStorageService);
         assertEquals(thingManager.isEnabled(unknownUID), false);

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingManager.java
@@ -27,7 +27,8 @@ public interface ThingManager {
      * @param thingUID UID of the {@link Thing}.
      * @return {@code false} when the {@link Thing} has {@link ThingStatus} with {@link ThingStatusDetail#DISABLED}.
      *         Returns {@code true} in all other cases.
-     * @throws IllegalArgumentException if there is no Thing with thingUID as its UID.
+     * @throws IllegalArgumentException if there is no Thing with thingUID as its UID and also there is no persisted
+     *             value in the storage for hat thingUID.
      */
     public boolean isEnabled(ThingUID thingUID);
 
@@ -38,7 +39,6 @@ public interface ThingManager {
      *
      * @param thingUID UID of the {@link Thing}.
      * @param isEnabled a new <b>enabled / disabled</b> state of the {@link Thing}.
-     * @throws IllegalArgumentException if there is no Thing with thingUID as its UID.
      */
     public void setEnabled(ThingUID thingUID, boolean isEnabled);
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingManager.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/ThingManager.java
@@ -27,8 +27,6 @@ public interface ThingManager {
      * @param thingUID UID of the {@link Thing}.
      * @return {@code false} when the {@link Thing} has {@link ThingStatus} with {@link ThingStatusDetail#DISABLED}.
      *         Returns {@code true} in all other cases.
-     * @throws IllegalArgumentException if there is no Thing with thingUID as its UID and also there is no persisted
-     *             value in the storage for hat thingUID.
      */
     public boolean isEnabled(ThingUID thingUID);
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -158,7 +158,7 @@ public class ThingManagerImpl
     private SafeCaller safeCaller;
     private volatile boolean active = false;
     private StorageService storageService;
-    private Storage<Boolean> storage;
+    private Storage<String> storage;
 
     private final ThingHandlerCallback thingHandlerCallback = new ThingHandlerCallback() {
 
@@ -1263,7 +1263,7 @@ public class ThingManagerImpl
             storage.remove(thingUID.getAsString());
         } else {
             // Mark the thing as disabled in the storage.
-            storage.put(thingUID.getAsString(), enabled);
+            storage.put(thingUID.getAsString(), "false");
         }
     }
 
@@ -1279,7 +1279,7 @@ public class ThingManagerImpl
     }
 
     private boolean isDisabledByStorage(ThingUID thingUID) {
-        return storage != null && Boolean.FALSE.equals(storage.get(thingUID.getAsString()));
+        return storage != null && storage.containsKey(thingUID.getAsString());
     }
 
     @Reference

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1263,7 +1263,7 @@ public class ThingManagerImpl
             storage.remove(thingUID.getAsString());
         } else {
             // Mark the thing as disabled in the storage.
-            storage.put(thingUID.getAsString(), "false");
+            storage.put(thingUID.getAsString(), "");
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1276,7 +1276,7 @@ public class ThingManagerImpl
 
         logger.debug("Thing with UID {} is unknown. Will try to get the enabled status from the persistent storage.");
         if (storage != null) {
-            return storage.get(thingUID.getAsString());
+            return !Boolean.FALSE.equals(storage.get(thingUID.getAsString()));
         }
         throw new IllegalArgumentException(
                 String.format("Cannot get the enabled status of thing with UID '%s'.", thingUID)) ;

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1252,8 +1252,9 @@ public class ThingManagerImpl
     }
 
     private void persistThingEnableStatus(ThingUID thingUID, boolean enabled) {
-        if (storage != null) {
+        if (storage == null) {
             logger.debug("Cannot persist thing enable status. Storage unavailable.");
+            return;
         }
 
         logger.debug("Thing with UID {} will be persisted as {}.", thingUID, enabled?"enabled.":"disabled.");
@@ -1269,14 +1270,11 @@ public class ThingManagerImpl
 
     @Override
     public boolean isEnabled(ThingUID thingUID) {
-        Thing thing = getThing(thingUID);
-
-        if (thing == null) {
+        if (storage == null) {
             throw new IllegalArgumentException(
-                    String.format("Thing with the UID '%s' is unknown, cannot get its enabled status.", thingUID));
+                    String.format("Thing with UID {} is unknown, cannot get its enabled status.", thingUID));
         }
-
-        return thing.isEnabled();
+        return storage.get(thingUID.getAsString());
     }
 
     private boolean isDisabledByStorage(ThingUID thingUID) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1275,11 +1275,7 @@ public class ThingManagerImpl
         }
 
         logger.debug("Thing with UID {} is unknown. Will try to get the enabled status from the persistent storage.");
-        if (storage != null) {
-            return !Boolean.FALSE.equals(storage.get(thingUID.getAsString()));
-        }
-        throw new IllegalArgumentException(
-                String.format("Cannot get the enabled status of thing with UID '%s'.", thingUID)) ;
+        return !isDisabledByStorage(thingUID);
     }
 
     private boolean isDisabledByStorage(ThingUID thingUID) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1208,18 +1208,16 @@ public class ThingManagerImpl
     @Override
     public void setEnabled(ThingUID thingUID, boolean enabled) {
         Thing thing = getThing(thingUID);
-        
+
+        persistThingEnableStatus(thingUID, enabled);
+
         if (thing == null) {
-            throw new IllegalArgumentException(String.format("Thing with the UID '%s' is unknown, cannot set its enabled status.", thingUID));
+            logger.debug("Thing with the UID {} is unknown, cannot set its enabled status.", thingUID);
+            return;
         }
-        
+
         if (enabled) {
             // Enable a thing
-            // Clear the disabled thing storage. Otherwise the handler will NOT be initialized later.
-            if (storage != null) {
-                storage.remove(thingUID.getAsString());
-            }
-
             if (thing.getStatus().equals(ThingStatus.ONLINE)) {
                 logger.debug("Thing {} is already in the required state.", thingUID);
                 return;
@@ -1235,11 +1233,6 @@ public class ThingManagerImpl
                 registerAndInitializeHandler(thing, findThingHandlerFactory(thing.getThingTypeUID()));
             }
         } else {
-            // Mark the thing as disabled in the storage.
-            if (storage != null) {
-                storage.put(thingUID.getAsString(), enabled);
-            }
-
             if (!thing.isEnabled()) {
                 logger.debug("Thing {} is already in the required state.", thingUID);
                 return;
@@ -1258,14 +1251,31 @@ public class ThingManagerImpl
         }
     }
 
+    private void persistThingEnableStatus(ThingUID thingUID, boolean enabled) {
+        if (storage != null) {
+            logger.debug("Cannot persist thing enable status. Storage unavailable.");
+        }
+
+        logger.debug("Thing with UID {} will be persisted as {}.", thingUID, enabled?"enabled.":"disabled.");
+        if (enabled) {
+            // Clear the disabled thing storage. Otherwise the handler will NOT be initialized later.
+            storage.remove(thingUID.getAsString());
+        } else {
+            // Mark the thing as disabled in the storage.
+            storage.put(thingUID.getAsString(), enabled);
+        }
+
+    }
+
     @Override
     public boolean isEnabled(ThingUID thingUID) {
         Thing thing = getThing(thingUID);
 
         if (thing == null) {
-            throw new IllegalArgumentException(String.format("Thing with the UID '%s' is unknown, cannot get its enabled status.", thingUID));
+            throw new IllegalArgumentException(
+                    String.format("Thing with the UID '%s' is unknown, cannot get its enabled status.", thingUID));
         }
-        
+
         return thing.isEnabled();
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1253,11 +1253,11 @@ public class ThingManagerImpl
 
     private void persistThingEnableStatus(ThingUID thingUID, boolean enabled) {
         if (storage == null) {
-            logger.debug("Cannot persist thing enable status. Storage unavailable.");
+            logger.debug("Cannot persist enable status of thing with UID {}. Persistent storage unavailable.", thingUID);
             return;
         }
 
-        logger.debug("Thing with UID {} will be persisted as {}.", thingUID, enabled?"enabled.":"disabled.");
+        logger.debug("Thing with UID {} will be persisted as {}.", thingUID, enabled ? "enabled." : "disabled.");
         if (enabled) {
             // Clear the disabled thing storage. Otherwise the handler will NOT be initialized later.
             storage.remove(thingUID.getAsString());
@@ -1265,16 +1265,21 @@ public class ThingManagerImpl
             // Mark the thing as disabled in the storage.
             storage.put(thingUID.getAsString(), enabled);
         }
-
     }
 
     @Override
     public boolean isEnabled(ThingUID thingUID) {
-        if (storage == null) {
-            throw new IllegalArgumentException(
-                    String.format("Thing with UID {} is unknown, cannot get its enabled status.", thingUID));
+        Thing thing = getThing(thingUID);
+        if (thing != null) {
+            return thing.isEnabled();
         }
-        return storage.get(thingUID.getAsString());
+
+        logger.debug("Thing with UID {} is unknown. Will try to get the enabled status from the persistent storage.");
+        if (storage != null) {
+            return storage.get(thingUID.getAsString());
+        }
+        throw new IllegalArgumentException(
+                String.format("Cannot get the enabled status of thing with UID '%s'.", thingUID)) ;
     }
 
     private boolean isDisabledByStorage(ThingUID thingUID) {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -124,9 +124,9 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
 
     @Override
     protected void notifyListenersAboutAddedElement(Thing element) {
+        super.notifyListenersAboutAddedElement(element);
         postEvent(ThingEventFactory.createAddedEvent(element));
         notifyTrackers(element, ThingTrackerEvent.THING_ADDED);
-        super.notifyListenersAboutAddedElement(element);
     }
 
     @Override
@@ -138,9 +138,9 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
 
     @Override
     protected void notifyListenersAboutUpdatedElement(Thing oldElement, Thing element) {
+        super.notifyListenersAboutUpdatedElement(oldElement, element);
         notifyTrackers(element, ThingTrackerEvent.THING_UPDATED);
         postEvent(ThingEventFactory.createUpdateEvent(element, oldElement));
-        super.notifyListenersAboutUpdatedElement(oldElement, element);
     }
 
     @Override

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -124,9 +124,9 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
 
     @Override
     protected void notifyListenersAboutAddedElement(Thing element) {
-        super.notifyListenersAboutAddedElement(element);
         postEvent(ThingEventFactory.createAddedEvent(element));
         notifyTrackers(element, ThingTrackerEvent.THING_ADDED);
+        super.notifyListenersAboutAddedElement(element);
     }
 
     @Override
@@ -138,9 +138,9 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
 
     @Override
     protected void notifyListenersAboutUpdatedElement(Thing oldElement, Thing element) {
-        super.notifyListenersAboutUpdatedElement(oldElement, element);
         notifyTrackers(element, ThingTrackerEvent.THING_UPDATED);
         postEvent(ThingEventFactory.createUpdateEvent(element, oldElement));
+        super.notifyListenersAboutUpdatedElement(oldElement, element);
     }
 
     @Override


### PR DESCRIPTION
In case of adding, removal and updating a `Thing` in the `ThingRegistryImpl`.
Since `ThingManagerImpl` is a `ThingTracker` and also keeps its own set of things, it needs to know about thing related changes before any `RegistryChangeListener`. Otherwise if a `RegistryChangeListener` tries to e.g. enable/disable a thing right after it is notified about thing been added, `ThingManagerImpl` will still not know about that thing. 