### PR TITLE
[core] keep different service instances for different things in the map

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/ScriptThingActions.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.module.script.defaultscope/src/main/java/org/eclipse/smarthome/automation/module/script/defaultscope/internal/ScriptThingActions.java
@@ -61,11 +61,8 @@ public class ScriptThingActions {
         if (thing != null) {
             ThingHandler handler = thing.getHandler();
             if (handler != null) {
-                ThingActions thingActions = thingActionsMap.get(scope);
-                if (thingActions != null) {
-                    thingActions.setThingHandler(handler);
-                    return thingActions;
-                }
+                ThingActions thingActions = thingActionsMap.get(getKey(scope, thingUid));
+                return thingActions;
             }
         }
         return null;
@@ -73,16 +70,30 @@ public class ScriptThingActions {
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
     void addThingActions(ThingActions thingActions) {
-        String scope = getScope(thingActions);
-        thingActionsMap.put(scope, thingActions);
+        String key = getKey(thingActions);
+        thingActionsMap.put(key, thingActions);
     }
 
     void removeThingActions(ThingActions thingActions) {
-        String scope = getScope(thingActions);
-        thingActionsMap.remove(scope);
+        String key = getKey(thingActions);
+        thingActionsMap.remove(key);
     }
 
-    private String getScope(ThingActions actions) {
+    private static String getKey(ThingActions thingActions) {
+        String scope = getScope(thingActions);
+        String thingUID = getThingUID(thingActions);
+        return getKey(scope, thingUID);
+    }
+
+    private static String getKey(String scope, String thingUID) {
+        return scope + "-" + thingUID;
+    }
+
+    private static String getThingUID(ThingActions actions) {
+        return actions.getThingHandler().getThing().getUID().getAsString();
+    }
+
+    private static String getScope(ThingActions actions) {
         ThingActionsScope scopeAnnotation = actions.getClass().getAnnotation(ThingActionsScope.class);
         return scopeAnnotation.name();
     }

--- a/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/internal/engine/action/ThingActionService.java
+++ b/bundles/model/org.eclipse.smarthome.model.script/src/org/eclipse/smarthome/model/script/internal/engine/action/ThingActionService.java
@@ -78,11 +78,8 @@ public class ThingActionService implements ActionService {
         if (thing != null) {
             ThingHandler handler = thing.getHandler();
             if (handler != null) {
-                ThingActions thingActions = thingActionsMap.get(scope);
-                if (thingActions != null) {
-                    thingActions.setThingHandler(handler);
-                    return thingActions;
-                }
+                ThingActions thingActions = thingActionsMap.get(getKey(scope, thingUid));
+                return thingActions;
             }
         }
         return null;
@@ -90,16 +87,30 @@ public class ThingActionService implements ActionService {
 
     @Reference(policy = ReferencePolicy.DYNAMIC, cardinality = ReferenceCardinality.MULTIPLE)
     public void addThingActions(ThingActions thingActions) {
-        String scope = getScope(thingActions);
-        thingActionsMap.put(scope, thingActions);
+        String key = getKey(thingActions);
+        thingActionsMap.put(key, thingActions);
     }
 
     public void removeThingActions(ThingActions thingActions) {
-        String scope = getScope(thingActions);
-        thingActionsMap.remove(scope);
+        String key = getKey(thingActions);
+        thingActionsMap.remove(key);
     }
 
-    private String getScope(ThingActions actions) {
+    private static String getKey(ThingActions thingActions) {
+        String scope = getScope(thingActions);
+        String thingUID = getThingUID(thingActions);
+        return getKey(scope, thingUID);
+    }
+
+    private static String getKey(String scope, String thingUID) {
+        return scope + "-" + thingUID;
+    }
+
+    private static String getThingUID(ThingActions actions) {
+        return actions.getThingHandler().getThing().getUID().getAsString();
+    }
+
+    private static String getScope(ThingActions actions) {
         ThingActionsScope scopeAnnotation = actions.getClass().getAnnotation(ThingActionsScope.class);
         return scopeAnnotation.name();
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/action/MQTTActions.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt/src/main/java/org/eclipse/smarthome/binding/mqtt/action/MQTTActions.java
@@ -21,7 +21,6 @@ import org.eclipse.smarthome.core.thing.binding.ThingActions;
 import org.eclipse.smarthome.core.thing.binding.ThingActionsScope;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.io.transport.mqtt.MqttBrokerConnection;
-import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +31,6 @@ import org.slf4j.LoggerFactory;
  * @author David Graeff - Initial contribution
  */
 @ThingActionsScope(name = "mqtt")
-@Component
 @NonNullByDefault
 public class MQTTActions implements ThingActions {
     private final Logger logger = LoggerFactory.getLogger(MQTTActions.class);


### PR DESCRIPTION
Previously, only once instance per action scope was kept and thus used within rules.
This PR makes sure that every registered actions instance is kept and correctly associated to rule calls.
Additionally, the MQTTActions class was accidentially registered as a service, which led to an additional service registration without any thing handler set for it. This has been fixed as well.

fixes https://github.com/eclipse/smarthome/issues/6765

Signed-off-by: Kai Kreuzer <kai@openhab.org>