### PR TITLE
Update children of disabled bridge to UNINITIALIZED/BRIDGE_UNINITIALIZED

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -1248,6 +1248,20 @@ public class ThingManagerImpl
                 // Only set the correct status to the thing. There is no handler to be disposed
                 setThingStatus(thing, buildStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.DISABLED));
             }
+
+            if (isBridge(thing)) {
+                updateChildThingStatusForDisabledBridges((Bridge) thing);
+            }
+        }
+    }
+
+    private void updateChildThingStatusForDisabledBridges(Bridge bridge) {
+        for (Thing childThing : bridge.getThings()) {
+            ThingStatusDetail statusDetail = childThing.getStatusInfo().getStatusDetail();
+            if (childThing.getStatus() == ThingStatus.UNINITIALIZED && statusDetail != ThingStatusDetail.DISABLED) {
+                setThingStatus(childThing,
+                        buildStatusInfo(ThingStatus.UNINITIALIZED, ThingStatusDetail.BRIDGE_UNINITIALIZED));
+            }
         }
     }
 


### PR DESCRIPTION
When a bridge is disabled, the child things have seen set to the status "UNINITIALIZED/HANDLER_MISSING_ERROR". Now, the status detail is changed to "BRIDGE_UNINITIALIZED" for such things, except if they were also already disabled.

Fixes #6584

Signed-off-by: Florian Stolte <fstolte@itemis.de>