### PR TITLE
MQTT: Add MQTT receive tests for all channel types

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/HomeAssistantMQTTImplementationTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/HomeAssistantMQTTImplementationTests.java
@@ -36,12 +36,12 @@ import org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassist
 import org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant.ComponentSwitch;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant.DiscoverComponents;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant.DiscoverComponents.ComponentDiscovered;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant.HaID;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.MqttChannelTypeProvider;
-import org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant.HaID;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.handler.ThingChannelConstants;
-import org.eclipse.smarthome.binding.mqtt.generic.internal.values.OnOffValue;
 import org.eclipse.smarthome.core.library.types.OnOffType;
+import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.UnDefType;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 import org.eclipse.smarthome.io.transport.mqtt.MqttConnectionObserver;
@@ -126,7 +126,7 @@ public class HomeAssistantMQTTImplementationTests extends JavaOSGiTest {
     public void tearDown() throws InterruptedException, ExecutionException, TimeoutException {
         if (connection != null) {
             connection.removeConnectionObserver(failIfChange);
-            connection.stop().get(500, TimeUnit.MILLISECONDS);
+            connection.stop().get(1000, TimeUnit.MILLISECONDS);
         }
     }
 
@@ -190,9 +190,9 @@ public class HomeAssistantMQTTImplementationTests extends JavaOSGiTest {
         verify(channelTypeProvider, times(1)).setChannelType(any(), any());
 
         // We expect a switch component with an OnOff channel with the initial value UNDEF:
-        OnOffValue value = (OnOffValue) haComponents.get(haID.getChannelGroupID()).channelTypes()
-                .get(ComponentSwitch.switchChannelID).channelState.getValue();
-        assertThat(value.getValue(), is(UnDefType.UNDEF));
+        State value = haComponents.get(haID.getChannelGroupID()).channelTypes()
+                .get(ComponentSwitch.switchChannelID).channelState.getCache().getChannelState();
+        assertThat(value, is(UnDefType.UNDEF));
 
         haComponents.values().stream().map(e -> e.start(connection, scheduler, 100))
                 .reduce(CompletableFuture.completedFuture(null), (a, v) -> a.thenCompose(b -> v)).exceptionally(e -> {
@@ -204,9 +204,9 @@ public class HomeAssistantMQTTImplementationTests extends JavaOSGiTest {
         verify(channelStateUpdateListener, times(1)).updateChannelState(any(), any());
 
         // Value should be ON now.
-        value = (OnOffValue) haComponents.get(haID.getChannelGroupID()).channelTypes()
-                .get(ComponentSwitch.switchChannelID).channelState.getValue();
-        assertThat(value.getValue(), is(OnOffType.ON));
+        value = haComponents.get(haID.getChannelGroupID()).channelTypes()
+                .get(ComponentSwitch.switchChannelID).channelState.getCache().getChannelState();
+        assertThat(value, is(OnOffType.ON));
 
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateTests.java
@@ -12,12 +12,16 @@
  */
 package org.eclipse.smarthome.binding.mqtt.generic.internal.generic;
 
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -28,11 +32,18 @@ import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant.DiscoverComponents.ComponentDiscovered;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.ColorValue;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.DateTimeValue;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.ImageValue;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.LocationValue;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.NumberValue;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.PercentageValue;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.values.TextValue;
+import org.eclipse.smarthome.core.library.types.HSBType;
+import org.eclipse.smarthome.core.library.types.RawType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
-import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +55,7 @@ import org.mockito.Spy;
  *
  * @author David Graeff - Initial contribution
  */
-public class ChannelStateTests extends JavaOSGiTest {
+public class ChannelStateTests {
     @Mock
     MqttBrokerConnection connection;
 
@@ -61,6 +72,8 @@ public class ChannelStateTests extends JavaOSGiTest {
     TextValue textValue;
 
     ScheduledExecutorService scheduler;
+
+    ChannelConfig config = ChannelConfigBuilder.create("state", "command").build();
 
     @Before
     public void setUp() {
@@ -84,9 +97,7 @@ public class ChannelStateTests extends JavaOSGiTest {
 
     @Test
     public void noInteractionTimeoutTest() throws InterruptedException, ExecutionException, TimeoutException {
-
-        ChannelState c = spy(new ChannelState(ChannelConfigBuilder.create("state", "command").build(), channelUID,
-                textValue, channelStateUpdateListener));
+        ChannelState c = spy(new ChannelState(config, channelUID, textValue, channelStateUpdateListener));
         c.start(connection, scheduler, 50).get(100, TimeUnit.MILLISECONDS);
         verify(connection).subscribe(eq("state"), eq(c));
         c.stop().get();
@@ -94,47 +105,33 @@ public class ChannelStateTests extends JavaOSGiTest {
     }
 
     @Test
-    public void publishTest() throws InterruptedException, ExecutionException, TimeoutException {
-        ChannelState c = spy(new ChannelState(ChannelConfigBuilder.create("state", "command").build(), channelUID,
-                textValue, channelStateUpdateListener));
+    public void publishFormatTest() throws InterruptedException, ExecutionException, TimeoutException {
+        ChannelState c = spy(new ChannelState(config, channelUID, textValue, channelStateUpdateListener));
 
         c.start(connection, scheduler, 0).get(50, TimeUnit.MILLISECONDS);
         verify(connection).subscribe(eq("state"), eq(c));
 
-        c.setValue(new StringType("UPDATE")).get();
+        c.publishValue(new StringType("UPDATE")).get();
         verify(connection).publish(eq("command"), argThat(p -> Arrays.equals(p, "UPDATE".getBytes())), anyInt(),
                 eq(false));
 
         c.config.formatBeforePublish = "prefix%s";
-        c.setValue(new StringType("UPDATE")).get();
+        c.publishValue(new StringType("UPDATE")).get();
         verify(connection).publish(eq("command"), argThat(p -> Arrays.equals(p, "prefixUPDATE".getBytes())), anyInt(),
                 eq(false));
 
         c.config.formatBeforePublish = "%1$s-%1$s";
-        c.setValue(new StringType("UPDATE")).get();
+        c.publishValue(new StringType("UPDATE")).get();
         verify(connection).publish(eq("command"), argThat(p -> Arrays.equals(p, "UPDATE-UPDATE".getBytes())), anyInt(),
                 eq(false));
 
         c.config.formatBeforePublish = "%s";
         c.config.retained = true;
-        c.setValue(new StringType("UPDATE")).get();
+        c.publishValue(new StringType("UPDATE")).get();
         verify(connection).publish(eq("command"), any(), anyInt(), eq(true));
 
         c.stop().get();
         verify(connection).unsubscribe(eq("state"), eq(c));
-    }
-
-    @Test
-    public void receiveTest() throws InterruptedException, ExecutionException, TimeoutException {
-        ChannelState c = spy(new ChannelState(ChannelConfigBuilder.create("state", "command").build(), channelUID,
-                textValue, channelStateUpdateListener));
-
-        CompletableFuture<@Nullable Void> future = c.start(connection, scheduler, 100);
-        c.processMessage("state", "A TEST".getBytes());
-        future.get(300, TimeUnit.MILLISECONDS);
-
-        assertThat(textValue.getValue().toString(), is("A TEST"));
-        verify(channelStateUpdateListener).updateChannelState(eq(channelUID), any());
     }
 
     @Test
@@ -146,7 +143,146 @@ public class ChannelStateTests extends JavaOSGiTest {
         c.processMessage("state/bla/topic", "A TEST".getBytes());
         future.get(300, TimeUnit.MILLISECONDS);
 
-        assertThat(textValue.getValue().toString(), is("A TEST"));
+        assertThat(textValue.getChannelState().toString(), is("A TEST"));
         verify(channelStateUpdateListener).updateChannelState(eq(channelUID), any());
+    }
+
+    @Test
+    public void receiveStringTest() throws InterruptedException, ExecutionException, TimeoutException {
+        ChannelState c = spy(new ChannelState(config, channelUID, textValue, channelStateUpdateListener));
+
+        CompletableFuture<@Nullable Void> future = c.start(connection, scheduler, 100);
+        c.processMessage("state", "A TEST".getBytes());
+        future.get(300, TimeUnit.MILLISECONDS);
+
+        assertThat(textValue.getChannelState().toString(), is("A TEST"));
+        verify(channelStateUpdateListener).updateChannelState(eq(channelUID), any());
+    }
+
+    @Test
+    public void receiveDecimalTest() throws InterruptedException, ExecutionException, TimeoutException {
+        NumberValue value = new NumberValue(null, null, new BigDecimal(10));
+        ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
+        c.start(connection, mock(ScheduledExecutorService.class), 100);
+
+        c.processMessage("state", "15".getBytes());
+        assertThat(value.getChannelState().toString(), is("15"));
+
+        c.processMessage("state", "INCREASE".getBytes());
+        assertThat(value.getChannelState().toString(), is("25"));
+
+        c.processMessage("state", "DECREASE".getBytes());
+        assertThat(value.getChannelState().toString(), is("15"));
+
+        verify(channelStateUpdateListener, times(3)).updateChannelState(eq(channelUID), any());
+    }
+
+    @Test
+    public void receiveDecimalFractionalTest() throws InterruptedException, ExecutionException, TimeoutException {
+        NumberValue value = new NumberValue(null, null, new BigDecimal(10.5));
+        ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
+        c.start(connection, mock(ScheduledExecutorService.class), 100);
+
+        c.processMessage("state", "5.5".getBytes());
+        assertThat(value.getChannelState().toString(), is("5.5"));
+
+        c.processMessage("state", "INCREASE".getBytes());
+        assertThat(value.getChannelState().toString(), is("16.0"));
+    }
+
+    @Test
+    public void receivePercentageTest() throws InterruptedException, ExecutionException, TimeoutException {
+        PercentageValue value = new PercentageValue(new BigDecimal(-100), new BigDecimal(100), new BigDecimal(10));
+        ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
+        c.start(connection, mock(ScheduledExecutorService.class), 100);
+
+        c.processMessage("state", "-100".getBytes()); // 0%
+        assertThat(value.getChannelState().toString(), is("0"));
+
+        c.processMessage("state", "100".getBytes()); // 100%
+        assertThat(value.getChannelState().toString(), is("100"));
+
+        c.processMessage("state", "0".getBytes()); // 50%
+        assertThat(value.getChannelState().toString(), is("50"));
+
+        c.processMessage("state", "INCREASE".getBytes());
+        assertThat(value.getChannelState().toString(), is("60"));
+    }
+
+    @Test
+    public void receiveRGBColorTest() throws InterruptedException, ExecutionException, TimeoutException {
+        ColorValue value = new ColorValue(true, "FON", "FOFF");
+        ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
+        c.start(connection, mock(ScheduledExecutorService.class), 100);
+
+        c.processMessage("state", "ON".getBytes());
+        assertThat(value.getChannelState().toString(), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue().toString(), is("25,25,25"));
+
+        c.processMessage("state", "FOFF".getBytes());
+        assertThat(value.getChannelState().toString(), is("0,0,0"));
+        assertThat(value.getMQTTpublishValue().toString(), is("0,0,0"));
+
+        HSBType t = HSBType.fromRGB(12, 18, 231);
+
+        c.processMessage("state", "12,18,231".getBytes());
+        assertThat(value.getChannelState(), is(t)); // HSB
+        // rgb -> hsv -> rgb is quite lossy
+        assertThat(value.getMQTTpublishValue().toString(), is("13,20,225"));
+    }
+
+    @Test
+    public void receiveHSBColorTest() throws InterruptedException, ExecutionException, TimeoutException {
+        ColorValue value = new ColorValue(false, "FON", "FOFF");
+        ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
+        c.start(connection, mock(ScheduledExecutorService.class), 100);
+
+        c.processMessage("state", "ON".getBytes()); // Minimum brightness is 10
+        assertThat(value.getChannelState().toString(), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue().toString(), is("0,0,10"));
+
+        c.processMessage("state", "FOFF".getBytes());
+        assertThat(value.getChannelState().toString(), is("0,0,0"));
+        assertThat(value.getMQTTpublishValue().toString(), is("0,0,0"));
+
+        c.processMessage("state", "12,18,100".getBytes());
+        assertThat(value.getChannelState().toString(), is("12,18,100"));
+        assertThat(value.getMQTTpublishValue().toString(), is("12,18,100"));
+    }
+
+    @Test
+    public void receiveLocationTest() throws InterruptedException, ExecutionException, TimeoutException {
+        LocationValue value = new LocationValue();
+        ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
+        c.start(connection, mock(ScheduledExecutorService.class), 100);
+
+        c.processMessage("state", "46.833974, 7.108433".getBytes());
+        assertThat(value.getChannelState().toString(), is("46.833974,7.108433"));
+        assertThat(value.getMQTTpublishValue().toString(), is("46.833974,7.108433"));
+    }
+
+    @Test
+    public void receiveDateTimeTest() throws InterruptedException, ExecutionException, TimeoutException {
+        DateTimeValue value = new DateTimeValue();
+        ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
+        c.start(connection, mock(ScheduledExecutorService.class), 100);
+
+        ZonedDateTime zd = ZonedDateTime.now();
+        String datetime = zd.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+        c.processMessage("state", datetime.getBytes());
+        assertThat(value.getChannelState().toString(), is(datetime + "+0100"));
+        assertThat(value.getMQTTpublishValue().toString(), is(datetime));
+    }
+
+    @Test
+    public void receiveImageTest() throws InterruptedException, ExecutionException, TimeoutException {
+        ImageValue value = new ImageValue();
+        ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
+        c.start(connection, mock(ScheduledExecutorService.class), 100);
+
+        byte payload[] = new byte[] { (byte) 0xFF, (byte) 0xD8, 0x01, 0x02, (byte) 0xFF, (byte) 0xD9 };
+        c.processMessage("state", payload);
+        assertThat(value.getChannelState(), is(instanceOf(RawType.class)));
+        assertThat(((RawType) value.getChannelState()).getMimeType(), is("image/jpeg"));
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateTransformationTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateTransformationTests.java
@@ -126,6 +126,6 @@ public class ChannelStateTransformationTests {
         channelConfig.processMessage(channelConfig.getStateTopic(), payload);
 
         verify(callback).stateUpdated(eq(textChannelUID), argThat(arg -> "23.2".equals(arg.toString())));
-        assertThat(channelConfig.getValue().getValue().toString(), is("23.2"));
+        assertThat(channelConfig.getCache().getChannelState().toString(), is("23.2"));
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/GenericThingHandlerTests.java
@@ -132,11 +132,11 @@ public class GenericThingHandlerTests {
         thingHandler.initialize();
 
         TextValue value = spy(new TextValue());
-        doReturn(value).when(channelConfig).getValue();
+        doReturn(value).when(channelConfig).getCache();
         thingHandler.connection = connection;
 
         thingHandler.handleCommand(textChannelUID, RefreshType.REFRESH);
-        verify(value).getValue();
+        verify(value).getChannelState();
     }
 
     @Test
@@ -152,7 +152,7 @@ public class GenericThingHandlerTests {
         StringType updateValue = new StringType("UPDATE");
         thingHandler.handleCommand(textChannelUID, updateValue);
         verify(value).update(eq(updateValue));
-        assertThat(channelConfig.getValue().getValue().toString(), is("UPDATE"));
+        assertThat(channelConfig.getCache().getChannelState().toString(), is("UPDATE"));
     }
 
     @Test
@@ -169,7 +169,7 @@ public class GenericThingHandlerTests {
         thingHandler.handleCommand(textChannelUID, updateValue);
 
         verify(value).update(eq(updateValue));
-        assertThat(channelConfig.getValue().getValue(), is(OnOffType.ON));
+        assertThat(channelConfig.getCache().getChannelState(), is(OnOffType.ON));
     }
 
     @Test
@@ -187,6 +187,6 @@ public class GenericThingHandlerTests {
         verify(callback).statusUpdated(eq(thing), argThat(arg -> arg.getStatus().equals(ThingStatus.ONLINE)));
 
         verify(callback).stateUpdated(eq(textChannelUID), argThat(arg -> "UPDATE".equals(arg.toString())));
-        assertThat(textValue.getValue().toString(), is("UPDATE"));
+        assertThat(textValue.getChannelState().toString(), is("UPDATE"));
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/HomieThingHandlerTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/HomieThingHandlerTests.java
@@ -230,7 +230,7 @@ public class HomieThingHandlerTests {
         thingHandler.handleCommand(property.channelUID, RefreshType.REFRESH);
 
         verify(callback).stateUpdated(argThat(arg -> property.channelUID.equals(arg)),
-                argThat(arg -> property.getChannelState().getValue().getValue().equals(arg)));
+                argThat(arg -> property.getChannelState().getCache().getChannelState().equals(arg)));
     }
 
     @SuppressWarnings("null")
@@ -260,21 +260,21 @@ public class HomieThingHandlerTests {
         StringType updateValue = new StringType("UPDATE");
         thingHandler.handleCommand(property.channelUID, updateValue);
 
-        assertThat(property.getChannelState().getValue().getValue().toString(), is("UPDATE"));
+        assertThat(property.getChannelState().getCache().getChannelState().toString(), is("UPDATE"));
         verify(connection, times(1)).publish(any(), any(), anyInt(), anyBoolean());
 
         // Check non writable property
         property.attributes.settable = false;
         property.attributesReceived();
         // Assign old value
-        Value value = property.getChannelState().getValue();
+        Value value = property.getChannelState().getCache();
         Command command = TypeParser.parseCommand(value.getSupportedCommandTypes(), "OLDVALUE");
-        property.getChannelState().getValue().update(command);
+        property.getChannelState().getCache().update(command);
         // Try to update with new value
         updateValue = new StringType("SOMETHINGNEW");
         thingHandler.handleCommand(property.channelUID, updateValue);
         // Expect old value and no MQTT publish
-        assertThat(property.getChannelState().getValue().getValue().toString(), is("OLDVALUE"));
+        assertThat(property.getChannelState().getCache().getChannelState().toString(), is("OLDVALUE"));
         verify(connection, times(1)).publish(any(), any(), anyInt(), anyBoolean());
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ValueTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ValueTests.java
@@ -58,16 +58,16 @@ public class ValueTests {
         v.update(p(v, "255, 255, 255"));
 
         v.update(p(v, "OFF"));
-        assertThat(((HSBType) v.getValue()).getBrightness().intValue(), is(0));
+        assertThat(((HSBType) v.getChannelState()).getBrightness().intValue(), is(0));
         // Minimum brightness setting after brightness 0 is 10 for ON command
         v.update(p(v, "ON"));
-        assertThat(((HSBType) v.getValue()).getBrightness().intValue(), is(10));
+        assertThat(((HSBType) v.getChannelState()).getBrightness().intValue(), is(10));
 
         v.update(p(v, "0"));
-        assertThat(((HSBType) v.getValue()).getBrightness().intValue(), is(0));
+        assertThat(((HSBType) v.getChannelState()).getBrightness().intValue(), is(0));
         // Minimum brightness setting after brightness 0 is 10 for ON command
         v.update(p(v, "1"));
-        assertThat(((HSBType) v.getValue()).getBrightness().intValue(), is(10));
+        assertThat(((HSBType) v.getChannelState()).getBrightness().intValue(), is(10));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -78,13 +78,13 @@ public class ValueTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void illegalNumberCommand() {
-        NumberValue v = new NumberValue(null, null, null, null, false);
+        NumberValue v = new NumberValue(null, null, null);
         v.update(OnOffType.OFF);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void illegalPercentCommand() {
-        NumberValue v = new NumberValue(null, null, null, null, false);
+        PercentageValue v = new PercentageValue(null, null, null);
         v.update(OnOffType.OFF);
     }
 
@@ -96,7 +96,7 @@ public class ValueTests {
 
     @Test(expected = IllegalArgumentException.class)
     public void illegalPercentUpdate() {
-        NumberValue v = new NumberValue(null, null, null, null, true);
+        PercentageValue v = new PercentageValue(null, null, null);
         v.update(new DecimalType(101.0));
     }
 
@@ -104,69 +104,81 @@ public class ValueTests {
     public void onoffUpdate() {
         OnOffValue v = new OnOffValue("fancyON", "fancyOff");
         // Test with command
-        assertThat(v.update(OnOffType.OFF), is("fancyOff"));
-        assertThat(v.getValue(), is(OnOffType.OFF));
-        assertThat(v.update(OnOffType.ON), is("fancyON"));
-        assertThat(v.getValue(), is(OnOffType.ON));
+        v.update(OnOffType.OFF);
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getChannelState(), is(OnOffType.OFF));
+        v.update(OnOffType.ON);
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getChannelState(), is(OnOffType.ON));
 
         // Test with string, representing the command
-        assertThat(v.update(new StringType("OFF")), is("fancyOff"));
-        assertThat(v.getValue(), is(OnOffType.OFF));
-        assertThat(v.update(new StringType("ON")), is("fancyON"));
-        assertThat(v.getValue(), is(OnOffType.ON));
+        v.update(new StringType("OFF"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getChannelState(), is(OnOffType.OFF));
+        v.update(new StringType("ON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getChannelState(), is(OnOffType.ON));
 
         // Test with custom string, setup in the constructor
-        assertThat(v.update(new StringType("fancyOff")), is("fancyOff"));
-        assertThat(v.getValue(), is(OnOffType.OFF));
-        assertThat(v.update(new StringType("fancyON")), is("fancyON"));
-        assertThat(v.getValue(), is(OnOffType.ON));
+        v.update(new StringType("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getChannelState(), is(OnOffType.OFF));
+        v.update(new StringType("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getChannelState(), is(OnOffType.ON));
     }
 
     @Test
     public void openCloseUpdate() {
         OpenCloseValue v = new OpenCloseValue("fancyON", "fancyOff");
         // Test with command
-        assertThat(v.update(OpenClosedType.CLOSED), is("fancyOff"));
-        assertThat(v.getValue(), is(OpenClosedType.CLOSED));
-        assertThat(v.update(OpenClosedType.OPEN), is("fancyON"));
-        assertThat(v.getValue(), is(OpenClosedType.OPEN));
+        v.update(OpenClosedType.CLOSED);
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
+        v.update(OpenClosedType.OPEN);
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
 
         // Test with string, representing the command
-        assertThat(v.update(new StringType("CLOSED")), is("fancyOff"));
-        assertThat(v.getValue(), is(OpenClosedType.CLOSED));
-        assertThat(v.update(new StringType("OPEN")), is("fancyON"));
-        assertThat(v.getValue(), is(OpenClosedType.OPEN));
+        v.update(new StringType("CLOSED"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
+        v.update(new StringType("OPEN"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
 
         // Test with custom string, setup in the constructor
-        assertThat(v.update(new StringType("fancyOff")), is("fancyOff"));
-        assertThat(v.getValue(), is(OpenClosedType.CLOSED));
-        assertThat(v.update(new StringType("fancyON")), is("fancyON"));
-        assertThat(v.getValue(), is(OpenClosedType.OPEN));
+        v.update(new StringType("fancyOff"));
+        assertThat(v.getMQTTpublishValue(), is("fancyOff"));
+        assertThat(v.getChannelState(), is(OpenClosedType.CLOSED));
+        v.update(new StringType("fancyON"));
+        assertThat(v.getMQTTpublishValue(), is("fancyON"));
+        assertThat(v.getChannelState(), is(OpenClosedType.OPEN));
     }
 
     @Test
     public void percentCalc() {
-        NumberValue v = new NumberValue(true, new BigDecimal(10.0), new BigDecimal(110.0), new BigDecimal(1.0), true);
+        PercentageValue v = new PercentageValue(new BigDecimal(10.0), new BigDecimal(110.0), new BigDecimal(1.0));
         v.update(new DecimalType(110.0));
-        assertThat((PercentType) v.getValue(), is(new PercentType(100)));
+        assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
         v.update(new DecimalType(10.0));
-        assertThat((PercentType) v.getValue(), is(new PercentType(0)));
+        assertThat((PercentType) v.getChannelState(), is(new PercentType(0)));
     }
 
     @Test
     public void decimalCalc() {
-        NumberValue v = new NumberValue(true, new BigDecimal(0.1), new BigDecimal(1.0), new BigDecimal(0.1), true);
+        PercentageValue v = new PercentageValue(new BigDecimal(0.1), new BigDecimal(1.0), new BigDecimal(0.1));
         v.update(new DecimalType(1.0));
-        assertThat((PercentType) v.getValue(), is(new PercentType(100)));
+        assertThat((PercentType) v.getChannelState(), is(new PercentType(100)));
         v.update(new DecimalType(0.1));
-        assertThat((PercentType) v.getValue(), is(new PercentType(0)));
+        assertThat((PercentType) v.getChannelState(), is(new PercentType(0)));
         v.update(new DecimalType(0.2));
-        assertEquals(((PercentType) v.getValue()).floatValue(), 11.11f, 0.01f);
+        assertEquals(((PercentType) v.getChannelState()).floatValue(), 11.11f, 0.01f);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void percentCalcInvalid() {
-        NumberValue v = new NumberValue(true, new BigDecimal(10.0), new BigDecimal(110.0), new BigDecimal(1.0), true);
+        PercentageValue v = new PercentageValue(new BigDecimal(10.0), new BigDecimal(110.0), new BigDecimal(1.0));
         v.update(new DecimalType(9.0));
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/string-channel-config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/string-channel-config.xml
@@ -4,14 +4,14 @@
 	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
-	<config-description uri="thing-type:mqtt:number_channel">
+	<config-description uri="thing-type:mqtt:string_channel">
 		<parameter name="stateTopic" type="text">
 			<label>MQTT state topic</label>
-			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less then and will publish values non-retained.</description>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
 		</parameter>
 		<parameter name="commandTopic" type="text">
 			<label>MQTT command topic</label>
-			<description>An MQTT topic that this thing will send a command to. This can be left empty</description>
+			<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only channel.</description>
 		</parameter>
 		<parameter name="transformationPattern" type="text">
 			<label>Incoming value transformation</label>
@@ -30,19 +30,16 @@
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
+		<parameter name="postCommand" type="boolean">
+			<label>Is command</label>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
 
-		<parameter name="min" type="decimal">
-			<label>Absolute minimum</label>
-			<description>This configuration represents the minimum of the allowed range. For a percentage channel that equals zero percent.</description>
-		</parameter>
-		<parameter name="max" type="decimal">
-			<label>Absolute maximum</label>
-			<description>This configuration represents the maximum of the allowed range. For a percentage channel that equals one-hundred percent.</description>
-		</parameter>
-		<parameter name="step" type="decimal">
-			<label>Delta value</label>
-			<description>A number/dimmer channel can receive Increase/Decrease commands and computes the target number by adding or subtracting this delta value.</description>
-			<default>1.0</default>
+		<parameter name="allowedStates" type="text">
+			<label>Allowed states</label>
+			<description>If your MQTT topic is limited to a set of one or more specific commands or specific states, define those states here. Separate multiple states with commas. An example for a light bulb state set: ON,DIMMED,OFF</description>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/switch-channel-config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/switch-channel-config.xml
@@ -4,14 +4,14 @@
 	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
 
-	<config-description uri="thing-type:mqtt:number_channel">
+	<config-description uri="thing-type:mqtt:switch_channel">
 		<parameter name="stateTopic" type="text">
 			<label>MQTT state topic</label>
-			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less then and will publish values non-retained.</description>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
 		</parameter>
 		<parameter name="commandTopic" type="text">
 			<label>MQTT command topic</label>
-			<description>An MQTT topic that this thing will send a command to. This can be left empty</description>
+			<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only switch.</description>
 		</parameter>
 		<parameter name="transformationPattern" type="text">
 			<label>Incoming value transformation</label>
@@ -30,19 +30,23 @@
 			<default>false</default>
 			<advanced>true</advanced>
 		</parameter>
+		<parameter name="postCommand" type="boolean">
+			<label>Is command</label>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
 
-		<parameter name="min" type="decimal">
-			<label>Absolute minimum</label>
-			<description>This configuration represents the minimum of the allowed range. For a percentage channel that equals zero percent.</description>
+		<parameter name="on" type="text">
+			<label>On/Open value</label>
+			<description>A number (like 1, 10) or a string (like "enabled") that is recognised as on/open state. You can use this parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
+			<default>1</default>
+			<advanced>true</advanced>
 		</parameter>
-		<parameter name="max" type="decimal">
-			<label>Absolute maximum</label>
-			<description>This configuration represents the maximum of the allowed range. For a percentage channel that equals one-hundred percent.</description>
-		</parameter>
-		<parameter name="step" type="decimal">
-			<label>Delta value</label>
-			<description>A number/dimmer channel can receive Increase/Decrease commands and computes the target number by adding or subtracting this delta value.</description>
-			<default>1.0</default>
+		<parameter name="off" type="text">
+			<label>Off/Closed value</label>
+			<description>A number (like 0, -10) or a string (like "disabled") that is recognised as off/closed state. You can use this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
+			<default>0</default>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/channels.xml
@@ -7,314 +7,67 @@
 	<channel-type id="string">
 		<item-type>String</item-type>
 		<label>Text value</label>
-		<config-description>
-			<parameter name="stateTopic" type="text">
-				<label>MQTT state topic</label>
-				<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
-			</parameter>
-			<parameter name="commandTopic" type="text">
-				<label>MQTT command topic</label>
-				<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only channel.</description>
-			</parameter>
-			<parameter name="transformationPattern" type="text">
-				<label>Incoming value transformation</label>
-				<description>Applies a transformation to an incoming MQTT topic value. A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for a json {device: {status: { temperature: 23.2 }}}. Any supported transformation service can be used.</description>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="formatBeforePublish" type="text">
-				<label>Outgoing value format</label>
-				<description>Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".</description>
-				<advanced>true</advanced>
-				<default>%s</default>
-			</parameter>
-			<parameter name="retained" type="boolean">
-				<label>Retained</label>
-				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="postCommand" type="boolean">
-				<label>Is command</label>
-				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-
-			<parameter name="allowedStates" type="text">
-				<label>Allowed states</label>
-				<description>If your MQTT topic is limited to a set of one or more specific commands or specific states, define those states here. Separate multiple states with commas. An example for a light bulb state set: ON,DIMMED,OFF</description>
-				<advanced>true</advanced>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:mqtt:string_channel"/>
 	</channel-type>
 
+    <channel-type id="datetime">
+        <item-type>DateTime</item-type>
+        <label>Date/Time value</label>
+        <description>Current date and/or time</description>
+        <config-description-ref uri="thing-type:mqtt:string_channel"/>
+    </channel-type>
+    
+    <channel-type id="image">
+        <item-type>Image</item-type>
+        <label>Image</label>
+        <description>An image to display. Send a binary bmp, jpg, png or any other supported format to this channel.</description>
+        <state readOnly="true"/>
+        <config-description-ref uri="thing-type:mqtt:string_channel"/>
+    </channel-type>
+    
+    <channel-type id="location">
+        <item-type>Location</item-type>
+        <label>Location</label>
+        <description>GPS coordinates as Latitude,Longitude,Altitude</description>
+        <config-description-ref uri="thing-type:mqtt:string_channel"/>
+    </channel-type>
+    
 	<channel-type id="number">
 		<item-type>Number</item-type>
 		<label>Number value</label>
-		<config-description-ref uri="mqtt:number_channel"></config-description-ref>
+		<config-description-ref uri="thing-type:mqtt:number_channel"></config-description-ref>
 	</channel-type>
 
 	<channel-type id="dimmer">
 		<item-type>Dimmer</item-type>
 		<label>Percentage value</label>
-		<config-description>
-			<parameter name="stateTopic" type="text">
-				<label>MQTT state topic</label>
-				<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
-			</parameter>
-			<parameter name="commandTopic" type="text">
-				<label>MQTT command topic</label>
-				<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only channel.</description>
-			</parameter>
-			<parameter name="transformationPattern" type="text">
-				<label>Incoming value transformation</label>
-				<description>Applies a transformation to an incoming MQTT topic value. A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for a json {device: {status: { temperature: 23.2 }}}. Any supported transformation service can be used.</description>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="formatBeforePublish" type="text">
-				<label>Outgoing value format</label>
-				<description>Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".</description>
-				<advanced>true</advanced>
-				<default>%s</default>
-			</parameter>
-			<parameter name="retained" type="boolean">
-				<label>Retained</label>
-				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="postCommand" type="boolean">
-				<label>Is command</label>
-				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-
-			<parameter name="min" type="decimal">
-				<label>Range minimum</label>
-				<description>The received number needs to be converted to a percentage. This configuration represents the minimum of the allowed range that equals zero percent.</description>
-				<default>0.0</default>
-			</parameter>
-			<parameter name="max" type="decimal">
-				<label>Range maximum</label>
-				<description>The received number needs to be converted to a percentage. This configuration represents the maximum of the allowed range that equals one-hundred percent.</description>
-				<default>100.0</default>
-			</parameter>
-			<parameter name="step" type="decimal">
-				<label>Delta percentage</label>
-				<description>A dimmer channel can receive Increase/Decrease commands and computes the target percentage by adding or subtracting this delta percentage.</description>
-				<default>10.0</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="isDecimal" type="boolean">
-				<label>Is Decimal?</label>
-				<description>If enabled, the value will be published to the MQTT broker including the fractional part of the number and a dot as the decimal marker.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-		</config-description>
+        <config-description-ref uri="thing-type:mqtt:number_channel"></config-description-ref>
 	</channel-type>
 
 	<channel-type id="switch">
 		<item-type>Switch</item-type>
 		<label>On/Off switch</label>
-		<config-description>
-			<parameter name="stateTopic" type="text">
-				<label>MQTT state topic</label>
-				<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
-			</parameter>
-			<parameter name="commandTopic" type="text">
-				<label>MQTT command topic</label>
-				<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only switch.</description>
-			</parameter>
-			<parameter name="transformationPattern" type="text">
-				<label>Incoming value transformation</label>
-				<description>Applies a transformation to an incoming MQTT topic value. A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for a json {device: {status: { temperature: 23.2 }}}. Any supported transformation service can be used.</description>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="formatBeforePublish" type="text">
-				<label>Outgoing value format</label>
-				<description>Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".</description>
-				<advanced>true</advanced>
-				<default>%s</default>
-			</parameter>
-			<parameter name="retained" type="boolean">
-				<label>Retained</label>
-				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="postCommand" type="boolean">
-				<label>Is command</label>
-				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-
-			<parameter name="on" type="text">
-				<label>ON value</label>
-				<description>A number (like 1, 10) or a string (like enabled) that is recognised as on state. "ON" (case insensitive) will always be recognised. You can use this parameter for a second keyword.</description>
-				<default>1</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="off" type="text">
-				<label>OFF value</label>
-				<description>A number (like 0, -10) or a string (like disabled) that is recognised as off state. "OFF" (case insensitive) will always be recognised. You can use this parameter for a second keyword.</description>
-				<default>0</default>
-				<advanced>true</advanced>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:mqtt:switch_channel"></config-description-ref>
 	</channel-type>
 
 	<channel-type id="contact">
 		<item-type>Contact</item-type>
 		<label>Open/Close contact</label>
-		<config-description>
-			<parameter name="stateTopic" type="text" required="true">
-				<label>MQTT state topic</label>
-				<description>An MQTT topic that this thing will subscribe to, to receive the state.</description>
-			</parameter>
-			<parameter name="transformationPattern" type="text">
-				<label>Incoming value transformation</label>
-				<description>Applies a transformation to an incoming MQTT topic value. A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for a json {device: {status: { temperature: 23.2 }}}. Any supported transformation service can be used.</description>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="formatBeforePublish" type="text">
-				<label>Outgoing value format</label>
-				<description>Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".</description>
-				<advanced>true</advanced>
-				<default>%s</default>
-			</parameter>
-			<parameter name="retained" type="boolean">
-				<label>Retained</label>
-				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="postCommand" type="boolean">
-				<label>Is command</label>
-				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-
-			<parameter name="on" type="text">
-				<label>Open value</label>
-				<description>A number (like 1, 10) or a string (like "positionUp") that is recognised as open state. "OPEN" (case insensitive) will always be recognised. You can use this parameter for a second keyword.</description>
-				<default>1</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="off" type="text">
-				<label>Close value</label>
-				<description>A number (like 0, -10) or a string (like "positionDown") that is recognised as close state. "CLOSED" (case insensitive) will always be recognised. You can use this parameter for a second keyword.</description>
-				<default>0</default>
-				<advanced>true</advanced>
-			</parameter>
-		</config-description>
+		<config-description-ref uri="thing-type:mqtt:switch_channel"></config-description-ref>
 	</channel-type>
 
 	<channel-type id="colorRGB">
 		<item-type>Color</item-type>
 		<label>Color value (Red,Green,Blue)</label>
 		<description></description>
-		<config-description>
-			<parameter name="stateTopic" type="text">
-				<label>MQTT state topic</label>
-				<description>An MQTT topic that this thing will subscribe to, to receive the state.</description>
-			</parameter>
-			<parameter name="commandTopic" type="text">
-				<label>MQTT command topic</label>
-				<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only channel.</description>
-			</parameter>
-			<parameter name="transformationPattern" type="text">
-				<label>Incoming value transformation</label>
-				<description>Applies a transformation to an incoming MQTT topic value. A transformation example for a received JSON would be "JSONPATH:$.device.color.rgb" for a json {device: {color: { rgb: "12,43,112" }}}. Any supported transformation service can be used.</description>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="formatBeforePublish" type="text">
-				<label>Outgoing value format</label>
-				<description>Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".</description>
-				<advanced>true</advanced>
-				<default>%s</default>
-			</parameter>
-			<parameter name="retained" type="boolean">
-				<label>Retained</label>
-				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="postCommand" type="boolean">
-				<label>Is command</label>
-				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-
-			<parameter name="on" type="text">
-				<label>ON value</label>
-				<description>A number (like 1, 10) or a string (like ON) that is recognised as on state.</description>
-				<default>ON</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="off" type="text">
-				<label>OFF value</label>
-				<description>A number (like 0, -10) or a string (like OFF) that is recognised as off state.</description>
-				<default>OFF</default>
-				<advanced>true</advanced>
-			</parameter>
-		</config-description>
+        <config-description-ref uri="thing-type:mqtt:switch_channel"></config-description-ref>
 	</channel-type>
 
 	<channel-type id="colorHSB">
 		<item-type>Color</item-type>
 		<label>Color value (Hue,Saturation,Brightness)</label>
 		<description></description>
-		<config-description>
-			<parameter name="stateTopic" type="text">
-				<label>MQTT state topic</label>
-				<description>An MQTT topic that this thing will subscribe to, to receive the state.</description>
-			</parameter>
-			<parameter name="commandTopic" type="text">
-				<label>MQTT command topic</label>
-				<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only channel.</description>
-			</parameter>
-			<parameter name="transformationPattern" type="text">
-				<label>Incoming value transformation</label>
-				<description>Applies a transformation to an incoming MQTT topic value. A transformation example for a received JSON would be "JSONPATH:$.device.color.hsb" for a json {device: {color: { hsb: "12,43,112" }}}. Any supported transformation service can be used.</description>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="formatBeforePublish" type="text">
-				<label>Outgoing value format</label>
-				<description>Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".</description>
-				<advanced>true</advanced>
-				<default>%s</default>
-			</parameter>
-			<parameter name="retained" type="boolean">
-				<label>Retained</label>
-				<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="postCommand" type="boolean">
-				<label>Is command</label>
-				<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
-				<default>false</default>
-				<advanced>true</advanced>
-			</parameter>
-
-			<parameter name="on" type="text">
-				<label>ON value</label>
-				<description>A number (like 1, 10) or a string (like ON) that is recognised as on state.</description>
-				<default>ON</default>
-				<advanced>true</advanced>
-			</parameter>
-			<parameter name="off" type="text">
-				<label>OFF value</label>
-				<description>A number (like 0, -10) or a string (like OFF) that is recognised as off state.</description>
-				<default>OFF</default>
-				<advanced>true</advanced>
-			</parameter>
-		</config-description>
+        <config-description-ref uri="thing-type:mqtt:switch_channel"></config-description-ref>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
@@ -49,6 +49,9 @@ You can manually add the following channels:
 * **switch**: This channel represents a on/off state of a given topic and can send an on/off value to a given topic.
 * **colorRGB**: This channel handles color values in RGB format.
 * **colorHSB**: This channel handles color values in HSB format.
+* **location**: This channel handles a location.
+* **image**: This channel handles binary images in common java supported formats (bmp,jpg,png).
+* **datetime**: This channel handles date/time values.
 
 ## Thing and Channel configuration
 
@@ -68,13 +71,13 @@ All things require a configured broker.
 You can connect this channel to a String item.
 
 ### Channel Type "number"
- 
-* __min__: An optional minimum value
-* __max__: An optional maximum value
-* __step__: For decrease, increase commands the step needs to be known
-* __isDecimal__: If set to true the value is send as a decimal value, otherwise it is send as integer.
 
-If any of the parameters is a float/double (has a decimal point value), then a float value is send to the MQTT topic otherwise an int value is send.
+* __min__: An optional minimum value.
+* __max__: An optional maximum value.
+* __step__: For decrease, increase commands the step needs to be known
+
+A decimal value (like 0.2) is send to the MQTT topic if the number has a fractional part.
+If you always require an integer, please use the formatter.
 
 You can connect this channel to a Number item.
 
@@ -85,6 +88,8 @@ You can connect this channel to a Number item.
 * __step__: For decrease, increase commands the step needs to be known
 
 The value is internally stored as a percentage for a value between **min** and **max**.
+
+The channel will publish a value between 0 and 100.
 
 You can connect this channel to a Rollershutter or Dimmer item.
 
@@ -106,6 +111,31 @@ You can connect this channel to a Color item.
 
 This channel will publish the color as comma separated list to the MQTT broker,
 e.g. "112,54,123" for an RGB channel (0-255 per component) and "360,100,100" for a HSB channel (0-359 for hue and 0-100 for saturation and brightness).
+
+The channel expects values on the corresponding MQTT topic to be in this format as well. 
+
+### Channel Type "location"
+
+You can connect this channel to a Location item.
+
+The channel will publish the location as comma separated list to the MQTT broker,
+e.g. "112,54,123" for latitude, longitude, altitude. The altitude is optional. 
+
+The channel expects values on the corresponding MQTT topic to be in this format as well. 
+
+### Channel Type "image"
+
+You can connect this channel to an Image item. This is a read-only channel.
+
+The channel expects values on the corresponding MQTT topic to contain the binary
+data of a bmp, jpg, png or any other format that the installed java runtime supports. 
+
+### Channel Type "datetime"
+
+You can connect this channel to a DateTime item.
+
+The channel will publish the date/time in the format "yyyy-MM-dd'T'HH:mm"
+for example 2018-01-01T12:14:00. If you require another format, please use the formatter.
 
 The channel expects values on the corresponding MQTT topic to be in this format as well. 
 

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/MqttBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/MqttBindingConstants.java
@@ -35,11 +35,13 @@ public class MqttBindingConstants {
     public static final String COLOR_RGB = "colorRGB";
     public static final String COLOR_HSB = "colorHSB";
     public static final String CONTACT = "contact";
-    public static final String DATETIME = "dateTime";
     public static final String DIMMER = "dimmer";
     public static final String NUMBER = "number";
     public static final String STRING = "string";
     public static final String SWITCH = "switch";
+    public static final String IMAGE = "image";
+    public static final String LOCATION = "location";
+    public static final String DATETIME = "datetime";
 
     public static final String CONFIG_HA_CHANNEL = "mqtt:ha_channel";
     public static final String CONFIG_HOMIE_CHANNEL = "mqtt:homie_channel";

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/AbstractComponent.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/AbstractComponent.java
@@ -174,7 +174,7 @@ public abstract class AbstractComponent {
      * to the MQTT broker got lost.
      */
     public void resetState() {
-        channels.values().forEach(c -> c.channelState.getValue().resetState());
+        channels.values().forEach(c -> c.channelState.getCache().resetState());
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelConfig.java
@@ -47,7 +47,6 @@ public class ChannelConfig {
     public @Nullable BigDecimal min;
     public @Nullable BigDecimal max;
     public @Nullable BigDecimal step;
-    public boolean isDecimal = false;
     public @Nullable String on;
     public @Nullable String off;
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelConfigBuilder.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelConfigBuilder.java
@@ -40,6 +40,11 @@ public class ChannelConfigBuilder {
         return config;
     }
 
+    public ChannelConfigBuilder withFormatter(String formatter) {
+        config.formatBeforePublish = formatter;
+        return this;
+    }
+
     public ChannelConfigBuilder withStateTopic(@Nullable String topic) {
         if (topic != null) {
             config.stateTopic = topic;

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateTransformation.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateTransformation.java
@@ -45,7 +45,7 @@ public class ChannelStateTransformation {
      *            temperature: 23.2 }}}.
      * @param channelUID The channel UID, used in processMessage() to inform the respective channel
      *            of an update.
-     * @param value A value object
+     * @param cachedValue A value object
      * @param provider The transformation service provider
      */
     public ChannelStateTransformation(String pattern, TransformationServiceProvider provider) {

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/AbstractMQTTThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/AbstractMQTTThingHandler.java
@@ -112,11 +112,11 @@ public abstract class AbstractMQTTThingHandler extends BaseThingHandler implemen
         }
 
         if (command instanceof RefreshType || data.isReadOnly()) {
-            updateState(channelUID.getId(), data.getValue().getValue());
+            updateState(channelUID.getId(), data.getCache().getChannelState());
             return;
         }
 
-        final CompletableFuture<@Nullable Void> future = data.setValue(command);
+        final CompletableFuture<@Nullable Void> future = data.publishValue(command);
         future.exceptionally(e -> {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getLocalizedMessage());
             return null;

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/GenericThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/handler/GenericThingHandler.java
@@ -94,7 +94,7 @@ public class GenericThingHandler extends AbstractMQTTThingHandler implements Cha
 
     @Override
     protected void stop() {
-        channelStateByChannelUID.values().forEach(c -> c.getValue().resetState());
+        channelStateByChannelUID.values().forEach(c -> c.getCache().resetState());
     }
 
     @Override

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/DateTimeValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/DateTimeValue.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.binding.mqtt.generic.internal.values;
+
+import java.time.format.DateTimeFormatter;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.library.types.DateTimeType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.UnDefType;
+
+/**
+ * Implements a datetime value.
+ *
+ * @author David Graeff - Initial contribution
+ */
+@NonNullByDefault
+public class DateTimeValue extends Value {
+    public DateTimeValue() {
+        super(CoreItemFactory.DATETIME, Stream.of(DateTimeType.class, StringType.class).collect(Collectors.toList()));
+    }
+
+    @Override
+    public void update(Command command) throws IllegalArgumentException {
+        if (command instanceof DateTimeType) {
+            state = ((DateTimeType) command);
+        } else {
+            state = DateTimeType.valueOf(command.toString());
+        }
+    }
+
+    @Override
+    public String getMQTTpublishValue() {
+        if (state == UnDefType.UNDEF) {
+            return "";
+        }
+
+        return ((DateTimeType) state).getZonedDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ImageValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ImageValue.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.binding.mqtt.generic.internal.values;
+
+import java.util.Collections;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.types.Command;
+
+/**
+ * Implements an image value.
+ *
+ * @author David Graeff - Initial contribution
+ */
+@NonNullByDefault
+public class ImageValue extends Value {
+    public ImageValue() {
+        super(CoreItemFactory.IMAGE, Collections.emptyList());
+    }
+
+    @Override
+    public void update(Command command) throws IllegalArgumentException {
+        throw new IllegalArgumentException("Binary type. Command not allowed");
+    }
+
+    @Override
+    public boolean isBinary() {
+        return true;
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/LocationValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/LocationValue.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.binding.mqtt.generic.internal.values;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.library.types.PointType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.types.Command;
+
+/**
+ * Implements a location value.
+ *
+ * @author David Graeff - Initial contribution
+ */
+@NonNullByDefault
+public class LocationValue extends Value {
+    public LocationValue() {
+        super(CoreItemFactory.LOCATION, Stream.of(PointType.class, StringType.class).collect(Collectors.toList()));
+    }
+
+    @Override
+    public void update(Command command) throws IllegalArgumentException {
+        if (command instanceof PointType) {
+            state = ((PointType) command);
+        } else {
+            state = PointType.valueOf(command.toString());
+        }
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/OnOffValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/OnOffValue.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.binding.mqtt.generic.internal.values;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -23,9 +21,6 @@ import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.StateDescription;
-import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * Implements an on/off boolean value.
@@ -33,21 +28,17 @@ import org.eclipse.smarthome.core.types.UnDefType;
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
-public class OnOffValue implements Value {
-    private State state = UnDefType.UNDEF;
-    private OnOffType onOffValue;
+public class OnOffValue extends Value {
     private final String onString;
     private final String offString;
-    private List<Class<? extends Command>> commandTypes = Stream.of(OnOffType.class, StringType.class)
-            .collect(Collectors.toList());
 
     /**
      * Creates a switch On/Off type, that accepts "ON", "1" for on and "OFF","0" for off.
      */
     public OnOffValue() {
+        super(CoreItemFactory.SWITCH, Stream.of(OnOffType.class, StringType.class).collect(Collectors.toList()));
         this.onString = OnOffType.ON.name();
         this.offString = OnOffType.OFF.name();
-        this.onOffValue = OnOffType.OFF;
     }
 
     /**
@@ -57,58 +48,29 @@ public class OnOffValue implements Value {
      * @param offValue The OFF value string. This will be compared to MQTT messages.
      */
     public OnOffValue(@Nullable String onValue, @Nullable String offValue) {
+        super(CoreItemFactory.SWITCH, Stream.of(OnOffType.class, StringType.class).collect(Collectors.toList()));
         this.onString = onValue == null ? OnOffType.ON.name() : onValue;
         this.offString = offValue == null ? OnOffType.OFF.name() : offValue;
-        this.onOffValue = OnOffType.OFF;
     }
 
     @Override
-    public State getValue() {
-        return state;
-    }
-
-    @Override
-    public String update(Command command) throws IllegalArgumentException {
+    public void update(Command command) throws IllegalArgumentException {
         if (command instanceof OnOffType) {
-            onOffValue = ((OnOffType) command);
-        } else if (command instanceof StringType) {
-            final String updatedValue = command.toString();
-            final String upperCase = updatedValue.toUpperCase();
-            if (onString.equals(updatedValue) || OnOffType.ON.name().equals(upperCase)) {
-                onOffValue = OnOffType.ON;
-            } else if (offString.equals(updatedValue) || OnOffType.OFF.name().equals(upperCase)) {
-                onOffValue = OnOffType.OFF;
-            } else {
-                throw new IllegalArgumentException("Didn't recognise the on/off value " + updatedValue);
-            }
-
+            state = (OnOffType) command;
         } else {
-            throw new IllegalArgumentException(
-                    "Type " + command.getClass().getName() + " not supported for OnOffValue");
+            final String updatedValue = command.toString();
+            if (onString.equals(updatedValue)) {
+                state = OnOffType.ON;
+            } else if (offString.equals(updatedValue)) {
+                state = OnOffType.OFF;
+            } else {
+                state = OnOffType.valueOf(updatedValue);
+            }
         }
-
-        state = onOffValue;
-        return (onOffValue == OnOffType.ON) ? onString : offString;
     }
 
     @Override
-    public String getItemType() {
-        return CoreItemFactory.SWITCH;
-    }
-
-    @Override
-    public StateDescription createStateDescription(String unit, boolean readOnly) {
-        return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), readOnly,
-                Collections.emptyList());
-    }
-
-    @Override
-    public List<Class<? extends Command>> getSupportedCommandTypes() {
-        return commandTypes;
-    }
-
-    @Override
-    public void resetState() {
-        state = UnDefType.UNDEF;
+    public String getMQTTpublishValue() {
+        return (state == OnOffType.ON) ? onString : offString;
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/OpenCloseValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/OpenCloseValue.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.binding.mqtt.generic.internal.values;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -23,9 +21,6 @@ import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.OpenClosedType;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.State;
-import org.eclipse.smarthome.core.types.StateDescription;
-import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * Implements an open/close boolean value.
@@ -33,21 +28,17 @@ import org.eclipse.smarthome.core.types.UnDefType;
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
-public class OpenCloseValue implements Value {
-    private State state = UnDefType.UNDEF;
-    private OpenClosedType boolValue;
+public class OpenCloseValue extends Value {
     private final String openString;
     private final String closeString;
-    private List<Class<? extends Command>> commandTypes = Stream.of(OpenClosedType.class, StringType.class)
-            .collect(Collectors.toList());
 
     /**
      * Creates a contact Open/Close type.
      */
     public OpenCloseValue() {
+        super(CoreItemFactory.CONTACT, Stream.of(OpenClosedType.class, StringType.class).collect(Collectors.toList()));
         this.openString = OpenClosedType.OPEN.name();
         this.closeString = OpenClosedType.CLOSED.name();
-        this.boolValue = OpenClosedType.CLOSED;
     }
 
     /**
@@ -57,57 +48,29 @@ public class OpenCloseValue implements Value {
      * @param closeValue The OFF value string. This will be compared to MQTT messages.
      */
     public OpenCloseValue(@Nullable String openValue, @Nullable String closeValue) {
+        super(CoreItemFactory.CONTACT, Stream.of(OpenClosedType.class, StringType.class).collect(Collectors.toList()));
         this.openString = openValue == null ? OpenClosedType.OPEN.name() : openValue;
         this.closeString = closeValue == null ? OpenClosedType.CLOSED.name() : closeValue;
-        this.boolValue = OpenClosedType.CLOSED;
     }
 
     @Override
-    public State getValue() {
-        return state;
-    }
-
-    @Override
-    public String update(Command command) throws IllegalArgumentException {
+    public void update(Command command) throws IllegalArgumentException {
         if (command instanceof OpenClosedType) {
-            boolValue = ((OpenClosedType) command);
-        } else if (command instanceof StringType) {
-            final String updatedValue = ((StringType) command).toString();
-            final String upperCase = updatedValue.toUpperCase();
-            if (openString.equals(updatedValue) || OpenClosedType.OPEN.name().equals(upperCase)) {
-                boolValue = OpenClosedType.OPEN;
-            } else if (closeString.equals(updatedValue) || OpenClosedType.CLOSED.name().equals(upperCase)) {
-                boolValue = OpenClosedType.CLOSED;
-            } else {
-                throw new IllegalArgumentException("Didn't recognise the open/closed value " + updatedValue);
-            }
+            state = (OpenClosedType) command;
         } else {
-            throw new IllegalArgumentException(
-                    "Type " + command.getClass().getName() + " not supported for OpenCloseValue");
+            final String updatedValue = command.toString();
+            if (openString.equals(updatedValue)) {
+                state = OpenClosedType.OPEN;
+            } else if (closeString.equals(updatedValue)) {
+                state = OpenClosedType.CLOSED;
+            } else {
+                state = OpenClosedType.valueOf(updatedValue);
+            }
         }
-
-        state = boolValue;
-        return (boolValue == OpenClosedType.OPEN) ? openString : closeString;
     }
 
     @Override
-    public String getItemType() {
-        return CoreItemFactory.CONTACT;
-    }
-
-    @Override
-    public StateDescription createStateDescription(String unit, boolean readOnly) {
-        return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), readOnly,
-                Collections.emptyList());
-    }
-
-    @Override
-    public List<Class<? extends Command>> getSupportedCommandTypes() {
-        return commandTypes;
-    }
-
-    @Override
-    public void resetState() {
-        state = UnDefType.UNDEF;
+    public String getMQTTpublishValue() {
+        return (state == OpenClosedType.OPEN) ? openString : closeString;
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/PercentageValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/PercentageValue.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.binding.mqtt.generic.internal.values;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.IncreaseDecreaseType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.StateDescription;
+import org.eclipse.smarthome.core.types.UnDefType;
+
+/**
+ * Implements a percentage value. Minimum and maximum are definable.
+ *
+ * <p>
+ * Accepts user updates from a DecimalType, IncreaseDecreaseType and UpDownType.
+ * If this is a percent value, PercentType
+ * </p>
+ * Accepts MQTT state updates as DecimalType, IncreaseDecreaseType and UpDownType
+ * StringType with comma separated HSB ("h,s,b"), RGB ("r,g,b") and on, off strings.
+ * On, Off strings can be customized.
+ *
+ * @author David Graeff - Initial contribution
+ */
+@NonNullByDefault
+public class PercentageValue extends Value {
+    private final double min;
+    private final double max;
+    private final double step;
+
+    public PercentageValue(@Nullable BigDecimal min, @Nullable BigDecimal max, @Nullable BigDecimal step) {
+        super(CoreItemFactory.DIMMER, Stream.of(DecimalType.class, IncreaseDecreaseType.class, UpDownType.class)
+                .collect(Collectors.toList()));
+        this.min = min == null ? 0.0 : min.doubleValue();
+        this.max = max == null ? 100.0 : max.doubleValue();
+        if (this.min >= this.max) {
+            throw new IllegalArgumentException("Min need to be smaller than max!");
+        }
+        this.step = step == null ? 1.0 : step.doubleValue();
+    }
+
+    @Override
+    public void update(Command command) throws IllegalArgumentException {
+        PercentType oldvalue = (state == UnDefType.UNDEF) ? new PercentType() : (PercentType) state;
+        if (command instanceof PercentType) {
+            state = (PercentType) command;
+        } else if (command instanceof DecimalType) {
+            double v = ((DecimalType) command).doubleValue();
+            v = (v - min) * 100.0 / (max - min);
+            state = new PercentType(new BigDecimal(v));
+        } else if (command instanceof IncreaseDecreaseType) {
+            if (((IncreaseDecreaseType) command) == IncreaseDecreaseType.INCREASE) {
+                final double v = oldvalue.doubleValue() + step;
+                state = new PercentType(new BigDecimal(v <= max ? v : max));
+            } else {
+                double v = oldvalue.doubleValue() - step;
+                state = new PercentType(new BigDecimal(v >= min ? v : min));
+            }
+        } else if (command instanceof UpDownType) {
+            if (((UpDownType) command) == UpDownType.UP) {
+                final double v = oldvalue.doubleValue() + step;
+                state = new PercentType(new BigDecimal(v <= max ? v : max));
+            } else {
+                final double v = oldvalue.doubleValue() - step;
+                state = new PercentType(new BigDecimal(v >= min ? v : min));
+            }
+        } else {
+            state = PercentType.valueOf(command.toString());
+        }
+    }
+
+    @Override
+    public StateDescription createStateDescription(String unit, boolean readOnly) {
+        return new StateDescription(new BigDecimal(min), new BigDecimal(max), new BigDecimal(step),
+                "%s " + unit.replace("%", "%%"), readOnly, Collections.emptyList());
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/TextValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/TextValue.java
@@ -25,10 +25,8 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
 import org.eclipse.smarthome.core.library.types.StringType;
 import org.eclipse.smarthome.core.types.Command;
-import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.StateOption;
-import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
  * Implements a text/string value. Allows to restrict the incoming value to a set of states.
@@ -36,9 +34,7 @@ import org.eclipse.smarthome.core.types.UnDefType;
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
-public class TextValue implements Value {
-    private State state = UnDefType.UNDEF;
-    private StringType strValue;
+public class TextValue extends Value {
     private final @Nullable Set<String> states;
 
     /**
@@ -48,7 +44,7 @@ public class TextValue implements Value {
      *            will be allowed.
      */
     public TextValue(String[] states) {
-        strValue = new StringType();
+        super(CoreItemFactory.STRING, Collections.singletonList(StringType.class));
         Set<String> s = Stream.of(states).filter(e -> StringUtils.isNotBlank(e)).collect(Collectors.toSet());
         if (s.size() > 0) {
             this.states = s;
@@ -58,30 +54,18 @@ public class TextValue implements Value {
     }
 
     public TextValue() {
-        strValue = new StringType();
+        super(CoreItemFactory.STRING, Collections.singletonList(StringType.class));
         this.states = null;
     }
 
     @Override
-    public State getValue() {
-        return state;
-    }
-
-    @Override
-    public String update(Command command) throws IllegalArgumentException {
+    public void update(Command command) throws IllegalArgumentException {
         final Set<String> states = this.states;
-        String value = command.toString();
-        if (states != null && !states.contains(value)) {
-            throw new IllegalArgumentException("Value " + value + " not within range");
+        String valueStr = command.toString();
+        if (states != null && !states.contains(valueStr)) {
+            throw new IllegalArgumentException("Value " + valueStr + " not within range");
         }
-        strValue = new StringType(value);
-        state = strValue;
-        return value;
-    }
-
-    @Override
-    public String getItemType() {
-        return CoreItemFactory.STRING;
+        state = new StringType(valueStr);
     }
 
     /**
@@ -101,15 +85,5 @@ public class TextValue implements Value {
             }
         }
         return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), readOnly, stateOptions);
-    }
-
-    @Override
-    public void resetState() {
-        state = UnDefType.UNDEF;
-    }
-
-    @Override
-    public List<Class<? extends Command>> getSupportedCommandTypes() {
-        return Collections.singletonList(StringType.class);
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/Value.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/Value.java
@@ -12,32 +12,49 @@
  */
 package org.eclipse.smarthome.binding.mqtt.generic.internal.values;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URLConnection;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.handler.GenericThingHandler;
 import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.RawType;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.State;
 import org.eclipse.smarthome.core.types.StateDescription;
 import org.eclipse.smarthome.core.types.UnDefType;
 
 /**
- * MQTT topics are not inherently typed. Users are able to map topic values to framework types, for example
- * for numbers {@link NumberValue}, boolean values {@link OnOffValue}, number values
- * with limits {@link NumberValue} and string values {@link TextValue}.
+ * MQTT topics are not inherently typed.
  *
- * This interface allows the handler class {@link GenericThingHandler} to treat all MQTT topics the same.
- * {@link #getValue()} is used to retrieve the topic state and a call to {@link #update(Command)} sets the value.
+ * <p>
+ * With this class users are able to map MQTT topic values to framework types,
+ * for example for numbers {@link NumberValue}, boolean values {@link OnOffValue}, percentage values
+ * {@link PercentageValue}, string values {@link TextValue} and more.
+ * </p>
+ *
+ * <p>
+ * This abstract class allows the handler class {@link GenericThingHandler} to treat all MQTT topics the same.
+ * {@link #getCache()} is used to retrieve the topic state and a call to {@link #update(Command)} sets the value.
+ * </p>
  *
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
-public interface Value {
-    /**
-     * Returns the item-type (one of {@link CoreItemFactory}).
-     */
-    String getItemType();
+public abstract class Value {
+    protected State state = UnDefType.UNDEF;
+    protected final List<Class<? extends Command>> commandTypes;
+    private final String itemType;
+
+    protected Value(String itemType, List<Class<? extends Command>> commandTypes) {
+        this.itemType = itemType;
+        this.commandTypes = commandTypes;
+    }
 
     /**
      * Return a list of supported command types. The order of the list is important.
@@ -45,29 +62,96 @@ public interface Value {
      * The framework will try to parse an incoming string into one of those command types,
      * starting with the first and continue until it succeeds.
      * </p>
+     * <p>
+     * Your {@link #update(Command)} method must accept all command types of this list.
+     * You may accept more command types. This allows you to restrict the parsing of incoming
+     * MQTT values to the listed types, but handle more user commands.
+     * </p>
+     * A prominent example is the {@link NumberValue}, which does not return {@link PercentType},
+     * because that would interfere with {@link DecimalType} while parsing the MQTT value.
+     * It does however accept a {@link PercentType} for {@link #update(Command)}, because a
+     * linked Item could send that type of command.
      */
-    List<Class<? extends Command>> getSupportedCommandTypes();
+    public final List<Class<? extends Command>> getSupportedCommandTypes() {
+        return commandTypes;
+    }
+
+    /**
+     * Returns the item-type (one of {@link CoreItemFactory}).
+     */
+    public final String getItemType() {
+        return itemType;
+    }
 
     /**
      * Returns the current value state.
      */
-    State getValue();
+    public final State getChannelState() {
+        return state;
+    }
+
+    public String getMQTTpublishValue() {
+        return state.toString();
+    }
 
     /**
-     * Updates the internal value state with the given command.
-     *
-     * @param command The command to update the internal value.
-     * @return An updated value state. The same as if {@link #getValue()} is called.
-     * @exception IllegalArgumentException Thrown if for example a text is assigned to a number type.
+     * Returns true if this is a binary type.
      */
-    String update(Command command) throws IllegalArgumentException;
+    public boolean isBinary() {
+        return false;
+    }
 
     /**
      * If the MQTT connection is not yet initialised or no values have
      * been received yet, the default value is {@link UnDefType#UNDEF}. To restore to the
      * default value after a connection got lost etc, this method will be called.
      */
-    void resetState();
+    public final void resetState() {
+        state = UnDefType.UNDEF;
+    }
 
-    StateDescription createStateDescription(String unit, boolean readOnly);
+    /**
+     * Updates the internal value state with the given command.
+     *
+     * @param command The command to update the internal value.
+     * @exception IllegalArgumentException Thrown if for example a text is assigned to a number type.
+     */
+    public abstract void update(Command command) throws IllegalArgumentException;
+
+    /**
+     * Updates the internal value state with the given binary payload.
+     *
+     * @param data The binary payload to update the internal value.
+     * @exception IllegalArgumentException Thrown if for example a text is assigned to a number type.
+     */
+    public void update(byte data[]) throws IllegalArgumentException {
+        String mimeType = null;
+
+        // URLConnection.guessContentTypeFromStream(input) is not sufficient to detect all JPEG files
+        if (data.length >= 2 && data[0] == (byte) 0xFF && data[1] == (byte) 0xD8 && data[data.length - 2] == (byte) 0xFF
+                && data[data.length - 1] == (byte) 0xD9) {
+            mimeType = "image/jpeg";
+        } else {
+            try (final ByteArrayInputStream input = new ByteArrayInputStream(data)) {
+                try {
+                    mimeType = URLConnection.guessContentTypeFromStream(input);
+                } catch (final IOException ignored) {
+                }
+            } catch (final IOException ignored) {
+            }
+        }
+        state = new RawType(data, mimeType == null ? RawType.DEFAULT_MIME_TYPE : mimeType);
+    }
+
+    /**
+     * Return the state description for this value state.
+     *
+     * @param unit An optional unit string. Might be an empty string.
+     * @param readOnly True if this is a read-only value.
+     * @return A state description
+     */
+    public StateDescription createStateDescription(String unit, boolean readOnly) {
+        return new StateDescription(null, null, null, "%s " + unit.replace("%", "%%"), readOnly,
+                Collections.emptyList());
+    }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ValueFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ValueFactory.java
@@ -37,11 +37,20 @@ public class ValueFactory {
                 value = StringUtils.isBlank(config.allowedStates) ? new TextValue()
                         : new TextValue(config.allowedStates.split(","));
                 break;
+            case MqttBindingConstants.DATETIME:
+                value = new DateTimeValue();
+                break;
+            case MqttBindingConstants.IMAGE:
+                value = new ImageValue();
+                break;
+            case MqttBindingConstants.LOCATION:
+                value = new LocationValue();
+                break;
             case MqttBindingConstants.NUMBER:
-                value = new NumberValue(config.isDecimal, config.min, config.max, config.step, false);
+                value = new NumberValue(config.min, config.max, config.step);
                 break;
             case MqttBindingConstants.DIMMER:
-                value = new NumberValue(config.isDecimal, config.min, config.max, config.step, true);
+                value = new PercentageValue(config.min, config.max, config.step);
                 break;
             case MqttBindingConstants.COLOR_RGB:
                 value = new ColorValue(true, config.on, config.off);


### PR DESCRIPTION
The TypeParser commit a few days ago allowed to send command strings
like INCREASE/DECREASE. Unfortunately it broke a few channels.

* This commit adds tests for all channel types.
* The RGB color channel was broken (even before the TypeParser commit): Fixed.

Added features:
* Add location, datetime and image channel types including
  tests and readme sections.

Refactor:
* The internal.values.* classes are a lot slimmer. Value itself
  is not an interface but an abstract class now.
* Move the xml thing/channel configurations to ESH-INF/config.
* Rename two methods for clarity, so that value.getValue().getValue()
  is not a think anymore.

Signed-off-by: David Gräff <david.graeff@web.de>