### PR TITLE
[MQTT] fix number formattting

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/number-channel-config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/number-channel-config.xml
@@ -37,7 +37,7 @@
 			<default>10.0</default>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="isfloat" type="boolean">
+		<parameter name="isFloat" type="boolean">
 			<label>Is Decimal?</label>
 			<description>If enabled, the value will be published to the MQTT broker including the fractional part of the number and a dot as the decimal marker.</description>
 			<default>false</default>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
@@ -72,7 +72,7 @@ You can connect this channel to a String item.
 * __min__: An optional minimum value
 * __max__: An optional maximum value
 * __step__: For decrease, increase commands the step needs to be known
-* __isfloat__: If set to true the value is send as a decimal value, otherwise it is send as integer.
+* __isFloat__: If set to true the value is send as a decimal value, otherwise it is send as integer.
 
 If any of the parameters is a float/double (has a decimal point value), then a float value is send to the MQTT topic otherwise an int value is send.
 


### PR DESCRIPTION
fixes an issue where numbers are always send as integers, regardless of the isDecimal setting

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>