### PR TITLE
[OneWire] Minor Updates and fixes

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/device/DS2405Test.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/device/DS2405Test.java
@@ -16,10 +16,11 @@ import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 
+import java.util.BitSet;
+
 import org.eclipse.smarthome.binding.onewire.internal.OwException;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2405;
 import org.eclipse.smarthome.binding.onewire.test.AbstractDeviceTest;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.junit.Assert;
 import org.junit.Before;
@@ -60,16 +61,19 @@ public class DS2405Test extends AbstractDeviceTest {
     private void digitalChannelTest(OnOffType state, int channelNo) {
         instantiateDevice();
 
-        DecimalType returnValue = new DecimalType((state == OnOffType.ON) ? 255 : 0);
+        BitSet returnValue = new BitSet(8);
+        if (state == OnOffType.ON) {
+            returnValue.flip(0, 7);
+        }
 
         try {
             Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(returnValue);
+            Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
 
             testDevice.configureChannels();
             testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
+            inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
             inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
         } catch (OwException e) {
             Assert.fail("caught unexpected OwException");

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/device/DS2406_DS2413Test.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/device/DS2406_DS2413Test.java
@@ -16,10 +16,11 @@ import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 
+import java.util.BitSet;
+
 import org.eclipse.smarthome.binding.onewire.internal.OwException;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2406_DS2413;
 import org.eclipse.smarthome.binding.onewire.test.AbstractDeviceTest;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.junit.Assert;
 import org.junit.Before;
@@ -64,16 +65,19 @@ public class DS2406_DS2413Test extends AbstractDeviceTest {
     private void digitalChannelTest(OnOffType state, int channelNo) {
         instantiateDevice();
 
-        DecimalType returnValue = new DecimalType((state == OnOffType.ON) ? 255 : 0);
+        BitSet returnValue = new BitSet(8);
+        if (state == OnOffType.ON) {
+            returnValue.flip(0, 7);
+        }
 
         try {
             Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(returnValue);
+            Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
 
             testDevice.configureChannels();
             testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
+            inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
             inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
         } catch (OwException e) {
             Assert.fail("caught unexpected OwException");

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/device/DS2408Test.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/device/DS2408Test.java
@@ -16,10 +16,11 @@ import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 
+import java.util.BitSet;
+
 import org.eclipse.smarthome.binding.onewire.internal.OwException;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2408;
 import org.eclipse.smarthome.binding.onewire.test.AbstractDeviceTest;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.junit.Assert;
 import org.junit.Before;
@@ -64,16 +65,19 @@ public class DS2408Test extends AbstractDeviceTest {
     private void digitalChannelTest(OnOffType state, int channelNo) {
         instantiateDevice();
 
-        DecimalType returnValue = new DecimalType((state == OnOffType.ON) ? 255 : 0);
+        BitSet returnValue = new BitSet(8);
+        if (state == OnOffType.ON) {
+            returnValue.flip(0, 8);
+        }
 
         try {
             Mockito.when(mockBridgeHandler.checkPresence(testSensorId)).thenReturn(OnOffType.ON);
-            Mockito.when(mockBridgeHandler.readDecimalType(eq(testSensorId), any())).thenReturn(returnValue);
+            Mockito.when(mockBridgeHandler.readBitSet(eq(testSensorId), any())).thenReturn(returnValue);
 
             testDevice.configureChannels();
             testDevice.refresh(mockBridgeHandler, true);
 
-            inOrder.verify(mockBridgeHandler, times(2)).readDecimalType(eq(testSensorId), any());
+            inOrder.verify(mockBridgeHandler, times(2)).readBitSet(eq(testSensorId), any());
             inOrder.verify(mockThingHandler).postUpdate(eq(channelName(channelNo)), eq(state));
         } catch (OwException e) {
             Assert.fail("caught unexpected OwException");

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/DigitalIOThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/DigitalIOThingHandlerTest.java
@@ -86,7 +86,7 @@ public class DigitalIOThingHandlerTest extends AbstractThingHandlerTest {
 
         try {
             inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
-            inOrder.verify(bridgeHandler, times(2)).readDecimalType(eq(new SensorId(TEST_ID)), any());
+            inOrder.verify(bridgeHandler, times(2)).readBitSet(eq(new SensorId(TEST_ID)), any());
 
             inOrder.verifyNoMoreInteractions();
         } catch (OwException e) {

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/UtilTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/UtilTest.java
@@ -12,17 +12,13 @@
  */
 package org.eclipse.smarthome.binding.onewire.internal;
 
-import static org.junit.Assert.*;
-
-import java.util.List;
+import static org.junit.Assert.assertEquals;
 
 import javax.measure.quantity.Dimensionless;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.smarthome.core.library.dimension.Density;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
-import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 
 /**
@@ -31,15 +27,6 @@ import org.junit.Test;
  * @author Jan N. Klug - Initial contribution
  */
 public class UtilTest {
-
-    @Test
-    public void decimalTypeToBooleanListTest() {
-        DecimalType testDecimal = new DecimalType(0b10001111);
-        Boolean expectedResult[] = { true, true, true, true, false, false, false, true };
-        List<Boolean> conversionResult = Util.decimalTypeToBooleanList(testDecimal);
-
-        assertThat(conversionResult, IsIterableContainingInOrder.contains(expectedResult));
-    }
 
     @Test
     public void convertAbsoluteHumidityTest() {

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/test/AbstractThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/test/AbstractThingHandlerTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.
 import static org.mockito.ArgumentMatchers.any;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -108,6 +109,10 @@ public abstract class AbstractThingHandlerTest extends JavaTest {
             Mockito.doAnswer(answer -> {
                 return new DecimalType(10);
             }).when(bridgeHandler).readDecimalType(any(), any());
+
+            Mockito.doAnswer(answer -> {
+                return new BitSet(8);
+            }).when(bridgeHandler).readBitSet(any(), any());
 
         } catch (OwException e) {
             Assert.fail("caught unexpected OwException");

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
@@ -53,6 +53,7 @@ Bridges of type `owserver` are extensible with channels of type `owfs-number` an
 
 The counter thing supports the DS2423 chip, a dual counter.
 Two `counterX` channels are supported. 
+`X` is either `0` or `1`.
 
 It has two parameters: sensor id `id` and refresh time `refresh`.
  
@@ -61,6 +62,7 @@ It has two parameters: sensor id `id` and refresh time `refresh`.
 
 The digital I/O things support the DS2405, DS2406, DS2408 and DS2413 chips.
 Depending on the chip, one (DS2405), two (DS2406/DS2413) or eight (DS2408) `digitalX`  channels are supported.
+`X` is a number from `0` to `7`.
 
 It has two parameters: sensor id `id` and refresh time `refresh`.
 
@@ -197,7 +199,10 @@ For best performance it is recommended to set the resolution only as high as nee
  
 ## Full Example
 
-This is the configuration for a OneWire network consisting of an owserver as bridge (`onewire:owserver:mybridge`) as well as a temperature sensor and a BMS as things (`onewire:temperature:mybridge:mysensor`, `onewire:bms:mybridge:mybms`). 
+** Attention: Adding channels with UIDs different from the ones mentioned in the thing description will not work and may cause problems.
+Please use the pre-defined channel names only. **
+
+This is the configuration for a OneWire network consisting of an owserver as bridge (`onewire:owserver:mybridge`) as well as a temperature sensor, a BMS and a 2-port Digital I/O as things (`onewire:temperature:mybridge:mysensor`, `onewire:bms:mybridge:mybms`, `onewire:digitalio2:mybridge:mydio`). 
 
 ### demo.things:
 
@@ -229,6 +234,18 @@ Bridge onewire:owserver:mybridge [
                 ]
         } 
 
+    Thing digitalio2 mydio [
+        id="3A.134E47DB60000"
+        ] {
+            Channels:
+                Type dio : digital0 [
+                    mode="input"
+                ]
+                Type dio : digital1 [
+                    mode="output"
+                ]
+        }
+        
     Channels:
         Type owfs-number : crc8errors [
             path="statistics/errors/CRC8_errors"
@@ -239,10 +256,12 @@ Bridge onewire:owserver:mybridge [
 ### demo.items:
 
 ```
-Number:Temperature MySensor "MySensor [%.1f %unit%]" { channel="onewire:temperature:mybridge:mysensor:temperature" }
-Number:Temperature MyBMS_T "MyBMS Temperature [%.1f %unit%]" { channel="onewire:bms:mybridge:mybms:temperature" }
-Number:Dimensionless MyBMS_H "MyBMS Humidity [%.1f %unit%]"  { channel="onewire:bms:mybridge:mybms:humidity" }
-Number  CRC8Errors "Bus-Errors [%d]" { channel="onewire:owserver:mybridge:crc8errors" }
+Number:Temperature      MySensor    "MySensor [%.1f °C]"            { channel="onewire:temperature:mybridge:mysensor:temperature" }
+Number:Temperature      MyBMS_T     "MyBMS Temperature [%.1f °F]"   { channel="onewire:bms:mybridge:mybms:temperature" }
+Number:Dimensionless    MyBMS_H     "MyBMS Humidity [%.1f %unit%]"  { channel="onewire:bms:mybridge:mybms:humidity" }
+Switch                  Digital0    "Digital 0"                     { channel="onewire:digitalio2:mybridge:mydio:digital0" }
+Switch                  Digital1    "Digital 1"                     { channel="onewire:digitalio2:mybridge:mydio:digital1" }
+Number                  CRC8Errors  "Bus-Errors [%d]"               { channel="onewire:owserver:mybridge:crc8errors" }
 ```
 
 ### demo.sitemap:
@@ -255,6 +274,8 @@ sitemap demo label="Main Menu"
         Text item=MyBMS_T
         Text item=MyBMS_H
         Text item=CRC8Errors
+        Text item=Digital0
+        Switch item=Digital1
     }
 }
 ```

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
@@ -84,6 +84,9 @@ If the voltage input of the DS2438 is connected to a humidity sensor, several co
 
 It has two parameters: sensor id `id` and refresh time `refresh`.
 
+Known DS2438-base sensors are iButtonLink (https://www.ibuttonlink.com/) MS-T (recognized as generic DS2438), MS-TH, MS-TC, MS-TL, MS-TV.
+Unknown multisensors are added as generic DS2438 and have `temperature`, `current`, `voltage` and `supplyvoltage` channels.
+
 ### Temperature sensor (`temperature`)
 
 The temperature thing supports DS18S20, DS18B20 and DS1822 sensors.

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/DS2438Configuration.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/DS2438Configuration.java
@@ -31,7 +31,7 @@ public class DS2438Configuration {
             .compile("^(26|28|3A)([0-9A-Fa-f]{12})[0-9A-Fa-f]{2}$");
 
     private OwSensorType sensorSubType = OwSensorType.DS2438;
-    private String vendor = "";
+    private String vendor = "Dallas/Maxim";
     private String hwRevision = "0";
     private String prodDate = "unknown";
 
@@ -41,10 +41,6 @@ public class DS2438Configuration {
     public DS2438Configuration(OwPageBuffer pageBuffer) {
         String sensorTypeId = pageBuffer.getPageString(3).substring(0, 2);
         switch (sensorTypeId) {
-            case "00":
-                vendor = "iButtonLink";
-                sensorSubType = OwSensorType.MS_T;
-                break;
             case "19":
                 vendor = "iButtonLink";
                 sensorSubType = OwSensorType.MS_TH;
@@ -168,7 +164,7 @@ public class DS2438Configuration {
     /**
      * determine multisensor type
      *
-     * @param mainsensorType        the type of the main sensor
+     * @param mainsensorType the type of the main sensor
      * @param associatedSensorTypes a list of OwSensorTypes of all associated sensors
      * @return the multisensor type (if known)
      */

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/OwBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/OwBindingConstants.java
@@ -110,6 +110,7 @@ public class OwBindingConstants {
         initThingTypeMap.put(OwSensorType.DS2406, THING_TYPE_DIGITALIO2);
         initThingTypeMap.put(OwSensorType.DS2408, THING_TYPE_DIGITALIO8);
         initThingTypeMap.put(OwSensorType.DS2413, THING_TYPE_DIGITALIO2);
+        initThingTypeMap.put(OwSensorType.DS2438, THING_TYPE_MS_TX);
         initThingTypeMap.put(OwSensorType.MS_T, THING_TYPE_MS_TX);
         initThingTypeMap.put(OwSensorType.MS_TC, THING_TYPE_MS_TX);
         initThingTypeMap.put(OwSensorType.MS_TH, THING_TYPE_MS_TX);

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/Util.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/Util.java
@@ -14,16 +14,12 @@ package org.eclipse.smarthome.binding.onewire.internal;
 
 import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.CHANNEL_TEMPERATURE;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.measure.quantity.Dimensionless;
 import javax.measure.quantity.Temperature;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.dimension.Density;
-import org.eclipse.smarthome.core.library.types.DecimalType;
 import org.eclipse.smarthome.core.library.types.QuantityType;
 import org.eclipse.smarthome.core.library.unit.SIUnits;
 import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
@@ -41,22 +37,6 @@ import org.eclipse.smarthome.core.types.State;
  */
 @NonNullByDefault
 public class Util {
-
-    /**
-     * convert a number to a list of booleans
-     *
-     * @param decimal
-     * @return
-     */
-    public static List<Boolean> decimalTypeToBooleanList(DecimalType decimal) {
-        List<Boolean> returnValues = new ArrayList<Boolean>();
-        int value = decimal.intValue();
-        for (int i = 0; i < 8; i++) {
-            returnValues.add((value & (1 << i)) > 0);
-        }
-        return returnValues;
-    }
-
     /**
      * calculate absolute humidity in g/m³ from measured values
      *

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/device/AbstractDigitalOwDevice.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/device/AbstractDigitalOwDevice.java
@@ -15,6 +15,7 @@ package org.eclipse.smarthome.binding.onewire.internal.device;
 import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.*;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -22,7 +23,6 @@ import org.eclipse.smarthome.binding.onewire.internal.DigitalIoConfig;
 import org.eclipse.smarthome.binding.onewire.internal.OwDynamicStateDescriptionProvider;
 import org.eclipse.smarthome.binding.onewire.internal.OwException;
 import org.eclipse.smarthome.binding.onewire.internal.SensorId;
-import org.eclipse.smarthome.binding.onewire.internal.Util;
 import org.eclipse.smarthome.binding.onewire.internal.handler.OwBaseBridgeHandler;
 import org.eclipse.smarthome.binding.onewire.internal.handler.OwBaseThingHandler;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -101,10 +101,8 @@ public abstract class AbstractDigitalOwDevice extends AbstractOwDevice {
         if (isConfigured) {
             State state;
 
-            List<Boolean> statesSensed = Util
-                    .decimalTypeToBooleanList((DecimalType) bridgeHandler.readDecimalType(sensorId, fullInParam));
-            List<Boolean> statesPIO = Util
-                    .decimalTypeToBooleanList((DecimalType) bridgeHandler.readDecimalType(sensorId, fullOutParam));
+            BitSet statesSensed = bridgeHandler.readBitSet(sensorId, fullInParam);
+            BitSet statesPIO = bridgeHandler.readBitSet(sensorId, fullOutParam);
 
             for (int i = 0; i < ioConfig.size(); i++) {
                 if (ioConfig.get(i).isInput()) {

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
@@ -38,6 +38,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
@@ -79,7 +80,9 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
             return;
         }
 
-        if (getThing().getStatus() == ThingStatus.OFFLINE) {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        if (statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
@@ -35,6 +35,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
@@ -74,7 +75,9 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
             return;
         }
 
-        if (getThing().getStatus() == ThingStatus.OFFLINE) {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        if (statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
@@ -122,6 +122,23 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
             case MS_T:
                 // no other channels
                 break;
+            case DS2438:
+                if (thing.getChannel(CHANNEL_VOLTAGE) == null) {
+                    thingBuilder.withChannel(ChannelBuilder
+                            .create(new ChannelUID(thing.getUID(), CHANNEL_VOLTAGE), "Number:ElectricPotential")
+                            .withLabel("Voltage").withType(new ChannelTypeUID(BINDING_ID, "voltage")).build());
+                    isEdited = true;
+                }
+                sensors.get(0).enableChannel(CHANNEL_VOLTAGE);
+                if (thing.getChannel(CHANNEL_CURRENT) == null) {
+                    thingBuilder.withChannel(ChannelBuilder
+                            .create(new ChannelUID(thing.getUID(), CHANNEL_CURRENT), "Number:ElectricCurrent")
+                            .withLabel("Current").withType(new ChannelTypeUID(BINDING_ID, "current")).build());
+                    isEdited = true;
+                }
+                ((DS2438) sensors.get(0)).setCurrentSensorType(CurrentSensorType.INTERNAL);
+                sensors.get(0).enableChannel(CHANNEL_CURRENT);
+                break;
             case DS1923:
                 // DS1923 has fixed humidity sensor on-board
                 if (thing.getChannel(CHANNEL_HUMIDITY) == null) {
@@ -134,14 +151,14 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
                 break;
             case MS_TC:
                 if (thing.getChannel(CHANNEL_CURRENT) == null) {
-                    thingBuilder.withChannel(
-                            ChannelBuilder.create(new ChannelUID(thing.getUID(), CHANNEL_LIGHT), "Number:Current")
-                                    .withLabel("Current").withType(new ChannelTypeUID(BINDING_ID, "current")).build());
+                    thingBuilder.withChannel(ChannelBuilder
+                            .create(new ChannelUID(thing.getUID(), CHANNEL_CURRENT), "Number:ElectricCurrent")
+                            .withLabel("Current").withType(new ChannelTypeUID(BINDING_ID, "current")).build());
                     isEdited = true;
-                    sensors.get(0).enableChannel(CHANNEL_CURRENT);
-                    ((DS2438) sensors.get(0)).setCurrentSensorType(CurrentSensorType.IBUTTONLINK);
                 }
-                sensors.get(0).enableChannel(CHANNEL_LIGHT);
+                ((DS2438) sensors.get(0)).setCurrentSensorType(CurrentSensorType.IBUTTONLINK);
+                sensors.get(0).enableChannel(CHANNEL_CURRENT);
+                break;
             case MS_TH:
                 // DS2438 can have different sensors
                 if (thing.getChannel(CHANNEL_HUMIDITY) == null) {

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/CounterSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/CounterSensorThingHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -50,7 +51,9 @@ public class CounterSensorThingHandler extends OwBaseThingHandler {
             return;
         }
 
-        if (getThing().getStatus() == ThingStatus.OFFLINE) {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        if (statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/DigitalIOThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/DigitalIOThingHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.slf4j.Logger;
@@ -88,7 +89,9 @@ public class DigitalIOThingHandler extends OwBaseThingHandler {
             return;
         }
 
-        if (getThing().getStatus() == ThingStatus.OFFLINE) {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        if (statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/EDSSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/EDSSensorThingHandler.java
@@ -32,6 +32,7 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
@@ -68,7 +69,9 @@ public class EDSSensorThingHandler extends OwBaseThingHandler {
             return;
         }
 
-        if (getThing().getStatus() == ThingStatus.OFFLINE) {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        if (statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/IButtonThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/IButtonThingHandler.java
@@ -25,6 +25,7 @@ import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -49,7 +50,9 @@ public class IButtonThingHandler extends OwBaseThingHandler {
             return;
         }
 
-        if (getThing().getStatus() == ThingStatus.OFFLINE) {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        if (statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/OwBaseBridgeHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/OwBaseBridgeHandler.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.smarthome.binding.onewire.internal.handler;
 
+import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -190,6 +191,18 @@ public abstract class OwBaseBridgeHandler extends BaseBridgeHandler {
     public abstract State readDecimalType(SensorId sensorId, OwDeviceParameterMap parameter) throws OwException;
 
     /**
+     * read a BitSet value from a sensor
+     *
+     * @param sensorId sensorId the sensor's full ID
+     * @param parameter device parameters needed for this request
+     * @return a BitSet
+     * @throws OwException
+     */
+    public BitSet readBitSet(SensorId sensorId, OwDeviceParameterMap parameter) throws OwException {
+        return BitSet.valueOf(new long[] { ((DecimalType) readDecimalType(sensorId, parameter)).longValue() });
+    }
+
+    /**
      * read an array of decimal values from a sensor
      *
      * @param sensorId sensorId the sensor's full ID
@@ -219,6 +232,17 @@ public abstract class OwBaseBridgeHandler extends BaseBridgeHandler {
      */
     public abstract void writeDecimalType(SensorId sensorId, OwDeviceParameterMap parameter, DecimalType value)
             throws OwException;
+
+    /**
+     * writes a BitSet to the sensor
+     *
+     * @param sensorId sensorId the sensor's full ID
+     * @param parameter device parameters needed for this request
+     * @throws OwException
+     */
+    public void writeBitSet(SensorId sensorId, OwDeviceParameterMap parameter, BitSet value) throws OwException {
+        writeDecimalType(sensorId, parameter, new DecimalType(value.toLongArray()[0]));
+    }
 
     /**
      * returns if this bridge is refreshable

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/TemperatureSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/TemperatureSensorThingHandler.java
@@ -28,6 +28,7 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 
@@ -53,7 +54,9 @@ public class TemperatureSensorThingHandler extends OwBaseThingHandler {
             return;
         }
 
-        if (getThing().getStatus() == ThingStatus.OFFLINE) {
+        ThingStatusInfo statusInfo = getThing().getStatusInfo();
+        if (statusInfo.getStatus() == ThingStatus.OFFLINE
+                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 


### PR DESCRIPTION
- After a thing has been edited in PaperUI initialization could not finish if the thing was ok OFFLINE status before
- Documentation has been made more clear regarding the channel naming (esp. for digital channels)
- Minor internal code changes that removes proprietary code in favor of standard classes
- If the exact DS2438 multisensor type could not be determined the sensor was dropped. This has been fixed.

For easier review I have left the individual commits in place.