### PR TITLE
moving dependencies to the right plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,27 @@
               <artifactId>org.eclipse.equinox.common</artifactId>
               <version>3.10.0</version>
             </dependency>
+            <!-- see https://github.com/eclipse/xtext/issues/1373#issuecomment-449001543 -->
+            <dependency>
+              <groupId>org.eclipse.jdt</groupId>
+              <artifactId>org.eclipse.jdt.core</artifactId>
+              <version>3.13.102</version>
+            </dependency>
+            <dependency>
+              <groupId>org.eclipse.jdt</groupId>
+              <artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+              <version>1.3.110</version>
+            </dependency>
+            <dependency>
+              <groupId>org.eclipse.jdt</groupId>
+              <artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+              <version>1.2.101</version>
+            </dependency>
+            <dependency>
+              <groupId>org.eclipse.emf</groupId>
+              <artifactId>org.eclipse.emf.codegen</artifactId>
+              <version>2.11.0</version>
+            </dependency>
           </dependencies>
           <executions>
             <execution>
@@ -416,29 +437,6 @@
             </fileset>
           </filesets>
         </configuration>
-        <!-- see https://github.com/eclipse/xtext/issues/1373#issuecomment-449001543 -->
-        <dependencies>        
-          <dependency>
-            <groupId>org.eclipse.jdt</groupId>
-            <artifactId>org.eclipse.jdt.core</artifactId>
-            <version>3.13.102</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jdt</groupId>
-            <artifactId>org.eclipse.jdt.compiler.apt</artifactId>
-            <version>1.3.110</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.jdt</groupId>
-            <artifactId>org.eclipse.jdt.compiler.tool</artifactId>
-            <version>1.2.101</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.emf</groupId>
-            <artifactId>org.eclipse.emf.codegen</artifactId>
-            <version>2.11.0</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Correction for https://github.com/eclipse/smarthome/pull/6718 and https://github.com/eclipse/smarthome/pull/6722

Signed-off-by: Kai Kreuzer <kai@openhab.org>