### PR TITLE
[OpenWeatherMap] Added channel for 'icon-id'

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.openweathermap/ESH-INF/i18n/openweathermap_de.properties
+++ b/extensions/binding/org.eclipse.smarthome.binding.openweathermap/ESH-INF/i18n/openweathermap_de.properties
@@ -183,6 +183,9 @@ channel-type.openweathermap.condition-id.description = Zeigt die ID der Wetterla
 channel-type.openweathermap.condition-icon.label = Icon
 channel-type.openweathermap.condition-icon.description = Zeigt das Icon der Wetterlage an.
 
+channel-type.openweathermap.condition-icon.label = Icon-ID
+channel-type.openweathermap.condition-icon.description = Zeigt die ID für das Icon der Wetterlage an.
+
 channel-type.openweathermap.forecasted-outdoor-temperature.label = Vorhergesagte Temperatur
 channel-type.openweathermap.forecasted-outdoor-temperature.description = Zeigt die vorhergesagte Außentemperatur an.
 

--- a/extensions/binding/org.eclipse.smarthome.binding.openweathermap/ESH-INF/thing/channel-types.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.openweathermap/ESH-INF/thing/channel-types.xml
@@ -25,6 +25,7 @@
 			<channel id="condition" typeId="condition" />
 			<channel id="condition-id" typeId="condition-id" />
 			<channel id="icon" typeId="condition-icon" />
+			<channel id="icon-id" typeId="condition-icon-id" />
 			<channel id="temperature" typeId="system.outdoor-temperature" />
 			<channel id="pressure" typeId="system.barometric-pressure" />
 			<channel id="humidity" typeId="system.atmospheric-humidity" />
@@ -45,6 +46,7 @@
 			<channel id="condition" typeId="forecasted-condition" />
 			<channel id="condition-id" typeId="condition-id" />
 			<channel id="icon" typeId="condition-icon" />
+			<channel id="icon-id" typeId="condition-icon-id" />
 			<channel id="temperature" typeId="forecasted-outdoor-temperature" />
 			<channel id="pressure" typeId="forecasted-barometric-pressure" />
 			<channel id="humidity" typeId="forecasted-atmospheric-humidity" />
@@ -65,6 +67,7 @@
 			<channel id="condition" typeId="forecasted-condition" />
 			<channel id="condition-id" typeId="condition-id" />
 			<channel id="icon" typeId="condition-icon" />
+			<channel id="icon-id" typeId="condition-icon-id" />
 			<channel id="min-temperature" typeId="forecasted-min-outdoor-temperature" />
 			<channel id="max-temperature" typeId="forecasted-max-outdoor-temperature" />
 			<channel id="pressure" typeId="forecasted-barometric-pressure" />
@@ -162,6 +165,13 @@
 		<item-type>Image</item-type>
 		<label>Icon</label>
 		<description>Icon representing the weather condition.</description>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="condition-icon-id" advanced="true">
+		<item-type>String</item-type>
+		<label>Icon Id</label>
+		<description>Id of the icon to create the URL.</description>
 		<state readOnly="true" />
 	</channel-type>
 

--- a/extensions/binding/org.eclipse.smarthome.binding.openweathermap/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.openweathermap/README.md
@@ -79,58 +79,61 @@ Once the parameter `forecastDays` will be changed, the available channel groups 
 
 ### Current Weather
 
-| Channel Group ID | Channel ID     | Item Type            | Description                                       |
-|------------------|----------------|----------------------|---------------------------------------------------|
-| current          | time-stamp     | DateTime             | Time of data observation.                         |
-| current          | condition      | String               | Current weather condition.                        |
-| current          | condition-id   | String               | Id of the current weather condition. **Advanced** |
-| current          | icon           | Image                | Icon representing the current weather condition.  |
-| current          | temperature    | Number:Temperature   | Current temperature.                              |
-| current          | pressure       | Number:Pressure      | Current barometric pressure.                      |
-| current          | humidity       | Number:Dimensionless | Current atmospheric humidity.                     |
-| current          | wind-speed     | Number:Speed         | Current wind speed.                               |
-| current          | wind-direction | Number:Angle         | Current wind direction.                           |
-| current          | gust-speed     | Number:Speed         | Current gust speed. **Advanced**                  |
-| current          | cloudiness     | Number:Dimensionless | Current cloudiness.                               |
-| current          | rain           | Number:Length        | Rain volume for the last three hours.             |
-| current          | snow           | Number:Length        | Snow volume for the last three hours.             |
+| Channel Group ID | Channel ID     | Item Type            | Description                                                             |
+|------------------|----------------|----------------------|-------------------------------------------------------------------------|
+| current          | time-stamp     | DateTime             | Time of data observation.                                               |
+| current          | condition      | String               | Current weather condition.                                              |
+| current          | condition-id   | String               | Id of the current weather condition. **Advanced**                       |
+| current          | icon           | Image                | Icon representing the current weather condition.                        |
+| current          | icon-id        | String               | Id of the icon representing the current weather condition. **Advanced** |
+| current          | temperature    | Number:Temperature   | Current temperature.                                                    |
+| current          | pressure       | Number:Pressure      | Current barometric pressure.                                            |
+| current          | humidity       | Number:Dimensionless | Current atmospheric humidity.                                           |
+| current          | wind-speed     | Number:Speed         | Current wind speed.                                                     |
+| current          | wind-direction | Number:Angle         | Current wind direction.                                                 |
+| current          | gust-speed     | Number:Speed         | Current gust speed. **Advanced**                                        |
+| current          | cloudiness     | Number:Dimensionless | Current cloudiness.                                                     |
+| current          | rain           | Number:Length        | Rain volume for the last three hours.                                   |
+| current          | snow           | Number:Length        | Snow volume for the last three hours.                                   |
 
 ### 3 Hour Forecast
 
-| Channel Group ID                                       | Channel ID     | Item Type            | Description                                          |
-|--------------------------------------------------------|----------------|----------------------|------------------------------------------------------|
-| forecastHours03, forecastHours06, ... forecastHours120 | time-stamp     | DateTime             | Time of data forecasted.                             |
-| forecastHours03, forecastHours06, ... forecastHours120 | condition      | String               | Forecast weather condition.                          |
-| forecastHours03, forecastHours06, ... forecastHours120 | condition-id   | String               | Id of the forecasted weather condition. **Advanced** |
-| forecastHours03, forecastHours06, ... forecastHours120 | icon           | Image                | Icon representing the forecasted weather condition.  |
-| forecastHours03, forecastHours06, ... forecastHours120 | temperature    | Number:Temperature   | Forecasted temperature.                              |
-| forecastHours03, forecastHours06, ... forecastHours120 | pressure       | Number:Pressure      | Forecasted barometric pressure.                      |
-| forecastHours03, forecastHours06, ... forecastHours120 | humidity       | Number:Dimensionless | Forecasted atmospheric humidity.                     |
-| forecastHours03, forecastHours06, ... forecastHours120 | wind-speed     | Number:Speed         | Forecasted wind speed.                               |
-| forecastHours03, forecastHours06, ... forecastHours120 | wind-direction | Number:Angle         | Forecasted wind direction.                           |
-| forecastHours03, forecastHours06, ... forecastHours120 | gust-speed     | Number:Speed         | Forecasted gust speed. **Advanced**                  |
-| forecastHours03, forecastHours06, ... forecastHours120 | cloudiness     | Number:Dimensionless | Forecasted cloudiness.                               |
-| forecastHours03, forecastHours06, ... forecastHours120 | rain           | Number:Length        | Expected rain volume for the next 3 hours.           |
-| forecastHours03, forecastHours06, ... forecastHours120 | snow           | Number:Length        | Expected snow volume for the next 3 hours.           |
+| Channel Group ID                                       | Channel ID     | Item Type            | Description                                                                |
+|--------------------------------------------------------|----------------|----------------------|----------------------------------------------------------------------------|
+| forecastHours03, forecastHours06, ... forecastHours120 | time-stamp     | DateTime             | Time of data forecasted.                                                   |
+| forecastHours03, forecastHours06, ... forecastHours120 | condition      | String               | Forecast weather condition.                                                |
+| forecastHours03, forecastHours06, ... forecastHours120 | condition-id   | String               | Id of the forecasted weather condition. **Advanced**                       |
+| forecastHours03, forecastHours06, ... forecastHours120 | icon           | Image                | Icon representing the forecasted weather condition.                        |
+| forecastHours03, forecastHours06, ... forecastHours120 | icon-id        | String               | Id fo the icon representing the forecasted weather condition. **Advanced** |
+| forecastHours03, forecastHours06, ... forecastHours120 | temperature    | Number:Temperature   | Forecasted temperature.                                                    |
+| forecastHours03, forecastHours06, ... forecastHours120 | pressure       | Number:Pressure      | Forecasted barometric pressure.                                            |
+| forecastHours03, forecastHours06, ... forecastHours120 | humidity       | Number:Dimensionless | Forecasted atmospheric humidity.                                           |
+| forecastHours03, forecastHours06, ... forecastHours120 | wind-speed     | Number:Speed         | Forecasted wind speed.                                                     |
+| forecastHours03, forecastHours06, ... forecastHours120 | wind-direction | Number:Angle         | Forecasted wind direction.                                                 |
+| forecastHours03, forecastHours06, ... forecastHours120 | gust-speed     | Number:Speed         | Forecasted gust speed. **Advanced**                                        |
+| forecastHours03, forecastHours06, ... forecastHours120 | cloudiness     | Number:Dimensionless | Forecasted cloudiness.                                                     |
+| forecastHours03, forecastHours06, ... forecastHours120 | rain           | Number:Length        | Expected rain volume for the next 3 hours.                                 |
+| forecastHours03, forecastHours06, ... forecastHours120 | snow           | Number:Length        | Expected snow volume for the next 3 hours.                                 |
 
 ### Daily Forecast
 
-| Channel Group ID                                                 | Channel ID      | Item Type            | Description                                          |
-|------------------------------------------------------------------|-----------------|----------------------|------------------------------------------------------|
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | time-stamp      | DateTime             | Date of data forecasted.                             |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | condition       | String               | Forecast weather condition.                          |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | condition-id    | String               | Id of the forecasted weather condition. **Advanced** |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | icon            | Image                | Icon representing the forecasted weather condition.  |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | min-temperature | Number:Temperature   | Minimum forecasted temperature of a day.             |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | max-temperature | Number:Temperature   | Maximum forecasted temperature of a day.             |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | pressure        | Number:Pressure      | Forecasted barometric pressure.                      |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | humidity        | Number:Dimensionless | Forecasted atmospheric humidity.                     |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | wind-speed      | Number:Speed         | Forecasted wind speed.                               |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | wind-direction  | Number:Angle         | Forecasted wind direction.                           |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | gust-speed      | Number:Speed         | Forecasted gust speed. **Advanced**                  |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | cloudiness      | Number:Dimensionless | Forecasted cloudiness.                               |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | rain            | Number:Length        | Expected rain volume of a day.                       |
-| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | snow            | Number:Length        | Expected snow volume of a day.                       |
+| Channel Group ID                                                 | Channel ID      | Item Type            | Description                                                                |
+|------------------------------------------------------------------|-----------------|----------------------|----------------------------------------------------------------------------|
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | time-stamp      | DateTime             | Date of data forecasted.                                                   |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | condition       | String               | Forecast weather condition.                                                |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | condition-id    | String               | Id of the forecasted weather condition. **Advanced**                       |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | icon            | Image                | Icon representing the forecasted weather condition.                        |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | icon-id         | String               | Id of the icon representing the forecasted weather condition. **Advanced** |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | min-temperature | Number:Temperature   | Minimum forecasted temperature of a day.                                   |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | max-temperature | Number:Temperature   | Maximum forecasted temperature of a day.                                   |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | pressure        | Number:Pressure      | Forecasted barometric pressure.                                            |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | humidity        | Number:Dimensionless | Forecasted atmospheric humidity.                                           |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | wind-speed      | Number:Speed         | Forecasted wind speed.                                                     |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | wind-direction  | Number:Angle         | Forecasted wind direction.                                                 |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | gust-speed      | Number:Speed         | Forecasted gust speed. **Advanced**                                        |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | cloudiness      | Number:Dimensionless | Forecasted cloudiness.                                                     |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | rain            | Number:Length        | Expected rain volume of a day.                                             |
+| forecastToday, forecastTomorrow, forecastDay2, ... forecastDay16 | snow            | Number:Length        | Expected snow volume of a day.                                             |
 
 ### UV Index
 

--- a/extensions/binding/org.eclipse.smarthome.binding.openweathermap/src/main/java/org/eclipse/smarthome/binding/openweathermap/internal/OpenWeatherMapBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.openweathermap/src/main/java/org/eclipse/smarthome/binding/openweathermap/internal/OpenWeatherMapBindingConstants.java
@@ -65,6 +65,7 @@ public class OpenWeatherMapBindingConstants {
     public static final String CHANNEL_CONDITION = "condition";
     public static final String CHANNEL_CONDITION_ID = "condition-id";
     public static final String CHANNEL_CONDITION_ICON = "icon";
+    public static final String CHANNEL_CONDITION_ICON_ID = "icon-id";
     public static final String CHANNEL_TEMPERATURE = "temperature";
     public static final String CHANNEL_MIN_TEMPERATURE = "min-temperature";
     public static final String CHANNEL_MAX_TEMPERATURE = "max-temperature";

--- a/extensions/binding/org.eclipse.smarthome.binding.openweathermap/src/main/java/org/eclipse/smarthome/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.openweathermap/src/main/java/org/eclipse/smarthome/binding/openweathermap/internal/handler/OpenWeatherMapWeatherAndForecastHandler.java
@@ -259,6 +259,9 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     state = getRawTypeState(
                             OpenWeatherMapConnection.getWeatherIcon(weatherData.getWeather().get(0).getIcon()));
                     break;
+                case CHANNEL_CONDITION_ICON_ID:
+                    state = getStringTypeState(weatherData.getWeather().get(0).getIcon());
+                    break;
                 case CHANNEL_TEMPERATURE:
                     state = getQuantityTypeState(weatherData.getMain().getTemp(), CELSIUS);
                     break;
@@ -327,6 +330,9 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                     state = getRawTypeState(
                             OpenWeatherMapConnection.getWeatherIcon(forecastData.getWeather().get(0).getIcon()));
                     break;
+                case CHANNEL_CONDITION_ICON_ID:
+                    state = getStringTypeState(forecastData.getWeather().get(0).getIcon());
+                    break;
                 case CHANNEL_TEMPERATURE:
                     state = getQuantityTypeState(forecastData.getMain().getTemp(), CELSIUS);
                     break;
@@ -394,6 +400,9 @@ public class OpenWeatherMapWeatherAndForecastHandler extends AbstractOpenWeather
                 case CHANNEL_CONDITION_ICON:
                     state = getRawTypeState(
                             OpenWeatherMapConnection.getWeatherIcon(forecastData.getWeather().get(0).getIcon()));
+                    break;
+                case CHANNEL_CONDITION_ICON_ID:
+                    state = getStringTypeState(forecastData.getWeather().get(0).getIcon());
                     break;
                 case CHANNEL_MIN_TEMPERATURE:
                     state = getQuantityTypeState(forecastData.getTemp().getMin(), CELSIUS);


### PR DESCRIPTION
- Added channel for 'icon-id'

During initial commit of the binding we decided to drop this channel (see https://github.com/eclipse/smarthome/pull/5694#discussion_r220073929). But there seems to be quite some interest in it (see https://community.openhab.org/t/openweathermap-condition-icon/60653) because the icon differs from weather condition (e.g. different versions for day and night).

On the other hand we can provide the full Icon URL if needed.

Closes #6732

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>