### PR TITLE
pin jdt versions required by xtend-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,6 +416,24 @@
             </fileset>
           </filesets>
         </configuration>
+        <!-- see https://github.com/eclipse/xtext-xtend/issues/493#issuecomment-424706415 -->
+        <dependencies>        
+          <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.core</artifactId>
+            <version>3.15.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+            <version>1.3.300</version>
+          </dependency>
+          <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+            <version>1.2.300</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Might (?) fix https://github.com/eclipse/smarthome/issues/6717

Signed-off-by: Kai Kreuzer <kai@openhab.org>