### PR TITLE
Remove commented code from SerialPortManager

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPortManager.java
+++ b/bundles/io/org.eclipse.smarthome.io.transport.serial/src/main/java/org/eclipse/smarthome/io/transport/serial/SerialPortManager.java
@@ -38,7 +38,6 @@ public interface SerialPortManager {
         } else {
             return null;
         }
-        // return getIdentifiers().filter(id -> id.getName().equals(name)).findFirst().orElse(null);
     }
 
     /**


### PR DESCRIPTION
The commented code is more elegant but would throw exceptions. :slightly_frowning_face: 