### PR TITLE
Extend usb serial discovery service to contain product ID …

### DIFF
--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.test/src/test/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryServiceTest.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial.test/src/test/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryServiceTest.java
@@ -22,8 +22,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.Map;
 
 import org.eclipse.smarthome.config.discovery.DiscoveryListener;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
@@ -36,6 +38,7 @@ import org.eclipse.smarthome.core.thing.ThingUID;
 import org.eclipse.smarthome.test.java.JavaOSGiTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
@@ -135,16 +138,29 @@ public class UsbSerialDiscoveryServiceTest extends JavaOSGiTest {
         // when only the first discovery participant supports a newly discovered device, the device is discovered
         UsbSerialDeviceInformation deviceInfoA = generateDeviceInfo();
         DiscoveryResult discoveryResultA = mock(DiscoveryResult.class);
+        when(discoveryResultA.getThingUID()).thenReturn(new ThingUID("mock:thing:uida"));
+        when(discoveryResultA.getTimeToLive()).thenReturn(10L);
         when(discoveryParticipantA.createResult(deviceInfoA)).thenReturn(discoveryResultA);
         usbSerialDiscoveryService.usbSerialDeviceDiscovered(deviceInfoA);
-        verify(discoveryListener, times(1)).thingDiscovered(usbSerialDiscoveryService, discoveryResultA);
+        ArgumentCaptor<DiscoveryResult> captor = ArgumentCaptor.forClass(DiscoveryResult.class);
+        verify(discoveryListener, times(1)).thingDiscovered(eq(usbSerialDiscoveryService), captor.capture());
+        DiscoveryResult actualDiscoveryResultA = captor.getValue();
+        assertThat(actualDiscoveryResultA.getProperties(),
+                is(createUsbPropertiesMap(discoveryResultA.getProperties(), deviceInfoA)));
+        reset(discoveryListener);
+
 
         // when only the second discovery participant supports a newly discovered device, the device is also discovered
         UsbSerialDeviceInformation deviceInfoB = generateDeviceInfo();
         DiscoveryResult discoveryResultB = mock(DiscoveryResult.class);
-        when(discoveryParticipantA.createResult(deviceInfoB)).thenReturn(discoveryResultB);
+        when(discoveryResultB.getThingUID()).thenReturn(new ThingUID("mock:thing:uidb"));
+        when(discoveryResultB.getTimeToLive()).thenReturn(10L);
+        when(discoveryParticipantB.createResult(deviceInfoB)).thenReturn(discoveryResultB);
         usbSerialDiscoveryService.usbSerialDeviceDiscovered(deviceInfoB);
-        verify(discoveryListener, times(1)).thingDiscovered(usbSerialDiscoveryService, discoveryResultB);
+        verify(discoveryListener, times(1)).thingDiscovered(eq(usbSerialDiscoveryService), captor.capture());
+        DiscoveryResult actualDiscoveryResultB = captor.getValue();
+        assertThat(actualDiscoveryResultB.getProperties(),
+                is(createUsbPropertiesMap(discoveryResultB.getProperties(), deviceInfoB)));
     }
 
     @Test
@@ -209,4 +225,11 @@ public class UsbSerialDiscoveryServiceTest extends JavaOSGiTest {
         return usbSerialDeviceInformationGenerator.generate();
     }
 
+    private Map<String, Object> createUsbPropertiesMap(Map<String, Object> properties,
+            UsbSerialDeviceInformation usbSerialDeviceInformation) {
+        Map<String, Object> resultProperties = new HashMap<>(properties);
+        resultProperties.put("usb_vendor_id", usbSerialDeviceInformation.getVendorId());
+        resultProperties.put("usb_product_id", usbSerialDeviceInformation.getProductId());
+        return resultProperties;
+    }
 }

--- a/bundles/config/org.eclipse.smarthome.config.discovery.usbserial/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
+++ b/bundles/config/org.eclipse.smarthome.config.discovery.usbserial/src/main/java/org/eclipse/smarthome/config/discovery/usbserial/internal/UsbSerialDiscoveryService.java
@@ -14,6 +14,7 @@ package org.eclipse.smarthome.config.discovery.usbserial.internal;
 
 import static java.util.stream.Collectors.toSet;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -23,6 +24,7 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
 import org.eclipse.smarthome.config.discovery.DiscoveryService;
 import org.eclipse.smarthome.config.discovery.usbserial.UsbSerialDeviceInformation;
 import org.eclipse.smarthome.config.discovery.usbserial.UsbSerialDiscovery;
@@ -63,6 +65,9 @@ import org.slf4j.LoggerFactory;
         UsbSerialDiscoveryService.class }, configurationPid = "discovery.usbserial")
 public class UsbSerialDiscoveryService extends AbstractDiscoveryService implements UsbSerialDiscoveryListener {
 
+    private static final String THING_PROPERTY_USB_VENDOR_ID = "usb_vendor_id";
+    private static final String THING_PROPERTY_USB_PRODUCT_ID = "usb_product_id";
+
     private final Logger logger = LoggerFactory.getLogger(UsbSerialDiscoveryService.class);
 
     private final Set<UsbSerialDiscoveryParticipant> discoveryParticipants = new CopyOnWriteArraySet<>();
@@ -100,7 +105,7 @@ public class UsbSerialDiscoveryService extends AbstractDiscoveryService implemen
         for (UsbSerialDeviceInformation usbSerialDeviceInformation : previouslyDiscovered) {
             DiscoveryResult result = participant.createResult(usbSerialDeviceInformation);
             if (result != null) {
-                thingDiscovered(result);
+                thingDiscovered(createDiscoveryResultWithUsbProperties(result, usbSerialDeviceInformation));
             }
         }
     }
@@ -162,7 +167,7 @@ public class UsbSerialDiscoveryService extends AbstractDiscoveryService implemen
         for (UsbSerialDiscoveryParticipant participant : discoveryParticipants) {
             DiscoveryResult result = participant.createResult(usbSerialDeviceInformation);
             if (result != null) {
-                thingDiscovered(result);
+                thingDiscovered(createDiscoveryResultWithUsbProperties(result, usbSerialDeviceInformation));
             }
         }
     }
@@ -179,4 +184,19 @@ public class UsbSerialDiscoveryService extends AbstractDiscoveryService implemen
         }
     }
 
+    private DiscoveryResult createDiscoveryResultWithUsbProperties(DiscoveryResult result,
+            UsbSerialDeviceInformation usbSerialDeviceInformation) {
+        Map<String, Object> resultProperties = new HashMap<>(result.getProperties());
+        resultProperties.put(THING_PROPERTY_USB_VENDOR_ID, usbSerialDeviceInformation.getVendorId());
+        resultProperties.put(THING_PROPERTY_USB_PRODUCT_ID, usbSerialDeviceInformation.getProductId());
+
+        return DiscoveryResultBuilder.create(result.getThingUID())
+                .withProperties(resultProperties)
+                .withBridge(result.getBridgeUID())
+                .withTTL(result.getTimeToLive())
+                .withLabel(result.getLabel())
+                .withRepresentationProperty(result.getRepresentationProperty())
+                .build();
+
+    }
 }


### PR DESCRIPTION
For better differentiation between different USB devices `UsbSerialDiscoveryService` is extended to add `usb_vendor_id` and `usb_product_id` properties to every thing which represents USB device. 
Signed-off-by: YordanDZhelev <zhelev.yordan@gmail.com>