### PR TITLE
correct swagger response type definition

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.core/src/main/java/org/eclipse/smarthome/io/rest/core/internal/thing/ThingResource.java
@@ -401,7 +401,7 @@ public class ThingResource implements RESTResource {
     @Path("/{thingUID}/config")
     @Consumes(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Updates thing's configuration.")
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = Thing.class),
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "OK", response = ThingDTO.class),
             @ApiResponse(code = 400, message = "Configuration of the thing is not valid."),
             @ApiResponse(code = 404, message = "Thing not found"),
             @ApiResponse(code = 409, message = "Thing could not be updated as it is not editable.") })


### PR DESCRIPTION
Swagger generates an invalid swagger.json file with the Thing.class as return type.
This PR fixes https://github.com/openhab/openhab2-addons/issues/4302.
I have no clue though, why it still used to work two week ago, because nothing has really changed about that code in the meantime...

Signed-off-by: Kai Kreuzer <kai@openhab.org>