### PR TITLE
MQTT: Remove broker id from AbstractBrokerHandler

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/AbstractBrokerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/AbstractBrokerHandler.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements MqttConnectionObserver {
     private final Logger logger = LoggerFactory.getLogger(AbstractBrokerHandler.class);
     public static int TIMEOUT_DEFAULT = 1200; /* timeout in milliseconds */
-    protected final String brokerID;
     final Map<ChannelUID, PublishTriggerChannel> channelStateByChannelUID = new HashMap<>();
 
     @NonNullByDefault({})
@@ -57,7 +56,6 @@ public abstract class AbstractBrokerHandler extends BaseBridgeHandler implements
 
     public AbstractBrokerHandler(Bridge thing) {
         super(thing);
-        this.brokerID = thing.getUID().getId();
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/SystemBrokerHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/handler/SystemBrokerHandler.java
@@ -46,6 +46,7 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
     public static final String PROPERTY_RECONNECT_TIME = "reconnect_time_ms";
     public static final String PROPERTY_KEEP_ALIVE_TIME = "keep_alive_time_ms";
     public static final String PROPERTY_CONNECT_TIMEOUT = "connect_timeout_ms";
+    protected String brokerID = "";
 
     protected final MqttService service;
 
@@ -113,6 +114,7 @@ public class SystemBrokerHandler extends AbstractBrokerHandler implements MqttSe
 
     @Override
     public void initialize() {
+        this.brokerID = getConfiguration().get("brokerid");
         service.addBrokersListener(this);
 
         connection = service.getBrokerConnection(brokerID);


### PR DESCRIPTION
* Remove broker id from AbstractBrokerHandler
* Add "brokerID", assigned from configuration, to SystemBrokerHandler

Second part of fixing #6600. Travis CI tests success is crucial as I have made the changes on the webeditor.

Signed-off-by: David Graeff <david.graeff@web.de>