### PR TITLE
Keep persisted disabled status when thing is removed

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -913,7 +913,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     }
 
     @Test
-    public void testStorageEntryIsRetainedOnThingRemoval() throws Exception {
+    public void testStorageEntryRetainedOnThingRemoval() throws Exception {
         registerThingTypeProvider();
 
         AtomicReference<ThingHandlerCallback> thingHandlerCallback = new AtomicReference<>();
@@ -981,7 +981,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         new Thread((Runnable) () -> managedThingProvider.remove(THING.getUID())).start();
 
         waitForAssert(() -> {
-            assertThat(THING.getStatus(), is(ThingStatus.REMOVED));
+            assertThat(thingRegistry.get(THING.getUID()), is(equalTo(null)));
         }, SafeCaller.DEFAULT_TIMEOUT - 100, 50);
 
         assertThat(storage.containsKey(THING_UID.getAsString()), is(true));

--- a/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing.test/src/test/java/org/eclipse/smarthome/core/thing/internal/ThingManagerOSGiJavaTest.java
@@ -913,7 +913,7 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
     }
 
     @Test
-    public void testStorageEntryRemovedOnThingRemoval() throws Exception {
+    public void testStorageEntryIsRetainedOnThingRemoval() throws Exception {
         registerThingTypeProvider();
 
         AtomicReference<ThingHandlerCallback> thingHandlerCallback = new AtomicReference<>();
@@ -981,8 +981,10 @@ public class ThingManagerOSGiJavaTest extends JavaOSGiTest {
         new Thread((Runnable) () -> managedThingProvider.remove(THING.getUID())).start();
 
         waitForAssert(() -> {
-            assertThat(storage.containsKey(THING_UID.getAsString()), is(false));
+            assertThat(THING.getStatus(), is(ThingStatus.REMOVED));
         }, SafeCaller.DEFAULT_TIMEOUT - 100, 50);
+
+        assertThat(storage.containsKey(THING_UID.getAsString()), is(true));
     }
 
     private void assertThingStatus(Map<String, Object> propsThing, Map<String, Object> propsChannel, ThingStatus status,

--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/internal/ThingManagerImpl.java
@@ -484,7 +484,6 @@ public class ThingManagerImpl
             }
         }
 
-        storage.remove(thing.getUID().getAsString());
         this.things.remove(thing);
     }
 


### PR DESCRIPTION
The disabled status was not persisted after a restart since it was
removed on shutdown during the thing removal.
Now it will be persisted, but the disabled status of permanently deleted
disabled things will remain as orphan entry in the database.

Fixes #6840

Signed-off-by: Florian Stolte <fstolte@itemis.de>