### PR TITLE
Fixed possible stop of FW update execution if exception is present 

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/firmware/FirmwareUpdateServiceImpl.java
@@ -341,8 +341,10 @@ public final class FirmwareUpdateServiceImpl implements FirmwareUpdateService, E
                 } catch (Exception e) {
                     logger.error("Exception occurred during background firmware transfer.", e);
                     synchronized (this) {
-                        if (previousFirmwareStatusInfo != null) {
-                            // restore previous firmware status info in order that transfer can be re-triggered
+                        // restore previous firmware status info in order that transfer can be re-triggered
+                        if (previousFirmwareStatusInfo == null) {
+                            firmwareStatusInfoMap.remove(fubtHandler.getThing().getUID());
+                        } else {
                             firmwareStatusInfoMap.put(fubtHandler.getThing().getUID(), previousFirmwareStatusInfo);
                         }
                     }


### PR DESCRIPTION
@kaikreuzer This pull request is a continuation of PR #6859.

Basically, #6859 fixed a possible NPE, but didn't provide a fix for the issue that if an exception occurs the firmware transfer may never continue. Here's the reason why:

Inside `processFirmwareStatusInfo(...)` the following statement is declared:
  
```
 FirmwareStatusInfo previousFirmwareStatusInfo firmwareStatusInfoMap.put(newFirmwareStatusInfo.getThingUID(), newFirmwareStatusInfo);
```
On one hand, during the first time we set the value for the exact thing UID `previousFirmwareStatusInfo` is effectively assigned null. On the other hand, however, the value of `newFirmwareStatusInfo` for the current thing UID is added to the `firmwareStatusInfoMap`.

Then, inside `transferLatestFirmware(...)`, if an exception occurs, `firmwareStatusInfoMap` is not changed, because `previousFirmwareStatusInfo` is `null`, but at the same time it contains a value of `newFirmwareStatusInfo` for the current thing UID. Further ahead, e.g. after some time `processFirmwareStatusInfo(...)` is called again with the same value for `newFirmwareStatusInfo`, but the check `previousFirmwareStatusInfo == null || !previousFirmwareStatusInfo.equals(newFirmwareStatusInfo)` is not fulfilled, because `previousFirmwareStatusInfo` equals `newFirmwareStatusInfo` and is not `null`. In this situation, the code that is responsible for transferring the firmware is never executed and the update hangs on.

In order to prevent this, the change done in #6859 is now extended to remove the stored value for the current thing UID from `firmwareStatusInfoMap` if in case of an exception the `previousFirmwareStatusInfo` is `null`.
