### PR TITLE
[Automation] Rename the newly added actions service to thingActions

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/DefaultScriptScopeProvider.java
@@ -204,7 +204,7 @@ public class DefaultScriptScopeProvider implements ScriptExtensionProvider {
         elements.put("things", thingRegistry);
         elements.put("events", busEvent);
         elements.put("rules", ruleRegistry);
-        elements.put("actions", thingActions);
+        elements.put("thingActions", thingActions);
     }
 
     @Deactivate


### PR DESCRIPTION
This describes the action better for anyone using JSR223, and also does not step on the [`core.actions`](https://github.com/OH-Jython-Scripters/openhab2-jython/blob/master/Core/automation/lib/python/core/actions.py) Jython module. 

Now, what exactly does this provide and how do you use it? Or is this being used to provide MQTTActions in the default scope?