### PR TITLE
[Hue] Avoid dispatching events if 'last_updated' older than now minus two times polling interval

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueBridgeHandler.java
@@ -79,8 +79,8 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueClient {
 
-    private static final int DEFAULT_POLLING_INTERVAL = 10; // in seconds
-    private static final int DEFAULT_SENSOR_POLLING_INTERVAL = 500; // in milliseconds
+    private long pollingInterval = TimeUnit.SECONDS.toSeconds(10);
+    private long sensorPollingInterval = TimeUnit.MILLISECONDS.toMillis(500);
 
     final ReentrantLock pollingLock = new ReentrantLock();
 
@@ -371,7 +371,6 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
     private synchronized void onUpdate() {
         if (hueBridge != null) {
             if (pollingJob == null || pollingJob.isCancelled()) {
-                int pollingInterval = DEFAULT_POLLING_INTERVAL;
                 if (hueBridgeConfig.getPollingInterval() < 1) {
                     logger.info("Wrong configuration value for polling interval. Using default value: {}s",
                             pollingInterval);
@@ -381,9 +380,8 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
                 pollingJob = scheduler.scheduleWithFixedDelay(pollingRunnable, 1, pollingInterval, TimeUnit.SECONDS);
             }
             if (sensorPollingJob == null || sensorPollingJob.isCancelled()) {
-                int sensorPollingInterval = DEFAULT_SENSOR_POLLING_INTERVAL;
                 if (hueBridgeConfig.getSensorPollingInterval() < 50) {
-                    logger.info("Wrong configuration value for sensor polling interval. Using default value: {}s",
+                    logger.info("Wrong configuration value for sensor polling interval. Using default value: {}ms",
                             sensorPollingInterval);
                 } else {
                     sensorPollingInterval = hueBridgeConfig.getSensorPollingInterval();
@@ -717,5 +715,9 @@ public class HueBridgeHandler extends ConfigStatusBridgeHandler implements HueCl
         }
 
         return configStatusMessages;
+    }
+
+    public long getSensorPollingInterval() {
+        return sensorPollingInterval;
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/sensors/DimmerSwitchHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/sensors/DimmerSwitchHandler.java
@@ -12,22 +12,34 @@
  */
 package org.eclipse.smarthome.binding.hue.internal.handler.sensors;
 
+import static org.eclipse.smarthome.binding.hue.internal.FullSensor.STATE_LAST_UPDATED;
 import static org.eclipse.smarthome.binding.hue.internal.HueBindingConstants.*;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.binding.hue.internal.FullSensor;
 import org.eclipse.smarthome.binding.hue.internal.HueBridge;
 import org.eclipse.smarthome.binding.hue.internal.SensorConfigUpdate;
+import org.eclipse.smarthome.binding.hue.internal.handler.HueBridgeHandler;
 import org.eclipse.smarthome.binding.hue.internal.handler.HueSensorHandler;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 
 /**
  * Hue Dimmer Switch
@@ -39,8 +51,23 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 public class DimmerSwitchHandler extends HueSensorHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_DIMMER_SWITCH);
 
+    private long refreshIntervalInNanos = TimeUnit.MILLISECONDS.toNanos(1000);
+
     public DimmerSwitchHandler(Thing thing) {
         super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            ThingHandler bridgeHandler = bridge.getHandler();
+            if (bridgeHandler instanceof HueBridgeHandler) {
+                refreshIntervalInNanos = TimeUnit.MILLISECONDS
+                        .toNanos(((HueBridgeHandler) bridgeHandler).getSensorPollingInterval() * 2);
+            }
+        }
     }
 
     @Override
@@ -50,11 +77,29 @@ public class DimmerSwitchHandler extends HueSensorHandler {
 
     @Override
     protected void doSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor, Configuration config) {
+        ZoneId zoneId = ZoneId.systemDefault();
+        ZonedDateTime now = ZonedDateTime.now(zoneId), timestamp = now;
+
+        Object lastUpdated = sensor.getState().get(STATE_LAST_UPDATED);
+        if (lastUpdated != null) {
+            try {
+                timestamp = ZonedDateTime.ofInstant(
+                        LocalDateTime.parse(String.valueOf(lastUpdated), DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                        ZoneOffset.UTC, zoneId);
+            } catch (DateTimeParseException e) {
+                // do nothing
+            }
+        }
+
         Object buttonState = sensor.getState().get(FullSensor.STATE_BUTTON_EVENT);
         if (buttonState != null) {
             String value = String.valueOf(buttonState);
             updateState(CHANNEL_DIMMER_SWITCH, new DecimalType(value));
-            triggerChannel(EVENT_DIMMER_SWITCH, value);
+            Instant then = timestamp.toInstant();
+            Instant someSecondsEarlier = now.minusNanos(refreshIntervalInNanos).toInstant();
+            if (then.isAfter(someSecondsEarlier) && then.isBefore(now.toInstant())) {
+                triggerChannel(EVENT_DIMMER_SWITCH, value);
+            }
         }
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/sensors/TapSwitchHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/sensors/TapSwitchHandler.java
@@ -12,22 +12,34 @@
  */
 package org.eclipse.smarthome.binding.hue.internal.handler.sensors;
 
+import static org.eclipse.smarthome.binding.hue.internal.FullSensor.STATE_LAST_UPDATED;
 import static org.eclipse.smarthome.binding.hue.internal.HueBindingConstants.*;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.binding.hue.internal.FullSensor;
 import org.eclipse.smarthome.binding.hue.internal.HueBridge;
 import org.eclipse.smarthome.binding.hue.internal.SensorConfigUpdate;
+import org.eclipse.smarthome.binding.hue.internal.handler.HueBridgeHandler;
 import org.eclipse.smarthome.binding.hue.internal.handler.HueSensorHandler;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.DecimalType;
+import org.eclipse.smarthome.core.thing.Bridge;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 
 /**
  * Hue Tap Switch
@@ -38,8 +50,23 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 public class TapSwitchHandler extends HueSensorHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_TAP_SWITCH);
 
+    private long refreshIntervalInNanos = TimeUnit.MILLISECONDS.toNanos(1000);
+
     public TapSwitchHandler(Thing thing) {
         super(thing);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+        Bridge bridge = getBridge();
+        if (bridge != null) {
+            ThingHandler bridgeHandler = bridge.getHandler();
+            if (bridgeHandler instanceof HueBridgeHandler) {
+                refreshIntervalInNanos = TimeUnit.MILLISECONDS
+                        .toNanos(((HueBridgeHandler) bridgeHandler).getSensorPollingInterval() * 2);
+            }
+        }
     }
 
     @Override
@@ -49,11 +76,29 @@ public class TapSwitchHandler extends HueSensorHandler {
 
     @Override
     protected void doSensorStateChanged(@Nullable HueBridge bridge, FullSensor sensor, Configuration config) {
+        ZoneId zoneId = ZoneId.systemDefault();
+        ZonedDateTime now = ZonedDateTime.now(zoneId), timestamp = now;
+
+        Object lastUpdated = sensor.getState().get(STATE_LAST_UPDATED);
+        if (lastUpdated != null) {
+            try {
+                timestamp = ZonedDateTime.ofInstant(
+                        LocalDateTime.parse(String.valueOf(lastUpdated), DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                        ZoneOffset.UTC, zoneId);
+            } catch (DateTimeParseException e) {
+                // do nothing
+            }
+        }
+
         Object buttonState = sensor.getState().get(FullSensor.STATE_BUTTON_EVENT);
         if (buttonState != null) {
             String value = String.valueOf(buttonState);
             updateState(CHANNEL_TAP_SWITCH, new DecimalType(value));
-            triggerChannel(EVENT_TAP_SWITCH, value);
+            Instant then = timestamp.toInstant();
+            Instant someSecondsEarlier = now.minusNanos(refreshIntervalInNanos).toInstant();
+            if (then.isAfter(someSecondsEarlier) && then.isBefore(now.toInstant())) {
+                triggerChannel(EVENT_TAP_SWITCH, value);
+            }
         }
     }
 }


### PR DESCRIPTION
- Avoid dispatching events if 'last_updated' older than now minus two times polling interval (e.g. during restart)

See https://community.openhab.org/t/howto-use-philips-hue-sensors-motion-sensor-dimmer-switch/39344/130

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>