### PR TITLE
[OneWire] Fixed things staying in INTIALIZING status

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/TemperatureSensorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/TemperatureSensorThingHandlerTest.java
@@ -84,6 +84,8 @@ public class TemperatureSensorThingHandlerTest extends AbstractThingHandlerTest 
     @Test
     public void testRefresh() {
         thingHandler.initialize();
+        waitForAssert(() -> assertEquals(ThingStatus.UNKNOWN, thing.getStatusInfo().getStatus()));
+
         thingHandler.refresh(bridgeHandler, System.currentTimeMillis());
         try {
             inOrder.verify(bridgeHandler, times(1)).checkPresence(TEST_ID);

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/OwBaseThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/OwBaseThingHandler.java
@@ -261,6 +261,7 @@ public abstract class OwBaseThingHandler extends BaseThingHandler {
         }
 
         updateProperties(properties);
+        initialize();
     }
 
     /**


### PR DESCRIPTION
Fixes #6517

- fixes an issue where manually added or textual defined things stayed in INTIALIZING state forever (reported [here](https://community.openhab.org/t/define-things-channels-with-onewire-binding/59943))
- fixes failing test for tempperature sensor thing handler

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>