### PR TITLE
RFC: Notify listeners after ThingManager knows about added Thing

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -453,6 +453,10 @@ public class ThingManagerImpl
     public void thingAdded(Thing thing, ThingTrackerEvent thingTrackerEvent) {
         this.things.add(thing);
         logger.debug("Thing '{}' is tracked by ThingManager.", thing.getUID());
+    }
+
+    @Override
+    public void thingAddedFinished(Thing thing, ThingTrackerEvent thingTrackerEvent) {
         if (!isHandlerRegistered(thing)) {
             registerAndInitializeHandler(thing, getThingHandlerFactory(thing));
         } else {

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingRegistryImpl.java
@@ -124,9 +124,14 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
 
     @Override
     protected void notifyListenersAboutAddedElement(Thing element) {
-        super.notifyListenersAboutAddedElement(element);
-        postEvent(ThingEventFactory.createAddedEvent(element));
+        // let the ThingManagerImpl know about the thing
         notifyTrackers(element, ThingTrackerEvent.THING_ADDED);
+        // let all listeners process the added thing
+        super.notifyListenersAboutAddedElement(element);
+        // post event about the new thing
+        postEvent(ThingEventFactory.createAddedEvent(element));
+        // trigger ThingManager to create the handler and post thing status events
+        notifyTrackers(element, ThingTrackerEvent.THING_ADDED_FINISHED);
     }
 
     @Override
@@ -138,8 +143,8 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
 
     @Override
     protected void notifyListenersAboutUpdatedElement(Thing oldElement, Thing element) {
-        super.notifyListenersAboutUpdatedElement(oldElement, element);
         notifyTrackers(element, ThingTrackerEvent.THING_UPDATED);
+        super.notifyListenersAboutUpdatedElement(oldElement, element);
         postEvent(ThingEventFactory.createUpdateEvent(element, oldElement));
     }
 
@@ -208,6 +213,9 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
                     case THING_ADDED:
                         thingTracker.thingAdded(thing, ThingTrackerEvent.THING_ADDED);
                         break;
+                    case THING_ADDED_FINISHED:
+                        thingTracker.thingAddedFinished(thing, ThingTrackerEvent.THING_ADDED_FINISHED);
+                        break;
                     case THING_REMOVING:
                         thingTracker.thingRemoving(thing, ThingTrackerEvent.THING_REMOVING);
                         break;
@@ -230,6 +238,7 @@ public class ThingRegistryImpl extends AbstractRegistry<Thing, ThingUID, ThingPr
     private void notifyTrackerAboutAllThingsAdded(ThingTracker thingTracker) {
         for (Thing thing : getAll()) {
             thingTracker.thingAdded(thing, ThingTrackerEvent.TRACKER_ADDED);
+            thingTracker.thingAddedFinished(thing, ThingTrackerEvent.TRACKER_ADDED);
         }
     }
 

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingTracker.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingTracker.java
@@ -28,7 +28,13 @@ import org.eclipse.smarthome.core.thing.ThingRegistryChangeListener;
 public interface ThingTracker {
 
     public enum ThingTrackerEvent {
-        THING_ADDED, THING_REMOVING, THING_REMOVED, THING_UPDATED, TRACKER_ADDED, TRACKER_REMOVED
+        THING_ADDED,
+        THING_ADDED_FINISHED,
+        THING_REMOVING,
+        THING_REMOVED,
+        THING_UPDATED,
+        TRACKER_ADDED,
+        TRACKER_REMOVED
     }
 
     /**
@@ -40,7 +46,18 @@ public interface ThingTracker {
     void thingAdded(Thing thing, ThingTrackerEvent thingTrackerEvent);
 
     /**
-     * This method is called for every thing that is going to be removed from the {@link ThingRegistryImpl}. Moreover the method is
+     * This method is called after the thing was added and after further processing (like notifying listeners) happened.
+     * This method is called for every thing that exists in the {@link ThingRegistryImpl} and for every added thing.
+     *
+     * @param thing The thing which was added and can be safely post processed now.
+     */
+    default void thingAddedFinished(Thing thing, ThingTrackerEvent thingTrackerEvent) {
+
+    }
+
+    /**
+     * This method is called for every thing that is going to be removed from the {@link ThingRegistryImpl}. Moreover
+     * the method is
      * called for every thing,
      * that exists in the {@link ThingRegistryImpl}, when the tracker is
      * unregistered.


### PR DESCRIPTION
This supersedes #6604 and also provides a new fix for #404.

The idea is to split adding the new Thing to the ThingManager and process the added Thing later. This will post Thing status events after the Thing added event was posted by the registry.

Signed-off-by: Henning Treu <henning.treu@googlemail.com>