### PR TITLE
[hue] Prevent NPE if 'modelid' is 'null'

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullHueObject.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullHueObject.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.smarthome.binding.hue.internal;
 
+import static org.eclipse.smarthome.binding.hue.internal.HueBindingConstants.NORMALIZE_ID_REGEX;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.gson.annotations.SerializedName;
@@ -22,16 +25,17 @@ import com.google.gson.annotations.SerializedName;
  * @author Samuel Leisering - Initial contribution
  * @author Christoph Weitkamp - Initial contribution
  */
+@NonNullByDefault
 public class FullHueObject extends HueObject {
 
-    private String type;
-    private String modelid;
+    private @NonNullByDefault({}) String type;
+    private @Nullable String modelid;
     @SerializedName("manufacturername")
-    private String manufacturerName;
+    private @NonNullByDefault({}) String manufacturerName;
     @SerializedName("productname")
-    private String productName;
-    private String swversion;
-    private String uniqueid;
+    private @NonNullByDefault({}) String productName;
+    private @Nullable String swversion;
+    private @Nullable String uniqueid;
 
     public FullHueObject() {
         super();
@@ -62,6 +66,10 @@ public class FullHueObject extends HueObject {
         return modelid;
     }
 
+    public @Nullable String getNormalizedModelID() {
+        return modelid != null ? modelid.replaceAll(NORMALIZE_ID_REGEX, "_") : modelid;
+    }
+
     /**
      * Set the model ID of the object.
      */
@@ -90,7 +98,7 @@ public class FullHueObject extends HueObject {
      *
      * @return software version
      */
-    public String getSoftwareVersion() {
+    public @Nullable String getSoftwareVersion() {
         return swversion;
     }
 
@@ -100,8 +108,8 @@ public class FullHueObject extends HueObject {
      *
      * @return the unique id, can be null for some virtual types like the daylight sensor
      */
-    @Nullable
-    public String getUniqueID() {
+
+    public @Nullable String getUniqueID() {
         return uniqueid;
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullHueObject.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullHueObject.java
@@ -58,7 +58,7 @@ public class FullHueObject extends HueObject {
      *
      * @return model id
      */
-    public String getModelID() {
+    public @Nullable String getModelID() {
         return modelid;
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBindingConstants.java
@@ -81,4 +81,6 @@ public class HueBindingConstants {
     public static final String SENSOR_ID = "sensorId";
     public static final String PRODUCT_NAME = "productName";
     public static final String UNIQUE_ID = "uniqueId";
+
+    public static final String NORMALIZE_ID_REGEX = "[^a-zA-Z0-9_]";
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -144,13 +144,15 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
         ThingUID thingUID = getThingUID(light);
         ThingTypeUID thingTypeUID = getThingTypeUID(light);
 
-        String modelId = light.getModelID().replaceAll(HueLightHandler.NORMALIZE_ID_REGEX, "_");
+        String modelId = light.getModelID();
 
         if (thingUID != null && thingTypeUID != null) {
             ThingUID bridgeUID = hueBridgeHandler.getThing().getUID();
             Map<String, Object> properties = new HashMap<>();
             properties.put(LIGHT_ID, light.getId());
-            properties.put(Thing.PROPERTY_MODEL_ID, modelId);
+            if (modelId != null) {
+                properties.put(Thing.PROPERTY_MODEL_ID, modelId.replaceAll(NORMALIZE_ID_REGEX, "_"));
+            }
             String uniqueID = light.getUniqueID();
             if (uniqueID != null) {
                 properties.put(UNIQUE_ID, uniqueID);
@@ -194,7 +196,7 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
 
     private @Nullable ThingTypeUID getThingTypeUID(FullHueObject hueObject) {
         String thingTypeId = TYPE_TO_ZIGBEE_ID_MAP
-                .get(hueObject.getType().replaceAll(HueLightHandler.NORMALIZE_ID_REGEX, "_").toLowerCase());
+                .get(hueObject.getType().replaceAll(NORMALIZE_ID_REGEX, "_").toLowerCase());
 
         return thingTypeId != null ? new ThingTypeUID(BINDING_ID, thingTypeId) : null;
     }
@@ -208,13 +210,15 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
         ThingUID thingUID = getThingUID(sensor);
         ThingTypeUID thingTypeUID = getThingTypeUID(sensor);
 
-        String modelId = sensor.getModelID().replaceAll(HueLightHandler.NORMALIZE_ID_REGEX, "_");
+        String modelId = sensor.getModelID();
 
         if (thingUID != null && thingTypeUID != null) {
             ThingUID bridgeUID = hueBridgeHandler.getThing().getUID();
             Map<String, Object> properties = new HashMap<>();
             properties.put(SENSOR_ID, sensor.getId());
-            properties.put(Thing.PROPERTY_MODEL_ID, modelId);
+            if (modelId != null) {
+                properties.put(Thing.PROPERTY_MODEL_ID, modelId.replaceAll(NORMALIZE_ID_REGEX, "_"));
+            }
             String uniqueID = sensor.getUniqueID();
             if (uniqueID != null) {
                 properties.put(UNIQUE_ID, uniqueID);

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/discovery/HueLightDiscoveryService.java
@@ -144,14 +144,14 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
         ThingUID thingUID = getThingUID(light);
         ThingTypeUID thingTypeUID = getThingTypeUID(light);
 
-        String modelId = light.getModelID();
+        String modelId = light.getNormalizedModelID();
 
         if (thingUID != null && thingTypeUID != null) {
             ThingUID bridgeUID = hueBridgeHandler.getThing().getUID();
             Map<String, Object> properties = new HashMap<>();
             properties.put(LIGHT_ID, light.getId());
             if (modelId != null) {
-                properties.put(Thing.PROPERTY_MODEL_ID, modelId.replaceAll(NORMALIZE_ID_REGEX, "_"));
+                properties.put(Thing.PROPERTY_MODEL_ID, modelId);
             }
             String uniqueID = light.getUniqueID();
             if (uniqueID != null) {
@@ -210,14 +210,14 @@ public class HueLightDiscoveryService extends AbstractDiscoveryService
         ThingUID thingUID = getThingUID(sensor);
         ThingTypeUID thingTypeUID = getThingTypeUID(sensor);
 
-        String modelId = sensor.getModelID();
+        String modelId = sensor.getNormalizedModelID();
 
         if (thingUID != null && thingTypeUID != null) {
             ThingUID bridgeUID = hueBridgeHandler.getThing().getUID();
             Map<String, Object> properties = new HashMap<>();
             properties.put(SENSOR_ID, sensor.getId());
             if (modelId != null) {
-                properties.put(Thing.PROPERTY_MODEL_ID, modelId.replaceAll(NORMALIZE_ID_REGEX, "_"));
+                properties.put(Thing.PROPERTY_MODEL_ID, modelId);
             }
             String uniqueID = sensor.getUniqueID();
             if (uniqueID != null) {

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueLightHandler.java
@@ -87,8 +87,6 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
 
     private static final String OSRAM_PAR16_50_TW_MODEL_ID = "PAR16_50_TW";
 
-    public static final String NORMALIZE_ID_REGEX = "[^a-zA-Z0-9_]";
-
     @NonNullByDefault({})
     private String lightId;
 
@@ -145,12 +143,17 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
         if (!propertiesInitializedSuccessfully) {
             FullHueObject fullLight = getLight();
             if (fullLight != null) {
-                String modelId = fullLight.getModelID().replaceAll(NORMALIZE_ID_REGEX, "_");
-                updateProperty(Thing.PROPERTY_MODEL_ID, modelId);
                 updateProperty(Thing.PROPERTY_FIRMWARE_VERSION, fullLight.getSoftwareVersion());
-                String vendor = getVendor(modelId);
-                if (vendor != null) {
-                    updateProperty(Thing.PROPERTY_VENDOR, vendor);
+                String modelId = fullLight.getModelID();
+                if (modelId != null) {
+                    modelId = modelId.replaceAll(NORMALIZE_ID_REGEX, "_");
+                    updateProperty(Thing.PROPERTY_MODEL_ID, modelId);
+                    String vendor = getVendor(modelId);
+                    if (vendor != null) {
+                        updateProperty(Thing.PROPERTY_VENDOR, vendor);
+                    }
+                } else {
+                    updateProperty(Thing.PROPERTY_VENDOR, fullLight.getManufacturerName());
                 }
                 String uniqueID = fullLight.getUniqueID();
                 if (uniqueID != null) {

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueLightHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueLightHandler.java
@@ -143,10 +143,12 @@ public class HueLightHandler extends BaseThingHandler implements LightStatusList
         if (!propertiesInitializedSuccessfully) {
             FullHueObject fullLight = getLight();
             if (fullLight != null) {
-                updateProperty(Thing.PROPERTY_FIRMWARE_VERSION, fullLight.getSoftwareVersion());
-                String modelId = fullLight.getModelID();
+                String softwareVersion = fullLight.getSoftwareVersion();
+                if (softwareVersion != null) {
+                    updateProperty(Thing.PROPERTY_FIRMWARE_VERSION, softwareVersion);
+                }
+                String modelId = fullLight.getNormalizedModelID();
                 if (modelId != null) {
-                    modelId = modelId.replaceAll(NORMALIZE_ID_REGEX, "_");
                     updateProperty(Thing.PROPERTY_MODEL_ID, modelId);
                     String vendor = getVendor(modelId);
                     if (vendor != null) {

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueSensorHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueSensorHandler.java
@@ -98,9 +98,11 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
         if (!propertiesInitializedSuccessfully) {
             FullHueObject fullSensor = getSensor();
             if (fullSensor != null) {
-                String modelId = fullSensor.getModelID().replaceAll(HueLightHandler.NORMALIZE_ID_REGEX, "_");
-                updateProperty(Thing.PROPERTY_MODEL_ID, modelId);
                 updateProperty(Thing.PROPERTY_FIRMWARE_VERSION, fullSensor.getSoftwareVersion());
+                String modelId = fullSensor.getModelID();
+                if (modelId != null) {
+                    updateProperty(Thing.PROPERTY_MODEL_ID, modelId.replaceAll(NORMALIZE_ID_REGEX, "_"));
+                }
                 updateProperty(Thing.PROPERTY_VENDOR, fullSensor.getManufacturerName());
                 updateProperty(PRODUCT_NAME, fullSensor.getProductName());
                 String uniqueID = fullSensor.getUniqueID();

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueSensorHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/handler/HueSensorHandler.java
@@ -98,10 +98,13 @@ public abstract class HueSensorHandler extends BaseThingHandler implements Senso
         if (!propertiesInitializedSuccessfully) {
             FullHueObject fullSensor = getSensor();
             if (fullSensor != null) {
-                updateProperty(Thing.PROPERTY_FIRMWARE_VERSION, fullSensor.getSoftwareVersion());
-                String modelId = fullSensor.getModelID();
+                String softwareVersion = fullSensor.getSoftwareVersion();
+                if (softwareVersion != null) {
+                    updateProperty(Thing.PROPERTY_FIRMWARE_VERSION, softwareVersion);
+                }
+                String modelId = fullSensor.getNormalizedModelID();
                 if (modelId != null) {
-                    updateProperty(Thing.PROPERTY_MODEL_ID, modelId.replaceAll(NORMALIZE_ID_REGEX, "_"));
+                    updateProperty(Thing.PROPERTY_MODEL_ID, modelId);
                 }
                 updateProperty(Thing.PROPERTY_VENDOR, fullSensor.getManufacturerName());
                 updateProperty(PRODUCT_NAME, fullSensor.getProductName());


### PR DESCRIPTION
- Prevent NPE if `modelid` is `null`

When pointing the Hue binding to a deCONZ emulated bridge it may occur that devices using an up-to-date firmware, which is not supported properly, and some properties (e.g. the `modelid`) have a `null` value. I decided to ignore this information because it is not mandatory (see https://community.openhab.org/t/huebridgehandler-and-huelightdiscoveryservice-error-further-auto-discovery-won-t-work/62693/).

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>