### PR TITLE
Bose Soundtouch - fixed an issue with async. websocket requests

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bosesoundtouch/src/main/java/org/eclipse/smarthome/binding/bosesoundtouch/internal/CommandExecutor.java
@@ -14,7 +14,6 @@ package org.eclipse.smarthome.binding.bosesoundtouch.internal;
 
 import static org.eclipse.smarthome.binding.bosesoundtouch.BoseSoundTouchBindingConstants.*;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -119,12 +118,8 @@ public class CommandExecutor implements AvailableSources {
     public void getInformations(APIRequest apiRequest) {
         String msg = "<msg><header " + "deviceID=\"" + handler.getMacAddress() + "\"" + " url=\"" + apiRequest
                 + "\" method=\"GET\"><request requestID=\"0\"><info type=\"new\"/></request></header></msg>";
-        try {
-            handler.getSession().getRemote().sendString(msg);
-            logger.debug("{}: sending request: {}", handler.getDeviceName(), msg);
-        } catch (IOException e) {
-            handler.onWebSocketError(e);
-        }
+        handler.getSession().getRemote().sendStringByFuture(msg);
+        logger.debug("{}: sending request: {}", handler.getDeviceName(), msg);
     }
 
     /**
@@ -380,9 +375,9 @@ public class CommandExecutor implements AvailableSources {
                 + "\" method=\"POST\"><request requestID=\"" + id + "\"><info " + infoAddon
                 + " type=\"new\"/></request></header><body>" + postData + "</body></msg>";
         try {
-            handler.getSession().getRemote().sendString(msg);
+            handler.getSession().getRemote().sendStringByFuture(msg);
             logger.debug("{}: sending request: {}", handler.getDeviceName(), msg);
-        } catch (IOException | NullPointerException e) {
+        } catch (NullPointerException e) {
             handler.onWebSocketError(e);
         }
     }


### PR DESCRIPTION
When a refresh command is sent to some of the Bose's items, the following exception could be thrown:

```
Exception occurred while informing handler: Blocking message pending 10000 for BLOCKING
java.lang.IllegalStateException: Blocking message pending 10000 for BLOCKING
	at org.eclipse.jetty.websocket.common.WebSocketRemoteEndpoint.lockMsg(WebSocketRemoteEndpoint.java:130)
	at org.eclipse.jetty.websocket.common.WebSocketRemoteEndpoint.sendString(WebSocketRemoteEndpoint.java:385)
	at org.eclipse.smarthome.binding.bosesoundtouch.internal.CommandExecutor.getInformations(CommandExecutor.java:123)
	at org.eclipse.smarthome.binding.bosesoundtouch.handler.BoseSoundTouchHandler.handleCommand(BoseSoundTouchHandler.java:190)
	at org.eclipse.smarthome.core.thing.binding.BaseThingHandler.channelLinked(BaseThingHandler.java:233)
	at org.eclipse.smarthome.core.thing.link.ThingLinkManager.lambda$0(ThingLinkManager.java:300)
	at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
	at java.util.concurrent.FutureTask.run(Unknown Source)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(Unknown Source)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.lang.Thread.run(Unknown Source)
```
Basically, the issue happens because multiple threads are trying to send commands to the same remote websocket endpoint. So, in order to prevent this, we excahge the usage of `void sendString(String text) throws IOException)` method to `Future<Void> sendStringByFuture(String text)` which initiates an asynchronous transmission of a text message. However, since all places where `sendStringByFuture(String text)` is called are void methods, we do not need to care of getting the future and checking the progress of the transmission.