### PR TITLE
[Hue] Fixed skipped creation of user if missing in configuration. Emergency last minute fix!

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBridge.java
@@ -182,7 +182,6 @@ public class HueBridge {
         handleErrors(result);
 
         Map<String, T> lightMap = safeFromJson(result.getBody(), gsonType);
-
         ArrayList<T> lightList = new ArrayList<>();
 
         for (String id : lightMap.keySet()) {
@@ -198,13 +197,14 @@ public class HueBridge {
      * Returns a list of sensors known to the bridge
      *
      * @return list of sensors
-     * @throws IOException
-     * @throws ApiException
+     * @throws UnauthorizedException thrown if the user no longer exists
      */
     public List<FullSensor> getSensors() throws IOException, ApiException {
         requireAuthentication();
 
         Result result = http.get(getRelativeURL("sensors"));
+
+        handleErrors(result);
 
         Map<String, FullSensor> sensorMap = safeFromJson(result.getBody(), FullSensor.GSON_TYPE);
         ArrayList<FullSensor> sensorList = new ArrayList<>();
@@ -216,7 +216,6 @@ public class HueBridge {
         }
 
         return sensorList;
-
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueBridgeHandler.java
@@ -91,6 +91,10 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                 pollingLock.lock();
                 try {
                     if (!lastBridgeConnectionState) {
+                        // if user is not set in configuration try to create a new user on Hue bridge
+                        if (hueBridgeConfig.getUserName() == null) {
+                            hueBridge.getFullConfig();
+                        }
                         lastBridgeConnectionState = tryResumeBridgeConnection();
                     }
                     if (lastBridgeConnectionState) {
@@ -432,8 +436,8 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     private boolean tryResumeBridgeConnection() throws IOException, ApiException {
         logger.debug("Connection to Hue Bridge {} established.", hueBridge.getIPAddress());
         if (hueBridgeConfig.getUserName() == null) {
-            logger.warn("User name for Hue bridge authentication not available in configuration. "
-                    + "Setting ThingStatus to offline.");
+            logger.warn(
+                    "User name for Hue bridge authentication not available in configuration. Setting ThingStatus to OFFLINE.");
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     "@text/offline.conf-error-no-username");
             return false;
@@ -495,7 +499,8 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
         config.put(USER_NAME, userName);
         try {
             updateConfiguration(config);
-            logger.debug("Updated configuration parameter {} to '{}'", USER_NAME, userName);
+            logger.debug("Updated configuration parameter '{}' to '{}'", USER_NAME, userName);
+            hueBridgeConfig = getConfigAs(HueBridgeConfig.class);
         } catch (IllegalStateException e) {
             logger.trace("Configuration update failed.", e);
             logger.warn("Unable to update configuration of Hue bridge.");


### PR DESCRIPTION
- Fixed skipped creation of user if missing in configuration

First API call happens if `lastBridgeConnectionState` is `true` which never happens if user is missing in configuration.

Regression introduced by #6511.

See https://community.openhab.org/t/oh2-4-hue-binding-user-name-does-not-appear-to-log-file-after-bridge-thing-is-added-and-authorization-button-is-pressed/59721

@kaikreuzer Can you please have a look? Thanks.

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>