### PR TITLE
Change method name 'little' to 'getLittleField'

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/fields/Field.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/fields/Field.java
@@ -96,7 +96,7 @@ public abstract class Field<T> {
      *
      * @return a little-endian version of this field
      */
-    public Field<T> little() {
+    public Field<T> getLittleField() {
         return new LittleField<>(this);
     }
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/fields/HSBKField.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/fields/HSBKField.java
@@ -22,10 +22,10 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 @NonNullByDefault
 public class HSBKField extends Field<HSBK> {
 
-    public static final Field<Integer> FIELD_HUE = new UInt16Field().little();
-    public static final Field<Integer> FIELD_SATURATION = new UInt16Field().little();
-    public static final Field<Integer> FIELD_BRIGHTNESS = new UInt16Field().little();
-    public static final Field<Integer> FIELD_KELVIN = new UInt16Field().little();
+    public static final Field<Integer> FIELD_HUE = new UInt16Field().getLittleField();
+    public static final Field<Integer> FIELD_SATURATION = new UInt16Field().getLittleField();
+    public static final Field<Integer> FIELD_BRIGHTNESS = new UInt16Field().getLittleField();
+    public static final Field<Integer> FIELD_KELVIN = new UInt16Field().getLittleField();
 
     @Override
     public int defaultLength() {

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Packet.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/Packet.java
@@ -41,15 +41,15 @@ import org.eclipse.smarthome.binding.lifx.internal.fields.UInt8Field;
  */
 public abstract class Packet {
 
-    public static final Field<Integer> FIELD_SIZE = new UInt16Field().little();
-    public static final Field<Integer> FIELD_PROTOCOL = new UInt16Field().little();
-    public static final Field<Long> FIELD_SOURCE = new UInt32Field().little();
+    public static final Field<Integer> FIELD_SIZE = new UInt16Field().getLittleField();
+    public static final Field<Integer> FIELD_PROTOCOL = new UInt16Field().getLittleField();
+    public static final Field<Long> FIELD_SOURCE = new UInt32Field().getLittleField();
     public static final Field<MACAddress> FIELD_TARGET = new MACAddressField();
     public static final Field<ByteBuffer> FIELD_RESERVED_1 = new ByteField(6);
     public static final Field<Integer> FIELD_ACK = new UInt8Field();
-    public static final Field<Integer> FIELD_SEQUENCE = new UInt8Field().little();
+    public static final Field<Integer> FIELD_SEQUENCE = new UInt8Field().getLittleField();
     public static final Field<ByteBuffer> FIELD_RESERVED_2 = new ByteField(8);
-    public static final Field<Integer> FIELD_PACKET_TYPE = new UInt16Field().little();
+    public static final Field<Integer> FIELD_PACKET_TYPE = new UInt16Field().getLittleField();
     public static final Field<ByteBuffer> FIELD_RESERVED_3 = new ByteField(2);
 
     /**

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetColorRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetColorRequest.java
@@ -30,7 +30,7 @@ public class SetColorRequest extends Packet {
 
     public static final Field<ByteBuffer> FIELD_STREAM = new ByteField(1);
     public static final HSBKField FIELD_COLOR = new HSBKField();
-    public static final Field<Long> FIELD_FADE_TIME = new UInt32Field().little();
+    public static final Field<Long> FIELD_FADE_TIME = new UInt32Field().getLittleField();
 
     private ByteBuffer stream;
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetColorZonesRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetColorZonesRequest.java
@@ -32,7 +32,7 @@ public class SetColorZonesRequest extends Packet {
     public static final Field<Integer> FIELD_START_INDEX = new UInt8Field();
     public static final Field<Integer> FIELD_END_INDEX = new UInt8Field();
     public static final HSBKField FIELD_COLOR = new HSBKField();
-    public static final Field<Long> FIELD_FADE_TIME = new UInt32Field().little();
+    public static final Field<Long> FIELD_FADE_TIME = new UInt32Field().getLittleField();
     public static final Field<Integer> FIELD_APPLY = new UInt8Field();
 
     private int startIndex = MIN_ZONE_INDEX;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetDimAbsoluteRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetDimAbsoluteRequest.java
@@ -26,8 +26,8 @@ public class SetDimAbsoluteRequest extends Packet {
 
     public static final int TYPE = 0x68;
 
-    public static final Field<Integer> FIELD_DIM = new UInt16Field().little();
-    public static final Field<Long> FIELD_DURATION = new UInt32Field().little();
+    public static final Field<Integer> FIELD_DIM = new UInt16Field().getLittleField();
+    public static final Field<Long> FIELD_DURATION = new UInt32Field().getLittleField();
 
     private int dim;
     private long duration;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightInfraredRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightInfraredRequest.java
@@ -24,7 +24,7 @@ public class SetLightInfraredRequest extends Packet {
 
     public static final int TYPE = 0x7A;
 
-    public static final Field<Integer> FIELD_STATE = new UInt16Field().little();
+    public static final Field<Integer> FIELD_STATE = new UInt16Field().getLittleField();
 
     private int infrared;
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightPowerRequest.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/SetLightPowerRequest.java
@@ -27,7 +27,7 @@ public class SetLightPowerRequest extends Packet {
     public static final int TYPE = 0x75;
 
     public static final Field<Integer> FIELD_STATE = new UInt16Field();
-    public static final Field<Long> FIELD_DURATION = new UInt32Field().little();
+    public static final Field<Long> FIELD_DURATION = new UInt32Field().getLittleField();
 
     private PowerState state;
     private long duration;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateGroupResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateGroupResponse.java
@@ -29,7 +29,7 @@ public class StateGroupResponse extends Packet {
 
     public static final Field<ByteBuffer> FIELD_GROUP = new ByteField(16);
     public static final Field<String> FIELD_LABEL = new StringField(32).utf8();
-    public static final Field<Long> FIELD_UPDATED_AT = new UInt64Field().little();
+    public static final Field<Long> FIELD_UPDATED_AT = new UInt64Field().getLittleField();
 
     private ByteBuffer group;
     private String label;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateHostFirmwareResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateHostFirmwareResponse.java
@@ -27,9 +27,9 @@ public class StateHostFirmwareResponse extends Packet {
 
     public static final int TYPE = 0x0F;
 
-    public static final Field<Long> FIELD_BUILD = new UInt64Field().little();
-    public static final Field<Long> FIELD_RESERVED = new UInt64Field().little();
-    public static final Field<Version> FIELD_VERSION = new VersionField().little();
+    public static final Field<Long> FIELD_BUILD = new UInt64Field().getLittleField();
+    public static final Field<Long> FIELD_RESERVED = new UInt64Field().getLittleField();
+    public static final Field<Version> FIELD_VERSION = new VersionField().getLittleField();
 
     private long build;
     private long reserved;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateHostInfoResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateHostInfoResponse.java
@@ -27,9 +27,9 @@ public class StateHostInfoResponse extends Packet {
 
     public static final int TYPE = 0x0D;
 
-    public static final Field<Float> FIELD_SIGNAL = new FloatField().little();
-    public static final Field<Long> FIELD_TX = new UInt32Field().little();
-    public static final Field<Long> FIELD_RX = new UInt32Field().little();
+    public static final Field<Float> FIELD_SIGNAL = new FloatField().getLittleField();
+    public static final Field<Long> FIELD_TX = new UInt32Field().getLittleField();
+    public static final Field<Long> FIELD_RX = new UInt32Field().getLittleField();
     public static final Field<ByteBuffer> FIELD_RESERVED_5 = new ByteField(2);
 
     private float signal;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateInfoResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateInfoResponse.java
@@ -25,9 +25,9 @@ public class StateInfoResponse extends Packet {
 
     public static final int TYPE = 0x23;
 
-    public static final Field<Long> FIELD_TIME = new UInt64Field().little();
-    public static final Field<Long> FIELD_UPTIME = new UInt64Field().little();
-    public static final Field<Long> FIELD_DOWNTIME = new UInt64Field().little();
+    public static final Field<Long> FIELD_TIME = new UInt64Field().getLittleField();
+    public static final Field<Long> FIELD_UPTIME = new UInt64Field().getLittleField();
+    public static final Field<Long> FIELD_DOWNTIME = new UInt64Field().getLittleField();
 
     private long time;
     private long uptime;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateLightInfraredResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateLightInfraredResponse.java
@@ -24,7 +24,7 @@ public class StateLightInfraredResponse extends Packet {
 
     public static final int TYPE = 0x79;
 
-    public static final Field<Integer> FIELD_STATE = new UInt16Field().little();
+    public static final Field<Integer> FIELD_STATE = new UInt16Field().getLittleField();
 
     private int infrared;
 

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateLocationResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateLocationResponse.java
@@ -29,7 +29,7 @@ public class StateLocationResponse extends Packet {
 
     public static final Field<ByteBuffer> FIELD_LOCATION = new ByteField(16);
     public static final Field<String> FIELD_LABEL = new StringField(32).utf8();
-    public static final Field<Long> FIELD_UPDATED_AT = new UInt64Field().little();
+    public static final Field<Long> FIELD_UPDATED_AT = new UInt64Field().getLittleField();
 
     private ByteBuffer location;
     private String label;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateResponse.java
@@ -30,7 +30,7 @@ public class StateResponse extends Packet {
     public static final int TYPE = 0x6B;
 
     public static final HSBKField FIELD_COLOR = new HSBKField();
-    public static final Field<Integer> FIELD_DIM = new UInt16Field().little();
+    public static final Field<Integer> FIELD_DIM = new UInt16Field().getLittleField();
     public static final Field<Integer> FIELD_POWER = new UInt16Field();
     public static final Field<String> FIELD_LABEL = new StringField(32);
     public static final Field<Long> FIELD_TAGS = new UInt64Field();

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateVersionResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateVersionResponse.java
@@ -25,9 +25,9 @@ public class StateVersionResponse extends Packet {
 
     public static final int TYPE = 0x21;
 
-    public static final Field<Long> FIELD_VENDOR = new UInt32Field().little();
-    public static final Field<Long> FIELD_PRODUCT = new UInt32Field().little();
-    public static final Field<Long> FIELD_VERSION = new UInt32Field().little();
+    public static final Field<Long> FIELD_VENDOR = new UInt32Field().getLittleField();
+    public static final Field<Long> FIELD_PRODUCT = new UInt32Field().getLittleField();
+    public static final Field<Long> FIELD_VERSION = new UInt32Field().getLittleField();
 
     private long vendor;
     private long product;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateWifiFirmwareResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateWifiFirmwareResponse.java
@@ -27,9 +27,9 @@ public class StateWifiFirmwareResponse extends Packet {
 
     public static final int TYPE = 0x13;
 
-    public static final Field<Long> FIELD_BUILD = new UInt64Field().little();
-    public static final Field<Long> FIELD_RESERVED = new UInt64Field().little();
-    public static final Field<Version> FIELD_VERSION = new VersionField().little();
+    public static final Field<Long> FIELD_BUILD = new UInt64Field().getLittleField();
+    public static final Field<Long> FIELD_RESERVED = new UInt64Field().getLittleField();
+    public static final Field<Version> FIELD_VERSION = new VersionField().getLittleField();
 
     private long build;
     private long reserved;

--- a/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateWifiInfoResponse.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.lifx/src/main/java/org/eclipse/smarthome/binding/lifx/internal/protocol/StateWifiInfoResponse.java
@@ -27,9 +27,9 @@ public class StateWifiInfoResponse extends Packet {
 
     public static final int TYPE = 0x11;
 
-    public static final Field<Float> FIELD_SIGNAL = new FloatField().little();
-    public static final Field<Long> FIELD_RX = new UInt32Field().little();
-    public static final Field<Long> FIELD_TX = new UInt32Field().little();
+    public static final Field<Float> FIELD_SIGNAL = new FloatField().getLittleField();
+    public static final Field<Long> FIELD_RX = new UInt32Field().getLittleField();
+    public static final Field<Long> FIELD_TX = new UInt32Field().getLittleField();
     public static final Field<Integer> FIELD_TEMP = new UInt16Field();
 
     private float signal;


### PR DESCRIPTION
This class is used to represent Field.  This method named 'little' is to get a LittleField object. Thus, the method name 'getLittleField' is more intuitive than 'little'.