### PR TITLE
mqtt generic doc:  changed demo to working example

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
@@ -220,7 +220,7 @@ demo.Things:
 ```xtend
 Bridge mqtt:broker:myUnsecureBroker [ host="192.168.0.42", secure=false ]
 {
-    Thing mqtt:topic:mything {
+    Thing topic mything {
     Channels:
         Type switch : lamp "Kitchen Lamp" [ stateTopic="lamp/enabled", commandTopic="lamp/enabled/set" ]
         Type switch : fancylamp "Fancy Lamp" [ stateTopic="fancy/lamp/state", commandTopic="fancy/lamp/command", on="i-am-on", off="i-am-off" ]
@@ -234,8 +234,8 @@ Bridge mqtt:broker:myUnsecureBroker [ host="192.168.0.42", secure=false ]
 demo.items:
 
 ```xtend
-Switch Kitchen_Light "Kitchen Light" {channel="mqtt:mybroker:topic:mything:lamp" }
-Rollershutter shutter "Blind" {channel="mqtt:mybroker:topic:mything:blind" }
+Switch Kitchen_Light "Kitchen Light" { channel="mqtt:topic:myUnsecureBroker:mything:lamp" }
+Rollershutter shutter "Blind" { channel="mqtt:topic:myUnsecureBroker:mything:blind" }
 ```
 
 demo.rules:


### PR DESCRIPTION
The demo.things and demo.item syntax for topic description and usage is not working in openhab 2.4. 
Changed it