### PR TITLE
[Hue] Add support for TransitionTime  #1722

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/internal/handler/HueLightHandlerTest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue.test/src/test/java/org/eclipse/smarthome/binding/hue/internal/handler/HueLightHandlerTest.java
@@ -97,43 +97,43 @@ public class HueLightHandlerTest {
 
     @Test
     public void assertCommandForColorChannelOn() {
-        String expectedReply = "{\"on\" : true}";
+        String expectedReply = "{\"on\" : true, \"transitiontime\" : 3}";
         assertSendCommandForColor(OnOffType.ON, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorTemperatureChannelOn() {
-        String expectedReply = "{\"on\" : true}";
+        String expectedReply = "{\"on\" : true, \"transitiontime\" : 3}";
         assertSendCommandForColorTemp(OnOffType.ON, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorChannelOff() {
-        String expectedReply = "{\"on\" : false}";
+        String expectedReply = "{\"on\" : false, \"transitiontime\" : 3}";
         assertSendCommandForColor(OnOffType.OFF, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorTemperatureChannelOff() {
-        String expectedReply = "{\"on\" : false}";
+        String expectedReply = "{\"on\" : false, \"transitiontime\" : 3}";
         assertSendCommandForColorTemp(OnOffType.OFF, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorTemperatureChannel0Percent() {
-        String expectedReply = "{\"ct\" : 153}";
+        String expectedReply = "{\"ct\" : 153, \"transitiontime\" : 3}";
         assertSendCommandForColorTemp(new PercentType(0), new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorTemperatureChannel50Percent() {
-        String expectedReply = "{\"ct\" : 327}";
+        String expectedReply = "{\"ct\" : 327, \"transitiontime\" : 3}";
         assertSendCommandForColorTemp(new PercentType(50), new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorTemperatureChannel1000Percent() {
-        String expectedReply = "{\"ct\" : 500}";
+        String expectedReply = "{\"ct\" : 500, \"transitiontime\" : 3}";
         assertSendCommandForColorTemp(new PercentType(100), new HueLightState(), expectedReply);
     }
 
@@ -157,140 +157,140 @@ public class HueLightHandlerTest {
 
     @Test
     public void assertCommandForColorChannel0Percent() {
-        String expectedReply = "{\"on\" : false}";
+        String expectedReply = "{\"on\" : false, \"transitiontime\" : 3}";
         assertSendCommandForColor(new PercentType(0), new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorChannel50Percent() {
-        String expectedReply = "{\"bri\" : 127, \"on\" : true}";
+        String expectedReply = "{\"bri\" : 127, \"on\" : true, \"transitiontime\" : 3}";
         assertSendCommandForColor(new PercentType(50), new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorChannel100Percent() {
-        String expectedReply = "{\"bri\" : 254, \"on\" : true}";
+        String expectedReply = "{\"bri\" : 254, \"on\" : true, \"transitiontime\" : 3}";
         assertSendCommandForColor(new PercentType(100), new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorChannelBlack() {
-        String expectedReply = "{\"on\" : false}";
+        String expectedReply = "{\"on\" : false, \"transitiontime\" : 3}";
         assertSendCommandForColor(HSBType.BLACK, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorChannelRed() {
-        String expectedReply = "{\"bri\" : 254, \"sat\" : 254, \"hue\" : 0}";
+        String expectedReply = "{\"bri\" : 254, \"sat\" : 254, \"hue\" : 0, \"transitiontime\" : 3}";
         assertSendCommandForColor(HSBType.RED, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorChannelGreen() {
-        String expectedReply = "{\"bri\" : 254, \"sat\" : 254, \"hue\" : 21845}";
+        String expectedReply = "{\"bri\" : 254, \"sat\" : 254, \"hue\" : 21845, \"transitiontime\" : 3}";
         assertSendCommandForColor(HSBType.GREEN, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorChannelBlue() {
-        String expectedReply = "{\"bri\" : 254, \"sat\" : 254, \"hue\" : 43690}";
+        String expectedReply = "{\"bri\" : 254, \"sat\" : 254, \"hue\" : 43690, \"transitiontime\" : 3}";
         assertSendCommandForColor(HSBType.BLUE, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertCommandForColorChannelWhite() {
-        String expectedReply = "{\"bri\" : 254, \"sat\" : 0, \"hue\" : 0}";
+        String expectedReply = "{\"bri\" : 254, \"sat\" : 0, \"hue\" : 0, \"transitiontime\" : 3}";
         assertSendCommandForColor(HSBType.WHITE, new HueLightState(), expectedReply);
     }
 
     @Test
     public void assertXYCommandForColorChannelBlack() {
-        String expectedReply = "{\"on\" : false}";
+        String expectedReply = "{\"on\" : false, \"transitiontime\" : 3}";
         assertSendCommandForColor(HSBType.BLACK, new HueLightState().colormode(ColorMode.XY), expectedReply);
     }
 
     @Test
     public void assertXYCommandForColorChannelWhite() {
-        String expectedReply = "{\"xy\" : [ 0.31271592 , 0.32900152 ], \"bri\" : 254}";
+        String expectedReply = "{\"xy\" : [ 0.31271592 , 0.32900152 ], \"bri\" : 254, \"transitiontime\" : 3}";
         assertSendCommandForColor(HSBType.WHITE, new HueLightState().colormode(ColorMode.XY), expectedReply);
     }
 
     @Test
     public void assertXYCommandForColorChannelColorful() {
-        String expectedReply = "{\"xy\" : [ 0.16969365 , 0.12379659 ], \"bri\" : 127}";
+        String expectedReply = "{\"xy\" : [ 0.16969365 , 0.12379659 ], \"bri\" : 127, \"transitiontime\" : 3}";
         assertSendCommandForColor(new HSBType("220,90,50"), new HueLightState().colormode(ColorMode.XY), expectedReply);
     }
 
     @Test
     public void asserCommandForColorChannelIncrease() {
         HueLightState currentState = new HueLightState().bri(1).on(false);
-        String expectedReply = "{\"bri\" : 30, \"on\" : true}";
+        String expectedReply = "{\"bri\" : 30, \"on\" : true, \"transitiontime\" : 3}";
         assertSendCommandForColor(IncreaseDecreaseType.INCREASE, currentState, expectedReply);
 
         currentState.bri(200).on(true);
-        expectedReply = "{\"bri\" : 230}";
+        expectedReply = "{\"bri\" : 230, \"transitiontime\" : 3}";
         assertSendCommandForColor(IncreaseDecreaseType.INCREASE, currentState, expectedReply);
 
         currentState.bri(230);
-        expectedReply = "{\"bri\" : 254}";
+        expectedReply = "{\"bri\" : 254, \"transitiontime\" : 3}";
         assertSendCommandForColor(IncreaseDecreaseType.INCREASE, currentState, expectedReply);
     }
 
     @Test
     public void asserCommandForColorChannelDecrease() {
         HueLightState currentState = new HueLightState().bri(200);
-        String expectedReply = "{\"bri\" : 170}";
+        String expectedReply = "{\"bri\" : 170, \"transitiontime\" : 3}";
         assertSendCommandForColor(IncreaseDecreaseType.DECREASE, currentState, expectedReply);
 
         currentState.bri(20);
-        expectedReply = "{\"on\" : false}";
+        expectedReply = "{\"on\" : false, \"transitiontime\" : 3}";
         assertSendCommandForColor(IncreaseDecreaseType.DECREASE, currentState, expectedReply);
     }
 
     @Test
     public void assertCommandForBrightnessChannel50Percent() {
         HueLightState currentState = new HueLightState();
-        String expectedReply = "{\"bri\" : 127, \"on\" : true}";
+        String expectedReply = "{\"bri\" : 127, \"on\" : true, \"transitiontime\" : 3}";
         assertSendCommandForBrightness(new PercentType(50), currentState, expectedReply);
     }
 
     @Test
     public void assertCommandForBrightnessChannelIncrease() {
         HueLightState currentState = new HueLightState().bri(1).on(false);
-        String expectedReply = "{\"bri\" : 30, \"on\" : true}";
+        String expectedReply = "{\"bri\" : 30, \"on\" : true, \"transitiontime\" : 3}";
         assertSendCommandForBrightness(IncreaseDecreaseType.INCREASE, currentState, expectedReply);
 
         currentState.bri(200).on(true);
-        expectedReply = "{\"bri\" : 230}";
+        expectedReply = "{\"bri\" : 230, \"transitiontime\" : 3}";
         assertSendCommandForBrightness(IncreaseDecreaseType.INCREASE, currentState, expectedReply);
 
         currentState.bri(230);
-        expectedReply = "{\"bri\" : 254}";
+        expectedReply = "{\"bri\" : 254, \"transitiontime\" : 3}";
         assertSendCommandForBrightness(IncreaseDecreaseType.INCREASE, currentState, expectedReply);
     }
 
     @Test
     public void assertCommandForBrightnessChannelDecrease() {
         HueLightState currentState = new HueLightState().bri(200);
-        String expectedReply = "{\"bri\" : 170}";
+        String expectedReply = "{\"bri\" : 170, \"transitiontime\" : 3}";
         assertSendCommandForBrightness(IncreaseDecreaseType.DECREASE, currentState, expectedReply);
 
         currentState.bri(20);
-        expectedReply = "{\"on\" : false}";
+        expectedReply = "{\"on\" : false, \"transitiontime\" : 3}";
         assertSendCommandForBrightness(IncreaseDecreaseType.DECREASE, currentState, expectedReply);
     }
 
     @Test
     public void assertCommandForBrightnessChannelOff() {
         HueLightState currentState = new HueLightState();
-        String expectedReply = "{\"on\" : false}";
+        String expectedReply = "{\"on\" : false, \"transitiontime\" : 3}";
         assertSendCommandForBrightness(OnOffType.OFF, currentState, expectedReply);
     }
 
     @Test
     public void assertCommandForBrightnessChannelOn() {
         HueLightState currentState = new HueLightState();
-        String expectedReply = "{\"on\" : true}";
+        String expectedReply = "{\"on\" : true, \"transitiontime\" : 3}";
         assertSendCommandForBrightness(OnOffType.ON, currentState, expectedReply);
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/ColorLight.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/ColorLight.xml
@@ -16,6 +16,7 @@
 			<channel id="color" typeId="color" />
 			<channel id="alert" typeId="alert" />
 			<channel id="effect" typeId="effect" />
+			<channel id="fadetime" typeId="fadetime" />
 		</channels>
 
 		<representation-property>uniqueId</representation-property>
@@ -25,6 +26,11 @@
 				<label>Light ID</label>
 				<description>The light identifier identifies one certain hue light.</description>
 				<required>true</required>
+			</parameter>
+			<parameter name="fadetime" type="integer" min="0">
+				<label>Fade time</label>
+				<description>Fade time in ms for changing values</description>
+				<default>300</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/ColorTemperatureLight.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/ColorTemperatureLight.xml
@@ -17,6 +17,7 @@
 			<channel id="brightness" typeId="brightness" />
 			<channel id="alert" typeId="alert" />
 			<channel id="effect" typeId="effect" />
+			<channel id="fadetime" typeId="fadetime" />
 		</channels>
 
 		<representation-property>uniqueId</representation-property>
@@ -26,6 +27,11 @@
 				<label>Light ID</label>
 				<description>The light identifier identifies one certain hue light.</description>
 				<required>true</required>
+			</parameter>
+			<parameter name="fadetime" type="integer" min="0">
+				<label>Fade time</label>
+				<description>Fade time in ms for changing values</description>
+				<default>300</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/DimmableLight.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/DimmableLight.xml
@@ -15,6 +15,7 @@
 		<channels>
 			<channel id="brightness" typeId="brightness" />
 			<channel id="alert" typeId="alert" />
+			<channel id="fadetime" typeId="fadetime" />
 		</channels>
 
 		<representation-property>uniqueId</representation-property>
@@ -24,6 +25,11 @@
 				<label>Light ID</label>
 				<description>The light identifier identifies one certain hue light.</description>
 				<required>true</required>
+			</parameter>
+			<parameter name="fadetime" type="integer" min="0">
+				<label>Fade time</label>
+				<description>Fade time in ms for changing values</description>
+				<default>300</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/DimmablePlug.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/DimmablePlug.xml
@@ -24,6 +24,11 @@
 				<description>The identifier that is used within the hue bridge.</description>
 				<required>true</required>
 			</parameter>
+			<parameter name="fadetime" type="integer" min="0">
+				<label>Fade time</label>
+				<description>Fade time in ms for changing values</description>
+				<default>300</default>
+			</parameter>
 		</config-description>
 	</thing-type>
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/ExtendedColorLight.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/ExtendedColorLight.xml
@@ -17,6 +17,7 @@
 			<channel id="color_temperature" typeId="color_temperature" />
 			<channel id="alert" typeId="alert" />
 			<channel id="effect" typeId="effect" />
+			<channel id="fadetime" typeId="fadetime" />
 		</channels>
 
 		<representation-property>uniqueId</representation-property>
@@ -26,6 +27,11 @@
 				<label>Light ID</label>
 				<description>The light identifier identifies one certain hue light.</description>
 				<required>true</required>
+			</parameter>
+			<parameter name="fadetime" type="integer" min="0">
+				<label>Fade time</label>
+				<description>Fade time in ms for changing values</description>
+				<default>300</default>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/channels.xml
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/ESH-INF/thing/channels.xml
@@ -199,4 +199,12 @@
 		<description>The effect channel allows putting the bulb in a color looping mode.</description>
 		<category>ColorLight</category>
 	</channel-type>
+
+	<!-- Fade Time Channel -->
+	<channel-type id="fadetime" advanced="true">
+		<item-type>Number</item-type>
+		<label>Fade Time</label>
+		<description>Current fade time.</description>
+	</channel-type>
+
 </thing:thing-descriptions>

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullLight.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/FullLight.java
@@ -13,6 +13,7 @@
 package org.eclipse.smarthome.binding.hue.internal;
 
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.Map;
 
 import com.google.gson.reflect.TypeToken;
@@ -30,6 +31,7 @@ public class FullLight extends FullHueObject {
     }.getType();
 
     private State state;
+    private final long fadetime = 300; // milliseconds
 
     FullLight() {
     }
@@ -41,5 +43,9 @@ public class FullLight extends FullHueObject {
      */
     public State getState() {
         return state;
+    }
+
+    public Duration getFadeTime() {
+        return Duration.ofMillis(fadetime);
     }
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBindingConstants.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/HueBindingConstants.java
@@ -67,6 +67,7 @@ public class HueBindingConstants {
     public static final String CHANNEL_LIGHT_LEVEL = "light_level";
     public static final String CHANNEL_DARK = "dark";
     public static final String CHANNEL_DAYLIGHT = "daylight";
+    public static final String CHANNEL_FADETIME = "fadetime";
 
     // List all triggers
     public static final String EVENT_DIMMER_SWITCH = "dimmer_switch_event";
@@ -81,6 +82,6 @@ public class HueBindingConstants {
     public static final String SENSOR_ID = "sensorId";
     public static final String PRODUCT_NAME = "productName";
     public static final String UNIQUE_ID = "uniqueId";
-
     public static final String NORMALIZE_ID_REGEX = "[^a-zA-Z0-9_]";
+    public static final String FADETIME = "fadetime";
 }

--- a/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/StateUpdate.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.hue/src/main/java/org/eclipse/smarthome/binding/hue/internal/StateUpdate.java
@@ -187,7 +187,7 @@ public class StateUpdate extends ConfigUpdate {
      * @param timeMillis time in milliseconds [0..6553600]
      * @return this object for chaining calls
      */
-    public StateUpdate setTransitionTime(int timeMillis) {
+    public StateUpdate setTransitionTime(long timeMillis) {
         if (timeMillis < 0 || timeMillis > 6553600) {
             throw new IllegalArgumentException("Transition time out of range");
         }


### PR DESCRIPTION
Implemented fade time config for light things.
Implemented fade time channel for dynamically changing the fade times of light things.

Bug: https://github.com/eclipse/smarthome/issues/1722
Signed-off-by: Jochen <jochen.leopold@model-view.com>