### PR TITLE
Suggest inclusion of sunrise/sunset in Tips

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.astro/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.astro/README.md
@@ -201,3 +201,5 @@ Do not worry if for example the "astro dawn" is undefined at your location.
 The reason might be that you live in a northern country and it is summer, such that the sun is not 18 degrees below the horizon in the morning.
 For details see [this Wikipedia article](https://en.wikipedia.org/wiki/Dawn).
 The "civil dawn" event might often be the better choice.
+
+Sunrise is equivalent to the START of "daylight" and sunset is equivalent to the END of "daylight".


### PR DESCRIPTION
I suggest adding a sentence in Tips showing how to get sunrise/sunset.  Users coming from other automation systems often want to trigger at sunrise or sunset, but nowhere on this page can you find them.  You need to look at the Wiki page to figure out that this is the start or end of daylight.  So I propose to add a sentence mentioning that the start/end of daylight can be used for sunrise/sunset.