### PR TITLE
Fixed possible NPE in FirmwareUpdateService

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
@@ -341,8 +341,10 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
                 } catch (Exception e) {
                     logger.error("Exception occurred during background firmware transfer.", e);
                     synchronized (this) {
-                        // restore previous firmware status info in order that transfer can be re-triggered
-                        firmwareStatusInfoMap.put(fubtHandler.getThing().getUID(), previousFirmwareStatusInfo);
+                        if (previousFirmwareStatusInfo != null) {
+                            // restore previous firmware status info in order that transfer can be re-triggered
+                            firmwareStatusInfoMap.put(fubtHandler.getThing().getUID(), previousFirmwareStatusInfo);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Basically, the method `private synchronized void processFirmwareStatusInfo(FirmwareUpdateHandler firmwareUpdateHandler, FirmwareStatusInfo newFirmwareStatusInfo, @Nullable Firmware latestFirmware)` performs the following operation:

```java
FirmwareStatusInfo previousFirmwareStatusInfo = firmwareStatusInfoMap.put(newFirmwareStatusInfo.getThingUID(), newFirmwareStatusInfo);
```

However, since `put(...)` returns the previous value associated with key, during the first time we set the value for the exact thing UID `previousFirmwareStatusInfo` is effectively assigned `null`. 

Further ahead,`processFirmwareStatusInfo(...)` calls `private void transferLatestFirmware(final FirmwareUpdateBackgroundTransferHandler fubtHandler, final Firmware latestFirmware, final FirmwareStatusInfo previousFirmwareStatusInfo)`, inside which the following operation is performed:

```java
firmwareStatusInfoMap.put(fubtHandler.getThing().getUID(), previousFirmwareStatusInfo);
```

This, in case `previousFirmwareStatusInfo` is `null` directly throws a NPE, since `null` values cannot go in a `ConcurrentHashMap`:

```java
java.lang.NullPointerException
     at java.util.concurrent.ConcurrentHashMap.putVal(Unknown Source)
     at java.util.concurrent.ConcurrentHashMap.put(Unknown Source)
     at org.eclipse.smarthome.core.thing.internal.firmware.FirmwareUpdateServiceImpl$2.run(FirmwareUpdateServiceImpl.java:345)
     at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
     at java.util.concurrent.FutureTask.run(Unknown Source)
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(Unknown Source)
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
     at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
     at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
     at java.lang.Thread.run(Unknown Source)
``` 

In order to prevent this, a simple non-null check is added.