### PR TITLE
Make min and max value for slider configurable

### DIFF
--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -542,6 +542,7 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
             bean.switchSupport = sliderWidget.isSwitchEnabled();
             bean.minValue = sliderWidget.getMinValue();
             bean.maxValue = sliderWidget.getMaxValue();
+            bean.step = sliderWidget.getStep();
         }
         if (widget instanceof List) {
             List listWidget = (List) widget;

--- a/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
+++ b/bundles/io/org.eclipse.smarthome.io.rest.sitemap/src/main/java/org/eclipse/smarthome/io/rest/sitemap/internal/SitemapResource.java
@@ -148,7 +148,7 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
 
     private final Map<String, EventOutput> eventOutputs = new MapMaker().weakValues().makeMap();
 
-    private ScheduledExecutorService scheduler = ThreadPoolManager
+    private final ScheduledExecutorService scheduler = ThreadPoolManager
             .getScheduledPool(ThreadPoolManager.THREAD_POOL_NAME_COMMON);
 
     private ScheduledFuture<?> cleanSubscriptionsJob;
@@ -540,6 +540,8 @@ public class SitemapResource implements RESTResource, SitemapSubscriptionCallbac
             Slider sliderWidget = (Slider) widget;
             bean.sendFrequency = sliderWidget.getFrequency();
             bean.switchSupport = sliderWidget.isSwitchEnabled();
+            bean.minValue = sliderWidget.getMinValue();
+            bean.maxValue = sliderWidget.getMaxValue();
         }
         if (widget instanceof List) {
             List listWidget = (List) widget;

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
@@ -87,6 +87,7 @@ Mapview:
 Slider:
     'Slider' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
     ('sendFrequency=' frequency=INT)? & (switchEnabled?='switchSupport')? &
+    ('minValue=' minValue=Number)? & ('maxValue=' maxValue=Number)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)* ']'))?);

--- a/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
+++ b/bundles/model/org.eclipse.smarthome.model.sitemap/src/org/eclipse/smarthome/model/Sitemap.xtext
@@ -87,7 +87,7 @@ Mapview:
 Slider:
     'Slider' (('item=' item=ItemRef) & ('label=' label=(ID | STRING))? & ('icon=' icon=Icon)? &
     ('sendFrequency=' frequency=INT)? & (switchEnabled?='switchSupport')? &
-    ('minValue=' minValue=Number)? & ('maxValue=' maxValue=Number)? &
+    ('minValue=' minValue=Number)? & ('maxValue=' maxValue=Number)? & ('step=' step=Number)? &
     ('labelcolor=[' (LabelColor+=ColorArray (',' LabelColor+=ColorArray)* ']'))? &
     ('valuecolor=[' (ValueColor+=ColorArray (',' ValueColor+=ColorArray)* ']'))? &
     ('visibility=[' (Visibility+=VisibilityRule (',' Visibility+=VisibilityRule)* ']'))?);

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/snippets/slider.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/snippets/slider.html
@@ -16,13 +16,13 @@
 		data-has-value="%has_value%"
 		data-widget-id="%widget_id%"
 	>
-		<input 
-			data-freq="%frequency%" 
+		<input
+			data-freq="%frequency%"
 			data-state="%state%"
-			class="mdl-slider mdl-js-slider" 
-			type="range"  
-			min="0" 
-			max="100" 
+			class="mdl-slider mdl-js-slider"
+			type="range"
+			min="%minValue%"
+			max="%maxValue%"
 			tabindex="0"
 			value="0"
 		/>

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/snippets/slider.html
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/snippets/slider.html
@@ -23,6 +23,7 @@
 			type="range"
 			min="%minValue%"
 			max="%maxValue%"
+			step="%step%"
 			tabindex="0"
 			value="0"
 		/>

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
@@ -76,7 +76,7 @@ public class SliderRenderer extends AbstractWidgetRenderer {
         snippet = StringUtils.replace(snippet, "%unit%", unit);
         snippet = StringUtils.replace(snippet, "%minValue%", minValueOf(s));
         snippet = StringUtils.replace(snippet, "%maxValue%", maxValueOf(s));
-        snippet = StringUtils.replace(snippet, "%step%", setpOf(s));
+        snippet = StringUtils.replace(snippet, "%step%", stepOf(s));
 
         // Process the color tags
         snippet = processColor(w, snippet);
@@ -99,7 +99,7 @@ public class SliderRenderer extends AbstractWidgetRenderer {
         return "0";
     }
 
-    private String setpOf(Slider slider) {
+    private String stepOf(Slider slider) {
         if (slider.getStep() != null) {
             return slider.getStep().toString();
         }

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
@@ -76,6 +76,7 @@ public class SliderRenderer extends AbstractWidgetRenderer {
         snippet = StringUtils.replace(snippet, "%unit%", unit);
         snippet = StringUtils.replace(snippet, "%minValue%", minValueOf(s));
         snippet = StringUtils.replace(snippet, "%maxValue%", maxValueOf(s));
+        snippet = StringUtils.replace(snippet, "%step%", setpOf(s));
 
         // Process the color tags
         snippet = processColor(w, snippet);
@@ -96,6 +97,13 @@ public class SliderRenderer extends AbstractWidgetRenderer {
             return slider.getMinValue().toString();
         }
         return "0";
+    }
+
+    private String setpOf(Slider slider) {
+        if (slider.getStep() != null) {
+            return slider.getStep().toString();
+        }
+        return "1";
     }
 
     @Override

--- a/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
+++ b/extensions/ui/org.eclipse.smarthome.ui.basic/src/main/java/org/eclipse/smarthome/ui/basic/internal/render/SliderRenderer.java
@@ -35,6 +35,7 @@ import org.osgi.service.component.annotations.Reference;
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Vlad Ivanov - BasicUI changes
+ * @author Florian Schmidt - Make min and max value configurable in Sitemap
  *
  */
 @Component(service = WidgetRenderer.class)
@@ -73,12 +74,28 @@ public class SliderRenderer extends AbstractWidgetRenderer {
         snippet = StringUtils.replace(snippet, "%frequency%", frequency);
         snippet = StringUtils.replace(snippet, "%switch%", s.isSwitchEnabled() ? "1" : "0");
         snippet = StringUtils.replace(snippet, "%unit%", unit);
+        snippet = StringUtils.replace(snippet, "%minValue%", minValueOf(s));
+        snippet = StringUtils.replace(snippet, "%maxValue%", maxValueOf(s));
 
         // Process the color tags
         snippet = processColor(w, snippet);
 
         sb.append(snippet);
         return null;
+    }
+
+    private String maxValueOf(Slider slider) {
+        if (slider.getMaxValue() != null) {
+            return slider.getMaxValue().toString();
+        }
+        return "100";
+    }
+
+    private String minValueOf(Slider slider) {
+        if (slider.getMinValue() != null) {
+            return slider.getMinValue().toString();
+        }
+        return "0";
     }
 
     @Override


### PR DESCRIPTION
Like for the setpoint, the min and max value for a slider can differ based
on the underlying thing that is being controlled, so it shouldn't be
hardcoded and a user should be able to change these values.

The default values, if the parameters are not given, are 0 (minValue) and
100 (maxValue), like they're currently, so that users shouldn't see a
difference when they're not changing their configurations.

Fixes #6776 

Signed-off-by: Florian <florian.schmidt.welzow@t-online.de>