### PR TITLE
[homematic] UoM support unexpected units

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/converter/BaseConverterTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/converter/BaseConverterTest.java
@@ -1,0 +1,29 @@
+package org.eclipse.smarthome.binding.homematic.internal.converter;
+
+import org.eclipse.smarthome.binding.homematic.internal.model.HmChannel;
+import org.eclipse.smarthome.binding.homematic.internal.model.HmDatapoint;
+import org.eclipse.smarthome.binding.homematic.internal.model.HmDevice;
+import org.eclipse.smarthome.binding.homematic.internal.model.HmInterface;
+import org.eclipse.smarthome.binding.homematic.internal.model.HmParamsetType;
+import org.eclipse.smarthome.binding.homematic.internal.model.HmValueType;
+import org.junit.Before;
+
+public class BaseConverterTest {
+
+    protected final HmDatapoint floatDp = new HmDatapoint("floatDp", "", HmValueType.FLOAT, null, false,
+            HmParamsetType.VALUES);
+    protected final HmDatapoint integerDp = new HmDatapoint("integerDp", "", HmValueType.INTEGER, null, false,
+            HmParamsetType.VALUES);
+    protected final HmDatapoint floatQuantityDp = new HmDatapoint("floatQuantityDp", "", HmValueType.FLOAT, null, false,
+            HmParamsetType.VALUES);
+    protected final HmDatapoint integerQuantityDp = new HmDatapoint("floatIntegerDp", "", HmValueType.INTEGER, null,
+            false, HmParamsetType.VALUES);
+
+    @Before
+    public void setup() {
+        HmChannel stubChannel = new HmChannel("stubChannel", 0);
+        stubChannel.setDevice(new HmDevice("LEQ123456", HmInterface.RF, "HM-STUB-DEVICE", "", "", ""));
+        floatDp.setChannel(stubChannel);
+    }
+
+}

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/converter/ConvertFromBindingTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic.test/src/test/java/org/eclipse/smarthome/binding/homematic/internal/converter/ConvertFromBindingTest.java
@@ -17,8 +17,6 @@ import static org.junit.Assert.assertThat;
 
 import org.eclipse.smarthome.binding.homematic.internal.converter.type.AbstractTypeConverter;
 import org.eclipse.smarthome.binding.homematic.internal.model.HmDatapoint;
-import org.eclipse.smarthome.binding.homematic.internal.model.HmParamsetType;
-import org.eclipse.smarthome.binding.homematic.internal.model.HmValueType;
 import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.ImperialUnits;
@@ -35,21 +33,15 @@ import tec.uom.se.quantity.QuantityDimension;
  * @author Michael Reitler - Initial Contribution
  *
  */
-public class ConvertFromBindingTest {
-
-    private final HmDatapoint floatDp = new HmDatapoint("floatDp", "", HmValueType.FLOAT, null, false,
-            HmParamsetType.VALUES);
-    private final HmDatapoint integerDp = new HmDatapoint("integerDp", "", HmValueType.INTEGER, null, false,
-            HmParamsetType.VALUES);
-    private final HmDatapoint floatQuantityDp = new HmDatapoint("floatQuantityDp", "", HmValueType.FLOAT, null, false,
-            HmParamsetType.VALUES);
-    private final HmDatapoint integerQuantityDp = new HmDatapoint("floatIntegerDp", "", HmValueType.INTEGER, null,
-            false, HmParamsetType.VALUES);
+public class ConvertFromBindingTest extends BaseConverterTest {
 
     @Test
     public void testDecimalTypeConverter() throws ConverterException {
         State convertedState;
         TypeConverter<?> decimalConverter = ConverterFactory.createConverter("Number");
+
+        // the binding is backwards compatible, so clients may still use DecimalType, even if a unit is used
+        floatDp.setUnit("%");
 
         floatDp.setValue(99.9);
         convertedState = decimalConverter.convertFromBinding(floatDp);
@@ -88,6 +80,10 @@ public class ConvertFromBindingTest {
         assertThat(((QuantityType<?>) convertedState).doubleValue(), is(10.5));
         assertThat(((QuantityType<?>) convertedState).toUnit(ImperialUnits.FAHRENHEIT).doubleValue(), is(50.9));
 
+        floatQuantityDp.setUnit("Â°C");
+        assertThat(((QuantityType<?>) convertedState).getDimension(), is(QuantityDimension.TEMPERATURE));
+        assertThat(((QuantityType<?>) convertedState).doubleValue(), is(10.5));
+
         integerQuantityDp.setValue(50000);
         integerQuantityDp.setUnit("mHz");
         convertedState = frequencyConverter.convertFromBinding(integerQuantityDp);
@@ -97,13 +93,14 @@ public class ConvertFromBindingTest {
         assertThat(((QuantityType<?>) convertedState).intValue(), is(50000));
         assertThat(((QuantityType<?>) convertedState).toUnit(SIUnits.HERTZ).intValue(), is(50));
 
-        floatQuantityDp.setValue(12);
-        floatQuantityDp.setUnit("month");
+        floatQuantityDp.setValue(0.7);
+        floatQuantityDp.setUnit("100%");
         convertedState = timeConverter.convertFromBinding(floatQuantityDp);
         assertThat(convertedState, instanceOf(QuantityType.class));
-        assertThat(((QuantityType<?>) convertedState).getDimension(), is(QuantityDimension.TIME));
-        assertThat(((QuantityType<?>) convertedState).doubleValue(), is(12.0));
-        assertThat(((QuantityType<?>) convertedState).toUnit(SmartHomeUnits.YEAR).doubleValue(), is(1.0));
+        assertThat(((QuantityType<?>) convertedState).getDimension(), is(QuantityDimension.NONE));
+        assertThat(((QuantityType<?>) convertedState).doubleValue(), is(70.0));
+        assertThat(((QuantityType<?>) convertedState).getUnit(), is(SmartHomeUnits.PERCENT));
+        assertThat(((QuantityType<?>) convertedState).toUnit(SmartHomeUnits.ONE).doubleValue(), is(0.7));
 
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/common/HomematicConfig.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/common/HomematicConfig.java
@@ -356,7 +356,7 @@ public class HomematicConfig {
     }
 
     /**
-     * Returns the encoding of a Homematic gateway.
+     * Returns the encoding that is suitable on requests to & responds from the Homematic gateway.
      */
     public String getEncoding() {
         if (gatewayInfo != null && gatewayInfo.isHomegear()) {

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/XmlRpcClient.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/communicator/client/XmlRpcClient.java
@@ -83,12 +83,12 @@ public class XmlRpcClient extends RpcClient<String> {
                     .timeout(config.getTimeout(), TimeUnit.SECONDS)
                     .header(HttpHeader.CONTENT_TYPE, "text/xml;charset=" + config.getEncoding()).send();
 
-            String result = new String(response.getContent(), config.getEncoding());
             if (logger.isTraceEnabled()) {
+                String result = new String(response.getContent(), config.getEncoding());
                 logger.trace("Client XmlRpcResponse (port {}):\n{}", port, result);
             }
 
-            Object[] data = new XmlRpcResponse(new ByteArrayInputStream(result.getBytes(config.getEncoding())),
+            Object[] data = new XmlRpcResponse(new ByteArrayInputStream(response.getContent()),
                     config.getEncoding()).getResponseData();
             return new RpcResponseParser(request).parse(data);
         } catch (UnknownRpcFailureException | UnknownParameterSetException ex) {

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/converter/type/AbstractTypeConverter.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/converter/type/AbstractTypeConverter.java
@@ -81,11 +81,9 @@ public abstract class AbstractTypeConverter<T extends State> implements TypeConv
     @SuppressWarnings("unchecked")
     @Override
     public Object convertToBinding(Type type, HmDatapoint dp) throws ConverterException {
-        if (logger.isTraceEnabled()) {
-            logger.trace("Converting type {} with value '{}' to {} value with {} for '{}'",
-                    type.getClass().getSimpleName(), type.toString(), dp.getType(), this.getClass().getSimpleName(),
-                    new HmDatapointInfo(dp));
-        }
+        logTraceOrDebug("Converting type {} with value '{}' using {} to datapoint '{}' (dpType='{}', dpUnit='{}')",
+                type.getClass().getSimpleName(), type.toString(), this.getClass().getSimpleName(),
+                new HmDatapointInfo(dp), dp.getType(), dp.getUnit());
 
         if (type == UnDefType.NULL) {
             return null;
@@ -105,10 +103,8 @@ public abstract class AbstractTypeConverter<T extends State> implements TypeConv
     @SuppressWarnings("unchecked")
     @Override
     public T convertFromBinding(HmDatapoint dp) throws ConverterException {
-        if (logger.isTraceEnabled()) {
-            logger.trace("Converting {} value '{}' with {} for '{}'", dp.getType(), dp.getValue(),
-                    this.getClass().getSimpleName(), new HmDatapointInfo(dp));
-        }
+        logTraceOrDebug("Converting datapoint '{}' (dpType='{}', dpUnit='{}', dpValue='{}') with {}",
+                new HmDatapointInfo(dp), dp.getType(), dp.getUnit(), dp.getValue(), this.getClass().getSimpleName());
 
         if (dp.getValue() == null) {
             return (T) UnDefType.NULL;
@@ -119,6 +115,12 @@ public abstract class AbstractTypeConverter<T extends State> implements TypeConv
         }
 
         return fromBinding(dp);
+    }
+
+    protected void logTraceOrDebug(String format, Object... arguments) {
+        if (logger.isTraceEnabled()) {
+            logger.trace(format, arguments);
+        }
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/converter/type/QuantityTypeConverter.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/converter/type/QuantityTypeConverter.java
@@ -26,7 +26,6 @@ import javax.measure.quantity.Power;
 import javax.measure.quantity.Pressure;
 import javax.measure.quantity.Speed;
 import javax.measure.quantity.Temperature;
-import javax.measure.quantity.Time;
 import javax.measure.quantity.Volume;
 
 import org.eclipse.smarthome.binding.homematic.internal.converter.ConverterException;
@@ -37,6 +36,8 @@ import org.eclipse.smarthome.core.library.unit.MetricPrefix;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
 import org.eclipse.smarthome.core.types.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Converts between a Homematic datapoint value and a {@link DecimalType}.
@@ -44,6 +45,8 @@ import org.eclipse.smarthome.core.types.Type;
  * @author Michael Reitler - Initial contribution
  */
 public class QuantityTypeConverter extends AbstractTypeConverter<QuantityType<? extends Quantity<?>>> {
+    private final Logger logger = LoggerFactory.getLogger(QuantityTypeConverter.class);
+
     @Override
     protected boolean toBindingValidation(HmDatapoint dp, Class<? extends Type> typeClass) {
         return dp.isNumberType() && typeClass.isAssignableFrom(QuantityType.class);
@@ -68,22 +71,25 @@ public class QuantityTypeConverter extends AbstractTypeConverter<QuantityType<? 
 
         // convert the given QuantityType to a QuantityType with the unit of the target datapoint
         switch (dp.getUnit()) {
-            case "minutes":
-                return type.toUnit(SmartHomeUnits.MINUTE);
-            case "day":
-                return type.toUnit(SmartHomeUnits.DAY);
-            case "month":
-                return type.toUnit(SmartHomeUnits.YEAR.divide(12));
-            case "year":
-                return type.toUnit(SmartHomeUnits.YEAR);
             case "Lux":
                 return type.toUnit(SmartHomeUnits.LUX);
             case "degree":
                 return type.toUnit(SmartHomeUnits.DEGREE_ANGLE);
+            case "100%":
+                return type.toUnit(SmartHomeUnits.ONE);
+            case "Â°C":
+                return type.toUnit(SIUnits.CELSIUS);
+            case "minutes":
+            case "day":
+            case "month":
+            case "year":
+            case "":
+                return type;
+            default:
+                // According to datapoint documentation, the following values are remaining
+                // °C, V, %, s, min, mHz, Hz, hPa, km/h, mm, W, m3
+                return type.toUnit(dp.getUnit());
         }
-        // According to datapoint documentation, the following values are remaining
-        // °C, V, %, s, min, mHz, Hz, hPa, km/h, mm, W, m3
-        return type.toUnit(dp.getUnit());
     }
 
     @Override
@@ -103,23 +109,13 @@ public class QuantityTypeConverter extends AbstractTypeConverter<QuantityType<? 
         // create a QuantityType from the datapoint's value based on the datapoint's unit
         String unit = dp.getUnit() != null ? dp.getUnit() : "";
         switch (unit) {
+            case "Â°C":
             case "°C":
                 return new QuantityType<Temperature>(number, SIUnits.CELSIUS);
             case "V":
                 return new QuantityType<ElectricPotential>(number, SmartHomeUnits.VOLT);
             case "%":
                 return new QuantityType<Dimensionless>(number, SmartHomeUnits.PERCENT);
-            case "s":
-                return new QuantityType<Time>(number, SmartHomeUnits.SECOND);
-            case "min":
-            case "minutes":
-                return new QuantityType<Time>(number, SmartHomeUnits.MINUTE);
-            case "day":
-                return new QuantityType<Time>(number, SmartHomeUnits.DAY);
-            case "month":
-                return new QuantityType<Time>(number, SmartHomeUnits.YEAR.divide(12));
-            case "year":
-                return new QuantityType<Time>(number, SmartHomeUnits.YEAR);
             case "mHz":
                 return new QuantityType<Frequency>(number, MetricPrefix.MILLI(SmartHomeUnits.HERTZ));
             case "Hz":
@@ -140,8 +136,25 @@ public class QuantityTypeConverter extends AbstractTypeConverter<QuantityType<? 
                 return new QuantityType<Energy>(number, SmartHomeUnits.WATT_HOUR);
             case "m3":
                 return new QuantityType<Volume>(number, SIUnits.CUBIC_METRE);
+            case "100%":
+                // "100%" is a commonly used "unit" in datapoints. Generated channel-type
+                // is of DecimalType, but clients may define a QuantityType if preferred
+                return new QuantityType<Dimensionless>(number.doubleValue() * 100.0, SmartHomeUnits.PERCENT);
+            case "s":
+            case "min":
+            case "minutes":
+            case "day":
+            case "month":
+            case "year":
+            case "":
+            default:
+                return new QuantityType<Dimensionless>(number, SmartHomeUnits.ONE);
         }
-        return new QuantityType<Dimensionless>(number, SmartHomeUnits.ONE);
+    }
+
+    @Override
+    protected void logTraceOrDebug(String format, Object... arguments) {
+        logger.debug(format, arguments);
     }
 
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/MetadataUtils.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.homematic/src/main/java/org/eclipse/smarthome/binding/homematic/internal/type/MetadataUtils.java
@@ -294,20 +294,13 @@ public class MetadataUtils {
                 // determine QuantityType
                 String unit = dp.getUnit() != null ? dp.getUnit() : "";
                 switch (unit) {
+                    case "Â°C":
                     case "°C":
                         return ITEM_TYPE_NUMBER + ":Temperature";
                     case "V":
                         return ITEM_TYPE_NUMBER + ":ElectricPotential";
                     case "%":
-                    case "":
                         return ITEM_TYPE_NUMBER + ":Dimensionless";
-                    case "s":
-                    case "min":
-                    case "minutes":
-                    case "day":
-                    case "month":
-                    case "year":
-                        return ITEM_TYPE_NUMBER + ":Time";
                     case "mHz":
                     case "Hz":
                         return ITEM_TYPE_NUMBER + ":Frequency";
@@ -327,8 +320,17 @@ public class MetadataUtils {
                         return ITEM_TYPE_NUMBER + ":Energy";
                     case "m3":
                         return ITEM_TYPE_NUMBER + ":Volume";
+                    case "s":
+                    case "min":
+                    case "minutes":
+                    case "day":
+                    case "month":
+                    case "year":
+                    case "100%":
+                    case "":
+                    default:
+                        return ITEM_TYPE_NUMBER;
                 }
-                return ITEM_TYPE_NUMBER;
             }
         } else if (dp.isDateTimeType()) {
             return ITEM_TYPE_DATETIME;


### PR DESCRIPTION
* add support for "100%" and "À°C" which may be present in datapoints
* remove UoM for time (since hardly anybody will want to convert on those items)
* Extend unittests and improve logging

It is not a fix for https://github.com/eclipse/smarthome/issues/6612 but at least it will improve logging

Signed-off-by: Michael Reitler <michael.reitler@telekom.de>