### PR TITLE
Add missing Automatic-Module-Name manifest entries

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.java.demo/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Import-Package:
  org.eclipse.smarthome.core.common.registry,
  org.osgi.service.component
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.sample.java.demo

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.json.demo/META-INF/MANIFEST.MF
@@ -9,3 +9,4 @@ Bundle-Vendor: Eclipse.org/SmartHome
 Bundle-Version: 0.10.0.qualifier
 Import-Package: org.eclipse.jdt.annotation;resolution:=optional
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.sample.json.demo

--- a/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/META-INF/MANIFEST.MF
+++ b/bundles/automation/org.eclipse.smarthome.automation.sample.moduletype.demo/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Import-Package:
  org.osgi.util.tracker,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.automation.sample.moduletype.demo

--- a/bundles/io/org.eclipse.smarthome.io.http.auth.basic/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.http.auth.basic/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.http.auth.basic

--- a/bundles/io/org.eclipse.smarthome.io.http.auth/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.http.auth/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.http.auth

--- a/bundles/io/org.eclipse.smarthome.io.http.test/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.http.test/META-INF/MANIFEST.MF
@@ -15,3 +15,4 @@ Import-Package:
  org.junit;version="4.0.0",
  org.mockito,
  org.mockito.stubbing
+Automatic-Module-Name: org.eclipse.smarthome.io.http.test

--- a/bundles/io/org.eclipse.smarthome.io.http/META-INF/MANIFEST.MF
+++ b/bundles/io/org.eclipse.smarthome.io.http/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Import-Package:
  org.osgi.service.http,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.io.http

--- a/extensions/binding/org.eclipse.smarthome.binding.meteoblue.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.meteoblue.test/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Import-Package: org.eclipse.smarthome.binding.meteoblue,
  org.osgi.service.device,
  org.osgi.framework
 Export-Package: org.eclipse.smarthome.binding.meteoblue;uses:="org.eclipse.smarthome.test"
+Automatic-Module-Name: org.eclipse.smarthome.binding.meteoblue.test

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/META-INF/MANIFEST.MF
@@ -37,3 +37,4 @@ Import-Package:
  org.osgi.service.device,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.onewire.test

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/META-INF/MANIFEST.MF
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/META-INF/MANIFEST.MF
@@ -23,3 +23,4 @@ Import-Package: javax.measure.quantity,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.binding.onewire

--- a/extensions/persistence/org.eclipse.smarthome.persistence.mapdb.test/META-INF/MANIFEST.MF
+++ b/extensions/persistence/org.eclipse.smarthome.persistence.mapdb.test/META-INF/MANIFEST.MF
@@ -19,3 +19,4 @@ Import-Package:
  org.junit,
  org.junit.rules,
  org.osgi.service.cm
+Automatic-Module-Name: org.eclipse.smarthome.persistence.mapdb.test

--- a/extensions/persistence/org.eclipse.smarthome.persistence.mapdb/META-INF/MANIFEST.MF
+++ b/extensions/persistence/org.eclipse.smarthome.persistence.mapdb/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Import-Package: com.google.gson,
  org.osgi.framework,
  org.slf4j
 Service-Component: OSGI-INF/*.xml
+Automatic-Module-Name: org.eclipse.smarthome.persistence.mapdb


### PR DESCRIPTION
Fixes warnings shown in Eclipse caused by bundles that were recently merged.