### PR TITLE
[OneWire] simplify multisensor configuration and improve thing discovery

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/multisensor.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/multisensor.xml
@@ -74,12 +74,6 @@
 				<description>Sensor ID of the DS2438 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
 				<required>true</required>
 			</parameter>
-			<parameter name="id1" type="text">
-				<context>network_address</context>
-				<label>Temperature sensor ID</label>
-				<description>Sensor ID of the DS18B20 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
-				<required>true</required>
-			</parameter>
 			<parameter name="lightsensor" type="boolean">
 				<label>Ambient light</label>
 				<description>Ambient light connected</description>
@@ -132,24 +126,6 @@
 			<parameter name="id" type="text">
 				<label>TH(S) sensor ID</label>
 				<description>Sensor ID of the DS2438 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
-				<required>true</required>
-			</parameter>
-			<parameter name="id1" type="text">
-				<context>network_address</context>
-				<label>Temperature sensor ID</label>
-				<description>Sensor ID of the DS18B20 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
-				<required>true</required>
-			</parameter>
-			<parameter name="id2" type="text">
-				<context>network_address</context>
-				<label>AI sensor ID</label>
-				<description>Sensor ID of the DS2438 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
-				<required>true</required>
-			</parameter>
-			<parameter name="id3" type="text">
-				<context>network_address</context>
-				<label>Digital I/O sensor ID</label>
-				<description>Sensor ID of the DS2413 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
 				<required>true</required>
 			</parameter>
 			<parameter name="lightsensor" type="boolean">

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
@@ -105,9 +105,8 @@ These sensors provide `temperature`, `humidity` and `supplyvoltage` channels.
 If the light sensor is attached and configured, a `light` channel is provided, otherwise a `current` channel.
 The AMS has an additional `voltage`and two `digitalX` channels.
 
-It has two (`bms`) or four (`ams`) sensor ids (`id`, `id1`, `id2`, `id3`).
-The first id is always the main DS2438, the second id the DS18B20 temperature sensor.
-In the case of the AMS, the third sensor id has to be the second DS2438 and the fourth the DS2413.
+It has two (`bms`) or four (`ams`) sensors.
+The id parameter (`id`) has to be configured with the sensor id of the humidity sensor.
 
 Additionally the refresh time `refresh` can be configured.
 The AMS supports a `digitalrefresh` parameter for the refresh time of the digital channels.
@@ -225,11 +224,10 @@ Bridge onewire:owserver:mybridge [
         } 
     
     Thing bms mybms [
-        id="26.CD497C010000", 
-        id1="28.D3E45A040000", 
+        id="26.CD497C010000",
+        refresh=60, 
         lightsensor=true, 
         temperaturesensor="DS18B20", 
-        refresh=60
         ] {
             Channels:
                 Type temperature-por-res : temperature [

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/README.md
@@ -87,6 +87,8 @@ It has two parameters: sensor id `id` and refresh time `refresh`.
 Known DS2438-base sensors are iButtonLink (https://www.ibuttonlink.com/) MS-T (recognized as generic DS2438), MS-TH, MS-TC, MS-TL, MS-TV.
 Unknown multisensors are added as generic DS2438 and have `temperature`, `current`, `voltage` and `supplyvoltage` channels.
 
+In case the sensor is not properly detected (e.g. because it is a self-made sensor), check if it is compatible with one of the sensors listed above. If so, the first byte of page 3 of the DS2438 needs to be set to the correct identification (0x00 = generic/MS-T, 0x19 = MS-TH, 0x1A = MS-TV, 0x1B = MS-TL, 0x1C = MS-TC). **Note: Updating the pages of a sensor can break other software. This is fully your own risk.** 
+
 ### Temperature sensor (`temperature`)
 
 The temperature thing supports DS18S20, DS18B20 and DS1822 sensors.

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/DS2438Configuration.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/DS2438Configuration.java
@@ -13,15 +13,19 @@
 package org.eclipse.smarthome.binding.onewire.internal;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
+import org.eclipse.smarthome.binding.onewire.internal.handler.OwBaseBridgeHandler;
 
 /**
- * The {@link DS2438Configuration} is ahelper class for the multisensor thing configuration
+ * The {@link DS2438Configuration} is a helper class for the multisensor thing configuration
  *
  * @author Jan N. Klug - Initial contribution
  */
@@ -35,10 +39,15 @@ public class DS2438Configuration {
     private String hwRevision = "0";
     private String prodDate = "unknown";
 
-    private final List<String> associatedSensorIds = new ArrayList<>();
-    private final List<OwSensorType> associatedSensorTypes = new ArrayList<>();
+    private final Map<SensorId, OwSensorType> associatedSensors = new HashMap<>();
 
-    public DS2438Configuration(OwPageBuffer pageBuffer) {
+    public DS2438Configuration(OwBaseBridgeHandler bridgeHandler, SensorId sensorId) throws OwException {
+        OwSensorType sensorType = bridgeHandler.getType(sensorId);
+        if (sensorType != OwSensorType.DS2438) {
+            throw new OwException("sensor " + sensorId.getId() + " is not a DS2438!");
+        }
+        OwPageBuffer pageBuffer = bridgeHandler.readPages(sensorId);
+
         String sensorTypeId = pageBuffer.getPageString(3).substring(0, 2);
         switch (sensorTypeId) {
             case "19":
@@ -73,29 +82,39 @@ public class DS2438Configuration {
             default:
         }
 
-        if (vendor.equals("Elaborated Networks") || sensorSubType == OwSensorType.MS_TH) {
+        if (sensorSubType == OwSensorType.MS_TH || sensorSubType == OwSensorType.MS_TH_S
+                || sensorSubType == OwSensorType.MS_TV) {
             for (int i = 4; i < 7; i++) {
-                Matcher matcher = ASSOC_SENSOR_ID_PATTERN.matcher(pageBuffer.getPageString(i));
+                String str = new StringBuilder(pageBuffer.getPageString(i)).insert(2, ".").delete(15, 17).toString();
+                Matcher matcher = SensorId.SENSOR_ID_PATTERN.matcher(str);
                 if (matcher.matches()) {
-                    associatedSensorIds.add(matcher.group(1) + "." + matcher.group(2));
-                    switch (matcher.group(1)) {
+                    SensorId associatedSensorId = new SensorId(sensorId.getPath() + matcher.group(2));
+
+                    switch (matcher.group(2).substring(0, 2)) {
                         case "26":
-                            associatedSensorTypes.add(OwSensorType.DS2438);
+                            DS2438Configuration associatedDs2438Config = new DS2438Configuration(bridgeHandler,
+                                    associatedSensorId);
+                            associatedSensors.put(associatedSensorId, associatedDs2438Config.getSensorSubType());
+                            associatedSensors.putAll(associatedDs2438Config.getAssociatedSensors());
                             break;
                         case "28":
-                            associatedSensorTypes.add(OwSensorType.DS18B20);
+                            associatedSensors.put(associatedSensorId, OwSensorType.DS18B20);
                             break;
                         case "3A":
-                            associatedSensorTypes.add(OwSensorType.DS2413);
+                            associatedSensors.put(associatedSensorId, OwSensorType.DS2413);
                             break;
+                        default:
                     }
                 }
             }
-
             prodDate = String.format("%d/%d", pageBuffer.getByte(5, 0),
                     256 * pageBuffer.getByte(5, 1) + pageBuffer.getByte(5, 2));
             hwRevision = String.valueOf(pageBuffer.getByte(5, 3));
         }
+    }
+
+    public Map<SensorId, OwSensorType> getAssociatedSensors() {
+        return associatedSensors;
     }
 
     /**
@@ -103,8 +122,19 @@ public class DS2438Configuration {
      *
      * @return a list of the sensor ids (if found), empty list otherwise
      */
-    public List<String> getAssociatedSensorIds() {
-        return associatedSensorIds;
+    public List<SensorId> getAssociatedSensorIds() {
+        return new ArrayList<>(associatedSensors.keySet());
+    }
+
+    /**
+     * get all secondary sensor ids of a given type
+     *
+     * @param sensorType filter for sensors
+     * @return a list of OwDiscoveryItems
+     */
+    public List<SensorId> getAssociatedSensorIds(OwSensorType sensorType) {
+        return associatedSensors.entrySet().stream().filter(s -> s.getValue() == sensorType).map(s -> s.getKey())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -113,7 +143,7 @@ public class DS2438Configuration {
      * @return a list of the sensor typess (if found), empty list otherwise
      */
     public List<OwSensorType> getAssociatedSensorTypes() {
-        return associatedSensorTypes;
+        return new ArrayList<>(associatedSensors.values());
     }
 
     /**
@@ -122,7 +152,7 @@ public class DS2438Configuration {
      * @return the number
      */
     public int getAssociatedSensorCount() {
-        return associatedSensorIds.size();
+        return associatedSensors.size();
     }
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/SensorId.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/SensorId.java
@@ -73,6 +73,15 @@ public class SensorId {
     }
 
     /**
+     * get the path of this sensorId
+     *
+     * @return path without sensor id (including hub parts, separated by "/" characters)
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
      * get family id (first to characters of sensor id)
      *
      * @return the family id

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/discovery/OwDiscoveryItem.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/discovery/OwDiscoveryItem.java
@@ -16,7 +16,9 @@ import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.DS2438Configuration;
@@ -41,16 +43,12 @@ public class OwDiscoveryItem {
     private final SensorId sensorId;
     private OwSensorType sensorType = OwSensorType.UNKNOWN;
     private String vendor = "Dallas/Maxim";
-    private String hwRevision = "";
-    private String prodDate = "";
 
     private OwPageBuffer pages = new OwPageBuffer();
 
     private ThingTypeUID thingTypeUID = new ThingTypeUID(BINDING_ID, "");
 
-    private final List<String> associatedSensorIds = new ArrayList<>();
-    private final List<OwSensorType> associatedSensorTypes = new ArrayList<>();
-    private final List<OwDiscoveryItem> associatedSensors = new ArrayList<>();
+    private final Map<SensorId, OwSensorType> associatedSensors = new HashMap<>();
 
     public OwDiscoveryItem(OwBaseBridgeHandler bridgeHandler, SensorId sensorId) throws OwException {
         this.sensorId = sensorId;
@@ -58,12 +56,10 @@ public class OwDiscoveryItem {
         switch (sensorType) {
             case DS2438:
                 pages = bridgeHandler.readPages(sensorId);
-                DS2438Configuration config = new DS2438Configuration(pages);
-                associatedSensorIds.addAll(config.getAssociatedSensorIds());
-                logger.trace("found associated sensors: {}", associatedSensorIds);
+                DS2438Configuration config = new DS2438Configuration(bridgeHandler, sensorId);
+                associatedSensors.putAll(config.getAssociatedSensors());
+                logger.trace("found associated sensors: {}", associatedSensors);
                 vendor = config.getVendor();
-                hwRevision = config.getHardwareRevision();
-                prodDate = config.getProductionDate();
                 sensorType = config.getSensorSubType();
                 break;
             case EDS:
@@ -75,10 +71,6 @@ public class OwDiscoveryItem {
                 } catch (IllegalArgumentException e) {
                     sensorType = OwSensorType.UNKNOWN;
                 }
-
-                int fwRevisionLow = pages.getByte(3, 3);
-                int fwRevisionHigh = pages.getByte(3, 4);
-                hwRevision = String.format("%d.%d", fwRevisionHigh, fwRevisionLow);
                 break;
             default:
         }
@@ -121,24 +113,6 @@ public class OwDiscoveryItem {
     }
 
     /**
-     * get production date (available on some multisensors)
-     *
-     * @return production date in format ww/yy
-     */
-    public String getProductionDate() {
-        return prodDate;
-    }
-
-    /**
-     * get hardware revision (available on some multisensors)
-     *
-     * @return hardware revision (where available)
-     */
-    public String getHardwareRevision() {
-        return hwRevision;
-    }
-
-    /**
      * get this sensors ThingTypeUID
      *
      * @return ThingTypeUID if mapping successful
@@ -158,7 +132,7 @@ public class OwDiscoveryItem {
      * @return true if this sensors pages include other sensor ids
      */
     public boolean hasAssociatedSensorIds() {
-        return !associatedSensorIds.isEmpty();
+        return !associatedSensors.isEmpty();
     }
 
     /**
@@ -166,8 +140,8 @@ public class OwDiscoveryItem {
      *
      * @return list of strings
      */
-    public List<String> getAssociatedSensorIds() {
-        return associatedSensorIds;
+    public List<SensorId> getAssociatedSensorIds() {
+        return new ArrayList<>(associatedSensors.keySet());
     }
 
     /**
@@ -180,49 +154,12 @@ public class OwDiscoveryItem {
     }
 
     /**
-     * add a sensor as secondary to this sensor
-     *
-     * @param associatedSensor
-     */
-    public void addAssociatedSensor(OwDiscoveryItem associatedSensor) {
-        associatedSensors.add(associatedSensor);
-        associatedSensorTypes.add(associatedSensor.getSensorType());
-    }
-
-    /**
-     * bulk add secondary sensors
-     *
-     * @param associatedSensors
-     */
-    public void addAssociatedSensors(List<OwDiscoveryItem> associatedSensors) {
-        for (OwDiscoveryItem associatedSensor : associatedSensors) {
-            addAssociatedSensor(associatedSensor);
-        }
-    }
-
-    /**
      * get all secondary sensors
      *
      * @return a list of OwDiscoveryItems
      */
-    public List<OwDiscoveryItem> getAssociatedSensors() {
+    public Map<SensorId, OwSensorType> getAssociatedSensors() {
         return associatedSensors;
-    }
-
-    /**
-     * get all secondary sensors of a given type
-     *
-     * @param sensorType filter for sensors
-     * @return a list of OwDiscoveryItems
-     */
-    public List<OwDiscoveryItem> getAssociatedSensors(OwSensorType sensorType) {
-        List<OwDiscoveryItem> returnList = new ArrayList<>();
-        for (OwDiscoveryItem owDiscoveryItem : associatedSensors) {
-            if (sensorType == owDiscoveryItem.getSensorType()) {
-                returnList.add(owDiscoveryItem);
-            }
-        }
-        return returnList;
     }
 
     /**
@@ -231,15 +168,7 @@ public class OwDiscoveryItem {
      * @return number of sensors
      */
     public int getAssociatedSensorCount() {
-        return associatedSensors.size() + 1;
-    }
-
-    /**
-     * clear all secondary sensors
-     *
-     */
-    public void clearAssociatedSensors() {
-        associatedSensors.clear();
+        return associatedSensors.size();
     }
 
     /**
@@ -251,7 +180,8 @@ public class OwDiscoveryItem {
         switch (sensorType) {
             case MS_TH:
             case MS_TH_S:
-                sensorType = DS2438Configuration.getMultisensorType(sensorType, associatedSensorTypes);
+                sensorType = DS2438Configuration.getMultisensorType(sensorType,
+                        new ArrayList<>(associatedSensors.values()));
                 break;
             default:
         }

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
@@ -24,7 +24,6 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.DS2438Configuration;
 import org.eclipse.smarthome.binding.onewire.internal.OwDynamicStateDescriptionProvider;
 import org.eclipse.smarthome.binding.onewire.internal.OwException;
-import org.eclipse.smarthome.binding.onewire.internal.OwPageBuffer;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS1923;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2438;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2438.CurrentSensorType;
@@ -200,8 +199,7 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
             properties.put(PROPERTY_MODELID, sensorType.toString());
             properties.put(PROPERTY_VENDOR, "Dallas/Maxim");
         } else {
-            OwPageBuffer pages = bridgeHandler.readPages(sensorIds.get(0));
-            DS2438Configuration ds2438configuration = new DS2438Configuration(pages);
+            DS2438Configuration ds2438configuration = new DS2438Configuration(bridgeHandler, sensorIds.get(0));
 
             sensorType = ds2438configuration.getSensorSubType();
             properties.put(PROPERTY_MODELID, sensorType.toString());


### PR DESCRIPTION
This PR improves the adnvanced (BMS/AMS) multisensor discovery as requested e.g. [here](https://github.com/eclipse/smarthome/issues/6751#issuecomment-450505734).  From now on you only have to set the sensor id of the main sensor, additional sensors are auto-discovered. Also includes code improvements for the discovery service which will make future additions a lot simpler.

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>