### PR TITLE
MQTT: Color channel can receive a single brightness value + HA components

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/HomeAssistantMQTTImplementationTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/HomeAssistantMQTTImplementationTests.java
@@ -56,6 +56,8 @@ import org.osgi.service.cm.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
+
 /**
  * A full implementation test, that starts the embedded MQTT broker and publishes a homeassistant MQTT discovery device
  * tree.
@@ -157,7 +159,7 @@ public class HomeAssistantMQTTImplementationTests extends JavaOSGiTest {
 
         ScheduledExecutorService scheduler = new ScheduledThreadPoolExecutor(4);
         DiscoverComponents discover = spy(new DiscoverComponents(ThingChannelConstants.testHomeAssistantThing,
-                scheduler, channelStateUpdateListener));
+                scheduler, channelStateUpdateListener, new Gson()));
 
         // The DiscoverComponents object calls ComponentDiscovered callbacks.
         // In the following implementation we add the found component to the `haComponents` map

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/DiscoverComponentsTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/DiscoverComponentsTests.java
@@ -31,6 +31,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import com.google.gson.Gson;
+
 /**
  * Tests the {@link DiscoverComponents} class.
  *
@@ -62,7 +64,7 @@ public class DiscoverComponentsTests extends JavaOSGiTest {
         ScheduledExecutorService scheduler = new ScheduledThreadPoolExecutor(1);
 
         DiscoverComponents discover = spy(
-                new DiscoverComponents(ThingChannelConstants.testHomeAssistantThing, scheduler, null));
+                new DiscoverComponents(ThingChannelConstants.testHomeAssistantThing, scheduler, null, new Gson()));
 
         discover.startDiscovery(connection, 50, new HaID("homeassistant", "object", "node", "component"), discovered)
                 .get(100, TimeUnit.MILLISECONDS);

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateTests.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic.test/src/test/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelStateTests.java
@@ -211,17 +211,21 @@ public class ChannelStateTests {
 
     @Test
     public void receiveRGBColorTest() throws InterruptedException, ExecutionException, TimeoutException {
-        ColorValue value = new ColorValue(true, "FON", "FOFF");
+        ColorValue value = new ColorValue(true, "FON", "FOFF", 10);
         ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
         c.start(connection, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "ON".getBytes());
+        c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
         assertThat(value.getMQTTpublishValue().toString(), is("25,25,25"));
 
-        c.processMessage("state", "FOFF".getBytes());
+        c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
         assertThat(value.getMQTTpublishValue().toString(), is("0,0,0"));
+
+        c.processMessage("state", "10".getBytes()); // Brightness only
+        assertThat(value.getChannelState().toString(), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue().toString(), is("25,25,25"));
 
         HSBType t = HSBType.fromRGB(12, 18, 231);
 
@@ -233,17 +237,21 @@ public class ChannelStateTests {
 
     @Test
     public void receiveHSBColorTest() throws InterruptedException, ExecutionException, TimeoutException {
-        ColorValue value = new ColorValue(false, "FON", "FOFF");
+        ColorValue value = new ColorValue(false, "FON", "FOFF", 10);
         ChannelState c = spy(new ChannelState(config, channelUID, value, channelStateUpdateListener));
         c.start(connection, mock(ScheduledExecutorService.class), 100);
 
-        c.processMessage("state", "ON".getBytes()); // Minimum brightness is 10
+        c.processMessage("state", "ON".getBytes()); // Normal on state
         assertThat(value.getChannelState().toString(), is("0,0,10"));
         assertThat(value.getMQTTpublishValue().toString(), is("0,0,10"));
 
-        c.processMessage("state", "FOFF".getBytes());
+        c.processMessage("state", "FOFF".getBytes()); // Custom off state
         assertThat(value.getChannelState().toString(), is("0,0,0"));
         assertThat(value.getMQTTpublishValue().toString(), is("0,0,0"));
+
+        c.processMessage("state", "10".getBytes()); // Brightness only
+        assertThat(value.getChannelState().toString(), is("0,0,10"));
+        assertThat(value.getMQTTpublishValue().toString(), is("0,0,10"));
 
         c.processMessage("state", "12,18,100".getBytes());
         assertThat(value.getChannelState().toString(), is("12,18,100"));

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/color-channel-config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/color-channel-config.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:mqtt:color_channel">
+		<parameter name="stateTopic" type="text">
+			<label>MQTT state topic</label>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
+		</parameter>
+		<parameter name="commandTopic" type="text">
+			<label>MQTT command topic</label>
+			<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only switch.</description>
+		</parameter>
+		<parameter name="transformationPattern" type="text">
+			<label>Incoming value transformation</label>
+			<description>Applies a transformation to an incoming MQTT topic value. A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for a json {device: {status: { temperature: 23.2 }}}. Any supported transformation service can be used.</description>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="formatBeforePublish" type="text">
+			<label>Outgoing value format</label>
+			<description>Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".</description>
+			<advanced>true</advanced>
+			<default>%s</default>
+		</parameter>
+		<parameter name="retained" type="boolean">
+			<label>Retained</label>
+			<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="postCommand" type="boolean">
+			<label>Is command</label>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="on" type="text">
+			<label>On/Open value</label>
+			<description>A number (like 1, 10) or a string (like "enabled") that is recognised as on/open state. You can use this parameter for a second keyword, next to ON (OPEN respectively on a Contact).</description>
+			<default>1</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="off" type="text">
+			<label>Off/Closed value</label>
+			<description>A number (like 0, -10) or a string (like "disabled") that is recognised as off/closed state. You can use this parameter for a second keyword, next to OFF (CLOSED respectively on a Contact).</description>
+			<default>0</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="onBrightness" type="integer" min="1" max="100">
+			<label>Initial brightness</label>
+			<description>If you connect this channel to a Switch item and turn it on,
+             color and saturation are preserved from the last state, but
+             the brightness will be set to this configured initial brightness percentage.</description>
+			<default>10</default>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/rollershutter-channel-config.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/config/rollershutter-channel-config.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="http://eclipse.org/smarthome/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/config-description/v1.0.0 http://eclipse.org/smarthome/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="thing-type:mqtt:rollershutter_channel">
+		<parameter name="stateTopic" type="text">
+			<label>MQTT state topic</label>
+			<description>An MQTT topic that this thing will subscribe to, to receive the state. This can be left empty, the channel will be state-less command-only channel.</description>
+		</parameter>
+		<parameter name="commandTopic" type="text">
+			<label>MQTT command topic</label>
+			<description>An MQTT topic that this thing will send a command to. If not set, this will be a read-only switch.</description>
+		</parameter>
+		<parameter name="transformationPattern" type="text">
+			<label>Incoming value transformation</label>
+			<description>Applies a transformation to an incoming MQTT topic value. A transformation example for a received JSON would be "JSONPATH:$.device.status.temperature" for a json {device: {status: { temperature: 23.2 }}}. Any supported transformation service can be used.</description>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="formatBeforePublish" type="text">
+			<label>Outgoing value format</label>
+			<description>Format a value before it is published to the MQTT broker. The default is to just pass the channel/item state. If you want to apply a prefix, say "MYCOLOR,", you would use "MYCOLOR,%s". If you want to adjust the precision of a number to for example 4 digits, you would use "%.4f".</description>
+			<advanced>true</advanced>
+			<default>%s</default>
+		</parameter>
+		<parameter name="retained" type="boolean">
+			<label>Retained</label>
+			<description>The value will be published to the command topic as retained message. A retained value stays on the broker and can even be seen by MQTT clients that are subscribing at a later point in time.</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="postCommand" type="boolean">
+			<label>Is command</label>
+			<description>If the received MQTT value should not only update the state of linked items, but command them, enable this option.</description>
+			<default>false</default>
+			<advanced>true</advanced>
+		</parameter>
+
+		<parameter name="on" type="text">
+			<label>Up value</label>
+			<description>A string (like "OPEN") that is recognised as UP state. You can use this parameter for a second keyword, next to UP.</description>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="off" type="text">
+			<label>Down value</label>
+			<description>A string (like "CLOSE") that is recognised as DOWN state. You can use this parameter for a second keyword, next to DOWN.</description>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="stop" type="text">
+			<label>Stop value</label>
+			<description>A string (like "STOP") that is recognised as stop state. Will set the rollershutter state to undefined, because the current position is unknown at that point.</description>
+			<default>STOP</default>
+			<advanced>true</advanced>
+		</parameter>
+	</config-description>
+</config-description:config-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/channels.xml
@@ -7,31 +7,31 @@
 	<channel-type id="string">
 		<item-type>String</item-type>
 		<label>Text value</label>
-		<config-description-ref uri="thing-type:mqtt:string_channel"/>
+		<config-description-ref uri="thing-type:mqtt:string_channel" />
 	</channel-type>
 
-    <channel-type id="datetime">
-        <item-type>DateTime</item-type>
-        <label>Date/Time value</label>
-        <description>Current date and/or time</description>
-        <config-description-ref uri="thing-type:mqtt:string_channel"/>
-    </channel-type>
-    
-    <channel-type id="image">
-        <item-type>Image</item-type>
-        <label>Image</label>
-        <description>An image to display. Send a binary bmp, jpg, png or any other supported format to this channel.</description>
-        <state readOnly="true"/>
-        <config-description-ref uri="thing-type:mqtt:string_channel"/>
-    </channel-type>
-    
-    <channel-type id="location">
-        <item-type>Location</item-type>
-        <label>Location</label>
-        <description>GPS coordinates as Latitude,Longitude,Altitude</description>
-        <config-description-ref uri="thing-type:mqtt:string_channel"/>
-    </channel-type>
-    
+	<channel-type id="datetime">
+		<item-type>DateTime</item-type>
+		<label>Date/Time value</label>
+		<description>Current date and/or time</description>
+		<config-description-ref uri="thing-type:mqtt:string_channel" />
+	</channel-type>
+
+	<channel-type id="image">
+		<item-type>Image</item-type>
+		<label>Image</label>
+		<description>An image to display. Send a binary bmp, jpg, png or any other supported format to this channel.</description>
+		<state readOnly="true" />
+		<config-description-ref uri="thing-type:mqtt:string_channel" />
+	</channel-type>
+
+	<channel-type id="location">
+		<item-type>Location</item-type>
+		<label>Location</label>
+		<description>GPS coordinates as Latitude,Longitude,Altitude</description>
+		<config-description-ref uri="thing-type:mqtt:string_channel" />
+	</channel-type>
+
 	<channel-type id="number">
 		<item-type>Number</item-type>
 		<label>Number value</label>
@@ -41,7 +41,7 @@
 	<channel-type id="dimmer">
 		<item-type>Dimmer</item-type>
 		<label>Percentage value</label>
-        <config-description-ref uri="thing-type:mqtt:number_channel"></config-description-ref>
+		<config-description-ref uri="thing-type:mqtt:number_channel"></config-description-ref>
 	</channel-type>
 
 	<channel-type id="switch">
@@ -56,18 +56,24 @@
 		<config-description-ref uri="thing-type:mqtt:switch_channel"></config-description-ref>
 	</channel-type>
 
+	<channel-type id="rollershutter">
+		<item-type>Rollershutter</item-type>
+		<label>Rollershutter</label>
+		<config-description-ref uri="thing-type:mqtt:rollershutter_channel"></config-description-ref>
+	</channel-type>
+
 	<channel-type id="colorRGB">
 		<item-type>Color</item-type>
 		<label>Color value (Red,Green,Blue)</label>
 		<description></description>
-        <config-description-ref uri="thing-type:mqtt:switch_channel"></config-description-ref>
+		<config-description-ref uri="thing-type:mqtt:color_channel"></config-description-ref>
 	</channel-type>
 
 	<channel-type id="colorHSB">
 		<item-type>Color</item-type>
 		<label>Color value (Hue,Saturation,Brightness)</label>
 		<description></description>
-        <config-description-ref uri="thing-type:mqtt:switch_channel"></config-description-ref>
+		<config-description-ref uri="thing-type:mqtt:color_channel"></config-description-ref>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/generic-thing.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/ESH-INF/thing/generic-thing.xml
@@ -4,7 +4,7 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="topic" extensible="string,number,dimmer,switch,contact,colorRGB,colorHSB,datetime,image,location">
+	<thing-type id="topic" extensible="string,number,dimmer,switch,contact,colorRGB,colorHSB,datetime,image,location,rollershutter">
 		<supported-bridge-type-refs>
 			<bridge-type-ref id="broker" />
 			<bridge-type-ref id="systemBroker" />

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
@@ -52,6 +52,7 @@ You can manually add the following channels:
 * **location**: This channel handles a location.
 * **image**: This channel handles binary images in common java supported formats (bmp,jpg,png).
 * **datetime**: This channel handles date/time values.
+* **rollershutter**: This channel is for rollershutters.
 
 ## Thing and Channel Configuration
 
@@ -95,8 +96,8 @@ You can connect this channel to a Rollershutter or Dimmer item.
 
 ### Channel Type "contact", "switch"
 
-* __on__: A number (like 1, 10) or a string (like "ON"/"Open") that is recognised as on/open state.
-* __off__: A number (like 0, -10) or a string (like "OFF"/"Close") that is recognised as off/closed state.
+* __on__: A optional number (like 1, 10) or a string (like "ON"/"Open") that is recognised as on/open state.
+* __off__: A optional number (like 0, -10) or a string (like "OFF"/"Close") that is recognised as off/closed state.
 
 The contact channel by default recognises `"OPEN"` and `"CLOSED"`. You can connect this channel to a Contact item.
 The switch channel by default recognises `"ON"` and `"OFF"`. You can connect this channel to a Switch item.
@@ -107,12 +108,18 @@ You can connect this channel to a Contact or Switch item.
 
 ### Channel Type "colorRGB", "colorHSB"
 
-You can connect this channel to a Color item.
+* __on__: An optional string (like "BRIGHT") that is recognised as on state. (ON will always be recognised.)
+* __off__: An optional string (like "DARK") that is recognised as off state. (OFF will always be recognised.)
+* __onBrightness__: If you connect this channel to a Switch item and turn it on,
+color and saturation are preserved from the last state, but
+the brightness will be set to this configured initial brightness (default: 10%).
+
+You can connect this channel to a Color, Dimmer and Switch item.
 
 This channel will publish the color as comma separated list to the MQTT broker,
 e.g. "112,54,123" for an RGB channel (0-255 per component) and "360,100,100" for a HSB channel (0-359 for hue and 0-100 for saturation and brightness).
 
-The channel expects values on the corresponding MQTT topic to be in this format as well. 
+The channel expects values on the corresponding MQTT topic to be in this format as well.
 
 ### Channel Type "location"
 
@@ -139,6 +146,14 @@ for example 2018-01-01T12:14:00. If you require another format, please use the f
 
 The channel expects values on the corresponding MQTT topic to be in this format as well. 
 
+### Channel Type "rollershutter"
+
+* __on__: An optional string (like "Open") that is recognised as UP state.
+* __off__: An optional string (like "Close") that is recognised as DOWN state.
+* __stop__: An optional string (like "Stop") that is recognised as STOP state.
+
+You can connect this channel to a Rollershutter or Dimmer item.
+
 ## Rule Actions
 
 This binding includes a rule action, which allows to publish MQTT messages from within rules.
@@ -159,7 +174,10 @@ mqttActions.publishMQTT("mytopic","myvalue")
 
 * This binding does not support Homie Node Instances.
 * Homie Device Statistics (except from "interval") are not supported.
-* The following HomeAssistant MQTT Components are not implemented: Camera, Climate, Fan, Cover. The light component only supports a on/off switch and no color or brightness changes.
+* The HomeAssistant Fan Components only support ON/OFF.
+* The HomeAssistant Cover Components only support OPEN/CLOSE/STOP.
+* The HomeAssistant Light Component does not support XY color changes.
+* The HomeAssistant Climate Components is not yet supported.
 
 ## Incoming Value Transformation
 

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/MqttBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/MqttBindingConstants.java
@@ -42,6 +42,7 @@ public class MqttBindingConstants {
     public static final String IMAGE = "image";
     public static final String LOCATION = "location";
     public static final String DATETIME = "datetime";
+    public static final String ROLLERSHUTTER = "rollershutter";
 
     public static final String CONFIG_HA_CHANNEL = "mqtt:ha_channel";
     public static final String CONFIG_HOMIE_CHANNEL = "mqtt:homie_channel";

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/AbstractComponent.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/AbstractComponent.java
@@ -32,6 +32,8 @@ import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeBuilder;
 import org.eclipse.smarthome.core.thing.type.ChannelGroupTypeUID;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
 
+import com.google.gson.Gson;
+
 /**
  * A HomeAssistant component is comparable to an ESH channel group.
  * It has a name and consists of multiple channels.
@@ -51,6 +53,7 @@ public abstract class AbstractComponent {
     // Used to determine if a component has changed.
     protected final int configHash;
     protected final String configJson;
+    private final Gson gson;
 
     /**
      * Provide a thingUID and HomeAssistant topic ID to determine the ESH channel group UID and type.
@@ -58,8 +61,9 @@ public abstract class AbstractComponent {
      * @param thing A ThingUID
      * @param haID A HomeAssistant topic ID
      * @param configJson The configuration string
+     * @param gson A Gson instance
      */
-    public AbstractComponent(ThingUID thing, HaID haID, String configJson) {
+    public AbstractComponent(ThingUID thing, HaID haID, String configJson, Gson gson) {
         this.channelGroupTypeUID = new ChannelGroupTypeUID(MqttBindingConstants.BINDING_ID,
                 haID.getChannelGroupTypeID());
         this.channelGroupUID = new ChannelGroupUID(thing, haID.getChannelGroupID());
@@ -67,6 +71,8 @@ public abstract class AbstractComponent {
 
         this.configJson = configJson;
         this.configHash = configJson.hashCode();
+
+        this.gson = gson;
     }
 
     /**
@@ -163,7 +169,7 @@ public abstract class AbstractComponent {
      */
     public ChannelGroupType type() {
         final List<ChannelDefinition> channelDefinitions = channels.values().stream()
-                .map(c -> new ChannelDefinitionBuilder(c.channelID, c.channelTypeUID).build())
+                .map(c -> new ChannelDefinitionBuilder(c.channelUID.getId(), c.channelTypeUID).build())
                 .collect(Collectors.toList());
         return ChannelGroupTypeBuilder.instance(channelGroupTypeUID, name()).withChannelDefinitions(channelDefinitions)
                 .build();

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/CChannel.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/CChannel.java
@@ -47,7 +47,7 @@ import org.eclipse.smarthome.core.thing.type.ChannelTypeUID;
  */
 @NonNullByDefault
 public class CChannel {
-    public final String channelID; // Channel ID
+    public final ChannelUID channelUID;
     public final ChannelState channelState; // Channel state (value)
     public final Channel channel; // ESH Channel
     public final ChannelType type;
@@ -67,8 +67,7 @@ public class CChannel {
     public CChannel(AbstractComponent component, String channelID, Value valueState, @Nullable String state_topic,
             @Nullable String command_topic, String label, String unit,
             @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        this.channelID = channelID;
-        final ChannelUID channelUID = new ChannelUID(component.channelGroupUID, channelID);
+        this.channelUID = new ChannelUID(component.channelGroupUID, channelID);
         channelTypeUID = component.haID.getChannelTypeID(channelID);
         channelState = new ChannelState(ChannelConfigBuilder.create().withRetain(true).withStateTopic(state_topic)
                 .withCommandTopic(command_topic).build(), channelUID, valueState, channelStateUpdateListener);

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/CFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/CFactory.java
@@ -20,6 +20,8 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.gson.Gson;
+
 /**
  * A factory to create HomeAssistant MQTT components. Those components are specified at:
  * https://www.home-assistant.io/docs/mqtt/discovery/
@@ -38,33 +40,33 @@ public class CFactory {
      *            component-id.
      * @param configJSON Most components expect a "name", a "state_topic" and "command_topic" like with
      *            "{name:'Name',state_topic:'homeassistant/switch/0/object/state',command_topic:'homeassistant/switch/0/object/set'".
-     * @param channelStateUpdateListener A channel state update listener
+     * @param updateListener A channel state update listener
      * @return A HA MQTT Component
      */
     public static @Nullable AbstractComponent createComponent(ThingUID thingUID, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
+            @Nullable ChannelStateUpdateListener updateListener, Gson gson) {
         try {
             switch (haID.component) {
                 case "alarm_control_panel":
-                    return new ComponentAlarmControlPanel(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentAlarmControlPanel(thingUID, haID, configJSON, updateListener, gson);
                 case "binary_sensor":
-                    return new ComponentBinarySensor(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentBinarySensor(thingUID, haID, configJSON, updateListener, gson);
                 case "camera":
-                    return new ComponentCamera(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentCamera(thingUID, haID, configJSON, updateListener, gson);
                 case "cover":
-                    return new ComponentCover(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentCover(thingUID, haID, configJSON, updateListener, gson);
                 case "fan":
-                    return new ComponentFan(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentFan(thingUID, haID, configJSON, updateListener, gson);
                 case "climate":
-                    return new ComponentClimate(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentClimate(thingUID, haID, configJSON, updateListener, gson);
                 case "light":
-                    return new ComponentLight(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentLight(thingUID, haID, configJSON, updateListener, gson);
                 case "lock":
-                    return new ComponentLock(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentLock(thingUID, haID, configJSON, updateListener, gson);
                 case "sensor":
-                    return new ComponentSensor(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentSensor(thingUID, haID, configJSON, updateListener, gson);
                 case "switch":
-                    return new ComponentSwitch(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentSwitch(thingUID, haID, configJSON, updateListener, gson);
             }
         } catch (UnsupportedOperationException e) {
             logger.warn("Not supported", e);
@@ -77,11 +79,11 @@ public class CFactory {
      *
      * @param basetopic The MQTT base topic, usually "homeassistant"
      * @param channel A channel with the JSON configuration embedded as configuration (key: 'config')
-     * @param channelStateUpdateListener A channel state update listener
+     * @param updateListener A channel state update listener
      * @return A HA MQTT Component
      */
     public static @Nullable AbstractComponent createComponent(String basetopic, Channel channel,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
+            @Nullable ChannelStateUpdateListener updateListener, Gson gson) {
         HaID haID = new HaID(basetopic, channel.getUID());
         ThingUID thingUID = channel.getUID().getThingUID();
         String configJSON = (String) channel.getConfiguration().get("config");
@@ -92,25 +94,25 @@ public class CFactory {
         try {
             switch (haID.component) {
                 case "alarm_control_panel":
-                    return new ComponentAlarmControlPanel(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentAlarmControlPanel(thingUID, haID, configJSON, updateListener, gson);
                 case "binary_sensor":
-                    return new ComponentBinarySensor(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentBinarySensor(thingUID, haID, configJSON, updateListener, gson);
                 case "camera":
-                    return new ComponentCamera(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentCamera(thingUID, haID, configJSON, updateListener, gson);
                 case "cover":
-                    return new ComponentCover(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentCover(thingUID, haID, configJSON, updateListener, gson);
                 case "fan":
-                    return new ComponentFan(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentFan(thingUID, haID, configJSON, updateListener, gson);
                 case "climate":
-                    return new ComponentClimate(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentClimate(thingUID, haID, configJSON, updateListener, gson);
                 case "light":
-                    return new ComponentLight(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentLight(thingUID, haID, configJSON, updateListener, gson);
                 case "lock":
-                    return new ComponentLock(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentLock(thingUID, haID, configJSON, updateListener, gson);
                 case "sensor":
-                    return new ComponentSensor(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentSensor(thingUID, haID, configJSON, updateListener, gson);
                 case "switch":
-                    return new ComponentSwitch(thingUID, haID, configJSON, channelStateUpdateListener);
+                    return new ComponentSwitch(thingUID, haID, configJSON, updateListener, gson);
             }
         } catch (UnsupportedOperationException e) {
             logger.warn("Not supported", e);

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentAlarmControlPanel.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentAlarmControlPanel.java
@@ -69,9 +69,9 @@ public class ComponentAlarmControlPanel extends AbstractComponent {
     protected Config config = new Config();
 
     public ComponentAlarmControlPanel(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
-        config = new Gson().fromJson(configJSON, Config.class);
+            @Nullable ChannelStateUpdateListener channelStateUpdateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
+        config = gson.fromJson(configJSON, Config.class);
 
         final String[] state_enum = { config.state_disarmed, config.state_armed_home, config.state_armed_away,
                 config.state_pending, config.state_triggered };

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentBinarySensor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentBinarySensor.java
@@ -57,9 +57,9 @@ public class ComponentBinarySensor extends AbstractComponent {
     protected Config config = new Config();
 
     public ComponentBinarySensor(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
-        config = new Gson().fromJson(configJSON, Config.class);
+            @Nullable ChannelStateUpdateListener channelStateUpdateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
+        config = gson.fromJson(configJSON, Config.class);
 
         if (config.force_update) {
             throw new UnsupportedOperationException("Component:Sensor does not support forced updates");

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentCamera.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentCamera.java
@@ -12,11 +12,13 @@
  */
 package org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.ImageValue;
 import org.eclipse.smarthome.core.thing.ThingUID;
+
+import com.google.gson.Gson;
 
 /**
  * A MQTT camera, following the https://www.home-assistant.io/components/camera.mqtt/ specification.
@@ -27,14 +29,35 @@ import org.eclipse.smarthome.core.thing.ThingUID;
  */
 @NonNullByDefault
 public class ComponentCamera extends AbstractComponent {
+    public static final String cameraChannelID = "camera"; // Randomly chosen channel "ID"
+
+    /**
+     * Configuration class for MQTT component
+     */
+    static class Config {
+        protected String name = "MQTT Camera";
+        protected String icon = "";
+        protected int qos = 1;
+        protected boolean retain = true;
+        protected @Nullable String unique_id;
+
+        protected String topic = "";
+    };
+
+    protected Config config = new Config();
+
     public ComponentCamera(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
-        throw new UnsupportedOperationException("Component:Camera not supported yet");
+            @Nullable ChannelStateUpdateListener channelStateUpdateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
+        config = gson.fromJson(configJSON, Config.class);
+
+        ImageValue value = new ImageValue();
+        channels.put(cameraChannelID, new CChannel(this, cameraChannelID, value, //
+                config.topic, null, config.name, "", channelStateUpdateListener));
     }
 
     @Override
-    public @NonNull String name() {
-        return "Camera";
+    public String name() {
+        return config.name;
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentClimate.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentClimate.java
@@ -18,6 +18,8 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
 import org.eclipse.smarthome.core.thing.ThingUID;
 
+import com.google.gson.Gson;
+
 /**
  * A MQTT climate component, following the https://www.home-assistant.io/components/climate.mqtt/ specification.
  *
@@ -28,8 +30,8 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 @NonNullByDefault
 public class ComponentClimate extends AbstractComponent {
     public ComponentClimate(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
+            @Nullable ChannelStateUpdateListener channelStateUpdateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
         throw new UnsupportedOperationException("Component:Climate not supported yet");
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentCover.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentCover.java
@@ -12,29 +12,58 @@
  */
 package org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.RollershutterValue;
 import org.eclipse.smarthome.core.thing.ThingUID;
+
+import com.google.gson.Gson;
 
 /**
  * A MQTT Cover component, following the https://www.home-assistant.io/components/cover.mqtt/ specification.
  *
- * At the moment this only notifies the user that this feature is not yet supported.
+ * Only Open/Close/Stop works so far.
  *
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
 public class ComponentCover extends AbstractComponent {
+    public static final String switchChannelID = "cover"; // Randomly chosen channel "ID"
+
+    /**
+     * Configuration class for MQTT component
+     */
+    static class Config {
+        protected String name = "MQTT fan";
+        protected String icon = "";
+        protected int qos = 1;
+        protected boolean retain = true;
+        protected @Nullable String state_value_template;
+        protected @Nullable String unique_id;
+
+        protected @Nullable String state_topic;
+        protected @Nullable String command_topic;
+        protected String payload_open = "OPEN";
+        protected String payload_close = "CLOSE";
+        protected String payload_stop = "STOP";
+    };
+
+    protected Config config = new Config();
+
     public ComponentCover(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
-        throw new UnsupportedOperationException("Component:Cover not supported yet");
+            @Nullable ChannelStateUpdateListener updateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
+        config = gson.fromJson(configJSON, Config.class);
+
+        RollershutterValue value = new RollershutterValue(config.payload_open, config.payload_close,
+                config.payload_stop);
+        channels.put(switchChannelID, new CChannel(this, switchChannelID, value, //
+                config.state_topic, config.command_topic, config.name, "", updateListener));
     }
 
     @Override
-    public @NonNull String name() {
-        return "Cover";
+    public String name() {
+        return config.name;
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentFan.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentFan.java
@@ -12,29 +12,56 @@
  */
 package org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant;
 
-import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
+import org.eclipse.smarthome.binding.mqtt.generic.internal.values.OnOffValue;
 import org.eclipse.smarthome.core.thing.ThingUID;
+
+import com.google.gson.Gson;
 
 /**
  * A MQTT Fan component, following the https://www.home-assistant.io/components/fan.mqtt/ specification.
  *
- * At the moment this only notifies the user that this feature is not yet supported.
+ * Only ON/OFF is supported so far.
  *
  * @author David Graeff - Initial contribution
  */
 @NonNullByDefault
 public class ComponentFan extends AbstractComponent {
+    public static final String switchChannelID = "fan"; // Randomly chosen channel "ID"
+
+    /**
+     * Configuration class for MQTT component
+     */
+    static class Config {
+        protected String name = "MQTT fan";
+        protected String icon = "";
+        protected int qos = 1;
+        protected boolean retain = true;
+        protected @Nullable String state_value_template;
+        protected @Nullable String unique_id;
+
+        protected @Nullable String state_topic;
+        protected String command_topic = "";
+        protected String payload_on = "ON";
+        protected String payload_off = "OFF";
+    };
+
+    protected Config config = new Config();
+
     public ComponentFan(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
-        throw new UnsupportedOperationException("Component:Fan not supported yet");
+            @Nullable ChannelStateUpdateListener updateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
+        config = gson.fromJson(configJSON, Config.class);
+
+        OnOffValue value = new OnOffValue(config.payload_on, config.payload_off);
+        channels.put(switchChannelID, new CChannel(this, switchChannelID, value, //
+                config.state_topic, config.command_topic, config.name, "", updateListener));
     }
 
     @Override
-    public @NonNull String name() {
-        return "Fan";
+    public String name() {
+        return config.name;
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentLock.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentLock.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.mqtt.generic.internal.convention.homeassistant;
 
 import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.generic.ChannelStateUpdateListener;
 import org.eclipse.smarthome.binding.mqtt.generic.internal.values.OnOffValue;
@@ -25,6 +26,7 @@ import com.google.gson.Gson;
  *
  * @author David Graeff - Initial contribution
  */
+@NonNullByDefault
 public class ComponentLock extends AbstractComponent {
     public static final String switchChannelID = "lock"; // Randomly chosen channel "ID"
 
@@ -54,9 +56,9 @@ public class ComponentLock extends AbstractComponent {
     protected Config config = new Config();
 
     public ComponentLock(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
-        config = new Gson().fromJson(configJSON, Config.class);
+            @Nullable ChannelStateUpdateListener channelStateUpdateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
+        config = gson.fromJson(configJSON, Config.class);
 
         // We do not support all HomeAssistant quirks
         if (config.optimistic && StringUtils.isNotBlank(config.state_topic)) {

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentSensor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentSensor.java
@@ -55,9 +55,9 @@ public class ComponentSensor extends AbstractComponent {
     protected Config config = new Config();
 
     public ComponentSensor(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
-        config = new Gson().fromJson(configJSON, Config.class);
+            @Nullable ChannelStateUpdateListener channelStateUpdateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
+        config = gson.fromJson(configJSON, Config.class);
 
         if (config.force_update) {
             throw new UnsupportedOperationException("Component:Sensor does not support forced updates");

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentSwitch.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homeassistant/ComponentSwitch.java
@@ -58,9 +58,9 @@ public class ComponentSwitch extends AbstractComponent {
     protected Config config = new Config();
 
     public ComponentSwitch(ThingUID thing, HaID haID, String configJSON,
-            @Nullable ChannelStateUpdateListener channelStateUpdateListener) {
-        super(thing, haID, configJSON);
-        config = new Gson().fromJson(configJSON, Config.class);
+            @Nullable ChannelStateUpdateListener channelStateUpdateListener, Gson gson) {
+        super(thing, haID, configJSON, gson);
+        config = gson.fromJson(configJSON, Config.class);
 
         // We do not support all HomeAssistant quirks
         if (config.optimistic && StringUtils.isNotBlank(config.state_topic)) {

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homie300/Property.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/convention/homie300/Property.java
@@ -165,7 +165,7 @@ public class Property implements AttributeChanged {
                 value = new OnOffValue("true", "false");
                 break;
             case color_:
-                value = new ColorValue(attributes.format.contains("rgb"), null, null);
+                value = new ColorValue(attributes.format.contains("rgb"), null, null, 100);
                 break;
             case enum_:
                 String enumValues[] = attributes.format.split(",");

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/generic/ChannelConfig.java
@@ -49,4 +49,7 @@ public class ChannelConfig {
     public @Nullable BigDecimal step;
     public @Nullable String on;
     public @Nullable String off;
+    public @Nullable String stop;
+
+    public int onBrightness = 10;
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/RollershutterValue.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/RollershutterValue.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.binding.mqtt.generic.internal.values;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.core.library.CoreItemFactory;
+import org.eclipse.smarthome.core.library.types.PercentType;
+import org.eclipse.smarthome.core.library.types.StopMoveType;
+import org.eclipse.smarthome.core.library.types.StringType;
+import org.eclipse.smarthome.core.library.types.UpDownType;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.UnDefType;
+
+/**
+ * Implements an rollershutter value.
+ *
+ * @author David Graeff - Initial contribution
+ */
+@NonNullByDefault
+public class RollershutterValue extends Value {
+    private final @Nullable String upString;
+    private final @Nullable String downString;
+    private final @Nullable String stopString;
+
+    /**
+     * Creates a new rollershutter value.
+     *
+     * @param upString The UP value string. This will be compared to MQTT messages.
+     * @param downString The DOWN value string. This will be compared to MQTT messages.
+     * @param stopString The STOP value string. This will be compared to MQTT messages.
+     */
+    public RollershutterValue(@Nullable String upString, @Nullable String downString, @Nullable String stopString) {
+        super(CoreItemFactory.ROLLERSHUTTER,
+                Stream.of(UpDownType.class, StopMoveType.class, PercentType.class, StringType.class)
+                        .collect(Collectors.toList()));
+        this.upString = upString;
+        this.downString = downString;
+        this.stopString = stopString;
+    }
+
+    @Override
+    public void update(Command command) throws IllegalArgumentException {
+        if (command instanceof UpDownType) {
+            PercentType newState = ((UpDownType) command).as(PercentType.class);
+            if (newState == null) { // Never happens
+                return;
+            }
+            state = newState;
+        } else if (command instanceof StopMoveType) {
+            if (command.equals(StopMoveType.STOP)) {
+                state = UnDefType.UNDEF;
+            }
+        } else if (command instanceof PercentType) {
+            state = (PercentType) command;
+        } else {
+            final String updatedValue = command.toString();
+            if (updatedValue.equals(upString)) {
+                state = PercentType.ZERO;
+            } else if (updatedValue.equals(downString)) {
+                state = PercentType.HUNDRED;
+            } else if (updatedValue.equals(stopString)) {
+                state = UnDefType.UNDEF;
+            } else {
+                state = PercentType.valueOf(updatedValue);
+            }
+        }
+    }
+
+    @Override
+    public String getMQTTpublishValue() {
+        return (state == UnDefType.UNDEF) ? "0" : String.valueOf(((PercentType) state).intValue());
+    }
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ValueFactory.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/src/main/java/org/eclipse/smarthome/binding/mqtt/generic/internal/values/ValueFactory.java
@@ -53,16 +53,19 @@ public class ValueFactory {
                 value = new PercentageValue(config.min, config.max, config.step);
                 break;
             case MqttBindingConstants.COLOR_RGB:
-                value = new ColorValue(true, config.on, config.off);
+                value = new ColorValue(true, config.on, config.off, config.onBrightness);
                 break;
             case MqttBindingConstants.COLOR_HSB:
-                value = new ColorValue(false, config.on, config.off);
+                value = new ColorValue(false, config.on, config.off, config.onBrightness);
                 break;
             case MqttBindingConstants.SWITCH:
                 value = new OnOffValue(config.on, config.off);
                 break;
             case MqttBindingConstants.CONTACT:
                 value = new OpenCloseValue(config.on, config.off);
+                break;
+            case MqttBindingConstants.ROLLERSHUTTER:
+                value = new RollershutterValue(config.on, config.off, config.stop);
                 break;
             default:
                 throw new IllegalArgumentException("ChannelTypeUID not recognised: " + channelTypeID);


### PR DESCRIPTION
…ents

* Color channel can receive a single brightness value + Tests
* Color channel: Add configuration value for initial brightness if switched on + Tests
  (Was hardcoded to 10%)
* New rollershutter channel + Tests
* HomeAssistant: Use a single GSon instance
* Implemented more of the HomeAssistant convention
  - Light can have brightness and color now
  - Fan, Cover: Basic support
  - Camera

Signed-off-by: David Gräff <david.graeff@web.de>