### PR TITLE
Change method name 'localize' to 'createChannelType'

### DIFF
--- a/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
+++ b/bundles/core/org.eclipse.smarthome.core.thing/src/main/java/org/eclipse/smarthome/core/thing/DefaultSystemChannelTypeProvider.java
@@ -391,7 +391,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
             return cachedEntry;
         }
 
-        ChannelType localizedChannelType = localize(bundle, channelType, locale);
+        ChannelType localizedChannelType = createChannelType(bundle, channelType, locale);
         if (localizedChannelType != null) {
             localizedChannelTypeCache.put(localizedChannelTypeKey, localizedChannelType);
             return localizedChannelType;
@@ -400,7 +400,7 @@ public class DefaultSystemChannelTypeProvider implements ChannelTypeProvider {
         }
     }
 
-    private @Nullable ChannelType localize(Bundle bundle, ChannelType channelType, Locale locale) {
+    private @Nullable ChannelType createChannelType(Bundle bundle, ChannelType channelType, Locale locale) {
         if (channelTypeI18nLocalizationService == null) {
             return null;
         }


### PR DESCRIPTION
This class is used to provide default system wide channel types.  This method named 'localize' is to create channel type. Thus, the method name 'createChannelType' is more intuitive than 'convert'.