### PR TITLE
[OneWire] add better runtime checks

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/CompletenessTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/CompletenessTest.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.binding.onewire.internal;
 
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -21,22 +22,38 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
+import org.eclipse.smarthome.binding.onewire.internal.handler.AdvancedMultisensorThingHandler;
+import org.eclipse.smarthome.binding.onewire.internal.handler.BasicMultisensorThingHandler;
+import org.eclipse.smarthome.binding.onewire.internal.handler.CounterSensorThingHandler;
+import org.eclipse.smarthome.binding.onewire.internal.handler.DigitalIOThingHandler;
+import org.eclipse.smarthome.binding.onewire.internal.handler.EDSSensorThingHandler;
+import org.eclipse.smarthome.binding.onewire.internal.handler.IButtonThingHandler;
+import org.eclipse.smarthome.binding.onewire.internal.handler.TemperatureSensorThingHandler;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests cases for {@link Util}.
+ * Tests cases for binding completeness
  *
  * @author Jan N. Klug - Initial contribution
  */
 public class CompletenessTest {
     // internal/temporary types, DS2409 (MicroLAN Coupler), DS2431 (EEPROM)
-    private static Set<OwSensorType> IGNORED_SENSOR_TYPES = Stream
+    private static final Set<OwSensorType> IGNORED_SENSOR_TYPES = Collections.unmodifiableSet(Stream
             .of(OwSensorType.DS2409, OwSensorType.DS2431, OwSensorType.EDS, OwSensorType.MS_TH_S, OwSensorType.UNKNOWN)
-            .collect(Collectors.toSet());
-    private static Set<ThingTypeUID> DEPRECATED_THING_TYPES = Stream
-            .of(OwBindingConstants.THING_TYPE_MS_TH, OwBindingConstants.THING_TYPE_MS_TV).collect(Collectors.toSet());
+            .collect(Collectors.toSet()));
+
+    private static final Set<OwSensorType> THINGHANDLER_SENSOR_TYPES = Collections.unmodifiableSet(Stream
+            .of(AdvancedMultisensorThingHandler.SUPPORTED_SENSOR_TYPES,
+                    BasicMultisensorThingHandler.SUPPORTED_SENSOR_TYPES,
+                    CounterSensorThingHandler.SUPPORTED_SENSOR_TYPES, DigitalIOThingHandler.SUPPORTED_SENSOR_TYPES,
+                    EDSSensorThingHandler.SUPPORTED_SENSOR_TYPES, IButtonThingHandler.SUPPORTED_SENSOR_TYPES,
+                    TemperatureSensorThingHandler.SUPPORTED_SENSOR_TYPES)
+            .flatMap(Set::stream).collect(Collectors.toSet()));
+
+    private static final Set<ThingTypeUID> DEPRECATED_THING_TYPES = Collections.unmodifiableSet(Stream
+            .of(OwBindingConstants.THING_TYPE_MS_TH, OwBindingConstants.THING_TYPE_MS_TV).collect(Collectors.toSet()));
 
     @Test
     public void allSupportedTypesInThingHandlerMap() {
@@ -44,6 +61,15 @@ public class CompletenessTest {
             if (!OwBindingConstants.THING_TYPE_MAP.containsKey(sensorType)
                     && !IGNORED_SENSOR_TYPES.contains(sensorType)) {
                 Assert.fail("missing thing type map for sensor type " + sensorType.name());
+            }
+        }
+    }
+
+    @Test
+    public void allSensorsSupportedByThingHandlers() {
+        for (OwSensorType sensorType : EnumSet.allOf(OwSensorType.class)) {
+            if (!THINGHANDLER_SENSOR_TYPES.contains(sensorType) && !IGNORED_SENSOR_TYPES.contains(sensorType)) {
+                Assert.fail("missing thing handler for sensor type " + sensorType.name());
             }
         }
     }

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/DigitalIOThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/DigitalIOThingHandlerTest.java
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 
+import org.eclipse.smarthome.binding.onewire.internal.OwException;
+import org.eclipse.smarthome.binding.onewire.internal.SensorId;
+import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.binding.onewire.internal.handler.DigitalIOThingHandler;
 import org.eclipse.smarthome.binding.onewire.test.AbstractThingHandlerTest;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -26,9 +29,9 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -43,15 +46,12 @@ public class DigitalIOThingHandlerTest extends AbstractThingHandlerTest {
     private static final ChannelUID CHANNEL_UID_DIO = new ChannelUID(THING_UID, CHANNEL_DIGITAL + "0");
 
     @Before
-    public void setup() {
+    public void setup() throws OwException {
         MockitoAnnotations.initMocks(this);
 
         initializeBridge();
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
-
-        thingProperties.put(PROPERTY_MODELID, "DS2408");
-        thingProperties.put(PROPERTY_VENDOR, "Dallas/Maxim");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_PRESENT, "Switch").build());
         channels.add(ChannelBuilder.create(CHANNEL_UID_DIO, "Switch").build());
@@ -69,27 +69,25 @@ public class DigitalIOThingHandlerTest extends AbstractThingHandlerTest {
 
         initializeHandlerMocks();
 
+        Mockito.doAnswer(answer -> {
+            return OwSensorType.DS2408;
+        }).when(secondBridgeHandler).getType(any());
     }
 
     @Test
     public void testInitializationEndsWithUnknown() {
         thingHandler.initialize();
-
         waitForAssert(() -> assertEquals(ThingStatus.UNKNOWN, thing.getStatusInfo().getStatus()));
     }
 
     @Test
-    public void testRefresh() {
+    public void testRefresh() throws OwException {
         thingHandler.initialize();
         thingHandler.refresh(bridgeHandler, System.currentTimeMillis());
 
-        try {
-            inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
-            inOrder.verify(bridgeHandler, times(2)).readBitSet(eq(new SensorId(TEST_ID)), any());
+        inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
+        inOrder.verify(bridgeHandler, times(2)).readBitSet(eq(new SensorId(TEST_ID)), any());
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/DigitalIOThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/DigitalIOThingHandlerTest.java
@@ -50,9 +50,8 @@ public class DigitalIOThingHandlerTest extends AbstractThingHandlerTest {
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
 
-        thingProperties.put(PROPERTY_SENSORCOUNT, "1");
-        thingProperties.put(PROPERTY_MODELID, "UNKNOWN");
-        thingProperties.put(PROPERTY_VENDOR, "generic");
+        thingProperties.put(PROPERTY_MODELID, "DS2408");
+        thingProperties.put(PROPERTY_VENDOR, "Dallas/Maxim");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_PRESENT, "Switch").build());
         channels.add(ChannelBuilder.create(CHANNEL_UID_DIO, "Switch").build());

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/EDSSensorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/EDSSensorThingHandlerTest.java
@@ -54,7 +54,9 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
         thingProperties.put(PROPERTY_SENSORCOUNT, "1");
+        thingProperties.put(PROPERTY_VENDOR, "Embedded Data Systems");
         thingProperties.put(PROPERTY_MODELID, "EDS0064");
+        thingProperties.put(PROPERTY_HW_REVISION, "21");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_TEMPERATURE, "Number:Temperature").build());
         channels.add(ChannelBuilder.create(CHANNEL_UID_HUMIDITY, "Number:Dimensionless").build());

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/EDSSensorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/EDSSensorThingHandlerTest.java
@@ -17,7 +17,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 
-import org.eclipse.smarthome.binding.onewire.internal.handler.BasicMultisensorThingHandler;
+import org.eclipse.smarthome.binding.onewire.internal.OwException;
+import org.eclipse.smarthome.binding.onewire.internal.OwPageBuffer;
+import org.eclipse.smarthome.binding.onewire.internal.SensorId;
 import org.eclipse.smarthome.binding.onewire.internal.handler.EDSSensorThingHandler;
 import org.eclipse.smarthome.binding.onewire.test.AbstractThingHandlerTest;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -27,9 +29,9 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -47,16 +49,12 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
     private static final ChannelUID CHANNEL_UID_DEWPOINT = new ChannelUID(THING_UID, CHANNEL_DEWPOINT);
 
     @Before
-    public void setup() {
+    public void setup() throws OwException {
         MockitoAnnotations.initMocks(this);
 
         initializeBridge();
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
-        thingProperties.put(PROPERTY_SENSORCOUNT, "1");
-        thingProperties.put(PROPERTY_VENDOR, "Embedded Data Systems");
-        thingProperties.put(PROPERTY_MODELID, "EDS0064");
-        thingProperties.put(PROPERTY_HW_REVISION, "21");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_TEMPERATURE, "Number:Temperature").build());
         channels.add(ChannelBuilder.create(CHANNEL_UID_HUMIDITY, "Number:Dimensionless").build());
@@ -67,7 +65,7 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
                 .withConfiguration(new Configuration(thingConfiguration)).withProperties(thingProperties)
                 .withBridge(bridge.getUID()).build();
 
-        thingHandler = new BasicMultisensorThingHandler(thing, stateProvider) {
+        thingHandler = new EDSSensorThingHandler(thing, stateProvider) {
             @Override
             protected Bridge getBridge() {
                 return bridge;
@@ -75,6 +73,10 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
         };
 
         initializeHandlerMocks();
+
+        Mockito.doAnswer(answer -> {
+            return new OwPageBuffer("EDS0065 ".getBytes());
+        }).when(secondBridgeHandler).readPages(any());
     }
 
     @Test
@@ -85,7 +87,7 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
     }
 
     @Test
-    public void testRefresh() {
+    public void testRefresh() throws OwException {
         thingHandler.initialize();
 
         // needed to determine initialization is finished
@@ -93,13 +95,9 @@ public class EDSSensorThingHandlerTest extends AbstractThingHandlerTest {
 
         thingHandler.refresh(bridgeHandler, System.currentTimeMillis());
 
-        try {
-            inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
-            inOrder.verify(bridgeHandler, times(3)).readDecimalType(eq(new SensorId(TEST_ID)), any());
+        inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
+        inOrder.verify(bridgeHandler, times(2)).readDecimalType(eq(new SensorId(TEST_ID)), any());
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/IButtonThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/IButtonThingHandlerTest.java
@@ -14,8 +14,12 @@ package org.eclipse.smarthome.binding.onewire.internal;
 
 import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.*;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
+import org.eclipse.smarthome.binding.onewire.internal.OwException;
+import org.eclipse.smarthome.binding.onewire.internal.SensorId;
+import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.binding.onewire.internal.handler.IButtonThingHandler;
 import org.eclipse.smarthome.binding.onewire.test.AbstractThingHandlerTest;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -25,9 +29,9 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -41,14 +45,12 @@ public class IButtonThingHandlerTest extends AbstractThingHandlerTest {
     private static final ChannelUID CHANNEL_UID_PRESENT = new ChannelUID(THING_UID, CHANNEL_PRESENT);
 
     @Before
-    public void setup() {
+    public void setup() throws OwException {
         MockitoAnnotations.initMocks(this);
 
         initializeBridge();
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
-        thingProperties.put(PROPERTY_MODELID, "DS2401");
-        thingProperties.put(PROPERTY_VENDOR, "Dallas/Maxim");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_PRESENT, "Switch").build());
 
@@ -64,6 +66,10 @@ public class IButtonThingHandlerTest extends AbstractThingHandlerTest {
         };
 
         initializeHandlerMocks();
+
+        Mockito.doAnswer(answer -> {
+            return OwSensorType.DS2401;
+        }).when(secondBridgeHandler).getType(any());
     }
 
     @Test
@@ -74,16 +80,12 @@ public class IButtonThingHandlerTest extends AbstractThingHandlerTest {
     }
 
     @Test
-    public void testRefresh() {
+    public void testRefresh() throws OwException {
         thingHandler.initialize();
         thingHandler.refresh(bridgeHandler, System.currentTimeMillis());
-        try {
-            inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
 
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/IButtonThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/IButtonThingHandlerTest.java
@@ -47,9 +47,8 @@ public class IButtonThingHandlerTest extends AbstractThingHandlerTest {
         initializeBridge();
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
-        thingProperties.put(PROPERTY_SENSORCOUNT, "1");
-        thingProperties.put(PROPERTY_MODELID, "UNKNOWN");
-        thingProperties.put(PROPERTY_VENDOR, "generic");
+        thingProperties.put(PROPERTY_MODELID, "DS2401");
+        thingProperties.put(PROPERTY_VENDOR, "Dallas/Maxim");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_PRESENT, "Switch").build());
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/MultisensorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/MultisensorThingHandlerTest.java
@@ -53,7 +53,7 @@ public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
         initializeBridge();
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
-        thingProperties.put(PROPERTY_SENSORCOUNT, "1");
+        thingProperties.put(PROPERTY_VENDOR, "iButtonLink");
         thingProperties.put(PROPERTY_MODELID, "MS_TH");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_TEMPERATURE, "Number:Temperature").build());

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/MultisensorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/MultisensorThingHandlerTest.java
@@ -17,6 +17,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 
+import org.eclipse.smarthome.binding.onewire.internal.OwException;
+import org.eclipse.smarthome.binding.onewire.internal.OwPageBuffer;
+import org.eclipse.smarthome.binding.onewire.internal.SensorId;
+import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.binding.onewire.internal.handler.BasicMultisensorThingHandler;
 import org.eclipse.smarthome.binding.onewire.test.AbstractThingHandlerTest;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -26,9 +30,9 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -47,14 +51,12 @@ public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
     private static final ChannelUID CHANNEL_UID_SUPPLYVOLTAGE = new ChannelUID(THING_UID, CHANNEL_SUPPLYVOLTAGE);
 
     @Before
-    public void setup() {
+    public void setup() throws OwException {
         MockitoAnnotations.initMocks(this);
 
         initializeBridge();
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
-        thingProperties.put(PROPERTY_VENDOR, "iButtonLink");
-        thingProperties.put(PROPERTY_MODELID, "MS_TH");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_TEMPERATURE, "Number:Temperature").build());
         channels.add(ChannelBuilder.create(CHANNEL_UID_HUMIDITY, "Number:Dimensionless").build());
@@ -74,6 +76,16 @@ public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
         };
 
         initializeHandlerMocks();
+
+        Mockito.doAnswer(answer -> {
+            return OwSensorType.DS2438;
+        }).when(secondBridgeHandler).getType(any());
+
+        Mockito.doAnswer(answer -> {
+            OwPageBuffer pageBuffer = new OwPageBuffer(8);
+            pageBuffer.setByte(3, 0, (byte) 0x19);
+            return pageBuffer;
+        }).when(secondBridgeHandler).readPages(any());
     }
 
     @Test
@@ -84,7 +96,7 @@ public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
     }
 
     @Test
-    public void testRefresh() {
+    public void testRefresh() throws OwException {
         thingHandler.initialize();
 
         // needed to determine initialization is finished
@@ -92,13 +104,9 @@ public class MultisensorThingHandlerTest extends AbstractThingHandlerTest {
 
         thingHandler.refresh(bridgeHandler, System.currentTimeMillis());
 
-        try {
-            inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
-            inOrder.verify(bridgeHandler, times(3)).readDecimalType(eq(new SensorId(TEST_ID)), any());
+        inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
+        inOrder.verify(bridgeHandler, times(3)).readDecimalType(eq(new SensorId(TEST_ID)), any());
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/TemperatureSensorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/TemperatureSensorThingHandlerTest.java
@@ -52,9 +52,8 @@ public class TemperatureSensorThingHandlerTest extends AbstractThingHandlerTest 
         initializeBridge();
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
-        thingProperties.put(PROPERTY_SENSORCOUNT, "1");
-        thingProperties.put(PROPERTY_MODELID, "UNKNOWN");
-        thingProperties.put(PROPERTY_VENDOR, "generic");
+        thingProperties.put(PROPERTY_MODELID, "DS18B20");
+        thingProperties.put(PROPERTY_VENDOR, "Dallas/Maxim");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_PRESENT, "Switch").build());
         channels.add(ChannelBuilder.create(CHANNEL_UID_TEMPERATURE, "Number").build());

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/TemperatureSensorThingHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire.test/src/test/java/org/eclipse/smarthome/binding/onewire/internal/TemperatureSensorThingHandlerTest.java
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.times;
 
+import org.eclipse.smarthome.binding.onewire.internal.OwException;
+import org.eclipse.smarthome.binding.onewire.internal.SensorId;
+import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.binding.onewire.internal.handler.TemperatureSensorThingHandler;
 import org.eclipse.smarthome.binding.onewire.test.AbstractThingHandlerTest;
 import org.eclipse.smarthome.config.core.Configuration;
@@ -27,9 +30,9 @@ import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ChannelBuilder;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -46,14 +49,12 @@ public class TemperatureSensorThingHandlerTest extends AbstractThingHandlerTest 
     protected Channel channel;
 
     @Before
-    public void setup() {
+    public void setup() throws OwException {
         MockitoAnnotations.initMocks(this);
 
         initializeBridge();
 
         thingConfiguration.put(CONFIG_ID, TEST_ID);
-        thingProperties.put(PROPERTY_MODELID, "DS18B20");
-        thingProperties.put(PROPERTY_VENDOR, "Dallas/Maxim");
 
         channels.add(ChannelBuilder.create(CHANNEL_UID_PRESENT, "Switch").build());
         channels.add(ChannelBuilder.create(CHANNEL_UID_TEMPERATURE, "Number").build());
@@ -71,6 +72,9 @@ public class TemperatureSensorThingHandlerTest extends AbstractThingHandlerTest 
 
         initializeHandlerMocks();
 
+        Mockito.doAnswer(answer -> {
+            return OwSensorType.DS18B20;
+        }).when(secondBridgeHandler).getType(any());
     }
 
     @Test
@@ -81,18 +85,15 @@ public class TemperatureSensorThingHandlerTest extends AbstractThingHandlerTest 
     }
 
     @Test
-    public void testRefresh() {
+    public void testRefresh() throws OwException {
         thingHandler.initialize();
         waitForAssert(() -> assertEquals(ThingStatus.UNKNOWN, thing.getStatusInfo().getStatus()));
 
         thingHandler.refresh(bridgeHandler, System.currentTimeMillis());
-        try {
-            inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
-            inOrder.verify(bridgeHandler, times(1)).readDecimalType(eq(new SensorId(TEST_ID)), any());
 
-            inOrder.verifyNoMoreInteractions();
-        } catch (OwException e) {
-            Assert.fail("caught unexpected OwException");
-        }
+        inOrder.verify(bridgeHandler, times(1)).checkPresence(new SensorId(TEST_ID));
+        inOrder.verify(bridgeHandler, times(1)).readDecimalType(eq(new SensorId(TEST_ID)), any());
+
+        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/DigitalIO.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/DigitalIO.xml
@@ -14,9 +14,6 @@
 				<label>Digital I/O 0</label>
 			</channel>
 		</channels>
-		<properties>
-			<property name="sensorCount">1</property>
-		</properties>
 		<config-description-ref uri="thing-type:onewire:fastthingconfig" />
 	</thing-type>
 	<thing-type id="digitalio2">
@@ -33,9 +30,6 @@
 				<label>Digital I/O 1</label>
 			</channel>
 		</channels>
-		<properties>
-			<property name="sensorCount">1</property>
-		</properties>
 		<config-description-ref uri="thing-type:onewire:fastthingconfig" />
 	</thing-type>
 	<thing-type id="digitalio8">
@@ -70,9 +64,6 @@
 				<label>Digital I/O 7</label>
 			</channel>
 		</channels>
-		<properties>
-			<property name="sensorCount">1</property>
-		</properties>
 		<config-description-ref uri="thing-type:onewire:fastthingconfig" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/counter.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/counter.xml
@@ -13,9 +13,6 @@
 			<channel id="counter0" typeId="counter" />
 			<channel id="counter1" typeId="counter" />
 		</channels>
-		<properties>
-			<property name="sensorCount">1</property>
-		</properties>
 		<config-description-ref uri="thing-type:onewire:fastthingconfig" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/iButton.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/iButton.xml
@@ -9,9 +9,6 @@
 		<channels>
 			<channel id="present" typeId="present" />
 		</channels>
-		<properties>
-			<property name="sensorCount">1</property>
-		</properties>
 		<config-description-ref uri="thing-type:onewire:basethingconfig" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/multisensor.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/multisensor.xml
@@ -66,12 +66,12 @@
 				<required>true</required>
 			</parameter>
 			<parameter name="refresh" type="integer" min="1">
-                <label>Refresh Time</label>
-                <description>Time in seconds after which the thing is refreshed</description>
-                <default>300</default>
-                <unitLabel>s</unitLabel>
-                <required>false</required>
-            </parameter>
+				<label>Refresh Time</label>
+				<description>Time in seconds after which the thing is refreshed</description>
+				<default>300</default>
+				<unitLabel>s</unitLabel>
+				<required>false</required>
+			</parameter>
 			<parameter name="lightsensor" type="boolean">
 				<label>Ambient light</label>
 				<description>Ambient light connected</description>
@@ -116,13 +116,13 @@
 				<description>Sensor ID of the DS2438 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
 				<required>true</required>
 			</parameter>
-            <parameter name="refresh" type="integer" min="1">
-                <label>Refresh Time for analog channels</label>
-                <description>Time in seconds after which the thing is refreshed</description>
-                <default>300</default>
-                <unitLabel>s</unitLabel>
-                <required>false</required>
-            </parameter>
+			<parameter name="refresh" type="integer" min="1">
+				<label>Refresh Time for analog channels</label>
+				<description>Time in seconds after which the thing is refreshed</description>
+				<default>300</default>
+				<unitLabel>s</unitLabel>
+				<required>false</required>
+			</parameter>
 			<parameter name="lightsensor" type="boolean">
 				<label>Ambient light</label>
 				<description>Ambient light connected</description>

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/multisensor.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/multisensor.xml
@@ -13,9 +13,6 @@
 			<channel id="temperature" typeId="temperature" />
 			<channel id="supplyvoltage" typeId="voltage" />
 		</channels>
-		<properties>
-			<property name="sensorCount">1</property>
-		</properties>
 		<config-description-ref uri="thing-type:onewire:basethingconfig" />
 	</thing-type>
 	<thing-type id="ms-th" listed="false">
@@ -47,9 +44,6 @@
 			<channel id="voltage" typeId="voltage" />
 			<channel id="supplyvoltage" typeId="voltage" />
 		</channels>
-		<properties>
-			<property name="sensorCount">1</property>
-		</properties>
 		<config-description-ref uri="thing-type:onewire:basethingconfig" />
 	</thing-type>
 	<thing-type id="bms">
@@ -65,26 +59,23 @@
 			<channel id="dewpoint" typeId="dewpoint" />
 			<channel id="supplyvoltage" typeId="voltage" />
 		</channels>
-		<properties>
-			<property name="sensorCount">2</property>
-		</properties>
 		<config-description>
 			<parameter name="id" type="text">
 				<label>TH(S) sensor ID</label>
 				<description>Sensor ID of the DS2438 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
 				<required>true</required>
 			</parameter>
+			<parameter name="refresh" type="integer" min="1">
+                <label>Refresh Time</label>
+                <description>Time in seconds after which the thing is refreshed</description>
+                <default>300</default>
+                <unitLabel>s</unitLabel>
+                <required>false</required>
+            </parameter>
 			<parameter name="lightsensor" type="boolean">
 				<label>Ambient light</label>
 				<description>Ambient light connected</description>
 				<default>false</default>
-				<required>false</required>
-			</parameter>
-			<parameter name="refresh" type="integer" min="1">
-				<label>Refresh Time</label>
-				<description>Time in seconds after which the thing is refreshed</description>
-				<default>300</default>
-				<unitLabel>s</unitLabel>
 				<required>false</required>
 			</parameter>
 			<parameter name="temperaturesensor" type="text">
@@ -119,26 +110,23 @@
 				<label>Digital I/O 1</label>
 			</channel>
 		</channels>
-		<properties>
-			<property name="sensorCount">4</property>
-		</properties>
 		<config-description>
 			<parameter name="id" type="text">
 				<label>TH(S) sensor ID</label>
 				<description>Sensor ID of the DS2438 sensor in format: xx.xxxxxxxxxxxx or a full path including hubs/branches</description>
 				<required>true</required>
 			</parameter>
+            <parameter name="refresh" type="integer" min="1">
+                <label>Refresh Time for analog channels</label>
+                <description>Time in seconds after which the thing is refreshed</description>
+                <default>300</default>
+                <unitLabel>s</unitLabel>
+                <required>false</required>
+            </parameter>
 			<parameter name="lightsensor" type="boolean">
 				<label>Ambient light</label>
 				<description>Ambient light connected</description>
 				<default>false</default>
-				<required>false</required>
-			</parameter>
-			<parameter name="refresh" type="integer" min="1">
-				<label>Refresh Time for analog channels</label>
-				<description>Time in seconds after which the thing is refreshed</description>
-				<default>300</default>
-				<unitLabel>s</unitLabel>
 				<required>false</required>
 			</parameter>
 			<parameter name="refreshdigital" type="integer" min="1">

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/temperature.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/ESH-INF/thing/temperature.xml
@@ -6,9 +6,6 @@
 		</supported-bridge-type-refs>
 		<label>Temperature sensor</label>
 		<description>A 1-wire temperature sensor (DS18x20)</description>
-		<properties>
-			<property name="sensorCount">1</property>
-		</properties>
 		<config-description-ref uri="thing-type:onewire:basethingconfig" />
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/discovery/OwDiscoveryItem.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/discovery/OwDiscoveryItem.java
@@ -79,14 +79,14 @@ public class OwDiscoveryItem {
     /**
      * get sensor type
      *
-     * @return full sensor type
+     * @return sensor type
      */
     public OwSensorType getSensorType() {
         return sensorType;
     }
 
     /**
-     * get sensor id (familyId.xxxxxxxxxx)
+     * get this sensor id
      *
      * @return sensor id
      */
@@ -127,48 +127,12 @@ public class OwDiscoveryItem {
     }
 
     /**
-     * check if associated sensors have been found
-     *
-     * @return true if this sensors pages include other sensor ids
-     */
-    public boolean hasAssociatedSensorIds() {
-        return !associatedSensors.isEmpty();
-    }
-
-    /**
      * get a list of all sensors associated to this sensor
      *
      * @return list of strings
      */
     public List<SensorId> getAssociatedSensorIds() {
         return new ArrayList<>(associatedSensors.keySet());
-    }
-
-    /**
-     * check if secondary sensors have been added
-     *
-     * @return true if sensors have been added
-     */
-    public boolean hasAssociatedSensors() {
-        return !associatedSensors.isEmpty();
-    }
-
-    /**
-     * get all secondary sensors
-     *
-     * @return a list of OwDiscoveryItems
-     */
-    public Map<SensorId, OwSensorType> getAssociatedSensors() {
-        return associatedSensors;
-    }
-
-    /**
-     * get the number of secondary sensors
-     *
-     * @return number of sensors
-     */
-    public int getAssociatedSensorCount() {
-        return associatedSensors.size();
     }
 
     /**
@@ -188,7 +152,7 @@ public class OwDiscoveryItem {
     }
 
     /**
-     * get Label "thingtype (id)"
+     * get Label "<thingtype> (<id>)"
      *
      * @return the thing label
      */

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/discovery/OwDiscoveryService.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/discovery/OwDiscoveryService.java
@@ -112,7 +112,6 @@ public class OwDiscoveryService extends AbstractDiscoveryService {
                 Map<String, Object> properties = new HashMap<>();
                 properties.put(PROPERTY_MODELID, owDiscoveryItem.getSensorType().toString());
                 properties.put(PROPERTY_VENDOR, owDiscoveryItem.getVendor());
-                properties.put(PROPERTY_SENSORCOUNT, String.valueOf(owDiscoveryItem.getAssociatedSensorCount() + 1));
                 properties.put(CONFIG_ID, owDiscoveryItem.getSensorId().getFullPath());
 
                 DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingUID).withThingType(thingTypeUID)

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
@@ -36,7 +36,6 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
-import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -77,12 +76,6 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
         Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
-            return;
-        }
-
-        ThingStatusInfo statusInfo = getThing().getStatusInfo();
-        if (statusInfo.getStatus() == ThingStatus.OFFLINE
-                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
@@ -97,9 +97,7 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
 
         // add sensors
 
-        sensors.add(new DS2438(sensorIds.get(0), this));
         sensors.add(new DS18x20(new SensorId(properties.get(PROPERTY_DS18B20)), this));
-
         if (THING_TYPE_AMS.equals(thingType)) {
             sensors.add(new DS2438(new SensorId(properties.get(PROPERTY_DS2438)), this));
             sensors.add(new DS2406_DS2413(new SensorId(properties.get(PROPERTY_DS2413)), this));
@@ -137,11 +135,11 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
                 lastRefresh = now;
 
                 if (thingType.equals(THING_TYPE_AMS)) {
-                    for (int i = 0; i < sensorCount - 1; i++) {
+                    for (int i = 0; i < sensors.size() - 1; i++) {
                         sensors.get(i).refresh(bridgeHandler, forcedRefresh);
                     }
                 } else {
-                    for (int i = 0; i < sensorCount; i++) {
+                    for (int i = 0; i < sensors.size(); i++) {
                         sensors.get(i).refresh(bridgeHandler, forcedRefresh);
                     }
                 }
@@ -227,7 +225,7 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
         updateThing(thingBuilder.build());
 
         try {
-            for (int i = 0; i < sensorCount; i++) {
+            for (int i = 0; i < sensors.size(); i++) {
                 sensors.get(i).configureChannels();
             }
         } catch (OwException e) {
@@ -242,7 +240,7 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
     @Override
     public Map<String, String> updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
         Map<String, String> properties = new HashMap<String, String>();
-        DS2438Configuration ds2438configuration = new DS2438Configuration(bridgeHandler, sensorIds.get(0));
+        DS2438Configuration ds2438configuration = new DS2438Configuration(bridgeHandler, sensorId);
 
         sensorType = DS2438Configuration.getMultisensorType(ds2438configuration.getSensorSubType(),
                 ds2438configuration.getAssociatedSensorTypes());

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/AdvancedMultisensorThingHandler.java
@@ -16,10 +16,13 @@ import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.DS2438Configuration;
@@ -51,23 +54,31 @@ import org.slf4j.LoggerFactory;
 public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
             Arrays.asList(THING_TYPE_AMS, THING_TYPE_BMS));
+    public static final Set<OwSensorType> SUPPORTED_SENSOR_TYPES = Collections
+            .unmodifiableSet(Stream.of(OwSensorType.AMS, OwSensorType.AMS_S, OwSensorType.BMS, OwSensorType.BMS_S)
+                    .collect(Collectors.toSet()));
 
     private static final String PROPERTY_DS18B20 = "ds18b20";
     private static final String PROPERTY_DS2413 = "ds2413";
     private static final String PROPERTY_DS2438 = "ds2438";
+    private static final Set<String> REQUIRED_PROPERTIES_AMS = Collections.unmodifiableSet(
+            Stream.of(PROPERTY_HW_REVISION, PROPERTY_PROD_DATE, PROPERTY_DS18B20, PROPERTY_DS2438, PROPERTY_DS2413)
+                    .collect(Collectors.toSet()));
+    private static final Set<String> REQUIRED_PROPERTIES_BMS = Collections.unmodifiableSet(
+            Stream.of(PROPERTY_HW_REVISION, PROPERTY_PROD_DATE, PROPERTY_DS18B20).collect(Collectors.toSet()));
 
     private final Logger logger = LoggerFactory.getLogger(AdvancedMultisensorThingHandler.class);
 
     private final ThingTypeUID thingType = this.thing.getThingTypeUID();
     private int hwRevision = 0;
-    private OwSensorType sensorType = OwSensorType.UNKNOWN;
 
     private int digitalRefreshInterval = 10 * 1000;
     private long digitalLastRefresh = 0;
 
     public AdvancedMultisensorThingHandler(Thing thing,
             OwDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
-        super(thing, dynamicStateDescriptionProvider);
+        super(thing, dynamicStateDescriptionProvider, SUPPORTED_SENSOR_TYPES,
+                getRequiredProperties(thing.getThingTypeUID()));
     }
 
     @Override
@@ -79,6 +90,8 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
             return;
         }
 
+        hwRevision = Integer.valueOf(properties.get(PROPERTY_HW_REVISION));
+
         if (configuration.containsKey(CONFIG_DIGITALREFRESH)) {
             digitalRefreshInterval = ((BigDecimal) configuration.get(CONFIG_DIGITALREFRESH)).intValue() * 1000;
         } else {
@@ -86,17 +99,7 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
         }
         digitalLastRefresh = 0;
 
-        if (!properties.containsKey(PROPERTY_MODELID) || !properties.containsKey(PROPERTY_PROD_DATE)
-                || !properties.containsKey(PROPERTY_HW_REVISION) || !properties.containsKey(PROPERTY_DS18B20)) {
-            updateSensorProperties();
-            return;
-        } else {
-            sensorType = OwSensorType.valueOf(properties.get(PROPERTY_MODELID));
-            hwRevision = Integer.valueOf(properties.get(PROPERTY_HW_REVISION));
-        }
-
-        // add sensors
-
+        sensors.add(new DS2438(sensorId, this));
         sensors.add(new DS18x20(new SensorId(properties.get(PROPERTY_DS18B20)), this));
         if (THING_TYPE_AMS.equals(thingType)) {
             sensors.add(new DS2438(new SensorId(properties.get(PROPERTY_DS2438)), this));
@@ -272,5 +275,19 @@ public class AdvancedMultisensorThingHandler extends OwBaseThingHandler {
         }
 
         return properties;
+    }
+
+    /**
+     * used to determine the correct set of required properties
+     *
+     * @param thingType
+     * @return
+     */
+    private static Set<String> getRequiredProperties(ThingTypeUID thingType) {
+        if (THING_TYPE_AMS.equals(thingType)) {
+            return REQUIRED_PROPERTIES_AMS;
+        } else {
+            return REQUIRED_PROPERTIES_BMS;
+        }
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
@@ -14,11 +14,12 @@ package org.eclipse.smarthome.binding.onewire.internal.handler;
 
 import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.*;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.DS2438Configuration;
@@ -35,8 +36,6 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The {@link BasicMultisensorThingHandler} is responsible for handling DS2438/DS1923 based multisensors (single
@@ -46,15 +45,15 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class BasicMultisensorThingHandler extends OwBaseThingHandler {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_MS_TX, THING_TYPE_MS_TH, THING_TYPE_MS_TV));
-
-    private final Logger logger = LoggerFactory.getLogger(BasicMultisensorThingHandler.class);
-    private OwSensorType sensorType = OwSensorType.UNKNOWN;
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(
+            Stream.of(THING_TYPE_MS_TX, THING_TYPE_MS_TH, THING_TYPE_MS_TV).collect(Collectors.toSet()));
+    public static final Set<OwSensorType> SUPPORTED_SENSOR_TYPES = Collections
+            .unmodifiableSet(Stream.of(OwSensorType.MS_TH, OwSensorType.MS_TC, OwSensorType.MS_TL, OwSensorType.MS_TV,
+                    OwSensorType.DS1923, OwSensorType.DS2438).collect(Collectors.toSet()));
 
     public BasicMultisensorThingHandler(Thing thing,
             OwDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
-        super(thing, dynamicStateDescriptionProvider);
+        super(thing, dynamicStateDescriptionProvider, SUPPORTED_SENSOR_TYPES);
     }
 
     @Override
@@ -63,17 +62,9 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
             changeThingType(THING_TYPE_MS_TX, getConfig());
         }
 
-        Map<String, String> properties = editProperties();
-
         if (!super.configure()) {
             return;
         }
-
-        if (!properties.containsKey(PROPERTY_MODELID)) {
-            updateSensorProperties();
-            return;
-        }
-        sensorType = OwSensorType.valueOf(properties.get(PROPERTY_MODELID));
 
         // add sensors
         if (sensorType == OwSensorType.DS1923) {

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
@@ -32,7 +32,6 @@ import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
-import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -67,12 +66,6 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
         Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
-            return;
-        }
-
-        ThingStatusInfo statusInfo = getThing().getStatusInfo();
-        if (statusInfo.getStatus() == ThingStatus.OFFLINE
-                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/BasicMultisensorThingHandler.java
@@ -77,9 +77,9 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
 
         // add sensors
         if (sensorType == OwSensorType.DS1923) {
-            sensors.add(new DS1923(sensorIds.get(0), this));
+            sensors.add(new DS1923(sensorId, this));
         } else {
-            sensors.add(new DS2438(sensorIds.get(0), this));
+            sensors.add(new DS2438(sensorId, this));
         }
 
         scheduler.execute(() -> {
@@ -186,13 +186,13 @@ public class BasicMultisensorThingHandler extends OwBaseThingHandler {
     @Override
     public Map<String, String> updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
         Map<String, String> properties = new HashMap<String, String>();
-        sensorType = bridgeHandler.getType(sensorIds.get(0));
+        sensorType = bridgeHandler.getType(sensorId);
 
         if (sensorType == OwSensorType.DS1923) {
             properties.put(PROPERTY_MODELID, sensorType.toString());
             properties.put(PROPERTY_VENDOR, "Dallas/Maxim");
         } else {
-            DS2438Configuration ds2438configuration = new DS2438Configuration(bridgeHandler, sensorIds.get(0));
+            DS2438Configuration ds2438configuration = new DS2438Configuration(bridgeHandler, sensorId);
 
             sensorType = ds2438configuration.getSensorSubType();
             properties.put(PROPERTY_MODELID, sensorType.toString());

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/CounterSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/CounterSensorThingHandler.java
@@ -26,7 +26,6 @@ import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
-import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -48,12 +47,6 @@ public class CounterSensorThingHandler extends OwBaseThingHandler {
         Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
-            return;
-        }
-
-        ThingStatusInfo statusInfo = getThing().getStatusInfo();
-        if (statusInfo.getStatus() == ThingStatus.OFFLINE
-                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/CounterSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/CounterSensorThingHandler.java
@@ -54,7 +54,7 @@ public class CounterSensorThingHandler extends OwBaseThingHandler {
             updateSensorProperties();
         }
 
-        sensors.add(new DS2423(sensorIds.get(0), this));
+        sensors.add(new DS2423(sensorId, this));
 
         try {
             sensors.get(0).configureChannels();

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/CounterSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/CounterSensorThingHandler.java
@@ -15,13 +15,13 @@ package org.eclipse.smarthome.binding.onewire.internal.handler;
 import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.*;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.OwDynamicStateDescriptionProvider;
 import org.eclipse.smarthome.binding.onewire.internal.OwException;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2423;
+import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -36,22 +36,18 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 @NonNullByDefault
 public class CounterSensorThingHandler extends OwBaseThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_COUNTER2);
+    public static final Set<OwSensorType> SUPPORTED_SENSOR_TYPES = Collections.singleton(OwSensorType.DS2423);
 
     public CounterSensorThingHandler(Thing thing, OwDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
-        super(thing, dynamicStateDescriptionProvider);
+        super(thing, dynamicStateDescriptionProvider, SUPPORTED_SENSOR_TYPES);
     }
 
     @Override
     public void initialize() {
         Configuration configuration = getConfig();
-        Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
             return;
-        }
-
-        if (!properties.containsKey(PROPERTY_MODELID)) {
-            updateSensorProperties();
         }
 
         sensors.add(new DS2423(sensorId, this));

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/DigitalIOThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/DigitalIOThingHandler.java
@@ -93,11 +93,11 @@ public class DigitalIOThingHandler extends OwBaseThingHandler {
         }
 
         if (this.thing.getThingTypeUID().equals(THING_TYPE_DIGITALIO)) {
-            sensors.add(new DS2405(sensorIds.get(0), this));
+            sensors.add(new DS2405(sensorId, this));
         } else if (this.thing.getThingTypeUID().equals(THING_TYPE_DIGITALIO2)) {
-            sensors.add(new DS2406_DS2413(sensorIds.get(0), this));
+            sensors.add(new DS2406_DS2413(sensorId, this));
         } else if (this.thing.getThingTypeUID().equals(THING_TYPE_DIGITALIO8)) {
-            sensors.add(new DS2408(sensorIds.get(0), this));
+            sensors.add(new DS2408(sensorId, this));
         }
 
         // sensor configuration

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/DigitalIOThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/DigitalIOThingHandler.java
@@ -33,7 +33,6 @@ import org.eclipse.smarthome.core.thing.ChannelUID;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
-import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.types.Command;
 import org.slf4j.Logger;
@@ -86,12 +85,6 @@ public class DigitalIOThingHandler extends OwBaseThingHandler {
         Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
-            return;
-        }
-
-        ThingStatusInfo statusInfo = getThing().getStatusInfo();
-        if (statusInfo.getStatus() == ThingStatus.OFFLINE
-                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/DigitalIOThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/DigitalIOThingHandler.java
@@ -14,10 +14,10 @@ package org.eclipse.smarthome.binding.onewire.internal.handler;
 
 import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.*;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Map;
+import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.OwDynamicStateDescriptionProvider;
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.binding.onewire.internal.device.AbstractDigitalOwDe
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2405;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2406_DS2413;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2408;
+import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.library.types.OnOffType;
 import org.eclipse.smarthome.core.thing.Bridge;
@@ -45,13 +46,16 @@ import org.slf4j.LoggerFactory;
  */
 @NonNullByDefault
 public class DigitalIOThingHandler extends OwBaseThingHandler {
-    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = new HashSet<>(
-            Arrays.asList(THING_TYPE_DIGITALIO, THING_TYPE_DIGITALIO2, THING_TYPE_DIGITALIO8));
+    public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.unmodifiableSet(
+            Stream.of(THING_TYPE_DIGITALIO, THING_TYPE_DIGITALIO2, THING_TYPE_DIGITALIO8).collect(Collectors.toSet()));
+    public static final Set<OwSensorType> SUPPORTED_SENSOR_TYPES = Collections.unmodifiableSet(
+            Stream.of(OwSensorType.DS2405, OwSensorType.DS2406, OwSensorType.DS2408, OwSensorType.DS2413)
+                    .collect(Collectors.toSet()));
 
     private final Logger logger = LoggerFactory.getLogger(DigitalIOThingHandler.class);
 
     public DigitalIOThingHandler(Thing thing, OwDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
-        super(thing, dynamicStateDescriptionProvider);
+        super(thing, dynamicStateDescriptionProvider, SUPPORTED_SENSOR_TYPES);
     }
 
     @Override
@@ -82,14 +86,9 @@ public class DigitalIOThingHandler extends OwBaseThingHandler {
     @Override
     public void initialize() {
         Configuration configuration = getConfig();
-        Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
             return;
-        }
-
-        if (!properties.containsKey(PROPERTY_MODELID)) {
-            updateSensorProperties();
         }
 
         if (this.thing.getThingTypeUID().equals(THING_TYPE_DIGITALIO)) {

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/EDSSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/EDSSensorThingHandler.java
@@ -31,7 +31,6 @@ import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
-import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 import org.eclipse.smarthome.core.types.UnDefType;
@@ -63,12 +62,6 @@ public class EDSSensorThingHandler extends OwBaseThingHandler {
         Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
-            return;
-        }
-
-        ThingStatusInfo statusInfo = getThing().getStatusInfo();
-        if (statusInfo.getStatus() == ThingStatus.OFFLINE
-                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/EDSSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/EDSSensorThingHandler.java
@@ -66,7 +66,7 @@ public class EDSSensorThingHandler extends OwBaseThingHandler {
         }
 
         // add sensors
-        sensors.add(new EDS006x(sensorIds.get(0), this));
+        sensors.add(new EDS006x(sensorId, this));
 
         // check sensors
         if (!properties.containsKey(PROPERTY_MODELID)) {
@@ -160,7 +160,7 @@ public class EDSSensorThingHandler extends OwBaseThingHandler {
     public Map<String, String> updateSensorProperties(OwBaseBridgeHandler bridgeHandler) throws OwException {
         Map<String, String> properties = new HashMap<String, String>();
 
-        OwPageBuffer pages = bridgeHandler.readPages(sensorIds.get(0));
+        OwPageBuffer pages = bridgeHandler.readPages(sensorId);
 
         OwSensorType sensorType = OwSensorType.UNKNOWN;
         try {

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/EDSSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/EDSSensorThingHandler.java
@@ -45,22 +45,19 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class EDSSensorThingHandler extends OwBaseThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_EDS_ENV);
-    private static final Set<OwSensorType> SUPPORTED_SENSOR_TYPES = Collections
+    public static final Set<OwSensorType> SUPPORTED_SENSOR_TYPES = Collections
             .unmodifiableSet(Stream.of(OwSensorType.EDS0064, OwSensorType.EDS0065, OwSensorType.EDS0066,
                     OwSensorType.EDS0067, OwSensorType.EDS0068).collect(Collectors.toSet()));
+    private static final Set<String> REQUIRED_PROPERTIES = Collections.singleton(PROPERTY_HW_REVISION);
 
     private final Logger logger = LoggerFactory.getLogger(EDSSensorThingHandler.class);
 
-    private OwSensorType sensorType = OwSensorType.UNKNOWN;
-
     public EDSSensorThingHandler(Thing thing, OwDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
-        super(thing, dynamicStateDescriptionProvider);
+        super(thing, dynamicStateDescriptionProvider, SUPPORTED_SENSOR_TYPES, REQUIRED_PROPERTIES);
     }
 
     @Override
     public void initialize() {
-        Map<String, String> properties = editProperties();
-
         if (!super.configure()) {
             return;
         }
@@ -68,14 +65,7 @@ public class EDSSensorThingHandler extends OwBaseThingHandler {
         // add sensors
         sensors.add(new EDS006x(sensorId, this));
 
-        // check sensors
-        if (!properties.containsKey(PROPERTY_MODELID)) {
-            updateSensorProperties();
-            return;
-        } else {
-            sensorType = OwSensorType.valueOf(properties.get(PROPERTY_MODELID));
-            ((EDS006x) sensors.get(0)).configureChannels(sensorType);
-        }
+        ((EDS006x) sensors.get(0)).configureChannels(sensorType);
 
         scheduler.execute(() -> {
             configureThingChannels();

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/IButtonThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/IButtonThingHandler.java
@@ -15,12 +15,14 @@ package org.eclipse.smarthome.binding.onewire.internal.handler;
 import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.*;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.OwDynamicStateDescriptionProvider;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS2401;
+import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -35,22 +37,19 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
 @NonNullByDefault
 public class IButtonThingHandler extends OwBaseThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_IBUTTON);
+    public static final Set<OwSensorType> SUPPORTED_SENSOR_TYPES = Collections
+            .unmodifiableSet(Stream.of(OwSensorType.DS1420, OwSensorType.DS2401).collect(Collectors.toSet()));
 
     public IButtonThingHandler(Thing thing, OwDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
-        super(thing, dynamicStateDescriptionProvider);
+        super(thing, dynamicStateDescriptionProvider, SUPPORTED_SENSOR_TYPES);
     }
 
     @Override
     public void initialize() {
         Configuration configuration = getConfig();
-        Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
             return;
-        }
-
-        if (!properties.containsKey(PROPERTY_MODELID)) {
-            updateSensorProperties();
         }
 
         sensors.add(new DS2401(sensorId, this));

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/IButtonThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/IButtonThingHandler.java
@@ -25,7 +25,6 @@ import org.eclipse.smarthome.config.core.Configuration;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
-import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 
 /**
@@ -47,12 +46,6 @@ public class IButtonThingHandler extends OwBaseThingHandler {
         Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
-            return;
-        }
-
-        ThingStatusInfo statusInfo = getThing().getStatusInfo();
-        if (statusInfo.getStatus() == ThingStatus.OFFLINE
-                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/IButtonThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/IButtonThingHandler.java
@@ -53,7 +53,7 @@ public class IButtonThingHandler extends OwBaseThingHandler {
             updateSensorProperties();
         }
 
-        sensors.add(new DS2401(sensorIds.get(0), this));
+        sensors.add(new DS2401(sensorId, this));
 
         if (configuration.get(CONFIG_REFRESH) == null) {
             // override default of 300s from base thing handler if no user-defined value is present

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/TemperatureSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/TemperatureSensorThingHandler.java
@@ -51,7 +51,7 @@ public class TemperatureSensorThingHandler extends OwBaseThingHandler {
             return;
         }
 
-        sensors.add(new DS18x20(sensorIds.get(0), this));
+        sensors.add(new DS18x20(sensorId, this));
 
         if (!properties.containsKey(PROPERTY_MODELID)) {
             updateSensorProperties();

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/TemperatureSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/TemperatureSensorThingHandler.java
@@ -17,11 +17,14 @@ import static org.eclipse.smarthome.binding.onewire.internal.OwBindingConstants.
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.smarthome.binding.onewire.internal.OwDynamicStateDescriptionProvider;
 import org.eclipse.smarthome.binding.onewire.internal.OwException;
 import org.eclipse.smarthome.binding.onewire.internal.device.DS18x20;
+import org.eclipse.smarthome.binding.onewire.internal.device.OwSensorType;
 import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
@@ -37,29 +40,26 @@ import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 @NonNullByDefault
 public class TemperatureSensorThingHandler extends OwBaseThingHandler {
     public static final Set<ThingTypeUID> SUPPORTED_THING_TYPES = Collections.singleton(THING_TYPE_TEMPERATURE);
+    public static final Set<OwSensorType> SUPPORTED_SENSOR_TYPES = Collections.unmodifiableSet(
+            Stream.of(OwSensorType.DS18B20, OwSensorType.DS18S20, OwSensorType.DS1822).collect(Collectors.toSet()));
 
     public TemperatureSensorThingHandler(Thing thing,
             OwDynamicStateDescriptionProvider dynamicStateDescriptionProvider) {
-        super(thing, dynamicStateDescriptionProvider);
+        super(thing, dynamicStateDescriptionProvider, SUPPORTED_SENSOR_TYPES);
     }
 
     @Override
     public void initialize() {
-        Map<String, String> properties = editProperties();
-
         if (!super.configure()) {
             return;
         }
 
         sensors.add(new DS18x20(sensorId, this));
 
-        if (!properties.containsKey(PROPERTY_MODELID)) {
-            updateSensorProperties();
-        } else {
-            scheduler.execute(() -> {
-                configureThingChannels();
-            });
-        }
+        scheduler.execute(() -> {
+            configureThingChannels();
+        });
+
     }
 
     private void configureThingChannels() {

--- a/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/TemperatureSensorThingHandler.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.onewire/src/main/java/org/eclipse/smarthome/binding/onewire/internal/handler/TemperatureSensorThingHandler.java
@@ -26,7 +26,6 @@ import org.eclipse.smarthome.core.thing.Channel;
 import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingStatus;
 import org.eclipse.smarthome.core.thing.ThingStatusDetail;
-import org.eclipse.smarthome.core.thing.ThingStatusInfo;
 import org.eclipse.smarthome.core.thing.ThingTypeUID;
 import org.eclipse.smarthome.core.thing.binding.builder.ThingBuilder;
 
@@ -49,12 +48,6 @@ public class TemperatureSensorThingHandler extends OwBaseThingHandler {
         Map<String, String> properties = editProperties();
 
         if (!super.configure()) {
-            return;
-        }
-
-        ThingStatusInfo statusInfo = getThing().getStatusInfo();
-        if (statusInfo.getStatus() == ThingStatus.OFFLINE
-                && statusInfo.getStatusDetail() == ThingStatusDetail.CONFIGURATION_ERROR) {
             return;
         }
 


### PR DESCRIPTION
This adds some checks if sensor type and thing type are compüatible and simplfies initialization code. Except from better error handling this is fully transparent to the user.

I have left my individual commits in place for easier review.