### PR TITLE
[TRANSFORM] use precompiled JavaScript for faster transformation

### DIFF
--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Import-Package:
  org.eclipse.jdt.annotation;resolution:=optional,
  org.eclipse.smarthome.config.core,
  org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.service,
  org.eclipse.smarthome.core.thing.profiles,
  org.eclipse.smarthome.core.transform,
  org.eclipse.smarthome.core.types,

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptEngineManager.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptEngineManager.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Simple cache for compiled JavaScript files.
  *
- * @author Thomas Kordelle pre compiled scripts
+ * @author Thomas Kordelle - pre compiled scripts
  *
  */
 @NonNullByDefault
@@ -48,12 +48,12 @@ public class JavaScriptEngineManager {
     private final Map<String, CompiledScript> compiledScriptMap = new ConcurrentHashMap<>(4, 0.5f, 2);
 
     /**
-     * Get a pre compiled script {@link CompiledScript } from cache. If it is not in the cache, then load it from
+     * Get a pre compiled script {@link CompiledScript} from cache. If it is not in the cache, then load it from
      * storage and put a pre compiled version into the cache.
      *
      * @param filename name of the JavaScript file to load
-     * @return a pre compiled script {@link CompiledScript }
-     * @throws TransformationException
+     * @return a pre compiled script {@link CompiledScript}
+     * @throws TransformationException if compile of JavaScript failed
      */
     protected CompiledScript getScript(final String filename) throws TransformationException {
         synchronized (compiledScriptMap) {

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptEngineManager.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptEngineManager.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.transform.javascript.internal;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.script.Compilable;
+import javax.script.CompiledScript;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.transform.TransformationException;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple cache for compiled JavaScript files.
+ *
+ * @author thomask
+ *
+ */
+@NonNullByDefault
+@Component(service = JavaScriptEngineManager.class)
+public class JavaScriptEngineManager {
+
+    private final Logger logger = LoggerFactory.getLogger(JavaScriptEngineManager.class);
+    private final ScriptEngineManager manager = new ScriptEngineManager();
+    /* keep memory foot print low. max 2 concurrent threads are estimated */
+    private final Map<String, CompiledScript> compiledScriptMap = new ConcurrentHashMap<>(4, 0.5f, 2);
+
+    /**
+     *
+     * @param filename
+     * @return
+     * @throws TransformationException
+     */
+    protected CompiledScript getScript(final String filename) throws TransformationException {
+        synchronized (compiledScriptMap) {
+            if (compiledScriptMap.containsKey(filename)) {
+                logger.debug("Loading JavaScript {} from cache.", filename);
+                return compiledScriptMap.get(filename);
+            } else {
+                final String path = TransformationScriptWatcher.TRANSFORM_FOLDER + File.separator + filename;
+                logger.debug("Loading script {} from storage ", path);
+                try (final Reader reader = new InputStreamReader(new FileInputStream(path))) {
+                    final ScriptEngine engine = manager.getEngineByName("javascript");
+                    final CompiledScript cScript = ((Compilable) engine).compile(reader);
+                    logger.debug("Putting compiled JavaScript {} to cache.", cScript);
+                    compiledScriptMap.put(filename, cScript);
+                    return cScript;
+                } catch (IOException | ScriptException e) {
+                    throw new TransformationException("An error occurred while loading JavaScript. " + e.getMessage(),
+                            e);
+                }
+            }
+        }
+    }
+
+    /**
+     *
+     * @param fileName
+     */
+    protected void removeFromCache(String fileName) {
+        synchronized (compiledScriptMap) {
+            logger.debug("Removing JavaScript {} from cache.", fileName);
+            compiledScriptMap.remove(fileName);
+        }
+    }
+}

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptEngineManager.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptEngineManager.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Simple cache for compiled JavaScript files.
  *
- * @author thomask
+ * @author Thomas Kordelle pre compiled scripts
  *
  */
 @NonNullByDefault
@@ -48,9 +48,11 @@ public class JavaScriptEngineManager {
     private final Map<String, CompiledScript> compiledScriptMap = new ConcurrentHashMap<>(4, 0.5f, 2);
 
     /**
+     * Get a pre compiled script {@link CompiledScript } from cache. If it is not in the cache, then load it from
+     * storage and put a pre compiled version into the cache.
      *
-     * @param filename
-     * @return
+     * @param filename name of the JavaScript file to load
+     * @return a pre compiled script {@link CompiledScript }
      * @throws TransformationException
      */
     protected CompiledScript getScript(final String filename) throws TransformationException {
@@ -76,13 +78,12 @@ public class JavaScriptEngineManager {
     }
 
     /**
+     * remove a pre compiled script from cache.
      *
-     * @param fileName
+     * @param fileName name of the script file to remove
      */
     protected void removeFromCache(String fileName) {
-        synchronized (compiledScriptMap) {
-            logger.debug("Removing JavaScript {} from cache.", fileName);
-            compiledScriptMap.remove(fileName);
-        }
+        logger.debug("Removing JavaScript {} from cache.", fileName);
+        compiledScriptMap.remove(fileName);
     }
 }

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -12,23 +12,18 @@
  */
 package org.eclipse.smarthome.transform.javascript.internal;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStreamReader;
-import java.io.Reader;
+import java.util.Objects;
 
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
+import javax.script.Bindings;
+import javax.script.CompiledScript;
 import javax.script.ScriptException;
 
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.smarthome.config.core.ConfigConstants;
 import org.eclipse.smarthome.core.transform.TransformationException;
 import org.eclipse.smarthome.core.transform.TransformationService;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,10 +32,23 @@ import org.slf4j.LoggerFactory;
  * input by Java Script.
  *
  * @author Pauli Anttila
+ * @author thomask
  */
 @NonNullByDefault
 @Component(immediate = true, property = { "smarthome.transform=JS" })
 public class JavaScriptTransformationService implements TransformationService {
+
+    private Logger logger = LoggerFactory.getLogger(JavaScriptTransformationService.class);
+    private @NonNullByDefault({}) JavaScriptEngineManager manager;
+
+    @Reference
+    public void setJavaScriptEngineManager(JavaScriptEngineManager manager) {
+        this.manager = manager;
+    }
+
+    public void unsetJavaScriptEngineManager(JavaScriptEngineManager manager) {
+        this.manager = null;
+    }
 
     /**
      * Transforms the input <code>source</code> by Java Script. It expects the
@@ -49,49 +57,31 @@ public class JavaScriptTransformationService implements TransformationService {
      * transformations one should use subfolders.
      *
      * @param filename the name of the file which contains the Java script
-     *            transformation rule. Transformation service inject input
-     *            (source) to 'input' variable.
-     * @param source the input to transform
+     *                     transformation rule. Transformation service inject input
+     *                     (source) to 'input' variable.
+     * @param source   the input to transform
      */
     @Override
     public @Nullable String transform(String filename, String source) throws TransformationException {
-        Logger logger = LoggerFactory.getLogger(JavaScriptTransformationService.class);
-        if (filename == null || source == null) {
-            throw new TransformationException("the given parameters 'filename' and 'source' must not be null");
-        }
+        Objects.requireNonNull(filename, "the given parameter 'filename' must not be null");
+        Objects.requireNonNull(source, "the given parameter 'source' must not be null");
 
-        logger.debug("about to transform '{}' by the Java Script '{}'", source, filename);
+        final long startTime = System.currentTimeMillis();
+        logger.debug("about to transform '{}' by the JavaScript '{}'", source, filename);
 
-        Reader reader;
-
-        try {
-            String path = ConfigConstants.getConfigFolder() + File.separator
-                    + TransformationService.TRANSFORM_FOLDER_NAME + File.separator + filename;
-            reader = new InputStreamReader(new FileInputStream(path));
-        } catch (FileNotFoundException e) {
-            throw new TransformationException("An error occurred while loading script.", e);
-        }
-
-        ScriptEngineManager manager = new ScriptEngineManager();
-
-        ScriptEngine engine = manager.getEngineByName("javascript");
-        engine.put("input", source);
-
-        Object result = null;
-
-        long startTime = System.currentTimeMillis();
+        String result = "";
 
         try {
-            result = engine.eval(reader);
+            final CompiledScript cScript = manager.getScript(filename);
+            final Bindings bindings = cScript.getEngine().createBindings();
+            bindings.put("input", source);
+            result = String.valueOf(cScript.eval(bindings));
+            return result;
         } catch (ScriptException e) {
-            throw new TransformationException("An error occurred while executing script.", e);
+            throw new TransformationException("An error occurred while executing script. " + e.getMessage(), e);
         } finally {
-            IOUtils.closeQuietly(reader);
+            logger.trace("JavaScript execution elapsed {} ms. Result: {}", System.currentTimeMillis() - startTime,
+                    result);
         }
-
-        logger.trace("JavaScript execution elapsed {} ms", System.currentTimeMillis() - startTime);
-
-        return String.valueOf(result);
     }
-
 }

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
@@ -29,8 +29,8 @@ import org.slf4j.LoggerFactory;
  * The implementation of {@link TransformationService} which transforms the
  * input by Java Script.
  *
- * @author Pauli Anttila Initial contribution
- * @author Thomas Kordelle pre compiled scripts
+ * @author Pauli Anttila - Initial contribution
+ * @author Thomas Kordelle - pre compiled scripts
  */
 @NonNullByDefault
 @Component(immediate = true, property = { "smarthome.transform=JS" })

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/JavaScriptTransformationService.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.smarthome.transform.javascript.internal;
 
-import java.util.Objects;
-
 import javax.script.Bindings;
 import javax.script.CompiledScript;
 import javax.script.ScriptException;
@@ -31,8 +29,8 @@ import org.slf4j.LoggerFactory;
  * The implementation of {@link TransformationService} which transforms the
  * input by Java Script.
  *
- * @author Pauli Anttila
- * @author thomask
+ * @author Pauli Anttila Initial contribution
+ * @author Thomas Kordelle pre compiled scripts
  */
 @NonNullByDefault
 @Component(immediate = true, property = { "smarthome.transform=JS" })
@@ -57,14 +55,15 @@ public class JavaScriptTransformationService implements TransformationService {
      * transformations one should use subfolders.
      *
      * @param filename the name of the file which contains the Java script
-     *                     transformation rule. Transformation service inject input
-     *                     (source) to 'input' variable.
-     * @param source   the input to transform
+     *            transformation rule. Transformation service inject input
+     *            (source) to 'input' variable.
+     * @param source the input to transform
      */
     @Override
     public @Nullable String transform(String filename, String source) throws TransformationException {
-        Objects.requireNonNull(filename, "the given parameter 'filename' must not be null");
-        Objects.requireNonNull(source, "the given parameter 'source' must not be null");
+        if (filename == null || source == null) {
+            throw new TransformationException("the given parameters 'filename' and 'source' must not be null");
+        }
 
         final long startTime = System.currentTimeMillis();
         logger.debug("about to transform '{}' by the JavaScript '{}'", source, filename);

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/TransformationScriptWatcher.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/TransformationScriptWatcher.java
@@ -80,7 +80,7 @@ public class TransformationScriptWatcher extends AbstractWatchService {
         final WatchEvent<Path> ev = (WatchEvent<Path>) event;
         final Path filename = ev.context();
 
-        logger.debug("Reloading javascript file {}.", filename.toString());
+        logger.debug("Reloading javascript file {}.", filename);
 
         manager.removeFromCache(filename.toString());
     }

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/TransformationScriptWatcher.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/TransformationScriptWatcher.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2014,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.smarthome.transform.javascript.internal;
+
+import static java.nio.file.StandardWatchEventKinds.*;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchEvent.Kind;
+
+import org.eclipse.smarthome.config.core.ConfigConstants;
+import org.eclipse.smarthome.core.service.AbstractWatchService;
+import org.eclipse.smarthome.core.transform.TransformationService;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * The {@link TransformationScriptWatcher} watches the transformation directory for files. If a deleted/modified file is
+ * detected, the script is passed to the {@link JavaScriptEngineManager}.
+ *
+ * @author thomask
+ *
+ */
+@Component(immediate = true)
+public class TransformationScriptWatcher extends AbstractWatchService {
+
+    public static final String TRANSFORM_FOLDER = ConfigConstants.getConfigFolder() + File.separator
+            + TransformationService.TRANSFORM_FOLDER_NAME;
+
+    private JavaScriptEngineManager manager;
+
+    public TransformationScriptWatcher() {
+        super(TRANSFORM_FOLDER);
+    }
+
+    @Reference
+    public void setJavaScriptEngineManager(JavaScriptEngineManager manager) {
+        this.manager = manager;
+    }
+
+    public void unsetJavaScriptEngineManager(JavaScriptEngineManager manager) {
+        this.manager = null;
+    }
+
+    @Override
+    public void activate() {
+        super.activate();
+    }
+
+    @Override
+    protected boolean watchSubDirectories() {
+        return true;
+    }
+
+    @Override
+    protected Kind<?>[] getWatchEventKinds(Path directory) {
+        return new Kind<?>[] { ENTRY_DELETE, ENTRY_MODIFY };
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected void processWatchEvent(WatchEvent<?> event, Kind<?> kind, Path path) {
+        logger.debug("New watch event {} for path {}.", kind, path);
+
+        if (kind == OVERFLOW) {
+            return;
+        }
+
+        final WatchEvent<Path> ev = (WatchEvent<Path>) event;
+        final Path filename = ev.context();
+
+        logger.debug("Reloading javascript file {}.", filename.toString());
+
+        manager.removeFromCache(filename.toString());
+    }
+}

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/TransformationScriptWatcher.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/TransformationScriptWatcher.java
@@ -29,10 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * The {@link TransformationScriptWatcher} watches the transformation directory for files. If a deleted/modified file is
  * detected, the script is passed to the {@link JavaScriptEngineManager}.
  *
- * @author Thomas Kordelle pre compiled scripts
+ * @author Thomas Kordelle - pre compiled scripts
  *
  */
-@Component(immediate = true)
+@Component()
 public class TransformationScriptWatcher extends AbstractWatchService {
 
     public static final String TRANSFORM_FOLDER = ConfigConstants.getConfigFolder() + File.separator

--- a/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/TransformationScriptWatcher.java
+++ b/extensions/transform/org.eclipse.smarthome.transform.javascript/src/main/java/org/eclipse/smarthome/transform/javascript/internal/TransformationScriptWatcher.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Reference;
  * The {@link TransformationScriptWatcher} watches the transformation directory for files. If a deleted/modified file is
  * detected, the script is passed to the {@link JavaScriptEngineManager}.
  *
- * @author thomask
+ * @author Thomas Kordelle pre compiled scripts
  *
  */
 @Component(immediate = true)


### PR DESCRIPTION
On an ARM machine transformation by JavaScript [takes ~15 seconds each time](https://community.openhab.org/t/js-transformation-takes-10-15-seconds-each-call/61566). To speed up this a little bit, each JavaScript file will be pre compiled and cached. This reduces the time of transformation to ~500ms. First call of each JavaScript still takes ~15 seconds. each further call needs then ~500ms.
Transformation directory will be observed for file changes and the cache will be refreshed.

This implementation is similar to [org.eclipse.smarthome.automation.module.script](https://github.com/eclipse/smarthome/tree/master/bundles/automation/org.eclipse.smarthome.automation.module.script)
