### PR TITLE
Improved docs and fixed typos

### DIFF
--- a/docs/documentation/concepts/items.md
+++ b/docs/documentation/concepts/items.md
@@ -16,7 +16,7 @@ The following Item types are currently available (alphabetical order):
 | Item Name          | Description | Command Types |
 |--------------------|-------------|---------------|
 | Color              | Color information (RGB) | OnOff, IncreaseDecrease, Percent, HSB |
-| Contact            | Item storing status of e.g. door/window contacts | OpenClose |
+| Contact            | Item storing status of e.g. door/window contacts | OpenClosed |
 | DateTime           | Stores date and time | - |
 | Dimmer             | Item carrying a percentage value for dimmers | OnOff, IncreaseDecrease, Percent |
 | Group              | Item to nest other Items / collect them in Groups | - |

--- a/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.fsinternetradio/README.md
@@ -7,7 +7,7 @@ This binding integrates internet radios based on the [Frontier Silicon chipset](
 Successfully tested are internet radios:
 
  * [Hama IR100](https://de.hama.com/00054823/hama-internetradio-ir110)
- * [Medion MD87180, MD86988, MD86955](http://internetradio.medion.com/)
+ * [Medion MD87180, MD86988, MD86955, MD87528](http://internetradio.medion.com/)
  * [Silvercrest SMRS18A1, SMRS30A1, SMRS35A1, SIRD 14 C2](http://www.silvercrest-multiroom.de/en/products/stereo-internet-radio/)
  * [Roberts Stream 83i and 93i](https://www.robertsradio.com/uk/products/radio/smart-radio/)
  * [Auna Connect 150, Auna KR200](https://www.auna.de/Radios/Internetradios/)

--- a/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.mqtt.generic/README.md
@@ -189,9 +189,9 @@ Here are a few examples to unwrap a value from a complex response:
 
 | Received value                                                      | Tr. Service | Transformation                            |
 |---------------------------------------------------------------------|-------------|-------------------------------------------|
-| `{device: {status: { temperature: 23.2 }}}`                         | JSONPATH    | `"JSONPATH:$.device.status.temperature"`    |
-| `<device><status><temperature>23.2</temperature></status></device>` | XPath       | `"XPath:/device/status/temperature/text()"` |
-| `THEVALUE:23.2°C`                                                    | REGEX       | `"REGEX::(.*?)°"`                          |
+| `{device: {status: { temperature: 23.2 }}}`                         | JSONPATH    | `JSONPATH:$.device.status.temperature`    |
+| `<device><status><temperature>23.2</temperature></status></device>` | XPath       | `XPath:/device/status/temperature/text()` |
+| `THEVALUE:23.2°C`                                                   | REGEX       | `REGEX::(.*?)°`                           |
 
 ## Format before Publish
 

--- a/extensions/binding/org.eclipse.smarthome.binding.openweathermap/README.md
+++ b/extensions/binding/org.eclipse.smarthome.binding.openweathermap/README.md
@@ -186,7 +186,7 @@ Number:Pressure localDailyForecastTodayPressure "Barometric pressure for today [
 Number:Dimensionless localDailyForecastTodayHumidity "Atmospheric humidity for today [%d %unit%]" <humidity> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#humidity" }
 Number:Speed localDailyForecastTodayWindSpeed "Wind speed for today [%.1f km/h]" <wind> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#wind-speed" }
 Number:Angle localDailyForecastTodayWindDirection "Wind direction for today [%d %unit%]" <wind> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#wind-direction" }
-Number:Dimensionless localDailyForecastTodaytCloudiness "Cloudiness for today [%d %unit%]" <clouds> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#cloudiness" }
+Number:Dimensionless localDailyForecastTodayCloudiness "Cloudiness for today [%d %unit%]" <clouds> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#cloudiness" }
 Number:Length localDailyForecastTodayRainVolume "Rain volume for today [%.1f %unit%]" <rain> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#rain" }
 Number:Length localDailyForecastTodaySnowVolume "Snow volume for today [%.1f %unit%]" <snow> { channel="openweathermap:weather-and-forecast:api:local:forecastToday#snow" }
 


### PR DESCRIPTION
Replaces https://github.com/eclipse/smarthome/pull/6850, https://github.com/eclipse/smarthome/pull/6804, https://github.com/eclipse/smarthome/pull/6799 and https://github.com/eclipse/smarthome/pull/6797.

Signed-off-by: Kai Kreuzer <kai@openhab.org>